### PR TITLE
Deprecated KotlinJvmOptions

### DIFF
--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryComposeConventionPlugin.kt
@@ -3,10 +3,10 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("UNUSED")
 class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
@@ -41,13 +41,12 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
                     targetCompatibility = JavaVersion.values()[javaVersion - 1]
                 }
 
-                (this as ExtensionAware).configure<KotlinJvmOptions> {
-                    jvmTarget = "$javaVersion"
-                    freeCompilerArgs = freeCompilerArgs + listOf(
-                        "-opt-in=kotlin.RequiresOptIn",
-                        "-opt-in=kotlinx.coroutines.FlowPreview",
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-                    )
+                tasks.withType<KotlinCompile>().configureEach {
+                    compilerOptions {
+                        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+                        freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
+                        freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
+                    }
                 }
 
                 buildFeatures {
@@ -58,6 +57,3 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
         }
     }
 }
-
-Kotlin Gradle Plugin: The KotlinJvmOptions class has been replaced by the kotlinOptions property in the KotlinJvmCompilerOptions class. You can access and configure JVM options using this property.
-Kotlin Compiler: The KotlinJvmOptions class has been replaced by the jvmTarget property in the KotlinCompilerOptions class. You can set the JVM target version using this property.

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryComposeConventionPlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("UNUSED")
@@ -43,6 +44,8 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
 
                 tasks.withType<KotlinCompile>().configureEach {
                     compilerOptions {
+                        jvmTarget.set(JvmTarget.JVM_17)
+
                         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                         freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
                         freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryComposeConventionPlugin.kt
@@ -58,3 +58,6 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
         }
     }
 }
+
+Kotlin Gradle Plugin: The KotlinJvmOptions class has been replaced by the kotlinOptions property in the KotlinJvmCompilerOptions class. You can access and configure JVM options using this property.
+Kotlin Compiler: The KotlinJvmOptions class has been replaced by the jvmTarget property in the KotlinCompilerOptions class. You can set the JVM target version using this property.

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryConventionPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("UNUSED")
@@ -43,6 +44,8 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
                 tasks.withType<KotlinCompile>().configureEach {
                     compilerOptions {
+                        jvmTarget.set(JvmTarget.JVM_17)
+
                         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                         freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
                         freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/AndroidLibraryConventionPlugin.kt
@@ -3,11 +3,11 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("UNUSED")
 class AndroidLibraryConventionPlugin : Plugin<Project> {
@@ -41,13 +41,12 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                     targetCompatibility = JavaVersion.values()[javaVersion - 1]
                 }
 
-                (this as ExtensionAware).configure<KotlinJvmOptions> {
-                    jvmTarget = "$javaVersion"
-                    freeCompilerArgs = freeCompilerArgs + listOf(
-                        "-opt-in=kotlin.RequiresOptIn",
-                        "-opt-in=kotlinx.coroutines.FlowPreview",
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-                    )
+                tasks.withType<KotlinCompile>().configureEach {
+                    compilerOptions {
+                        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+                        freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
+                        freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
+                    }
                 }
 
                 buildFeatures {

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/ApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/ApplicationConventionPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("UNUSED")
@@ -43,6 +44,8 @@ class ApplicationConventionPlugin : Plugin<Project> {
 
                 tasks.withType<KotlinCompile>().configureEach {
                     compilerOptions {
+                        jvmTarget.set(JvmTarget.JVM_17)
+
                         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                         freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
                         freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/ApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/ApplicationConventionPlugin.kt
@@ -3,11 +3,11 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 @Suppress("UNUSED")
 class ApplicationConventionPlugin : Plugin<Project> {
@@ -18,6 +18,7 @@ class ApplicationConventionPlugin : Plugin<Project> {
             val minSdkVersion = libs.findVersion("minSdk").get().toString().toInt()
             val targetSdkVersion = libs.findVersion("targetSdk").get().toString().toInt()
             val compileSdkVersion = libs.findVersion("compileSdk").get().toString().toInt()
+            //val composeCompilerVersion = libs.findPlugin("composeCompiler").get().toString()
 
             with(pluginManager) {
                 apply("com.android.application")
@@ -40,13 +41,12 @@ class ApplicationConventionPlugin : Plugin<Project> {
                     targetCompatibility = JavaVersion.values()[javaVersion - 1]
                 }
 
-                (this as ExtensionAware).configure<KotlinJvmOptions> {
-                    jvmTarget = "$javaVersion"
-                    freeCompilerArgs = freeCompilerArgs + listOf(
-                        "-opt-in=kotlin.RequiresOptIn",
-                        "-opt-in=kotlinx.coroutines.FlowPreview",
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
-                    )
+                tasks.withType<KotlinCompile>().configureEach {
+                    compilerOptions {
+                        freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+                        freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
+                        freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
+                    }
                 }
 
                 buildFeatures {
@@ -54,7 +54,7 @@ class ApplicationConventionPlugin : Plugin<Project> {
                     buildConfig = true
                 }
 
-                /*composeOptions {
+               /* composeOptions {
                     kotlinCompilerExtensionVersion = composeCompilerVersion
                 }*/
 

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/JvmLibraryConventionPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -26,9 +27,12 @@ class JvmLibraryConventionPlugin : Plugin<Project> {
             }
 
             tasks.withType<KotlinCompile>().configureEach {
+
                 compilerOptions {
                     val warningsAsErrors: String? by project
                     allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+
+                    jvmTarget.set(JvmTarget.JVM_17)
 
                     freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
                     freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/JvmLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/JvmLibraryConventionPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 class JvmLibraryConventionPlugin : Plugin<Project> {
@@ -25,17 +26,15 @@ class JvmLibraryConventionPlugin : Plugin<Project> {
             }
 
             tasks.withType<KotlinCompile>().configureEach {
-                kotlinOptions {
-                    jvmTarget = javaVersion.toString()
+                compilerOptions {
                     val warningsAsErrors: String? by project
-                    allWarningsAsErrors = warningsAsErrors.toBoolean()
-                    freeCompilerArgs = freeCompilerArgs + listOf(
-                        // Enable experimental coroutines APIs, including Flow
-                        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-                    )
+                    allWarningsAsErrors.set(warningsAsErrors.toBoolean())
+
+                    freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")
+                    freeCompilerArgs.add("-opt-in=kotlinx.coroutines.FlowPreview")
+                    freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
## KotlinJvmOptions is deprecated

**Fix following warning** 
'KotlinJvmOptions' is deprecated. The `kotlinOptions` types are deprecated, please migrate to the `compilerOptions` types. More details are here: https://kotl.in/u1r8ln

## No warning in project Yay!

![Screenshot 2024-09-28 at 9 40 50 am](https://github.com/user-attachments/assets/2a6695f1-c5f1-4457-93f2-272874e5d88e)

