### PR TITLE
Add Reverse Stop feature

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/searchstop/model/StopItem.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/searchstop/model/StopItem.kt
@@ -19,6 +19,7 @@ data class StopItem(
     fun toJsonString() = Json.encodeToString(serializer(), this)
 
     companion object {
-        fun fromJsonString(json: String) = Json.decodeFromString(serializer(), json)
+        fun fromJsonString(json: String) =
+            kotlin.runCatching { Json.decodeFromString(serializer(), json) }.getOrNull()
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/SearchStopRow.kt
@@ -32,6 +32,7 @@ fun SearchStopRow(
     toStopItem: StopItem? = null,
     fromButtonClick: () -> Unit,
     toButtonClick: () -> Unit,
+    onReverseButtonClick: () -> Unit = {},
     onSearchButtonClick: () -> Unit = {},
 ) {
     Row(
@@ -78,7 +79,7 @@ fun SearchStopRow(
                         colorFilter = ColorFilter.tint(LocalOnContentColor.current),
                     )
                 },
-                onClick = {},
+                onClick = onReverseButtonClick,
             )
 
             RoundIconButton(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/navigation/TripPlannerDestinations.kt
@@ -60,6 +60,9 @@ fun NavGraphBuilder.tripPlannerDestinations(
                     Timber.d("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
                     navController.navigate(SearchStopRoute(fieldType = SearchStopFieldType.TO))
                 },
+                onReverseButtonClick = {
+
+                },
                 onSearchButtonClick = {
                     if (fromStopItem != null && toStopItem != null) {
                         navController.navigate(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/navigation/TripPlannerDestinations.kt
@@ -2,6 +2,9 @@ package xyz.ksharma.krail.trip_planner.ui.navigation
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
@@ -33,19 +36,22 @@ fun NavGraphBuilder.tripPlannerDestinations(
             val viewModel = hiltViewModel<SavedTripsViewModel>()
             val savedTripState by viewModel.uiState.collectAsStateWithLifecycle()
 
-            val fromStopItem: StopItem? =
-                backStackEntry.savedStateHandle.get<String>(SearchStopFieldType.FROM.key)
-                    ?.let { fromJsonString(it) }
-            val toStopItem: StopItem? =
-                backStackEntry.savedStateHandle.get<String>(SearchStopFieldType.TO.key)
-                    ?.let { fromJsonString(it) }
+            val fromArg = backStackEntry.savedStateHandle.get<String>(SearchStopFieldType.FROM.key)
+                ?.let { fromJsonString(it) }
+            val toArg = backStackEntry.savedStateHandle.get<String>(SearchStopFieldType.TO.key)
+                ?.let { fromJsonString(it) }
 
-            LaunchedEffect(fromStopItem) {
-                Timber.d("fromStopItem: $fromStopItem")
+            var fromStopItem: StopItem? by rememberSaveable { mutableStateOf(fromArg) }
+            var toStopItem: StopItem? by rememberSaveable { mutableStateOf(toArg) }
+
+            LaunchedEffect(fromArg) {
+                fromStopItem = fromArg
+                Timber.d("Change fromStopItem: $fromStopItem")
             }
 
-            LaunchedEffect(toStopItem) {
-                Timber.d("toStopItem: $toStopItem")
+            LaunchedEffect(toArg) {
+                toStopItem = toArg
+                Timber.d("Change toStopItem: $toStopItem")
             }
 
             SavedTripsScreen(
@@ -61,16 +67,25 @@ fun NavGraphBuilder.tripPlannerDestinations(
                     navController.navigate(SearchStopRoute(fieldType = SearchStopFieldType.TO))
                 },
                 onReverseButtonClick = {
+                    Timber.d("onReverseButtonClick:")
+                    val bufferStop = fromStopItem
+                    backStackEntry.savedStateHandle[SearchStopFieldType.FROM.key] =
+                        toStopItem?.toJsonString()
+                    backStackEntry.savedStateHandle[SearchStopFieldType.TO.key] =
+                        bufferStop?.toJsonString()
+
+                    fromStopItem = toStopItem
+                    toStopItem = bufferStop
 
                 },
                 onSearchButtonClick = {
                     if (fromStopItem != null && toStopItem != null) {
                         navController.navigate(
                             TimeTableRoute(
-                                fromStopId = fromStopItem.stopId,
-                                fromStopName = fromStopItem.stopName,
-                                toStopId = toStopItem.stopId,
-                                toStopName = toStopItem.stopName,
+                                fromStopId = fromStopItem?.stopId!!,
+                                fromStopName = fromStopItem?.stopName!!,
+                                toStopId = toStopItem?.stopId!!,
+                                toStopName = toStopItem?.stopName!!,
                             )
                         )
                     } else {
@@ -101,7 +116,6 @@ fun NavGraphBuilder.tripPlannerDestinations(
             val viewModel = hiltViewModel<SearchStopViewModel>()
             val searchStopState by viewModel.uiState.collectAsStateWithLifecycle()
             val route: SearchStopRoute = backStackEntry.toRoute()
-            Timber.d("SearchStopRoute: $route")
 
             SearchStopScreen(
                 searchStopState = searchStopState,

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/savedtrips/SavedTripsScreen.kt
@@ -28,6 +28,7 @@ fun SavedTripsScreen(
     toStopItem: StopItem? = null,
     fromButtonClick: () -> Unit = {},
     toButtonClick: () -> Unit = {},
+    onReverseButtonClick: () -> Unit = {},
     onSearchButtonClick: () -> Unit = {},
     onEvent: (SavedTripUiEvent) -> Unit = {},
 ) {
@@ -50,6 +51,7 @@ fun SavedTripsScreen(
             toStopItem = toStopItem,
             fromButtonClick = fromButtonClick,
             toButtonClick = toButtonClick,
+            onReverseButtonClick = onReverseButtonClick,
             onSearchButtonClick = onSearchButtonClick,
         )
     }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -28,7 +28,6 @@ class SavedTripsViewModel @Inject constructor() : ViewModel() {
 
     private fun onSearchButtonClicked(fromStopItem: StopItem, toStopItem: StopItem) {
         Timber.d("onSearchButtonClicked")
-
     }
 
     private fun onSavedTripClicked(savedTrip: String) {
@@ -37,7 +36,6 @@ class SavedTripsViewModel @Inject constructor() : ViewModel() {
 
     private fun onLoadSavedTrips() {
         Timber.d("onLoadSavedTrips")
-
         updateUiState {
             copy(trip = "Central to Town Hall")
         }


### PR DESCRIPTION
### TL;DR

Implemented reverse functionality for trip planning and improved state management for stop selections.

### What changed?

- Added `onReverseButtonClick` functionality to `SearchStopRow` component
- Implemented reverse button logic in `TripPlannerDestinations`
- Enhanced state management for `fromStopItem` and `toStopItem` using `rememberSaveable`
- Updated `StopItem.fromJsonString` to handle potential parsing errors
- Adjusted `SavedTripsScreen` to include the new reverse button functionality

### Why make this change?

This change improves user experience by allowing quick reversal of selected stops, which is a common action in trip planning. It also enhances the robustness of the app by safely handling potential JSON parsing errors and improving state management for stop selections across configuration changes.

### Screenshot

https://github.com/user-attachments/assets/9ecbefdd-8597-4f33-a76e-dcd2cd2c18c7


