### PR TITLE
Update TripResponse mapper business logic

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
@@ -11,7 +11,7 @@ data class TimeTableState(
     data class JourneyCardInfo(
         val timeText: String, // "in x mins" - journeys.legs.first().origin.departureTimePlanned with Time.now()
 
-        val platformText: String, // "on Platform X" - journeys.legs.first().stopSequence.disassembledName
+        val platformText: String? = null, // "on Platform X" - journeys.legs.first().stopSequence.disassembledName
 
         // If first leg is not walking then,
         //      leg.first.origin.departureTimeEstimated ?: leg.first.origin.departureTimePlanned

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -50,7 +50,9 @@ fun TimeTableScreen(
         } else if (timeTableState.journeyList.isNotEmpty()) {
             items(timeTableState.journeyList) { journey ->
                 JourneyCardItem(
-                    departureText = journey.timeText + " on " + journey.platformText,
+                    departureText = journey.timeText + if (journey.platformText != null) {
+                        " on ${journey.platformText}"
+                    } else "",
                     timeText = journey.originTime + " - " + journey.destinationTime + " (${journey.travelTime})",
                     transportModeLineList = journey.transportModeLines.map {
                         TransportModeLine(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -30,14 +30,6 @@ internal fun TripResponse.buildJourneyList() = journeys?.map { journey ->
 
     val transportationProductClass =
         firstLeg?.transportation?.product?.productClass
-    val mode =
-        if (transportationProductClass?.toInt() == 99 ||
-            transportationProductClass?.toInt() == 100
-        ) {
-            "Walk"
-        } else {
-            "Public"
-        }
 
     TimeTableState.JourneyCardInfo(
         timeText = originTime?.let {
@@ -45,13 +37,19 @@ internal fun TripResponse.buildJourneyList() = journeys?.map { journey ->
         }
             ?: "NULL,",
 
-        platformText = if (mode == "Public") {
-            "Walking"
-        } else {
-            firstLeg?.stopSequence?.firstOrNull()?.disassembledName?.split(
-                ","
-            )?.lastOrNull()
-                ?: "NULL"
+        platformText = when (firstLeg?.transportation?.product?.productClass) {
+            // Walk
+            99L, 100L -> null
+
+            // Train or Metro
+            1L, 2L -> {
+                firstLeg.stopSequence?.firstOrNull()?.disassembledName?.split(",")?.lastOrNull()
+            }
+
+            // Others
+            else -> {
+                firstLeg?.stopSequence?.firstOrNull()?.disassembledName
+            }
         },
 
         originTime = originTime?.utcToAEST()?.aestToHHMM() ?: "NULL",


### PR DESCRIPTION
### TL;DR

Updated platform text handling in TimeTableState and improved journey information display.

### What changed?

- Made `platformText` nullable in `TimeTableState.JourneyCardInfo`
- Updated `TimeTableScreen` to conditionally display platform information
- Refined platform text logic in `TripResponseMapper`:
  - Set to null for walking journeys
  - Extract platform number for trains and metros
  - Use full disassembled name for other transportation modes

### Why make this change?

This change improves the accuracy and relevance of platform information displayed to users. It addresses different scenarios for various transportation modes, enhancing the overall user experience by providing more precise and appropriate journey details.