### PR TITLE
Fix StopItem parcelable crash

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -50,7 +50,7 @@ internal fun TripResponse.buildJourneyList() = journeys?.map { journey ->
             else -> {
                 firstLeg?.stopSequence?.firstOrNull()?.disassembledName
             }
-        },
+        }?.trim(),
 
         originTime = originTime?.utcToAEST()?.aestToHHMM() ?: "NULL",
 


### PR DESCRIPTION
### TL;DR

The app crashes when saving state in the background because `StopItem` is not `Parcelable`, and `rememberSaveable` attempts to save it.

### What changed?

- Updated `TripPlannerDestinations.kt` to handle `StopItem` parsing more efficiently:
  - Changed from `rememberSaveable` to `remember` for `fromStopItem` and `toStopItem`.
  - Implemented JSON parsing for stop items within `LaunchedEffect` blocks.
- Modified `TripResponseMapper.kt` to trim the origin name in the `buildJourneyList` function.

### Why make this change?

- To address potential issues with `StopItem` not being Parcelable, while still maintaining state across configuration changes.
- To improve the display of origin names in the journey list by removing any unnecessary whitespace.