### PR TITLE
Time Calculation Enhancement for Trip Planner

### DIFF
--- a/core/date-time/build.gradle.kts
+++ b/core/date-time/build.gradle.kts
@@ -8,4 +8,5 @@ android {
 dependencies {
     testImplementation(libs.test.kotlin)
     testImplementation(libs.test.googleTruth)
+    implementation(libs.kotlinx.datetime)
 }

--- a/core/date-time/src/main/kotlin/xyz/ksharma/krail/core/date_time/DateTimeHelper.kt
+++ b/core/date-time/src/main/kotlin/xyz/ksharma/krail/core/date_time/DateTimeHelper.kt
@@ -1,12 +1,14 @@
 package xyz.ksharma.krail.core.date_time
 
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import timber.log.Timber
 import java.time.Duration
-import java.time.Instant
-import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.math.absoluteValue
+import kotlin.time.DurationUnit
 
 object DateTimeHelper {
 
@@ -57,19 +59,15 @@ object DateTimeHelper {
      */
     fun calculateTimeDifferenceFromNow(
         utcDateString: String,
-        timeNow: ZonedDateTime = ZonedDateTime.now(),
-    ): Duration {
-        // Parse the UTC date string to a ZonedDateTime
-        val parsedDateTime =
-            ZonedDateTime.parse(utcDateString, DateTimeFormatter.ISO_ZONED_DATE_TIME)
-
-        // Calculate the duration between the two ZonedDateTime instances
-        return Duration.between(timeNow, parsedDateTime)
+        now: Instant = kotlinx.datetime.Clock.System.now(), // Get current Instant in UTC
+    ): kotlin.time.Duration {
+        val instant = Instant.parse(utcDateString) // Parse UTC string to Instant
+        return instant - now
     }
 
-    fun Duration.toFormattedString(): String {
-        val minutes = this.toMinutes()
-        val hours = this.toHours()
+    fun kotlin.time.Duration.toFormattedString(): String {
+        val minutes = this.toLong(DurationUnit.MINUTES)
+        val hours = this.toLong(DurationUnit.HOURS)
 
         val formattedDifference = when {
             minutes < 0 -> "${minutes.absoluteValue} mins ago"
@@ -77,21 +75,8 @@ object DateTimeHelper {
             hours >= 2 -> "in ${hours.absoluteValue} hrs"
             else -> "in ${minutes.absoluteValue} mins"
         }
+        Timber.d("\t minutes: $minutes, hours: $hours, formattedDifference: $formattedDifference -> originTime")
         return formattedDifference
-    }
-
-    fun calculateTimeDifferenceFromFormattedString(timeString: String): Duration {
-        // Define the formatter for the input time string
-        val formatter = DateTimeFormatter.ofPattern("hh:mm a")
-
-        // Parse the input time string to a LocalTime
-        val inputTime = LocalTime.parse(timeString, formatter)
-
-        // Get the current time
-        val currentTime = LocalTime.now()
-
-        // Calculate the duration between the current time and the input time
-        return Duration.between(currentTime, inputTime)
     }
 
     fun calculateTimeDifference(utcDateString1: String, utcDateString2: String): Duration {

--- a/core/date-time/src/test/kotlin/xyz/ksharma/krail/core/date_time/DateTimeHelperTest.kt
+++ b/core/date-time/src/test/kotlin/xyz/ksharma/krail/core/date_time/DateTimeHelperTest.kt
@@ -1,18 +1,35 @@
 package xyz.ksharma.krail.core.date_time
 
 import com.google.common.truth.Truth.assertThat
-import java.time.Instant
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 
 class DateTimeHelperTest {
 
     @Test
     fun testCalculateTimeDifference() {
-        /*val fixedInstant = Instant.parse("2024-10-07T09:00:00Z")
         val difference = DateTimeHelper.calculateTimeDifferenceFromNow(
-            utcDateString = "2024-10-07T08:20:00Z",
-            timeNow = fixedInstant,
+            utcDateString = "2024-10-07T09:00:00Z",
+            now = Instant.parse("2024-10-07T08:20:00Z"),
         )
-        assertThat(difference.toMinutes()).isEqualTo(-40L)*/
+        assertThat(difference.inWholeMinutes).isEqualTo(40L)
+    }
+
+    @Test
+    fun testCalculateTimeDifferenceNextDay() {
+        val difference = DateTimeHelper.calculateTimeDifferenceFromNow(
+            utcDateString = "2024-10-08T09:00:00Z",
+            now = Instant.parse("2024-10-07T08:20:00Z"),
+        )
+        assertThat(difference.inWholeMinutes).isEqualTo(1480L)
+    }
+
+    @Test
+    fun testCalculateTimeDifferencePreviousDay() {
+        val difference = DateTimeHelper.calculateTimeDifferenceFromNow(
+            utcDateString = "2024-10-06T09:00:00Z",
+            now = Instant.parse("2024-10-07T08:20:00Z"),
+        )
+        assertThat(difference.inWholeMinutes).isEqualTo(-1400L)
     }
 }

--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
@@ -18,6 +18,8 @@ data class TimeTableState(
         // else leg.first.destination.arrivalTimeEstimated ?: leg.first.destination.arrivalTimePlanned
         val originTime: String, // "11:30pm" stopSequence.arrivalTimeEstimated ?: stopSequence.arrivalTimePlanned
 
+        val originUtcDateTime: String, // "2024-09-24T19:00:00Z"
+
         // legs.last.destination.arrivalTimeEstimated ?: legs.last.destination.arrivalTimePlanned
         val destinationTime: String, // "11:40pm"
 

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -20,4 +20,5 @@ dependencies {
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.timber)
+    implementation(libs.kotlinx.datetime)
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableViewModel.kt
@@ -14,17 +14,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.aestToHHMM
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.calculateTimeDifference
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.calculateTimeDifferenceFromFormattedString
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.calculateTimeDifferenceFromNow
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.toFormattedString
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.utcToAEST
-import xyz.ksharma.krail.trip_planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip_planner.network.api.repository.TripPlanningRepository
-import xyz.ksharma.krail.trip_planner.ui.state.TransportMode
-import xyz.ksharma.krail.trip_planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip_planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip_planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip_planner.ui.timetable.business.buildJourneyList
@@ -80,6 +72,8 @@ class TimeTableViewModel @Inject constructor(
     }
 
     private fun updateTimeTextPeriodically() {
+        // TODO - this will keep running even if app is in background as long as the ViewModel is alive. Need to fix this.
+        //  Use kotlin.concurrent.fixedRateTimer
         viewModelScope.launch {
             flow {
                 while (true) {
@@ -91,8 +85,10 @@ class TimeTableViewModel @Inject constructor(
                     copy(
                         journeyList = journeyList.map { journeyCardInfo ->
                             journeyCardInfo.copy(
-                                timeText = journeyCardInfo.originTime.let {
-                                    calculateTimeDifferenceFromFormattedString(it).toFormattedString()
+                                timeText = journeyCardInfo.originUtcDateTime.let {
+                                    val x = calculateTimeDifferenceFromNow(utcDateString = it).toFormattedString()
+                                    Timber.d("\tupdate: $x")
+                                    x
                                 }
                             )
                         }.toImmutableList()

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -39,7 +39,8 @@ internal fun TripResponse.buildJourneyList() = journeys?.map { journey ->
 
     TimeTableState.JourneyCardInfo(
         timeText = originTime?.let {
-            calculateTimeDifferenceFromNow(it).toFormattedString()
+            Timber.d("originTime: $it :- ${calculateTimeDifferenceFromNow(utcDateString = it)}")
+            calculateTimeDifferenceFromNow(utcDateString = it).toFormattedString()
         } ?: "NULL,",
 
         platformText = when (firstPublicTransportLeg?.transportation?.product?.productClass) {
@@ -58,9 +59,9 @@ internal fun TripResponse.buildJourneyList() = journeys?.map { journey ->
         }?.trim(),
 
         originTime = originTime?.utcToAEST()?.aestToHHMM() ?: "NULL",
+        originUtcDateTime = originTime ?: "NULL",
 
-        destinationTime = arrivalTime?.utcToAEST()?.aestToHHMM()
-            ?: "NULL",
+        destinationTime = arrivalTime?.utcToAEST()?.aestToHHMM() ?: "NULL",
 
         travelTime = calculateTimeDifference(
             originTime!!,
@@ -91,14 +92,7 @@ internal fun TripResponse.logForUnderstandingData() {
                 leg.transportation?.product?.productClass
 
             Timber.d(
-                " LEG#${index + 1} -- Duration: ${leg.duration} -- " +
-                        if (transportationProductClass?.toInt() == 99 ||
-                            transportationProductClass?.toInt() == 100
-                        ) {
-                            "Mode: Walking"
-                        } else {
-                            "Mode: Public"
-                        }
+                " LEG#${index + 1} -- Duration: ${leg.duration} -- productClass:${transportationProductClass?.toInt()}"
             )
             Timber.d(
                 "\t\t ORG: ${

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ detektCompose = "0.4.15"
 hilt = "2.52"
 hiltNavigationCompose = "1.2.0"
 kotlinxCollectionsImmutable = "0.3.8"
+kotlinxDatetime = "0.6.1"
 okhttpBom = "4.12.0"
 kotlinxSerializationJson = "1.7.3"
 ksp = "2.0.21-1.0.25" # ksp to kotlin version mapping https://github.com/google/ksp/releases
@@ -40,6 +41,7 @@ appcompat = "1.7.0"
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "android-lifecycle" }
 lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "android-lifecycle" }
 lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "android-lifecycle" }


### PR DESCRIPTION
# Time Calculation Enhancement for Trip Planner

This update addresses an issue with time calculations in the trip planner feature. Previously, the time difference was calculated using a formatted string (hh:mm a) without timezone or date information, leading to inaccurate results.

Key changes:

1. Added `kotlinx-datetime` dependency for improved date-time handling.
2. Refactored `DateTimeHelper` to use `kotlinx-datetime` for more precise time difference calculations.
3. Introduced `originUtcDateTime` field in `TimeTableState.JourneyCardInfo` to store the full UTC date-time string.
4. Updated `TimeTableViewModel` to use the new `originUtcDateTime` for calculating time differences.
5. Modified `TripResponseMapper` to include the `originUtcDateTime` when building the journey list.

These changes ensure that time differences are calculated accurately, taking into account timezone and date information, resulting in more reliable departure time displays in the trip planner UI.