### PR TITLE
Update TimerText only when UI is visible

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableDestination.kt
@@ -20,6 +20,8 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
         if (isLoading) {
             viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(route.fromStopId, route.toStopId))
         }
+        // Subscribe to the isActive state flow - for updating the TimeText periodically.
+        val isActive by viewModel.isActive.collectAsStateWithLifecycle()
 
         TimeTableScreen(timeTableState)
     }


### PR DESCRIPTION
Purpose of this PR is to update Timer to Stop Updating when there are no consumers. 

This PR addresses the issue where the `updateTimeTextPeriodically` method continues to execute even when the app is in the background, as long as the ViewModel is alive.

## Before


https://github.com/user-attachments/assets/c3bf5f4c-fc9a-43ac-a75d-a80360384dd1


## After

https://github.com/user-attachments/assets/a7932c26-6dc3-4101-82e6-2218f920c617

