### PR TITLE
Add JourneyId to JourneyCardInfo

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
@@ -7,6 +7,7 @@ import xyz.ksharma.krail.trip_planner.ui.state.TransportModeLine
 data class TimeTableState(
     val isLoading: Boolean = false,
     val journeyList: ImmutableList<JourneyCardInfo> = persistentListOf(),
+    val journeyDetail: JourneyDetail? = null,
 ) {
     data class JourneyCardInfo(
         val timeText: String, // "in x mins" - journeys.legs.first().origin.departureTimePlanned with Time.now()
@@ -31,5 +32,8 @@ data class TimeTableState(
          * transportation.product.class -> TransportModeType
          */
         val transportModeLines: ImmutableList<TransportModeLine>,
-    )
+    ) {
+        val journeyId: String
+            get() = (originUtcDateTime + destinationTime).filter { it.isLetterOrDigit() }
+    }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -9,12 +9,14 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import timber.log.Timber
 import xyz.ksharma.krail.design.system.components.SeparatorIcon
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
@@ -51,6 +53,11 @@ fun TimeTableScreen(
             }
         } else if (timeTableState.journeyList.isNotEmpty()) {
             items(timeTableState.journeyList) { journey ->
+
+                LaunchedEffect(journey) {
+                    Timber.d("journeyId: ${journey.journeyId}")
+                }
+
                 JourneyCardItem(
                     departureTimeText = journey.timeText,
                     departureLocationText = journey.platformText?.let { "on ${journey.platformText}" },

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -16,13 +16,6 @@ import xyz.ksharma.krail.trip_planner.ui.state.timetable.TimeTableState
 
 internal fun TripResponse.buildJourneyList() = journeys?.mapNotNull { journey ->
 
-    // TODO -
-    //  1. Sanitise data in domain layer.
-    //  2. Pass non null items only to display in ViewModel.
-
-    val firstLeg = journey.legs?.firstOrNull()
-    val lastLeg = journey.legs?.lastOrNull()
-
     val firstPublicTransportLeg = journey.legs?.firstOrNull { leg ->
         leg.transportation?.product?.productClass != 99L &&
                 leg.transportation?.product?.productClass != 100L
@@ -40,12 +33,12 @@ internal fun TripResponse.buildJourneyList() = journeys?.mapNotNull { journey ->
     if (originTime != null && arrivalTime != null && firstPublicTransportLeg != null) {
 
         TimeTableState.JourneyCardInfo(
-            timeText = originTime?.let {
+            timeText = originTime.let {
                 Timber.d("originTime: $it :- ${calculateTimeDifferenceFromNow(utcDateString = it)}")
                 calculateTimeDifferenceFromNow(utcDateString = it).toFormattedString()
-            } ?: "NULL,",
+            },
 
-            platformText = when (firstPublicTransportLeg?.transportation?.product?.productClass) {
+            platformText = when (firstPublicTransportLeg.transportation?.product?.productClass) {
                 // Train or Metro
                 1L, 2L -> {
                     firstPublicTransportLeg.stopSequence?.firstOrNull()?.disassembledName?.split(",")
@@ -60,14 +53,14 @@ internal fun TripResponse.buildJourneyList() = journeys?.mapNotNull { journey ->
                 else -> null
             }?.trim(),
 
-            originTime = originTime?.utcToAEST()?.aestToHHMM() ?: "NULL",
-            originUtcDateTime = originTime ?: "NULL",
+            originTime = originTime.utcToAEST().aestToHHMM(),
+            originUtcDateTime = originTime ,
 
-            destinationTime = arrivalTime?.utcToAEST()?.aestToHHMM() ?: "NULL",
+            destinationTime = arrivalTime.utcToAEST().aestToHHMM(),
 
             travelTime = calculateTimeDifference(
-                originTime!!,
-                arrivalTime!!
+                originTime,
+                arrivalTime,
             ).toMinutes().toString() + " mins",
             transportModeLines = journey.legs?.mapNotNull { leg ->
                 leg.transportation?.product?.productClass?.toInt()?.let {
@@ -81,7 +74,9 @@ internal fun TripResponse.buildJourneyList() = journeys?.mapNotNull { journey ->
                         }
                 }
             }?.toImmutableList() ?: persistentListOf(),
-        )
+        ).also {
+            Timber.d("\tJourneyCardId: ${it.journeyId}")
+        }
 
     } else null
 


### PR DESCRIPTION
### TL;DR

Added a unique journeyId to JourneyCardInfo and improved logging for better debugging.

### What changed?

- Added a `journeyId` property to `JourneyCardInfo` in `TimeTableState.kt`
- Implemented logging of `journeyId` in `TimeTableScreen.kt` using LaunchedEffect
- Enhanced `TripResponseMapper.kt` to log the `journeyId` for each journey
- Removed TODO comments and null checks in `TripResponseMapper.kt`

### Why make this change?

The id will help to track which item was clicked and display the detail view in the list (inline).