### PR TITLE
Fix white screen issue when keyboard is opening

### DIFF
--- a/app/src/main/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 
@@ -12,8 +13,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        // Configures the system bars with a transparent background.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         enableEdgeToEdge()
 
         setContent {


### PR DESCRIPTION
This change implements a fix for the edge-to-edge layout in the MainActivity. It adds `WindowCompat.setDecorFitsSystemWindows(window, false)` before calling `enableEdgeToEdge()` to ensure proper handling of system windows and insets.

Related issues:
https://issuetracker.google.com/issues/300279937
https://issuetracker.google.com/issues/296001700