### PR TITLE
Expand to display JourneyDetailCard when clicked on JourneyCard

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -2,6 +2,5 @@ package xyz.ksharma.krail.trip_planner.ui.state.timetable
 
 sealed interface TimeTableUiEvent {
     data class LoadTimeTable(val fromStopId: String, val toStopId: String) : TimeTableUiEvent
-    data class JourneyCardClicked(val journeyCardInfo: TimeTableState.JourneyCardInfo) :
-        TimeTableUiEvent
+    data class JourneyCardClicked(val journeyId: String) : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip_planner.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.design.system.components.BasicJourneyCard
 import xyz.ksharma.krail.design.system.components.Text
@@ -19,9 +21,10 @@ import xyz.ksharma.krail.design.system.theme.KrailTheme
 fun JourneyDetailCard(
     header: String,
     journeyLegList: List<JourneyLeg>,
+    onClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
-    BasicJourneyCard(modifier = modifier) {
+    BasicJourneyCard(modifier = modifier.clickable(role = Role.Button, onClick = onClick)) {
         // TODO - consider meaningful text breaks in lines. "Platform" and Platform number text
         //  should be on same line.
         Text(header, style = KrailTheme.typography.titleMedium)

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableDestination.kt
@@ -21,7 +21,11 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
         }
         // Subscribe to the isActive state flow - for updating the TimeText periodically.
         val isActive by viewModel.isActive.collectAsStateWithLifecycle()
+        val expandedJourneyId: String? by viewModel.expandedJourneyId.collectAsStateWithLifecycle()
 
-        TimeTableScreen(timeTableState = timeTableState, onEvent = { viewModel.onEvent(it) })
+        TimeTableScreen(
+            timeTableState = timeTableState,
+            expandedJourneyId = expandedJourneyId,
+            onEvent = { viewModel.onEvent(it) })
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -9,20 +9,19 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import timber.log.Timber
 import xyz.ksharma.krail.design.system.components.SeparatorIcon
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip_planner.ui.R
 import xyz.ksharma.krail.trip_planner.ui.components.JourneyCard
+import xyz.ksharma.krail.trip_planner.ui.components.JourneyDetailCard
 import xyz.ksharma.krail.trip_planner.ui.components.TransportModeInfo
 import xyz.ksharma.krail.trip_planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip_planner.ui.state.TransportModeLine
@@ -32,6 +31,7 @@ import xyz.ksharma.krail.trip_planner.ui.state.timetable.TimeTableUiEvent
 @Composable
 fun TimeTableScreen(
     timeTableState: TimeTableState,
+    expandedJourneyId: String?,
     onEvent: (TimeTableUiEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -53,27 +53,33 @@ fun TimeTableScreen(
             }
         } else if (timeTableState.journeyList.isNotEmpty()) {
             items(timeTableState.journeyList) { journey ->
-
-                LaunchedEffect(journey) {
-                    Timber.d("journeyId: ${journey.journeyId}")
+                if (expandedJourneyId == journey.journeyId) {
+                    JourneyDetailCard(
+                        header = "Journey Details",
+                        journeyLegList = emptyList(),
+                        onClick = {
+                            onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                } else {
+                    JourneyCardItem(
+                        departureTimeText = journey.timeText,
+                        departureLocationText = journey.platformText?.let { "on ${journey.platformText}" },
+                        originDestinationTimeText = journey.originTime + " - " + journey.destinationTime,
+                        durationText = journey.travelTime,
+                        transportModeLineList = journey.transportModeLines.map {
+                            TransportModeLine(
+                                transportMode = it.transportMode,
+                                lineName = it.lineName,
+                            )
+                        }.toImmutableList(),
+                        onClick = {
+                            onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
                 }
-
-                JourneyCardItem(
-                    departureTimeText = journey.timeText,
-                    departureLocationText = journey.platformText?.let { "on ${journey.platformText}" },
-                    originDestinationTimeText = journey.originTime + " - " + journey.destinationTime,
-                    durationText = journey.travelTime,
-                    transportModeLineList = journey.transportModeLines.map {
-                        TransportModeLine(
-                            transportMode = it.transportMode,
-                            lineName = it.lineName,
-                        )
-                    }.toImmutableList(),
-                    onClick = {
-                        onEvent(TimeTableUiEvent.JourneyCardClicked(journey))
-                    },
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                )
             }
         } else {
             item {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableViewModel.kt
@@ -48,15 +48,19 @@ class TimeTableViewModel @Inject constructor(
         initialValue = true,
     )
 
+    private val _expandedJourneyId: MutableStateFlow<String?> = MutableStateFlow(null)
+    val expandedJourneyId: StateFlow<String?> = _expandedJourneyId
+
     fun onEvent(event: TimeTableUiEvent) {
         when (event) {
             is TimeTableUiEvent.LoadTimeTable -> onLoadTimeTable(event.fromStopId, event.toStopId)
-            is TimeTableUiEvent.JourneyCardClicked -> onJourneyCardClicked(event.journeyCardInfo)
+            is TimeTableUiEvent.JourneyCardClicked -> onJourneyCardClicked(event.journeyId)
         }
     }
 
-    private fun onJourneyCardClicked(journeyCardInfo: TimeTableState.JourneyCardInfo) {
-        Timber.d("Journey Card Clicked: $journeyCardInfo")
+    private fun onJourneyCardClicked(journeyId: String) {
+        Timber.d("Journey Card Clicked(JourneyId): $journeyId")
+        _expandedJourneyId.update { if (it == journeyId) null else journeyId }
     }
 
     private fun onLoadTimeTable(fromStopId: String?, toStopId: String?) {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -74,7 +74,7 @@ internal fun TripResponse.buildJourneyList() = journeys?.mapNotNull { journey ->
             }.toImmutableList(),
             legs = legs.mapNotNull { it.toUiModel() }.toImmutableList(),
         ).also {
-            Timber.d("\tJourneyCardId: ${it.journeyId}")
+            Timber.d("\tJourneyId: ${it.journeyId}")
         }
 
     } else null


### PR DESCRIPTION
# Implement Journey Card Expansion

This PR introduces the ability to expand journey cards in the TimeTableScreen. When a user clicks on a journey card, it toggles between a compact view and an expanded detail view.

## Changes

- Updated `TimeTableUiEvent.JourneyCardClicked` to use `journeyId` instead of `journeyCardInfo`
- Added `expandedJourneyId` state to `TimeTableViewModel` to track which journey is expanded
- Modified `TimeTableScreen` to display either a compact `JourneyCard` or an expanded `JourneyDetailCard` based on the `expandedJourneyId`
- Updated `JourneyDetailCard` to include a click listener for collapsing the expanded view
- Adjusted `TimeTableDestination` to pass the `expandedJourneyId` to the `TimeTableScreen`

## Screeenshots

https://github.com/user-attachments/assets/cbecdd7e-fa62-4f1b-9638-b9e325f2cd00


## TODO

- Implement the actual journey leg details in the expanded `JourneyDetailCard`