### PR TITLE
Update Time formatting

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.calculateTimeDifferenceFromNow
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.toFormattedString
+import xyz.ksharma.krail.core.date_time.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.trip_planner.network.api.repository.TripPlanningRepository
 import xyz.ksharma.krail.trip_planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip_planner.ui.state.timetable.TimeTableUiEvent
@@ -94,7 +94,7 @@ class TimeTableViewModel @Inject constructor(
             copy(
                 journeyList = journeyList.map { journeyCardInfo ->
                     journeyCardInfo.copy(
-                        timeText = calculateTimeDifferenceFromNow(utcDateString = journeyCardInfo.originUtcDateTime).toFormattedString()
+                        timeText = calculateTimeDifferenceFromNow(utcDateString = journeyCardInfo.originUtcDateTime).toGenericFormattedTimeString()
                     )
                 }.toImmutableList()
             )

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -7,7 +7,8 @@ import xyz.ksharma.krail.core.date_time.DateTimeHelper.aestToHHMM
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.calculateTimeDifference
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.formatTo12HourTime
-import xyz.ksharma.krail.core.date_time.DateTimeHelper.toFormattedString
+import xyz.ksharma.krail.core.date_time.DateTimeHelper.toFormattedDurationTimeString
+import xyz.ksharma.krail.core.date_time.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.date_time.DateTimeHelper.utcToAEST
 import xyz.ksharma.krail.trip_planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip_planner.ui.state.TransportMode
@@ -36,7 +37,7 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
             TimeTableState.JourneyCardInfo(
                 timeText = originTimeUTC.let {
                     Timber.d("originTime: $it :- ${calculateTimeDifferenceFromNow(utcDateString = it)}")
-                    calculateTimeDifferenceFromNow(utcDateString = it).toFormattedString()
+                    calculateTimeDifferenceFromNow(utcDateString = it).toGenericFormattedTimeString()
                 },
 
                 platformText = when (firstPublicTransportLeg.transportation?.product?.productClass) {
@@ -62,7 +63,7 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
                 travelTime = calculateTimeDifference(
                     originTimeUTC,
                     arrivalTimeUTC,
-                ).toMinutes().toString() + " mins",
+                ).toFormattedDurationTimeString(),
                 transportModeLines = legs.mapNotNull { leg ->
                     leg.transportation?.product?.productClass?.toInt()?.let {
                         TransportMode.toTransportModeType(productClass = it)


### PR DESCRIPTION
### TL;DR

Enhanced time formatting and improved journey information display in the trip planner feature.

### What changed?

- Added new time formatting functions in `DateTimeHelper`:
  - `toGenericFormattedTimeString()`: Provides a more detailed time representation
  - `toFormattedDurationTimeString()`: Formats duration in hours and minutes

- Updated `TimeTableViewModel` to use the new `toGenericFormattedTimeString()` function for journey time display

- Modified `TripResponseMapper` to:
  - Use `toGenericFormattedTimeString()` for journey time text
  - Implement `toFormattedDurationTimeString()` for travel time display

- Refactored `calculateTimeDifference()` to return a Kotlin Duration instead of Java Duration

### How to test?

1. Navigate to the trip planner feature
2. Check the time display for upcoming journeys
3. Verify that journey durations are correctly formatted in hours and minutes
4. Ensure that time differences are accurately represented (e.g., "in 1h 30m", "2 hrs ago")

### Why make this change?

This change improves the user experience by providing more precise and readable time information for journeys. The new formatting functions allow for better representation of time differences and durations, making it easier for users to understand their trip details at a glance.