### PR TITLE
Add color code for linename when its a Train

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/TransportModeLine.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/TransportModeLine.kt
@@ -13,4 +13,24 @@ data class TransportModeLine(
      * Line number e.g. T1, T4, F1, F2 etc.
      */
     val lineName: String,
-)
+
+    val lineColorCode: String? = calculateLineColorCode(
+        lineName = lineName,
+        isTrain = transportMode == TransportMode.Train()
+    ),
+) {
+    enum class TransportLine(val key: String, val hexColor: String) {
+        NORTH_SHORE_WESTERN("T1", "#f99d1c"),
+        LEPPINGTON_INNER_WEST("T2", "#0098cd"),
+        LIVERPOOL_INNER_WEST("T3", "#f37021"),
+        EASTERN_SUBURBS_ILLAWARRA("T4", "#005aa3"),
+        CUMBERLAND("T5", "#c4258f"),
+        LIDCOMBE_BANKSTOWN("T6", "#7d3f21"), // FUTURE
+        OLYMPIC_PARK("T7", "#6f818e"),
+        AIRPORT_SOUTH("T8", "#00954c"),
+        NORTHERN("T9", "#d11f2f");
+    }
+}
+
+private fun calculateLineColorCode(lineName: String, isTrain: Boolean) =
+    TransportModeLine.TransportLine.entries.firstOrNull { it.key == lineName && isTrain }?.hexColor

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyCard.kt
@@ -125,6 +125,7 @@ private fun JourneyCardTrainLongTextPreview() {
                 TransportModeInfo(
                     letter = 'T',
                     backgroundColor = "#005aa3".hexToComposeColor(),
+                    badgeColor = "#005aa3".hexToComposeColor(),
                     badgeText = "T4",
                 )
                 SeparatorIcon(modifier = Modifier.align(Alignment.CenterVertically))

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
@@ -43,6 +43,7 @@ fun JourneyDetailCard(
                     backgroundColor = leg.transportModeLine.transportMode.colorCode.hexToComposeColor(),
                     letter = leg.transportModeLine.transportMode.name.first(),
                     badgeText = leg.transportModeLine.lineName,
+                    badgeColor = leg.transportModeLine.lineColorCode?.hexToComposeColor(),
                 )
 
                 Text(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/TransportModeInfo.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/TransportModeInfo.kt
@@ -13,6 +13,7 @@ import xyz.ksharma.krail.design.system.theme.KrailTheme
 fun TransportModeInfo(
     letter: Char,
     backgroundColor: Color,
+    badgeColor: Color? = null,
     badgeText: String,
     modifier: Modifier = Modifier,
 ) {
@@ -20,7 +21,7 @@ fun TransportModeInfo(
         TransportModeIcon(letter = letter, backgroundColor = backgroundColor)
 
         TransportModeBadge(
-            backgroundColor = backgroundColor,
+            backgroundColor = badgeColor ?: backgroundColor,
             badgeText = badgeText,
         )
     }
@@ -36,6 +37,7 @@ private fun TransportModeInfoPreview() {
         TransportModeInfo(
             badgeText = "T4",
             backgroundColor = "#F6891F".hexToComposeColor(),
+            badgeColor = "#005aa3".hexToComposeColor(),
             letter = 'T'
         )
     }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -139,6 +139,7 @@ fun JourneyCardItem(
                     TransportModeInfo(
                         letter = line.transportMode.name.first(),
                         backgroundColor = line.transportMode.colorCode.hexToComposeColor(),
+                        badgeColor = line.lineColorCode?.hexToComposeColor(),
                         badgeText = line.lineName,
                     )
                     if (index < transportModeLineList.size - 1) SeparatorIcon()

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/business/TripResponseMapper.kt
@@ -65,15 +65,12 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
                     arrivalTimeUTC,
                 ).toFormattedDurationTimeString(),
                 transportModeLines = legs.mapNotNull { leg ->
-                    leg.transportation?.product?.productClass?.toInt()?.let {
-                        TransportMode.toTransportModeType(productClass = it)
-                            ?.let { it1 ->
-                                TransportModeLine(
-                                    transportMode = it1,
-                                    lineName = leg.transportation?.disassembledName
-                                        ?: "NULL"
-                                )
-                            }
+                    leg.transportation?.product?.productClass?.toInt()?.let { productClass ->
+                        val mode = TransportMode.toTransportModeType(productClass)
+                        val lineName = leg.transportation?.disassembledName
+                        if (mode != null && lineName != null) {
+                            TransportModeLine(transportMode = mode, lineName = lineName)
+                        } else null
                     }
                 }.toImmutableList(),
                 legs = legs.mapNotNull { it.toUiModel() }.toImmutableList(),


### PR DESCRIPTION
### TL;DR

Added line color support for train lines in the trip planner UI.

### What changed?

- Introduced `lineColorCode` property to `TransportModeLine` class
- Added an enum `TransportLine` with color codes for different train lines
- Implemented `calculateLineColorCode` function to determine the color based on line name
- Updated UI components to use the new line color for badges:
  - `JourneyCard`
  - `JourneyDetailCard`
  - `TransportModeInfo`
  - `TimeTableScreen`
- Modified `TripResponseMapper` to handle null values more gracefully

### How to test?

1. Open the trip planner feature
2. Search for a journey that includes train travel
3. Verify that the train line badges display the correct color for each line (e.g., T1 should be orange, T4 should be blue)
4. Check that non-train transport modes still display their default colors

### Why make this change?

This change enhances the visual representation of train lines in the trip planner UI, making it easier for users to distinguish between different train services. It aligns the app's design with the official color coding used by the transit authority, improving user recognition and navigation within the app.