### PR TITLE
Fix navigation bars padding and colors

### DIFF
--- a/app/src/main/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -1,10 +1,10 @@
 package xyz.ksharma.krail
 
 import android.os.Bundle
+import android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.core.view.WindowCompat
 import dagger.hilt.android.AndroidEntryPoint
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 
@@ -13,8 +13,10 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         enableEdgeToEdge()
+        // Required because https://issuetracker.google.com/issues/298296168
+        // Edge-to-edge does not draw behind 3-button nav
+        window.setFlags(FLAG_LAYOUT_NO_LIMITS, FLAG_LAYOUT_NO_LIMITS)
 
         setContent {
             KrailTheme {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/SearchStopRow.kt
@@ -5,14 +5,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
@@ -43,7 +45,13 @@ fun SearchStopRow(
                 shape = RoundedCornerShape(topStart = 36.dp, topEnd = 36.dp)
             )
             .padding(vertical = 24.dp, horizontal = 16.dp)
-            .navigationBarsPadding(),
+            .padding(bottom = with(LocalDensity.current) {
+                WindowInsets.navigationBars
+                    .getBottom(
+                        this
+                    )
+                    .toDp()
+            }),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/searchstop/SearchStopScreen.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,8 +68,7 @@ fun SearchStopScreen(
     LazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KrailTheme.colors.background)
-            .systemBarsPadding(),
+            .background(color = KrailTheme.colors.background),
         contentPadding = PaddingValues(vertical = 16.dp)
     ) {
         stickyHeader {
@@ -78,7 +77,8 @@ fun SearchStopScreen(
                 modifier = Modifier
                     .focusRequester(focusRequester)
                     .padding(horizontal = 16.dp)
-                    .padding(bottom = 12.dp),
+                    .padding(bottom = 12.dp)
+                    .statusBarsPadding(),
             ) { value ->
                 Timber.d("value: $value")
                 textFieldText = value.toString()

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -5,20 +5,17 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -49,8 +46,7 @@ fun TimeTableScreen(
 ) {
     LazyColumn(
         modifier = modifier
-            .background(color = KrailTheme.colors.background)
-            .systemBarsPadding(),
+            .background(color = KrailTheme.colors.background),
         contentPadding = PaddingValues(vertical = 16.dp)
     ) {
         item {


### PR DESCRIPTION
### TL;DR

Improved edge-to-edge support and UI adjustments for better user experience, when 3 button nav bar is used.

The following bug https://issuetracker.google.com/issues/298296168 in edgetoedge api does not make the 3 button nav bar transparent when edgetoedge mode is enabled.

### What changed?

- Updated MainActivity to use `FLAG_LAYOUT_NO_LIMITS` for better edge-to-edge support or 3 button nav bar
- Refined padding and insets handling in SearchStopRow and SearchStopScreen
- Removed systemBarsPadding from TimeTableScreen


## Screenshots

### Before

https://github.com/user-attachments/assets/b744b995-5aa0-4acb-9505-3c293c910976

### After

https://github.com/user-attachments/assets/c9f6976e-687d-43b9-bdd8-643437d1a717



