### PR TITLE
Add RealSandook impl for Sandook KeyValueStore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,8 @@ dependencies {
     implementation(projects.feature.tripPlanner.network.api)
     implementation(projects.feature.tripPlanner.network.real)
     implementation(projects.feature.tripPlanner.ui)
+    implementation(projects.sandook.api)
+    implementation(projects.sandook.real)
 
     implementation(libs.activity.compose)
     implementation(libs.compose.foundation)

--- a/sandook/api/src/main/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/api/src/main/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -4,4 +4,16 @@ import kotlin.reflect.KClass
 
 interface Sandook {
 
+    fun clear()
+    fun remove(key: String)
+    fun getLong(key: String, defaultValue: Long = 0L): Long
+    fun putLong(key: String, value: Long)
+    fun getFloat(key: String, defaultValue: Float = 0f): Float
+    fun putFloat(key: String, value: Float)
+    fun getBoolean(key: String, defaultValue: Boolean = false): Boolean
+    fun putBoolean(key: String, value: Boolean)
+    fun getInt(key: String, defaultValue: Int = 0): Int
+    fun putInt(key: String, value: Int)
+    fun getString(key: String, defaultValue: String? = null): String?
+    fun putString(key: String, value: String)
 }

--- a/sandook/real/build.gradle.kts
+++ b/sandook/real/build.gradle.kts
@@ -1,14 +1,10 @@
 plugins {
-    alias(libs.plugins.krail.jvm.library)
-    alias(libs.plugins.cash.sqldelight)
+    alias(libs.plugins.krail.android.library)
+    alias(libs.plugins.krail.android.hilt)
 }
 
-sqldelight {
-    databases {
-        create("Sandook") {
-            packageName.set("xyz.ksharma.sandook.real")
-        }
-    }
+android {
+    namespace = "xyz.ksharma.krail.sandook.real"
 }
 
 dependencies {

--- a/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -1,6 +1,55 @@
 package xyz.ksharma.krail.sandook
 
-class RealSandook {
+import android.content.SharedPreferences
+import javax.inject.Inject
 
+class RealSandook @Inject constructor(private val sharedPreferences: SharedPreferences) : Sandook {
 
+    override fun putString(key: String, value: String) {
+        sharedPreferences.edit().putString(key, value).apply()
+    }
+
+    override fun getString(key: String, defaultValue: String?): String? {
+        return sharedPreferences.getString(key, defaultValue)
+    }
+
+    override fun putInt(key: String, value: Int) {
+        sharedPreferences.edit().putInt(key, value).apply()
+    }
+
+    override fun getInt(key: String, defaultValue: Int): Int {
+        return sharedPreferences.getInt(key, defaultValue)
+    }
+
+    override fun putBoolean(key: String, value: Boolean) {
+        sharedPreferences.edit().putBoolean(key, value).apply()
+    }
+
+    override fun getBoolean(key: String, defaultValue: Boolean): Boolean {
+        return sharedPreferences.getBoolean(key, defaultValue)
+    }
+
+    override fun putFloat(key: String, value: Float) {
+        sharedPreferences.edit().putFloat(key, value).apply()
+    }
+
+    override fun getFloat(key: String, defaultValue: Float): Float {
+        return sharedPreferences.getFloat(key, defaultValue)
+    }
+
+    override fun putLong(key: String, value: Long) {
+        sharedPreferences.edit().putLong(key, value).apply()
+    }
+
+    override fun getLong(key: String, defaultValue: Long): Long {
+        return sharedPreferences.getLong(key, defaultValue)
+    }
+
+    override fun remove(key: String) {
+        sharedPreferences.edit().remove(key).apply()
+    }
+
+    override fun clear() {
+        sharedPreferences.edit().clear().apply()
+    }
 }

--- a/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
+++ b/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
@@ -1,0 +1,30 @@
+package xyz.ksharma.krail.sandook.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import xyz.ksharma.krail.sandook.RealSandook
+import xyz.ksharma.krail.sandook.Sandook
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SandookModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindSandook(impl: RealSandook): Sandook
+
+    companion object {
+
+        @Provides
+        fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences {
+            return context.getSharedPreferences("sandook_key_value", Context.MODE_PRIVATE)
+        }
+    }
+}


### PR DESCRIPTION
### TL;DR

Implemented Sandook, a key-value storage interface, using SharedPreferences.

### What changed?

- Added Sandook interface with methods for storing and retrieving various data types.
- Implemented RealSandook class using SharedPreferences to provide concrete implementation.
- Created SandookModule for dependency injection.
- Updated build configurations to support the new implementation.

### Why make this change?

This change introduces a standardized key-value storage solution for the app. By abstracting the storage mechanism behind an interface, we gain flexibility to change the underlying implementation in the future if needed. Using SharedPreferences provides a simple and efficient way to store small amounts of primitive data, which is suitable for most app settings and preferences.