### PR TITLE
Implement Save Trip functionality

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
@@ -6,6 +6,7 @@ import xyz.ksharma.krail.trip_planner.ui.state.TransportModeLine
 
 data class TimeTableState(
     val isLoading: Boolean = false,
+    val isTripSaved: Boolean = false,
     val journeyList: ImmutableList<JourneyCardInfo> = persistentListOf(),
 ) {
     data class JourneyCardInfo(

--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/Trip.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/Trip.kt
@@ -1,8 +1,19 @@
 package xyz.ksharma.krail.trip_planner.ui.state.timetable
 
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
 data class Trip(
     val fromStopId: String,
     val fromStopName: String,
     val toStopId: String,
     val toStopName: String,
-)
+) {
+    fun toJsonString() = Json.encodeToString(serializer(), this)
+
+    companion object {
+        fun fromJsonString(json: String) =
+            kotlin.runCatching { Json.decodeFromString(serializer(), json) }.getOrNull()
+    }
+}

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(projects.core.designSystem)
     implementation(projects.feature.tripPlanner.network.api)
     implementation(projects.feature.tripPlanner.state)
+    implementation(projects.sandook.api)
 
     implementation(libs.compose.foundation)
     implementation(libs.compose.navigation)

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -50,6 +52,16 @@ fun TimeTableScreen(
                 Text("Loading...", modifier = Modifier.padding(horizontal = 16.dp))
             }
         } else if (timeTableState.journeyList.isNotEmpty()) {
+            item {
+                Text(
+                    text = if (timeTableState.isTripSaved) "Trip Saved" else "Save Trip Button",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 16.dp)
+                        .clickable(enabled = !timeTableState.isTripSaved) { onEvent(TimeTableUiEvent.SaveTripButtonClicked) }
+                )
+            }
+
             items(timeTableState.journeyList) { journey ->
 
                 AnimatedVisibility(

--- a/sandook/api/src/main/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/api/src/main/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -1,7 +1,5 @@
 package xyz.ksharma.krail.sandook
 
-import kotlin.reflect.KClass
-
 interface Sandook {
 
     fun clear()


### PR DESCRIPTION
### TL;DR

Added functionality to save trips and display saved trip status in the TimeTableScreen.

### What changed?

- Added `isTripSaved` boolean to `TimeTableState`
- Implemented serialization and deserialization methods for `Trip` class
- Added a "Save Trip" button to the `TimeTableScreen`
- Implemented trip saving functionality in `TimeTableViewModel` using `Sandook`
- Updated `TimeTableScreen` to display "Trip Saved" when a trip is saved

### Why make this change?

This change allows users to save their trips for future reference, enhancing the app's functionality and user experience. It provides a convenient way for users to keep track of their frequently used or important trips without having to re-enter the information each time.