### PR TITLE
Optimize search debounce and text trimming

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/searchstop/SearchStopScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,6 +23,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -56,13 +58,18 @@ fun SearchStopScreen(
         keyboard?.show()
     }
 
-    LaunchedEffect(textFieldText) {
-        snapshotFlow { textFieldText }
+    val trimmedText by remember(textFieldText) { derivedStateOf { textFieldText.trim() } }
+
+    LaunchedEffect(trimmedText) {
+        snapshotFlow { trimmedText }
             .distinctUntilChanged()
-            .debounce(600)
+            .debounce(250)
             .filter { it.isNotBlank() }
-            .mapLatest { text -> onEvent(SearchStopUiEvent.SearchTextChanged(text)) }
-            .collect()
+            .mapLatest { text ->
+                Timber.d("Query - $text")
+                onEvent(SearchStopUiEvent.SearchTextChanged(text))
+            }
+            .collectLatest{}
     }
 
     LazyColumn(


### PR DESCRIPTION
### TL;DR

Improved search functionality in SearchStopScreen

### What changed?

- Added trimming of search text to remove leading and trailing whitespace
- Reduced debounce time from 600ms to 250ms for quicker search responses
- Implemented `derivedStateOf` for efficient text trimming
- Added logging of search queries using Timber
- Updated flow collection to use `collectLatest` for better handling of rapid input

### Why make this change?

These changes aim to enhance the user experience by providing more responsive and accurate search results. Trimming whitespace prevents unintended search queries, while the reduced debounce time allows for quicker feedback. The use of `derivedStateOf` and `collectLatest` optimizes performance and ensures that only the most recent search query is processed.


https://github.com/user-attachments/assets/c2bbcf40-8dc5-4049-ba09-011757f50cfa


