### PR TITLE
Add WalkingLeg to JourneyCardInfo and update UI

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/TransportMode.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/TransportMode.kt
@@ -15,6 +15,10 @@ sealed class TransportMode {
     abstract val name: String
     abstract val colorCode: String
     abstract val productClass: Int
+
+    /**
+     * Priority to sort the transport modes in Search Results
+     */
     abstract val priority: Int
 
     @Serializable

--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
@@ -39,21 +39,27 @@ data class TimeTableState(
             get() = (originUtcDateTime + destinationTime + transportModeLines
                 .joinToString { it.lineName }).filter { it.isLetterOrDigit() }
 
-        data class Leg(
-            // modeType - legs.transportation.product.class
-            // lineName - legs.transportation.disassembledName
-            val transportModeLine: TransportModeLine,
+        sealed class Leg {
+            data class WalkingLeg(
+                val duration: String, // "10mins"
+            ) : Leg()
 
-            // transportation.description -> "Burwood to Liverpool",
-            val displayText: String, // "towards X via X"
+            data class TransportLeg(
+                // modeType - legs.transportation.product.class
+                // lineName - legs.transportation.disassembledName
+                val transportModeLine: TransportModeLine,
 
-            // leg.stopSequence.size  (leg.duration seconds)
-            val stopsInfo: String, // "4 stops (12 min)"
+                // transportation.description -> "Burwood to Liverpool",
+                val displayText: String, // "towards X via X"
 
-            val stops: ImmutableList<Stop>,
+                // leg.stopSequence.size  (leg.duration seconds)
+                val stopsInfo: String, // "4 stops (12 min)"
 
-            val walkInterchange: WalkInterchange? = null,
-        )
+                val stops: ImmutableList<Stop>,
+
+                val walkInterchange: WalkInterchange? = null,
+            ) : Leg()
+        }
 
         data class WalkInterchange(
             // leg.footPathInfo.duration seconds

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
@@ -61,10 +61,16 @@ fun JourneyDetailCard(
                 width = 2.dp,
                 brush = Brush.verticalGradient(
                     colors = if (legList.size >= 2) {
-                        legList.map { it.transportModeLine.transportMode.colorCode.hexToComposeColor() }
+                        legList
+                            .filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                            .map {
+                                it.transportModeLine.transportMode.colorCode.hexToComposeColor()
+                            }
                     } else {
                         val color =
-                            legList.first().transportModeLine.transportMode.colorCode.hexToComposeColor()
+                            legList
+                                .filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                                .first().transportModeLine.transportMode.colorCode.hexToComposeColor()
                         listOf(color, color)
                     }),
                 shape = RoundedCornerShape(12.dp)
@@ -82,12 +88,14 @@ fun JourneyDetailCard(
             Text(
                 text = timeToDeparture,
                 style = KrailTheme.typography.titleLarge,
-                color = legList.first().transportModeLine.transportMode.colorCode.hexToComposeColor()
+                color = legList.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                    .first().transportModeLine.transportMode.colorCode.hexToComposeColor()
             )
             Text(
                 text = "Platform $platformNumber",
                 style = KrailTheme.typography.titleLarge,
-                color = legList.first().transportModeLine.transportMode.colorCode.hexToComposeColor()
+                color = legList.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                    .first().transportModeLine.transportMode.colorCode.hexToComposeColor()
             )
         }
 
@@ -143,54 +151,66 @@ fun JourneyDetailCard(
         )
 
         legList.forEachIndexed { index, leg ->
-            if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.BEFORE) {
-                leg.walkInterchange?.duration?.let { duration ->
+            when (leg) {
+                is TimeTableState.JourneyCardInfo.Leg.WalkingLeg -> {
                     WalkingLeg(
-                        duration = duration,
+                        duration = leg.duration,
                         modifier = Modifier
                             .padding(horizontal = 16.dp),
                     )
                 }
-            }
 
-            Spacer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(8.dp)
-            )
+                is TimeTableState.JourneyCardInfo.Leg.TransportLeg -> {
+                    if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.BEFORE) {
+                        leg.walkInterchange?.duration?.let { duration ->
+                            WalkingLeg(
+                                duration = duration,
+                                modifier = Modifier
+                                    .padding(horizontal = 16.dp),
+                            )
+                        }
+                    }
 
-            if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.IDEST) {
-                leg.walkInterchange?.duration?.let { duration ->
-                    WalkingLeg(
-                        duration = duration,
+                    Spacer(
                         modifier = Modifier
-                            .padding(horizontal = 16.dp),
+                            .fillMaxWidth()
+                            .height(8.dp)
                     )
-                }
-            } else {
-                JourneyLeg(
-                    transportModeLine = leg.transportModeLine,
-                    stopsInfo = leg.stopsInfo,
-                    departureTime = if (index == legList.lastIndex) leg.stops.last().time else leg.stops.first().time,
-                    stopName = if (index == legList.lastIndex) leg.stops.last().name else leg.stops.first().name,
-                    isWheelchairAccessible = false,
-                    modifier = Modifier.padding(start = 8.dp, end = 8.dp),
-                )
-            }
 
-            Spacer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(8.dp)
-            )
+                    if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.IDEST) {
+                        leg.walkInterchange?.duration?.let { duration ->
+                            WalkingLeg(
+                                duration = duration,
+                                modifier = Modifier
+                                    .padding(horizontal = 16.dp),
+                            )
+                        }
+                    } else {
+                        JourneyLeg(
+                            transportModeLine = leg.transportModeLine,
+                            stopsInfo = leg.stopsInfo,
+                            departureTime = if (index == legList.lastIndex) leg.stops.last().time else leg.stops.first().time,
+                            stopName = if (index == legList.lastIndex) leg.stops.last().name else leg.stops.first().name,
+                            isWheelchairAccessible = false,
+                            modifier = Modifier.padding(start = 8.dp, end = 8.dp),
+                        )
+                    }
 
-            if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.AFTER) {
-                leg.walkInterchange?.duration?.let { duration ->
-                    WalkingLeg(
-                        duration = duration,
+                    Spacer(
                         modifier = Modifier
-                            .padding(horizontal = 16.dp),
+                            .fillMaxWidth()
+                            .height(8.dp)
                     )
+
+                    if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.AFTER) {
+                        leg.walkInterchange?.duration?.let { duration ->
+                            WalkingLeg(
+                                duration = duration,
+                                modifier = Modifier
+                                    .padding(horizontal = 16.dp),
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -206,7 +226,7 @@ private fun PreviewJourneyDetailCard() {
             platformNumber = '1',
             totalTravelTime = "1h 30mins",
             legList = listOf(
-                TimeTableState.JourneyCardInfo.Leg(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
                     transportModeLine = TransportModeLine(
                         transportMode = TransportMode.Bus(),
                         lineName = "600",
@@ -239,7 +259,7 @@ private fun PreviewJourneyDetailCardWalkBefore() {
             platformNumber = '1',
             totalTravelTime = "1h 30mins",
             legList = listOf(
-                TimeTableState.JourneyCardInfo.Leg(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
                     walkInterchange = TimeTableState.JourneyCardInfo.WalkInterchange(
                         duration = "5 mins",
                         position = TimeTableState.JourneyCardInfo.WalkPosition.BEFORE,
@@ -276,7 +296,7 @@ private fun PreviewJourneyDetailCardWalkAfter() {
             platformNumber = '1',
             totalTravelTime = "1h 30mins",
             legList = listOf(
-                TimeTableState.JourneyCardInfo.Leg(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
                     walkInterchange = TimeTableState.JourneyCardInfo.WalkInterchange(
                         duration = "5 mins",
                         position = TimeTableState.JourneyCardInfo.WalkPosition.AFTER,
@@ -314,7 +334,7 @@ private fun PreviewMultiLegJourneyDetailCard() {
             platformNumber = '1',
             totalTravelTime = "1h 30mins",
             legList = listOf(
-                TimeTableState.JourneyCardInfo.Leg(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
                     walkInterchange = TimeTableState.JourneyCardInfo.WalkInterchange(
                         duration = "5 mins",
                         position = TimeTableState.JourneyCardInfo.WalkPosition.AFTER,
@@ -336,7 +356,7 @@ private fun PreviewMultiLegJourneyDetailCard() {
                         ),
                     ).toImmutableList()
                 ),
-                TimeTableState.JourneyCardInfo.Leg(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
                     transportModeLine = TransportModeLine(
                         transportMode = TransportMode.Train(),
                         lineName = "T5",


### PR DESCRIPTION
### TL;DR

Added support for walking legs in journey planning and updated the UI to display them correctly.

### What changed?

- Introduced a new `WalkingLeg` subclass in the `TimeTableState.JourneyCardInfo.Leg` sealed class.
- Updated `TripResponseMapper` to identify and create walking legs.
- Modified `JourneyDetailCard` to handle and display walking legs.
- Added a priority field to `TransportMode` for sorting search results.
- Updated the UI to correctly display colors and information for journeys with walking legs.

### Screenshots

**JSON Response**

<img width="417" alt="Screenshot 2024-10-21 at 10 24 58 pm" src="https://github.com/user-attachments/assets/b888a134-a1cc-4bc5-b562-27fbf9f6d89a">


https://github.com/user-attachments/assets/f23fe3e7-39d4-4029-a31f-aebf9af3638e




### Why make this change?

This change improves the accuracy and completeness of journey planning by including walking segments. It provides users with a more comprehensive view of their trip, including any necessary walking between different modes of transport or to/from stations. This enhancement will help users better plan their journeys and understand the full scope of their travel time.