### PR TITLE
Make transportModeLines nullable and update UI components

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/state/timetable/TimeTableState.kt
@@ -31,13 +31,13 @@ data class TimeTableState(
          * transportation.disassembledName -> lineName
          * transportation.product.class -> TransportModeType
          */
-        val transportModeLines: ImmutableList<TransportModeLine>,
+        val transportModeLines: ImmutableList<TransportModeLine>? = null,
 
         val legs: ImmutableList<Leg>,
     ) {
         val journeyId: String
             get() = (originUtcDateTime + destinationTime + transportModeLines
-                .joinToString { it.lineName }).filter { it.isLetterOrDigit() }
+                ?.joinToString { it.lineName }).filter { it.isLetterOrDigit() }
 
         sealed class Leg {
             data class WalkingLeg(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyCard.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,7 +32,6 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import timber.log.Timber
 import xyz.ksharma.krail.design.system.components.SeparatorIcon
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.theme.KrailTheme
@@ -42,7 +39,6 @@ import xyz.ksharma.krail.design.system.toAdaptiveDecorativeIconSize
 import xyz.ksharma.krail.design.system.toAdaptiveSize
 import xyz.ksharma.krail.trip_planner.ui.R
 import xyz.ksharma.krail.trip_planner.ui.state.TransportMode
-import kotlin.text.repeat
 
 /**
  * A card that displays information about a journey.
@@ -65,10 +61,15 @@ fun JourneyCard(
     totalTravelTime: String,
     platformNumber: Char? = null,
     isWheelchairAccessible: Boolean,
-    transportModeList: ImmutableList<TransportMode>,
+    transportModeList: ImmutableList<TransportMode>? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val onSurface: Color = KrailTheme.colors.onSurface
+    val borderColors = remember(transportModeList) { transportModeList.toColors(onSurface) }
+    val themeColor = transportModeList?.firstOrNull()?.colorCode?.hexToComposeColor()
+        ?: KrailTheme.colors.onSurface
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -77,7 +78,7 @@ fun JourneyCard(
             .border(
                 width = 2.dp,
                 shape = RoundedCornerShape(12.dp),
-                brush = Brush.linearGradient(colors = transportModeList.toColors()),
+                brush = Brush.linearGradient(colors = borderColors),
             )
             .clickable(role = Role.Button, onClick = onClick)
             .padding(vertical = 8.dp, horizontal = 12.dp),
@@ -89,7 +90,7 @@ fun JourneyCard(
         ) {
             Text(
                 text = timeToDeparture, style = KrailTheme.typography.titleMedium,
-                color = transportModeList.first().colorCode.hexToComposeColor(),
+                color = themeColor,
                 modifier = Modifier
                     .padding(end = 8.dp)
                     .align(Alignment.CenterVertically)
@@ -100,7 +101,7 @@ fun JourneyCard(
                     .weight(1f),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                transportModeList.forEachIndexed { index, mode ->
+                transportModeList?.forEachIndexed { index, mode ->
                     TransportModeIcon(
                         letter = mode.name.first(),
                         backgroundColor = mode.colorCode.hexToComposeColor(),
@@ -116,7 +117,7 @@ fun JourneyCard(
                     .size(28.dp.toAdaptiveDecorativeIconSize())
                     .border(
                         width = 3.dp,
-                        color = transportModeList.first().colorCode.hexToComposeColor(),
+                        color = themeColor,
                         shape = CircleShape
                     ),
                 contentAlignment = Alignment.Center,
@@ -179,9 +180,9 @@ fun JourneyCard(
     }
 }
 
-@Composable
-private fun List<TransportMode>.toColors(): List<Color> = when {
-    isEmpty() -> listOf(KrailTheme.colors.onSurface, KrailTheme.colors.onSurface)
+// toColors() now accepts onSurface color as a parameter
+internal fun List<TransportMode>?.toColors(onSurface: Color): List<Color> = when {
+    this.isNullOrEmpty() -> listOf(onSurface, onSurface)
     size >= 2 -> map { it.colorCode.hexToComposeColor() }
     else -> {
         val color = first().colorCode.hexToComposeColor()

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyCard.kt
@@ -17,10 +17,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
@@ -30,6 +34,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import timber.log.Timber
 import xyz.ksharma.krail.design.system.components.SeparatorIcon
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.theme.KrailTheme
@@ -37,6 +42,7 @@ import xyz.ksharma.krail.design.system.toAdaptiveDecorativeIconSize
 import xyz.ksharma.krail.design.system.toAdaptiveSize
 import xyz.ksharma.krail.trip_planner.ui.R
 import xyz.ksharma.krail.trip_planner.ui.state.TransportMode
+import kotlin.text.repeat
 
 /**
  * A card that displays information about a journey.
@@ -57,7 +63,7 @@ fun JourneyCard(
     originTime: String,
     destinationTime: String,
     totalTravelTime: String,
-    platformNumber: Char?=null,
+    platformNumber: Char? = null,
     isWheelchairAccessible: Boolean,
     transportModeList: ImmutableList<TransportMode>,
     onClick: () -> Unit,
@@ -70,14 +76,8 @@ fun JourneyCard(
             .background(color = KrailTheme.colors.surface)
             .border(
                 width = 2.dp,
-                brush = Brush.linearGradient(
-                    colors = if (transportModeList.size >= 2) {
-                        transportModeList.map { it.colorCode.hexToComposeColor() }
-                    } else {
-                        val color = transportModeList.first().colorCode.hexToComposeColor()
-                        listOf(color, color)
-                    }),
-                shape = RoundedCornerShape(12.dp)
+                shape = RoundedCornerShape(12.dp),
+                brush = Brush.linearGradient(colors = transportModeList.toColors()),
             )
             .clickable(role = Role.Button, onClick = onClick)
             .padding(vertical = 8.dp, horizontal = 12.dp),
@@ -90,10 +90,14 @@ fun JourneyCard(
             Text(
                 text = timeToDeparture, style = KrailTheme.typography.titleMedium,
                 color = transportModeList.first().colorCode.hexToComposeColor(),
-                modifier = Modifier.padding(end = 8.dp).align(Alignment.CenterVertically)
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .align(Alignment.CenterVertically)
             )
             Row(
-                modifier = Modifier.align(Alignment.CenterVertically).weight(1f),
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .weight(1f),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
                 transportModeList.forEachIndexed { index, mode ->
@@ -172,6 +176,16 @@ fun JourneyCard(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun List<TransportMode>.toColors(): List<Color> = when {
+    isEmpty() -> listOf(KrailTheme.colors.onSurface, KrailTheme.colors.onSurface)
+    size >= 2 -> map { it.colorCode.hexToComposeColor() }
+    else -> {
+        val color = first().colorCode.hexToComposeColor()
+        listOf(color, color)
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyDetailCard.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,6 +47,7 @@ fun JourneyDetailCard(
     timeToDeparture: String,
     platformNumber: Char,
     totalTravelTime: String,
+    transportModeList: ImmutableList<TransportMode>? = null, // TODO cannot be null. Need to handle this
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -54,7 +57,7 @@ fun JourneyDetailCard(
     val iconSize = with(density) { 14.sp.toDp() }
 
     val firstTransportLeg = remember(legList) {
-        legList.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>().first()
+        legList.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>().firstOrNull()
     }
 
     val transportLegColors = remember(legList) {
@@ -62,10 +65,13 @@ fun JourneyDetailCard(
             .map { it.transportModeLine.transportMode.colorCode.hexToComposeColor() }
     }
 
-    val borderColors = if (transportLegColors.size >= 2) {
-        transportLegColors
-    } else {
-        listOf(transportLegColors.first(), transportLegColors.first())
+    val onSurface = KrailTheme.colors.onSurface
+    val borderColors = remember(transportLegColors) { transportModeList.toColors(onSurface) }
+    val themeColor by remember {
+        mutableStateOf(
+            firstTransportLeg?.transportModeLine?.transportMode?.colorCode?.hexToComposeColor()
+                ?: onSurface
+        )
     }
 
     Column(
@@ -91,15 +97,15 @@ fun JourneyDetailCard(
             Text(
                 text = timeToDeparture,
                 style = KrailTheme.typography.titleLarge,
-                color = firstTransportLeg.transportModeLine.transportMode.colorCode.hexToComposeColor()
+                color = themeColor
             )
 
-            firstTransportLeg.transportModeLine.transportMode.buildPlatformText(platformNumber)
+            firstTransportLeg?.transportModeLine?.transportMode?.buildPlatformText(platformNumber)
                 ?.let { platformText ->
                     Text(
                         text = platformText,
                         style = KrailTheme.typography.titleLarge,
-                        color = firstTransportLeg.transportModeLine.transportMode.colorCode.hexToComposeColor()
+                        color = themeColor
                     )
                 }
         }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyLeg.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/components/JourneyLeg.kt
@@ -48,7 +48,7 @@ fun JourneyLeg(
             .background(
                 color = transportModeLine.transportMode.colorCode
                     .hexToComposeColor()
-                    .copy(alpha = if (isSystemInDarkTheme()) 0.7f else 0.2f)
+                    .copy(alpha = if (isSystemInDarkTheme()) 0.7f else 0.15f)
             )
             .padding(vertical = 8.dp, horizontal = 8.dp),
     ) {
@@ -96,7 +96,7 @@ fun JourneyLeg(
                 Text(
                     text = departureTime,
                     style = KrailTheme.typography.bodyMedium,
-                    color = KrailTheme.colors.onSurface,
+                    color = if (isSystemInDarkTheme()) KrailTheme.colors.surface else KrailTheme.colors.onSurface,
                     modifier = Modifier
                         .align(Alignment.CenterVertically)
                         .padding(start = 8.dp),
@@ -110,7 +110,7 @@ fun JourneyLeg(
                 Text(
                     text = stopName,
                     style = KrailTheme.typography.titleSmall,
-                    color = KrailTheme.colors.onSurface,
+                    color = if (isSystemInDarkTheme()) KrailTheme.colors.surface else KrailTheme.colors.onSurface,
                     modifier = Modifier.align(Alignment.CenterVertically),
                 )
                 if (isWheelchairAccessible) {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip_planner/ui/timetable/TimeTableScreen.kt
@@ -93,12 +93,12 @@ fun TimeTableScreen(
                         originTime = journey.originTime,
                         destinationTime = journey.destinationTime,
                         durationText = journey.travelTime,
-                        transportModeLineList = journey.transportModeLines.map {
+                        transportModeLineList = journey.transportModeLines?.map {
                             TransportModeLine(
                                 transportMode = it.transportMode,
                                 lineName = it.lineName,
                             )
-                        }.toImmutableList(),
+                        }?.toImmutableList(),
                         onClick = {
                             onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
                         },
@@ -121,7 +121,7 @@ fun JourneyCardItem(
     originTime: String,
     durationText: String,
     destinationTime: String,
-    transportModeLineList: ImmutableList<TransportModeLine>,
+    transportModeLineList: ImmutableList<TransportModeLine>? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -132,7 +132,8 @@ fun JourneyCardItem(
         totalTravelTime = durationText,
         platformNumber = departureLocationNumber,
         isWheelchairAccessible = false,
-        transportModeList = transportModeLineList.map { it.transportMode }.toImmutableList(),
+        transportModeList = transportModeLineList.takeIf { it?.isNotEmpty() == true }
+            ?.map { it.transportMode }?.toImmutableList(),
         onClick = onClick,
         modifier = modifier,
     )


### PR DESCRIPTION
# Handle null and empty scenarios for TransportMode list

- Modify `JourneyCard` and `JourneyDetailCard` components to conditionally check if transport modes are present before applying gradient
- Update `TimeTableState` to allow nullable `transportModeLines`
- Refactor `JourneyCard` to use a new `toColors()` extension function for handling null or empty transport mode lists
- Adjust `TimeTableScreen` to handle potentially null `transportModeLines`
- Update `TripResponseMapper` to handle scenarios where transport mode information might be missing

These changes improve the robustness of the UI components when dealing with missing or incomplete transport mode data.