### PR TITLE
UI: Display intermediate stops in journey timeline

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -31,15 +31,19 @@ data class TimeTableState(
          * transportation.disassembledName -> lineName
          * transportation.product.class -> TransportModeType
          */
-        val transportModeLines: ImmutableList<TransportModeLine>? = null,
+        val transportModeLines: ImmutableList<TransportModeLine>,
 
         val legs: ImmutableList<Leg>,
     ) {
         val journeyId: String
-            get() = (
-                originUtcDateTime + destinationTime + transportModeLines
-                    ?.joinToString { it.lineName }
-                ).filter { it.isLetterOrDigit() }
+            get() = buildString {
+                append(originUtcDateTime)
+                append(destinationTime)
+                append(
+                    transportModeLines.joinToString { it.lineName }
+                        .filter { it.isLetterOrDigit() },
+                )
+            }
 
         sealed class Leg {
             data class WalkingLeg(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -60,14 +60,14 @@ fun JourneyCard(
     destinationTime: String,
     totalTravelTime: String,
     isWheelchairAccessible: Boolean,
+    transportModeList: ImmutableList<TransportMode>,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     platformNumber: Char? = null,
-    transportModeList: ImmutableList<TransportMode>? = null,
 ) {
     val onSurface: Color = KrailTheme.colors.onSurface
     val borderColors = remember(transportModeList) { transportModeList.toColors(onSurface) }
-    val themeColor = transportModeList?.firstOrNull()?.colorCode?.hexToComposeColor()
+    val themeColor = transportModeList.firstOrNull()?.colorCode?.hexToComposeColor()
         ?: KrailTheme.colors.onSurface
 
     Column(
@@ -102,7 +102,7 @@ fun JourneyCard(
                     .weight(1f),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                transportModeList?.forEachIndexed { index, mode ->
+                transportModeList.forEachIndexed { index, mode ->
                     TransportModeIcon(
                         letter = mode.name.first(),
                         backgroundColor = mode.colorCode.hexToComposeColor(),

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -95,12 +95,12 @@ fun TimeTableScreen(
                         originTime = journey.originTime,
                         destinationTime = journey.destinationTime,
                         durationText = journey.travelTime,
-                        transportModeLineList = journey.transportModeLines?.map {
+                        transportModeLineList = journey.transportModeLines.map {
                             TransportModeLine(
                                 transportMode = it.transportMode,
                                 lineName = it.lineName,
                             )
-                        }?.toImmutableList(),
+                        }.toImmutableList(),
                         onClick = {
                             onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
                         },
@@ -127,16 +127,17 @@ fun JourneyCardItem(
     modifier: Modifier = Modifier,
     transportModeLineList: ImmutableList<TransportModeLine>? = null,
 ) {
-    JourneyCard(
-        timeToDeparture = timeToDeparture,
-        originTime = originTime,
-        destinationTime = destinationTime,
-        totalTravelTime = durationText,
-        platformNumber = departureLocationNumber,
-        isWheelchairAccessible = false,
-        transportModeList = transportModeLineList.takeIf { it?.isNotEmpty() == true }
-            ?.map { it.transportMode }?.toImmutableList(),
-        onClick = onClick,
-        modifier = modifier,
-    )
+    if (!transportModeLineList.isNullOrEmpty()) {
+        JourneyCard(
+            timeToDeparture = timeToDeparture,
+            originTime = originTime,
+            destinationTime = destinationTime,
+            totalTravelTime = durationText,
+            platformNumber = departureLocationNumber,
+            isWheelchairAccessible = false,
+            transportModeList = transportModeLineList.map { it.transportMode }.toImmutableList(),
+            onClick = onClick,
+            modifier = modifier,
+        )
+    }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -31,7 +31,9 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
         val transportModeLines = legs?.getTransportModeLines()
         val legsList = legs?.getLegsList()
 
-        if (originTimeUTC != null && arrivalTimeUTC != null && totalStops > 0 && legsList != null) {
+        if (originTimeUTC != null && arrivalTimeUTC != null && totalStops > 0 && legsList != null &&
+            transportModeLines != null
+        ) {
             TimeTableState.JourneyCardInfo(
                 timeText = originTimeUTC.getTimeText(),
                 platformText = platformText,


### PR DESCRIPTION
### TL;DR
Added intermediate stops to journey legs and made transport mode lines non-nullable

### What changed?
- Added intermediate stops display in the journey leg view
- Changed `transportModeLines` from nullable to non-nullable in `TimeTableState`
- Refactored `ProminentStopInfo` to `StopInfo` with prominence parameter
- Added new timeline modifier for intermediate stops
- Improved journey ID generation using `buildString`
- Updated journey card to handle non-nullable transport mode lists

### Why make this change?
To provide users with more detailed journey information by showing all intermediate stops along their route, making it easier to track the complete journey path. The non-nullable transport mode lines ensure consistent UI rendering and prevent potential null-related issues.