### PR TITLE
UI: Add expandable stops view in journey timeline

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -125,7 +125,7 @@ fun JourneyCard(
             )
 
             else -> JourneyCardContent(
-                isExpanded = cardState == JourneyCardState.EXPANDED,
+                isExpanded = false,
                 timeToDeparture = timeToDeparture,
                 themeColor = themeColor,
                 platformNumber = platformNumber,
@@ -178,7 +178,6 @@ fun JourneyCardContent(
                     }
             }
         }
-
         FlowRow(
             modifier = Modifier
                 .fillMaxWidth(),

--- a/feature/trip-planner/ui/src/main/res/values/strings.xml
+++ b/feature/trip-planner/ui/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="from_text_field_placeholder">Starting from</string>
     <string name="to_text_field_placeholder">To Destination</string>
     <string name="time_table_screen_title">Time Table</string>
+    <plurals name="stops">
+        <item quantity="one">Show %d stop</item>
+        <item quantity="other">Show %d stops</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
### TL;DR

Improved the JourneyCard component with collapsible stops and platform information.

### What changed?

- Modified JourneyCardContent to display platform information for the first transport leg.
- Updated LegView to include a clickable area for showing/hiding non-prominent stops.
- Added a new state variable `displayNonProminentStops` to control the visibility of intermediate stops.
- Implemented a plurals string resource for displaying the number of stops.
- Removed the dependency on `isExpanded` state for showing intermediate stops.

### Why make this change?

This change enhances the user experience by providing more detailed journey information while maintaining a clean interface. The collapsible stops feature allows users to view additional details on demand, reducing clutter in the initial view. The addition of platform information helps users quickly identify where to board their first transport leg.