### PR TITLE
UI: Refactor JourneyCard clickable area and simplify stops display

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -100,12 +99,6 @@ fun JourneyCard(
                     Modifier
                 },
             )
-            .clickable(
-                role = Role.Button,
-                onClick = onClick,
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            )
             .padding(
                 vertical = 8.dp,
                 horizontal = if (cardState == JourneyCardState.DEFAULT) 12.dp else 0.dp,
@@ -121,7 +114,12 @@ fun JourneyCard(
                 themeColor = themeColor,
                 transportModeList = transportModeList,
                 platformNumber = platformNumber,
-                modifier = Modifier,
+                modifier = Modifier.clickable(
+                    role = Role.Button,
+                    onClick = onClick,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ),
             )
 
             else -> JourneyCardContent(
@@ -132,7 +130,12 @@ fun JourneyCard(
                 iconSize = iconSize,
                 totalTravelTime = totalTravelTime,
                 legList = legList,
-                modifier = Modifier,
+                modifier = Modifier.clickable(
+                    role = Role.Button,
+                    onClick = onClick,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ),
             )
         }
     }
@@ -298,7 +301,7 @@ fun JourneyCardContent(
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun ColumnScope.DefaultJourneyCardContent(
+fun DefaultJourneyCardContent(
     timeToDeparture: String,
     originTime: String,
     destinationTime: String,

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -72,6 +72,12 @@ fun LegView(
                     .copy(alpha = 0.1f),
                 shape = RoundedCornerShape(12.dp),
             )
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = { displayNonProminentStops = !displayNonProminentStops },
+                role = Role.Button,
+            )
             .padding(vertical = 12.dp, horizontal = 12.dp),
     ) {
         FlowRow(
@@ -128,27 +134,17 @@ fun LegView(
                         color = timelineColor,
                         strokeWidth = strokeWidth,
                     )
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = { displayNonProminentStops = !displayNonProminentStops },
-                        role = Role.Button,
-                    )
                     .padding(start = 16.dp, top = 12.dp),
             ) {
                 if (stops.size > 2) {
                     val context = LocalContext.current
                     StopsRow(
                         // Need to pass count twice - https://developer.android.com/guide/topics/resources/string-resource#Plurals
-                        stops = if (displayNonProminentStops) {
-                            "Hide stops"
-                        } else {
-                            context.resources.getQuantityString(
-                                R.plurals.stops,
-                                stops.size - 2,
-                                stops.size - 2,
-                            )
-                        },
+                        stops = context.resources.getQuantityString(
+                            R.plurals.stops,
+                            stops.size - 2,
+                            stops.size - 2,
+                        ),
                         line = transportModeLine,
                     )
                 } else {

--- a/feature/trip-planner/ui/src/main/res/values/strings.xml
+++ b/feature/trip-planner/ui/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
     <string name="to_text_field_placeholder">To Destination</string>
     <string name="time_table_screen_title">Time Table</string>
     <plurals name="stops">
-        <item quantity="one">Show %d stop</item>
-        <item quantity="other">Show %d stops</item>
+        <item quantity="one">%d stop</item>
+        <item quantity="other">%d stops</item>
     </plurals>
 </resources>


### PR DESCRIPTION
### TL;DR

Improved JourneyCard and LegView components for better user interaction and display.

### What changed?

- Moved clickable modifier from JourneyCard to its content components for more precise touch areas.
- Removed redundant platform number display and info icon from JourneyCardContent.
- Simplified LegView by moving clickable modifier to the main column and adjusting the stops display logic.
- Updated plurals string resource for stops to be more concise.

### Why make this change?

These changes improve the user experience by:
1. Providing more precise touch areas in JourneyCards.
2. Simplifying the UI by removing redundant information.
3. Making the LegView component more intuitive to interact with.
4. Enhancing the readability of the stops count display.