### PR TITLE
UI: Enhance SavedTripCard with transport mode styling and interactions

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -25,20 +27,26 @@ import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.preview.PreviewComponent
 import xyz.ksharma.krail.design.system.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.design.system.R as DSR
 
 @Composable
 fun SavedTripCard(
     origin: String,
     destination: String,
+    primaryTransportMode: TransportMode,
+    onStarClick: () -> Unit,
+    onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onStarClick: () -> Unit = {},
-    onCardClick: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
-            .background(color = KrailTheme.colors.secondaryContainer)
+            .background(
+                color = primaryTransportMode.colorCode
+                    .hexToComposeColor()
+                    .copy(alpha = 0.15f), // TODO -  needs to be common logic for background color
+            )
             .clickable(
                 role = Role.Button,
                 onClickLabel = "Open Trip Details",
@@ -48,8 +56,8 @@ fun SavedTripCard(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         TransportModeIcon(
-            letter = 'T',
-            backgroundColor = "#00B5EF".hexToComposeColor(),
+            letter = primaryTransportMode.name.first().uppercaseChar(),
+            backgroundColor = primaryTransportMode.colorCode.hexToComposeColor(),
         )
 
         Column(
@@ -63,11 +71,13 @@ fun SavedTripCard(
 
         Box(
             modifier = Modifier
-                .size(32.dp)
+                .size(44.dp)
                 .clip(CircleShape)
                 .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
                     onClickLabel = "Remove Saved Trip",
-                    role = Role.RadioButton,
+                    role = Role.Button,
                     onClick = onStarClick,
                 )
                 .semantics(mergeDescendants = true) {},
@@ -76,7 +86,10 @@ fun SavedTripCard(
             Image(
                 imageVector = ImageVector.vectorResource(DSR.drawable.star),
                 contentDescription = "Save Trip",
-                colorFilter = ColorFilter.tint(KrailTheme.colors.secondary),
+                colorFilter = ColorFilter.tint(
+                    primaryTransportMode.colorCode
+                        .hexToComposeColor(),
+                ),
             )
         }
     }
@@ -91,6 +104,10 @@ private fun SavedTripCardPreview() {
         SavedTripCard(
             origin = "Edmondson Park Station",
             destination = "Harris Park Station",
+            primaryTransportMode = TransportMode.Train(),
+            onCardClick = {},
+            onStarClick = {},
+            modifier = Modifier.background(color = KrailTheme.colors.background),
         )
     }
 }
@@ -108,16 +125,25 @@ private fun SavedTripCardListPreview() {
             SavedTripCard(
                 origin = "Edmondson Park Station",
                 destination = "Harris Park Station",
+                primaryTransportMode = TransportMode.Train(),
+                onCardClick = {},
+                onStarClick = {},
             )
 
             SavedTripCard(
                 origin = "Harrington Street, Stand D",
                 destination = "Albert Rd, Stand A",
+                primaryTransportMode = TransportMode.Bus(),
+                onCardClick = {},
+                onStarClick = {},
             )
 
             SavedTripCard(
                 origin = "Manly Wharf",
                 destination = "Circular Quay Wharf",
+                primaryTransportMode = TransportMode.Ferry(),
+                onCardClick = {},
+                onStarClick = {},
             )
         }
     }


### PR DESCRIPTION
### TL;DR

Enhanced SavedTripCard component with transport mode-specific styling and improved interaction.

### What changed?

- Added `primaryTransportMode` parameter to `SavedTripCard` function
- Implemented dynamic background color based on transport mode
- Updated TransportModeIcon to use the first letter of the transport mode
- Modified star icon color to match the transport mode
- Improved clickable area and interaction for the star icon
- Made `onStarClick` and `onCardClick` required parameters

### How to test?

1. Run the app and navigate to the saved trips screen
2. Verify that each SavedTripCard displays the correct transport mode icon and color
3. Check that the background color of each card is a lighter shade of the transport mode color
4. Tap on a card to ensure it triggers the `onCardClick` action
5. Tap on the star icon to verify it calls the `onStarClick` function
6. Confirm that the star icon's touch area is larger (44dp) for better usability

### Why make this change?

This update improves the visual consistency and user experience of the SavedTripCard component. By incorporating transport mode-specific styling, users can quickly identify the primary mode of transportation for each saved trip. The enhanced interaction for the star icon also improves the ease of saving or removing trips from the user's favorites.


<img width="440" alt="Screenshot 2024-10-26 at 5 17 41 pm" src="https://github.com/user-attachments/assets/c2ff5597-22de-4556-949c-a93f9cd5c395">

