### PR TITLE
UI: Implement SavedTripsScreen with dynamic trip loading and display

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -1,3 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
 
-data class SavedTripsState(val trip: String = "Empty")
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+
+data class SavedTripsState(val savedTrips: ImmutableList<Trip> = persistentListOf())

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.preview.PreviewComponent
@@ -34,18 +34,19 @@ import xyz.ksharma.krail.design.system.R as DSR
 fun SavedTripCard(
     origin: String,
     destination: String,
-    primaryTransportMode: TransportMode,
     onStarClick: () -> Unit,
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
+    primaryTransportMode: TransportMode? = null,
 ) {
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(
-                color = primaryTransportMode.colorCode
-                    .hexToComposeColor()
-                    .copy(alpha = 0.15f), // TODO -  needs to be common logic for background color
+                color = primaryTransportMode?.colorCode
+                    ?.hexToComposeColor()
+                    ?.copy(alpha = 0.15f) ?: KrailTheme.colors.secondaryContainer,
+                // TODO -  needs to be common logic for background color
             )
             .clickable(
                 role = Role.Button,
@@ -55,10 +56,12 @@ fun SavedTripCard(
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        TransportModeIcon(
-            letter = primaryTransportMode.name.first().uppercaseChar(),
-            backgroundColor = primaryTransportMode.colorCode.hexToComposeColor(),
-        )
+        primaryTransportMode?.let {
+            TransportModeIcon(
+                letter = primaryTransportMode.name.first().uppercaseChar(),
+                backgroundColor = primaryTransportMode.colorCode.hexToComposeColor(),
+            )
+        }
 
         Column(
             modifier = Modifier
@@ -87,8 +90,8 @@ fun SavedTripCard(
                 imageVector = ImageVector.vectorResource(DSR.drawable.star),
                 contentDescription = "Save Trip",
                 colorFilter = ColorFilter.tint(
-                    primaryTransportMode.colorCode
-                        .hexToComposeColor(),
+                    primaryTransportMode?.colorCode
+                        ?.hexToComposeColor() ?: KrailTheme.colors.onSecondaryContainer,
                 ),
             )
         }
@@ -112,7 +115,7 @@ private fun SavedTripCardPreview() {
     }
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun SavedTripCardListPreview() {
     KrailTheme {
@@ -142,6 +145,14 @@ private fun SavedTripCardListPreview() {
                 origin = "Manly Wharf",
                 destination = "Circular Quay Wharf",
                 primaryTransportMode = TransportMode.Ferry(),
+                onCardClick = {},
+                onStarClick = {},
+            )
+
+            SavedTripCard(
+                origin = "Manly Wharf",
+                destination = "Circular Quay Wharf",
+                primaryTransportMode = null,
                 onCardClick = {},
                 onStarClick = {},
             )

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -16,15 +18,19 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem.Companion.fromJsonString
 
+@Suppress("LongMethod")
 internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostController) {
     composable<SavedTripsRoute> { backStackEntry ->
-        // val viewModel = hiltViewModel<SavedTripsViewModel>()
-        // val savedTripState by viewModel.uiState.collectAsStateWithLifecycle()
+        val viewModel = hiltViewModel<SavedTripsViewModel>()
+        val savedTripState by viewModel.uiState.collectAsStateWithLifecycle()
 
         val fromArg: String? =
             backStackEntry.savedStateHandle.get<String>(SearchStopFieldType.FROM.key)
         val toArg: String? =
             backStackEntry.savedStateHandle.get<String>(SearchStopFieldType.TO.key)
+
+        // Subscribe to the isActive state flow to Load Trips only once at the start.
+        val isActive by viewModel.isActive.collectAsStateWithLifecycle()
 
         // Cannot use 'rememberSaveable' here because StopItem is not Parcelable.
         // But it's saved in backStackEntry.savedStateHandle as json, so it's able to
@@ -45,6 +51,7 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
         }
 
         SavedTripsScreen(
+            savedTripsState = savedTripState,
             fromStopItem = fromStopItem,
             toStopItem = toStopItem,
             fromButtonClick = {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -3,8 +3,12 @@ package xyz.ksharma.krail.trip.planner.ui.savedtrips
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,12 +19,14 @@ import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.R
+import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 @Composable
 fun SavedTripsScreen(
-//    savedTripsState: SavedTripsState,
+    savedTripsState: SavedTripsState,
     modifier: Modifier = Modifier,
     fromStopItem: StopItem? = null,
     toStopItem: StopItem? = null,
@@ -40,6 +46,24 @@ fun SavedTripsScreen(
                 TitleBar(title = {
                     Text(text = stringResource(R.string.saved_trips_screen_title))
                 })
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            items(
+                items = savedTripsState.savedTrips,
+                key = { it.fromStopId + it.toStopId },
+            ) { trip ->
+                SavedTripCard(
+                    origin = trip.fromStopName,
+                    destination = trip.toStopName,
+                    onStarClick = {},
+                    onCardClick = {},
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
             }
         }
 
@@ -61,7 +85,7 @@ fun SavedTripsScreen(
 @Composable
 private fun SavedTripsScreenPreview() {
     KrailTheme {
-        SavedTripsScreen()
+        SavedTripsScreen(savedTripsState = SavedTripsState())
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -1,47 +1,96 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import xyz.ksharma.krail.di.AppDispatchers
+import xyz.ksharma.krail.di.Dispatcher
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.di.SandookFactory
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
-class SavedTripsViewModel @Inject constructor() : ViewModel() {
+class SavedTripsViewModel @Inject constructor(
+    sandookFactory: SandookFactory,
+    @Dispatcher(AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
 
-    // private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
-    // val uiState: StateFlow<SavedTripsState> = _uiState
-/*
+    private val sandook: Sandook = sandookFactory.create(SandookFactory.SandookKey.SAVED_TRIP)
 
-    fun onEvent(event: SavedTripUiEvent) {
-        when (event) {
-            is SavedTripUiEvent.DeleteSavedTrip -> onDeleteSavedTrip(event.savedTrip)
-            SavedTripUiEvent.LoadSavedTrips -> onLoadSavedTrips()
-            is SavedTripUiEvent.SavedTripClicked -> onSavedTripClicked(event.savedTrip)
-            is SavedTripUiEvent.OnSearchButtonClicked -> onSearchButtonClicked(event.fromStopItem, event.toStopItem)
+    private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
+    val uiState: StateFlow<SavedTripsState> = _uiState
+
+    private val _isActive: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isActive: StateFlow<Boolean> = _isActive.onStart {
+        loadSavedTrips()
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(ANR_TIMEOUT.inWholeMilliseconds),
+        initialValue = true,
+    )
+
+    private fun loadSavedTrips() {
+        viewModelScope.launch(context = ioDispatcher) {
+            val trips = sandook.keys().mapNotNull { key ->
+                val tripString = sandook.getString(key, null)
+                tripString?.let { tripJsonString ->
+                    Trip.fromJsonString(tripJsonString)
+                }
+            }.toImmutableList()
+            if (!trips.isEmpty()) {
+                updateUiState { copy(savedTrips = trips) }
+            }
         }
     }
 
-    private fun onSearchButtonClicked(fromStopItem: StopItem, toStopItem: StopItem) {
-        Timber.d("onSearchButtonClicked")
-    }
+    /*
 
-    private fun onSavedTripClicked(savedTrip: String) {
-        Timber.d("onSavedTripClicked")
-    }
-
-    private fun onLoadSavedTrips() {
-        Timber.d("onLoadSavedTrips")
-        updateUiState {
-            copy(trip = "Central to Town Hall")
+        fun onEvent(event: SavedTripUiEvent) {
+            when (event) {
+                is SavedTripUiEvent.DeleteSavedTrip -> onDeleteSavedTrip(event.savedTrip)
+                SavedTripUiEvent.LoadSavedTrips -> onLoadSavedTrips()
+                is SavedTripUiEvent.SavedTripClicked -> onSavedTripClicked(event.savedTrip)
+                is SavedTripUiEvent.OnSearchButtonClicked -> onSearchButtonClicked(event.fromStopItem, event.toStopItem)
+            }
         }
-    }
 
-    private fun onDeleteSavedTrip(savedTrip: String) {
-        Timber.d("onDeleteSavedTrip")
-    }
+        private fun onSearchButtonClicked(fromStopItem: StopItem, toStopItem: StopItem) {
+            Timber.d("onSearchButtonClicked")
+        }
 
+        private fun onSavedTripClicked(savedTrip: String) {
+            Timber.d("onSavedTripClicked")
+        }
 
+        private fun onLoadSavedTrips() {
+            Timber.d("onLoadSavedTrips")
+            updateUiState {
+                copy(trip = "Central to Town Hall")
+            }
+        }
+
+        private fun onDeleteSavedTrip(savedTrip: String) {
+            Timber.d("onDeleteSavedTrip")
+        }
+
+*/
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {
         _uiState.update(block)
     }
- */
+
+    companion object {
+        private val ANR_TIMEOUT = 5.seconds
+    }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -71,7 +71,7 @@ class TimeTableViewModel @Inject constructor(
         Timber.d("Save Trip Button Clicked")
         tripInfo?.let { trip ->
             Timber.d("Save Trip: $trip")
-            sandook.putString(key = trip.fromStopId + trip.toStopId, trip.toJsonString())
+            sandook.putString(key = trip.fromStopId + trip.toStopId, value = trip.toJsonString())
             sandook.getString(key = trip.fromStopId + trip.toStopId)?.let { savedTrip ->
                 Timber.d("Saved Trip (Pref): ${Trip.fromJsonString(savedTrip)}")
             }

--- a/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -5,6 +5,8 @@ import javax.inject.Inject
 
 internal class RealSandook @Inject constructor(private val sharedPreferences: SharedPreferences) : Sandook {
 
+    override fun keys(): Set<String> = sharedPreferences.all.keys
+
     override fun putString(key: String, value: String) {
         sharedPreferences.edit().putString(key, value).apply()
     }

--- a/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -14,4 +14,9 @@ interface Sandook {
     fun putInt(key: String, value: Int)
     fun getString(key: String, defaultValue: String? = null): String?
     fun putString(key: String, value: String)
+
+    /**
+     * Returns a set of all keys in the Sandook.
+     */
+    fun keys(): Set<String>
 }


### PR DESCRIPTION
### TL;DR

Implemented saved trips functionality and updated the SavedTripsScreen to display saved trips.

### What changed?

- Updated `SavedTripsState` to store a list of saved trips
- Modified `SavedTripCard` to handle null primary transport mode
- Implemented `SavedTripsViewModel` to load and manage saved trips
- Updated `SavedTripsScreen` to display the list of saved trips
- Added functionality to retrieve all keys from `Sandook`

### Why make this change?

This change implements the core functionality of the Saved Trips feature, allowing users to view their previously saved trips. It improves the user experience by providing easy access to frequently used routes and enhances the overall utility of the trip planner application.