### PR TITLE
UI: Refine leg filtering and add debug logging in TripResponseMapper

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -68,9 +68,7 @@ private fun TripResponse.Leg?.getDepartureTime() =
 private fun TripResponse.Leg?.getArrivalTime() =
     this?.destination?.arrivalTimeEstimated ?: this?.destination?.arrivalTimePlanned
 
-private fun TripResponse.Journey.getFilteredValidLegs() = legs?.filter {
-    it.transportation != null && it.stopSequence != null
-}
+private fun TripResponse.Journey.getFilteredValidLegs() = legs?.filter { it.transportation != null }
 
 private fun List<TripResponse.Leg>.getTotalStops() = sumOf { leg -> leg.stopSequence?.size ?: 0 }
 
@@ -108,6 +106,13 @@ private fun String.getTimeText() = let {
 
 @Suppress("ComplexCondition")
 private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
+    Timber.d(
+        "\tFFF Leg: ${this.duration}, " +
+            "leg: ${this.origin?.name} TO ${this.destination?.name}" +
+            " - isWalk:${this.isWalkingLeg()}, " +
+            "PClass-${this.transportation?.product?.productClass}",
+    )
+
     val transportMode =
         transportation?.product?.productClass?.toInt()
             ?.let { TransportMode.toTransportModeType(productClass = it) }
@@ -125,6 +130,7 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
         }
 
         else -> { // Public Transport Leg
+//            Timber.d("FFF PTLeg: $displayDuration, leg: ${this.destination?.name} ")
             if (transportMode != null && lineName != null && displayText != null &&
                 numberOfStops != null && stops != null
             ) {


### PR DESCRIPTION
### TL;DR

If the first leg is a walking leg, then it does not have any stop sequence and especially for Metro and Train. In those cases the walking leg was getting filtered out from  `val legs = journey.getFilteredValidLegs()` and not getting mapped ot Model in `private fun TripResponse.Leg.toUiModel()`.

Since only Public Transport legs have stopSequence it can be safely removed from the filter logic.

### What changed?

- Modified `getFilteredValidLegs()` function to only filter legs based on transportation, removing the check for `stopSequence`.
- Added detailed debug logging in the `toUiModel()` function to provide more information about each leg during the mapping process.

### Why make this change?

This change aims to improve the accuracy of leg filtering and provide better debugging capabilities. By removing the `stopSequence` check, we ensure that valid legs with transportation information are not accidentally filtered out. The added logging will help in troubleshooting and understanding the leg mapping process more effectively.