### PR TITLE
UI: Refactor screens layout and improve time formatting

### DIFF
--- a/core/date-time/src/main/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/main/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -74,9 +74,9 @@ object DateTimeHelper {
         val formattedDifference = when {
             totalMinutes < 0 -> "${totalMinutes.absoluteValue} mins ago"
             totalMinutes == 0L -> "Now"
-            hours == 1L -> "in ${hours.absoluteValue}h ${partialMinutes.absoluteValue}m"
-            hours >= 2 -> "in ${hours.absoluteValue} hrs"
-            else -> "in ${totalMinutes.absoluteValue} ${if (totalMinutes.absoluteValue == 1L) "min" else "mins"}"
+            hours == 1L -> "In ${hours.absoluteValue}h ${partialMinutes.absoluteValue}m"
+            hours >= 2 -> "In ${hours.absoluteValue} h"
+            else -> "In ${totalMinutes.absoluteValue} ${if (totalMinutes.absoluteValue == 1L) "min" else "mins"}"
         }
         Timber.d("\t minutes: $partialMinutes, hours: $hours, formattedDifference: $formattedDifference -> originTime")
         return formattedDifference

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -2,11 +2,13 @@ package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -40,41 +42,42 @@ fun SavedTripsScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KrailTheme.colors.background),
+            .background(color = KrailTheme.colors.background)
+            .statusBarsPadding(),
     ) {
-        LazyColumn(modifier = Modifier, contentPadding = PaddingValues(bottom = 300.dp)) {
-            item {
-                TitleBar(title = {
-                    Text(text = stringResource(R.string.saved_trips_screen_title))
-                })
-            }
+        Column {
+            TitleBar(title = {
+                Text(text = stringResource(R.string.saved_trips_screen_title))
+            })
 
-            item {
-                Spacer(modifier = Modifier.height(12.dp))
-            }
+            LazyColumn(contentPadding = PaddingValues(bottom = 300.dp)) {
+                item {
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
 
-            items(
-                items = savedTripsState.savedTrips,
-                key = { it.fromStopId + it.toStopId },
-            ) { trip ->
-                SavedTripCard(
-                    trip = trip,
-                    onStarClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
-                    onCardClick = {
-                        onSearchButtonClick(
-                            StopItem(
-                                stopId = trip.fromStopId,
-                                stopName = trip.fromStopName,
-                            ),
-                            StopItem(
-                                stopId = trip.toStopId,
-                                stopName = trip.toStopName,
-                            ),
-                        )
-                    },
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                )
-                Spacer(modifier = Modifier.height(12.dp))
+                items(
+                    items = savedTripsState.savedTrips,
+                    key = { it.fromStopId + it.toStopId },
+                ) { trip ->
+                    SavedTripCard(
+                        trip = trip,
+                        onStarClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
+                        onCardClick = {
+                            onSearchButtonClick(
+                                StopItem(
+                                    stopId = trip.fromStopId,
+                                    stopName = trip.fromStopName,
+                                ),
+                                StopItem(
+                                    stopId = trip.toStopId,
+                                    stopName = trip.toStopName,
+                                ),
+                            )
+                        },
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
             }
         }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -3,11 +3,14 @@ package xyz.ksharma.krail.trip.planner.ui.timetable
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -34,73 +37,74 @@ fun TimeTableScreen(
     onEvent: (TimeTableUiEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
+    Column(
         modifier = modifier
-            .background(color = KrailTheme.colors.background),
-        contentPadding = PaddingValues(vertical = 16.dp),
+            .fillMaxSize()
+            .background(color = KrailTheme.colors.background)
+            .statusBarsPadding(),
     ) {
-        item {
-            TitleBar(title = {
-                Text(text = stringResource(R.string.time_table_screen_title))
-            })
-        }
+        TitleBar(title = {
+            Text(text = stringResource(R.string.time_table_screen_title))
+        })
 
-        if (timeTableState.isLoading) {
-            item {
-                Text("Loading...", modifier = Modifier.padding(horizontal = 16.dp))
+        LazyColumn(contentPadding = PaddingValues(vertical = 16.dp)) {
+            if (timeTableState.isLoading) {
+                item {
+                    Text("Loading...", modifier = Modifier.padding(horizontal = 16.dp))
+                }
+            } else if (timeTableState.journeyList.isNotEmpty()) {
+                item {
+                    Text(
+                        text = if (timeTableState.isTripSaved) "Trip Saved" else "Save Trip Button",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 16.dp)
+                            .clickable(
+                                enabled = !timeTableState.isTripSaved,
+                            ) { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
+                    )
+                }
+
+                items(timeTableState.journeyList) { journey ->
+                    JourneyCardItem(
+                        timeToDeparture = journey.timeText,
+                        departureLocationNumber = journey.platformText,
+                        originTime = journey.originTime,
+                        destinationTime = journey.destinationTime,
+                        durationText = journey.travelTime,
+                        transportModeLineList = journey.transportModeLines.map {
+                            TransportModeLine(
+                                transportMode = it.transportMode,
+                                lineName = it.lineName,
+                            )
+                        }.toImmutableList(),
+                        legList = journey.legs.toImmutableList(),
+                        cardState = if (expandedJourneyId == journey.journeyId) {
+                            JourneyCardState.COLLAPSED
+                        } else {
+                            JourneyCardState.DEFAULT
+                        },
+                        onClick = {
+                            onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
+                        },
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .animateContentSize(),
+                    )
+                }
+            } else {
+                item {
+                    Text("No data found")
+                }
             }
-        } else if (timeTableState.journeyList.isNotEmpty()) {
+
             item {
-                Text(
-                    text = if (timeTableState.isTripSaved) "Trip Saved" else "Save Trip Button",
+                Spacer(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 16.dp)
-                        .clickable(
-                            enabled = !timeTableState.isTripSaved,
-                        ) { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
+                        .height(96.dp)
+                        .systemBarsPadding(),
                 )
             }
-
-            items(timeTableState.journeyList) { journey ->
-                JourneyCardItem(
-                    timeToDeparture = journey.timeText,
-                    departureLocationNumber = journey.platformText,
-                    originTime = journey.originTime,
-                    destinationTime = journey.destinationTime,
-                    durationText = journey.travelTime,
-                    transportModeLineList = journey.transportModeLines.map {
-                        TransportModeLine(
-                            transportMode = it.transportMode,
-                            lineName = it.lineName,
-                        )
-                    }.toImmutableList(),
-                    legList = journey.legs.toImmutableList(),
-                    cardState = if (expandedJourneyId == journey.journeyId) {
-                        JourneyCardState.COLLAPSED
-                    } else {
-                        JourneyCardState.DEFAULT
-                    },
-                    onClick = {
-                        onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
-                    },
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .animateContentSize(),
-                )
-            }
-        } else {
-            item {
-                Text("No data found")
-            }
-        }
-
-        item {
-            Spacer(
-                modifier = Modifier
-                    .height(96.dp)
-                    .systemBarsPadding(),
-            )
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Improved UI layout and formatting for time-related displays.

### What changed?

- Updated `DateTimeHelper` to capitalize the first letter in time difference strings.
- Refactored `SavedTripsScreen` layout:
  - Added status bar padding.
  - Moved `TitleBar` outside of `LazyColumn`.
- Restructured `TimeTableScreen`:
  - Added status bar padding.
  - Separated `TitleBar` from `LazyColumn`.
- Adjusted time formatting:
  - Changed "in 2 hrs" to "In 2 h".
  - Capitalized "In" for all time difference strings.

### Why make this change?

These changes improve the overall user interface consistency and readability. The layout adjustments ensure proper spacing and alignment with device status bars, while the time formatting changes enhance the clarity of time-related information presented to the user.