### PR TITLE
Network: Adjust OkHttp timeout settings

### DIFF
--- a/core/network/src/main/kotlin/xyz/ksharma/krail/network/di/NetworkModule.kt
+++ b/core/network/src/main/kotlin/xyz/ksharma/krail/network/di/NetworkModule.kt
@@ -33,9 +33,9 @@ object NetworkModule {
 
         // Add Timeouts
         okhttpBuilder
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(5, TimeUnit.MINUTES)
-            .writeTimeout(1, TimeUnit.MINUTES)
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
 
         return okhttpBuilder.build()
     }


### PR DESCRIPTION
### TL;DR

Adjusted OkHttp client timeouts for improved network performance.

### What changed?

- Reduced connect timeout from 30 seconds to 10 seconds
- Decreased read timeout from 5 minutes to 30 seconds
- Lowered write timeout from 1 minute to 30 seconds

### Why make this change?

The previous timeout values were unnecessarily long, potentially leading to poor user experience in case of network issues. By reducing these timeouts, we can:

1. Improve responsiveness of the application
2. Detect and handle network problems more quickly
3. Enhance overall user experience by failing fast in poor network conditions
4. Optimize resource usage by not keeping connections open for extended periods