### PR TITLE
UI: Add transportModeBackgroundColor function and adjust LegView background

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
@@ -1,6 +1,9 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 /**
  * Converts a hexadecimal color string to a Compose Color object.
@@ -33,4 +36,21 @@ private fun String.isValidHexColorCode(): Boolean {
     // Regular expression to match #RRGGBB or #RRGGBBAA hex color codes
     val hexColorRegex = Regex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})\$")
     return hexColorRegex.matches(this)
+}
+
+/**
+ * Will return a color based on the transport mode and the current theme (light / dark).
+ *
+ * @throws IllegalArgumentException if the provided string is not a valid
+ * hexadecimal color code.
+ *
+ * @return A Compose Color object representing the provided hex color code.
+ */
+@Composable
+internal fun transportModeBackgroundColor(transportMode: TransportMode): Color {
+    return if (isSystemInDarkTheme()) {
+        transportMode.colorCode.hexToComposeColor().copy(alpha = 0.45f)
+    } else {
+        transportMode.colorCode.hexToComposeColor().copy(alpha = 0.15f)
+    }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -67,9 +67,7 @@ fun LegView(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = transportModeLine.transportMode.colorCode
-                    .hexToComposeColor()
-                    .copy(alpha = 0.1f),
+                color = transportModeBackgroundColor(transportMode = transportModeLine.transportMode),
                 shape = RoundedCornerShape(12.dp),
             )
             .clickable(
@@ -282,7 +280,7 @@ private fun PreviewLegView() {
     }
 }
 
-@Preview
+@PreviewLightDark
 @Preview(fontScale = 2f)
 @Composable
 private fun PreviewLegViewTwoStops() {
@@ -291,8 +289,86 @@ private fun PreviewLegViewTwoStops() {
             duration = "1h 30m",
             routeText = "towards AVC via XYZ",
             transportModeLine = TransportModeLine(
-                transportMode = TransportMode.Bus(),
+                transportMode = TransportMode.Train(),
                 lineName = "700",
+            ),
+            stops = listOf(
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "12:00 am",
+                    name = "XYZ Station, Platform 1",
+                ),
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "01:00 am",
+                    name = "DEF Station, Platform 3",
+                ),
+            ).toImmutableList(),
+            modifier = Modifier.background(KrailTheme.colors.background),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewLegViewMetro() {
+    KrailTheme {
+        LegView(
+            duration = "1h 30m",
+            routeText = "towards AVC via XYZ",
+            transportModeLine = TransportModeLine(
+                transportMode = TransportMode.Metro(),
+                lineName = "M1",
+            ),
+            stops = listOf(
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "12:00 am",
+                    name = "XYZ Station, Platform 1",
+                ),
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "01:00 am",
+                    name = "DEF Station, Platform 3",
+                ),
+            ).toImmutableList(),
+            modifier = Modifier.background(KrailTheme.colors.background),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewLegViewFerry() {
+    KrailTheme {
+        LegView(
+            duration = "1h 30m",
+            routeText = "towards AVC via XYZ",
+            transportModeLine = TransportModeLine(
+                transportMode = TransportMode.Ferry(),
+                lineName = "F2",
+            ),
+            stops = listOf(
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "12:00 am",
+                    name = "XYZ Station, Platform 1",
+                ),
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "01:00 am",
+                    name = "DEF Station, Platform 3",
+                ),
+            ).toImmutableList(),
+            modifier = Modifier.background(KrailTheme.colors.background),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewLegViewLightRail() {
+    KrailTheme {
+        LegView(
+            duration = "1h 30m",
+            routeText = "towards AVC via XYZ",
+            transportModeLine = TransportModeLine(
+                transportMode = TransportMode.LightRail(),
+                lineName = "L1",
             ),
             stops = listOf(
                 TimeTableState.JourneyCardInfo.Stop(


### PR DESCRIPTION
### TL;DR

Added a new function for transport mode background color and updated LegView background color logic.

### What changed?

- Introduced a new `transportModeBackgroundColor` function in `ColorExt.kt` that returns a color based on the transport mode and current theme (light/dark).
- Updated the `LegView` component in `LegView.kt` to use the system's dark theme setting for determining background color opacity.
- Adjusted the background color opacity for both light and dark themes in `LegView`.

### Why make this change?

This change improves the visual consistency of the app across different system themes. By adjusting the background color opacity based on the theme, we enhance readability and user experience in both light and dark modes. The new `transportModeBackgroundColor` function also centralizes the logic for determining the appropriate background color, making it easier to maintain and update in the future.


### Screenshots

<img width="1242" alt="Screenshot 2024-10-30 at 7 12 17 pm" src="https://github.com/user-attachments/assets/84e8b4f0-f421-424c-a584-eafe7564c28f">

