### PR TITLE
UI: Remove SavedTripClicked event and refactor SavedTripsViewModel

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -4,6 +4,5 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 sealed interface SavedTripUiEvent {
     data object LoadSavedTrips : SavedTripUiEvent
-    data class SavedTripClicked(val trip: Trip) : SavedTripUiEvent
     data class DeleteSavedTrip(val trip: Trip) : SavedTripUiEvent
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -38,16 +38,18 @@ class SavedTripsViewModel @Inject constructor(
                     Trip.fromJsonString(tripJsonString)
                 }
             }.toImmutableList()
-            if (!trips.isEmpty()) {
-                updateUiState { copy(savedTrips = trips) }
+
+            trips.forEachIndexed { index, trip ->
+                Timber.d("\t SavedTrip: #$index ${trip.fromStopName} -> ${trip.toStopName}")
             }
+
+            updateUiState { copy(savedTrips = trips) }
         }
     }
 
     fun onEvent(event: SavedTripUiEvent) {
         when (event) {
             is SavedTripUiEvent.DeleteSavedTrip -> onDeleteSavedTrip(event.trip)
-            is SavedTripUiEvent.SavedTripClicked -> onSavedTripClicked(event.trip)
             SavedTripUiEvent.LoadSavedTrips -> loadSavedTrips()
         }
     }
@@ -58,10 +60,6 @@ class SavedTripsViewModel @Inject constructor(
             sandook.remove(key = savedTrip.tripId)
             loadSavedTrips()
         }
-    }
-
-    private fun onSavedTripClicked(savedTrip: Trip) {
-        Timber.d("onSavedTripClicked: $savedTrip")
     }
 
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {


### PR DESCRIPTION
### TL;DR

Removed SavedTripClicked event and related functionality, improved saved trips loading.

### What changed?

- Removed `SavedTripClicked` event from `SavedTripUiEvent` sealed interface
- Removed `onSavedTripClicked` function from `SavedTripsViewModel`
- Enhanced `loadSavedTrips` function to log each saved trip
- Updated `loadSavedTrips` to always update UI state, even if the trips list is empty

### Why make this change?

This change streamlines the saved trips functionality by removing unnecessary click handling. It also improves debugging capabilities by logging each saved trip during loading. The UI state update is now more consistent, ensuring that the view always reflects the current state of saved trips, even when the list is empty.


https://github.com/user-attachments/assets/98768ae5-c45b-4543-a25a-57aba546aaec

