### PR TITLE
UI: Add animations to JourneyCard and SavedTripsScreen

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -19,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -83,6 +86,11 @@ fun JourneyCard(
     // todo can be reusable logic for consistent icon size
     val iconSize = with(density) { 14.sp.toDp() }
 
+    val horizontalCardPadding by animateDpAsState(
+        if (cardState == JourneyCardState.DEFAULT) { 12.dp } else { 0.dp },
+        label = "cardPadding",
+    )
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -101,8 +109,9 @@ fun JourneyCard(
             )
             .padding(
                 vertical = 8.dp,
-                horizontal = if (cardState == JourneyCardState.DEFAULT) 12.dp else 0.dp,
-            ),
+                horizontal = horizontalCardPadding,
+            )
+            .animateContentSize(),
     ) {
         when (cardState) {
             JourneyCardState.DEFAULT -> DefaultJourneyCardContent(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -50,7 +51,9 @@ fun SavedTripsScreen(
                 Text(text = stringResource(R.string.saved_trips_screen_title))
             })
 
-            LazyColumn(contentPadding = PaddingValues(bottom = 300.dp)) {
+            LazyColumn(
+                contentPadding = PaddingValues(bottom = 300.dp),
+            ) {
                 item {
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -59,6 +62,7 @@ fun SavedTripsScreen(
                     items = savedTripsState.savedTrips,
                     key = { it.fromStopId + it.toStopId },
                 ) { trip ->
+
                     SavedTripCard(
                         trip = trip,
                         onStarClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
@@ -74,8 +78,11 @@ fun SavedTripsScreen(
                                 ),
                             )
                         },
-                        modifier = Modifier.padding(horizontal = 16.dp),
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp)
+                            .animateItem(fadeOutSpec = tween(durationMillis = 500)),
                     )
+
                     Spacer(modifier = Modifier.height(12.dp))
                 }
             }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -88,8 +87,7 @@ fun TimeTableScreen(
                             onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
                         },
                         modifier = Modifier
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .animateContentSize(),
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                     )
                 }
             } else {


### PR DESCRIPTION
### TL;DR

Added animations to journey cards and saved trip cards for a smoother user experience.

### What changed?

- Implemented `animateContentSize()` and `animateDpAsState()` for the `JourneyCard` component to smoothly transition between default and expanded states.
- Added an animation to the `SavedTripCard` in the `SavedTripsScreen` using `animateItem()` with a fade-out effect.
- Removed the `animateContentSize()` from the `JourneyCard` in the `TimeTableScreen`.

### Why make this change?

These animations enhance the overall user experience by providing visual feedback and creating a more polished look and feel for the app. The smooth transitions make the interface more engaging and intuitive for users when interacting with journey and saved trip cards.