### PR TITLE
Add TripInfo to TimeTableScreen

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -8,6 +8,7 @@ data class TimeTableState(
     val isLoading: Boolean = false,
     val isTripSaved: Boolean = false,
     val journeyList: ImmutableList<JourneyCardInfo> = persistentListOf(),
+    val trip: Trip? = null,
 ) {
     data class JourneyCardInfo(
         val timeText: String, // "in x mins"

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -1,9 +1,12 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,7 +17,9 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
@@ -45,6 +50,37 @@ fun TimeTableScreen(
         TitleBar(title = {
             Text(text = stringResource(R.string.time_table_screen_title))
         })
+
+        timeTableState.trip?.let { trip ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_location),
+                    contentDescription = null,
+                    modifier = Modifier,
+                )
+                Text(text = trip.fromStopName, style = KrailTheme.typography.titleMedium)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_location),
+                    contentDescription = null,
+                )
+                Text(text = trip.toStopName, style = KrailTheme.typography.titleMedium)
+            }
+        }
 
         LazyColumn(contentPadding = PaddingValues(vertical = 16.dp)) {
             if (timeTableState.isLoading) {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -87,7 +87,7 @@ class TimeTableViewModel @Inject constructor(
     private fun onLoadTimeTable(tripInfo: Trip) = with(tripInfo) {
         Timber.d("loadTimeTable API Call- fromStopItem: $fromStopId, toStopItem: $toStopId")
         this@TimeTableViewModel.tripInfo = this
-        updateUiState { copy(isLoading = true) }
+        updateUiState { copy(isLoading = true, trip = tripInfo) }
 
         viewModelScope.launch {
             require(!(fromStopId.isEmpty() || toStopId.isEmpty())) { "Invalid Stop Ids" }


### PR DESCRIPTION
### TL;DR
Added origin and destination station names to the TimeTable screen header

### What changed?
- Added a `trip` property to `TimeTableState` to store trip information
- Added two rows in the TimeTable screen header displaying the origin and destination station names
- Each row includes a location icon and the station name in title medium style
- Updated the `onLoadTimeTable` function to populate the trip information in the state

### Why make this change?
To improve user experience by clearly displaying the selected journey's origin and destination stations in the TimeTable screen header, providing better context for the displayed timetable information.