### PR TITLE
UI: Update theme colors and add trip details to TimeTableScreen

### DIFF
--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/RoundIconButton.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/RoundIconButton.kt
@@ -41,8 +41,8 @@ fun RoundIconButton(
     content: @Composable () -> Unit = {},
 ) {
     CompositionLocalProvider(
-        LocalContentColor provides KrailTheme.colors.secondaryContainer,
-        LocalOnContentColor provides KrailTheme.colors.onSecondaryContainer,
+        LocalContentColor provides KrailTheme.colors.surface,
+        LocalOnContentColor provides KrailTheme.colors.onSurface,
     ) {
         Box(
             modifier = modifier

--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TextFieldButton.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TextFieldButton.kt
@@ -41,7 +41,7 @@ fun TextFieldButton(
     val contentAlpha = if (enabled) 1f else TextFieldTokens.DisabledLabelOpacity
 
     CompositionLocalProvider(
-        LocalTextColor provides KrailTheme.colors.onSecondaryContainer,
+        LocalTextColor provides KrailTheme.colors.onSurface,
         LocalTextStyle provides KrailTheme.typography.bodyLarge,
         LocalContentAlpha provides contentAlpha,
     ) {
@@ -50,7 +50,7 @@ fun TextFieldButton(
                 .fillMaxWidth()
                 .height(TextFieldHeight)
                 .clip(RoundedCornerShape(TextFieldHeight.div(2)))
-                .background(color = KrailTheme.colors.secondaryContainer)
+                .background(color = KrailTheme.colors.surface)
                 .clickable(role = Role.Button, onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 4.dp),
             contentAlignment = Alignment.CenterStart,

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -37,15 +37,15 @@ fun SavedTripCard(
     onStarClick: () -> Unit,
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
-    primaryTransportMode: TransportMode? = null,
+    primaryTransportMode: TransportMode? = TransportMode.Train(), // TODO - theme color
 ) {
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(
-                color = primaryTransportMode?.colorCode
-                    ?.hexToComposeColor()
-                    ?.copy(alpha = 0.15f) ?: KrailTheme.colors.secondaryContainer,
+                color = primaryTransportMode?.let {
+                    transportModeBackgroundColor(primaryTransportMode)
+                } ?: KrailTheme.colors.surfaceVariant,
                 // TODO -  needs to be common logic for background color
             )
             .clickable(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
@@ -24,11 +25,13 @@ import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TextFieldButton
 import xyz.ksharma.krail.design.system.preview.PreviewComponent
 import xyz.ksharma.krail.design.system.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.trip.planner.ui.R as TripPlannerUiR
 
 @Composable
 fun SearchStopRow(
+    themeColor: Color,
     fromButtonClick: () -> Unit,
     toButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -41,7 +44,7 @@ fun SearchStopRow(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = KrailTheme.colors.onSecondaryContainer,
+                color = themeColor,
                 shape = RoundedCornerShape(topStart = 36.dp, topEnd = 36.dp),
             )
             .padding(vertical = 24.dp, horizontal = 16.dp)
@@ -112,7 +115,11 @@ fun SearchStopRow(
 @Composable
 private fun SearchStopColumnPreview() {
     KrailTheme {
-        SearchStopRow(fromButtonClick = {}, toButtonClick = {})
+        SearchStopRow(
+            fromButtonClick = {},
+            toButtonClick = {},
+            themeColor = TransportMode.Train().colorCode.hexToComposeColor(),
+        )
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -24,6 +24,8 @@ import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.R
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
+import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -96,6 +98,7 @@ fun SavedTripsScreen(
             toButtonClick = toButtonClick,
             onReverseButtonClick = onReverseButtonClick,
             onSearchButtonClick = { onSearchButtonClick(null, null) },
+            themeColor = TransportMode.Train().colorCode.hexToComposeColor(), // TODO - theme color
         )
     }
 }

--- a/feature/trip-planner/ui/src/main/res/values/strings.xml
+++ b/feature/trip-planner/ui/src/main/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="saved_trips_screen_title">Saved Trips</string>
-    <string name="from_text_field_placeholder">Starting from..</string>
-    <string name="to_text_field_placeholder">Going to..</string>
+    <string name="from_text_field_placeholder">From Station</string>
+    <string name="to_text_field_placeholder">To Station</string>
     <string name="time_table_screen_title">Time Table</string>
     <plurals name="stops">
         <item quantity="one">%d stop</item>


### PR DESCRIPTION
### TL;DR
Updated UI components to use surface colors and improved the time table screen with trip details.

### What changed?
- Changed RoundIconButton and TextFieldButton to use surface colors instead of secondary container colors
- Added trip details (from/to stations) to the TimeTableScreen with location icons
- Updated SavedTripCard background colors to use transport mode theming
- Modified placeholder text in text fields to be more descriptive
- Added trip information to TimeTableState


### Why make this change?
To improve visual consistency across the app by standardizing the use of surface colors and to enhance the user experience by displaying more detailed trip information in the time table view. The changes also better align with Material Design guidelines for surface treatments and provide clearer input field labels for users.