### PR TITLE
UI: Improve navigation bar handling and simplify TimeTableScreen layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:name=".KrailApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -15,6 +17,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -91,7 +94,15 @@ fun SavedTripsScreen(
         }
 
         SearchStopRow(
-            modifier = Modifier.align(Alignment.BottomCenter),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(
+                    bottom = with(LocalDensity.current) {
+                        WindowInsets.navigationBars
+                            .getBottom(this)
+                            .toDp()
+                    },
+                ),
             fromStopItem = fromStopItem,
             toStopItem = toStopItem,
             fromButtonClick = fromButtonClick,

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -1,26 +1,21 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -44,41 +39,24 @@ fun TimeTableScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KrailTheme.colors.background)
-            .statusBarsPadding(),
+            .background(color = KrailTheme.colors.background),
     ) {
         TitleBar(title = {
             Text(text = stringResource(R.string.time_table_screen_title))
         })
 
         timeTableState.trip?.let { trip ->
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_location),
-                    contentDescription = null,
-                    modifier = Modifier,
+
+            Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Text(
+                    text = trip.fromStopName,
+                    style = KrailTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
                 )
-                Text(text = trip.fromStopName, style = KrailTheme.typography.titleMedium)
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_location),
-                    contentDescription = null,
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = trip.toStopName,
+                    style = KrailTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
                 )
-                Text(text = trip.toStopName, style = KrailTheme.typography.titleMedium)
             }
         }
 


### PR DESCRIPTION
### TL;DR
Added predictive back gesture support and improved UI layout in saved trips and timetable screens

### What changed?
- Enabled predictive back gesture support in AndroidManifest
- Added navigation bar padding to SearchStopRow in SavedTripsScreen
- Simplified TimeTableScreen UI by:
  - Removing location icons
  - Converting Row layouts to Column layouts
  - Adjusting text styling with normal font weight
  - Removing redundant status bar padding

### Why make this change?
To improve gesture navigation support and streamline the UI design for better usability and visual consistency across screens