### PR TITLE
UI: Redesign TimeTableScreen header and journey route display

### DIFF
--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/Text.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/Text.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
@@ -27,6 +28,7 @@ fun Text(
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = if (maxLines == Int.MAX_VALUE) TextOverflow.Clip else TextOverflow.Ellipsis,
     fontFamily: FontFamily? = null,
+    onTextLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
     val contentAlpha = LocalContentAlpha.current
     CompositionLocalProvider(
@@ -43,6 +45,7 @@ fun Text(
             maxLines = maxLines,
             overflow = overflow,
             modifier = modifier,
+            onTextLayout = onTextLayout,
         )
     }
 }

--- a/core/design-system/src/main/res/drawable/star_outline.xml
+++ b/core/design-system/src/main/res/drawable/star_outline.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="24">
     <path
         android:strokeColor="#FFFFFFFF"
-        android:strokeWidth="1"
+        android:strokeWidth="2"
         android:pathData="M12,17.77L18.18,21.5L16.54,14.47L22,9.74L14.81,9.13L12,2.5L9.19,9.13L2,9.74L7.46,14.47L5.82,21.5L12,17.77Z" />
 </vector>

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -1,11 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -14,34 +13,35 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.delay
-import xyz.ksharma.krail.design.system.LocalOnContentColor
-import xyz.ksharma.krail.design.system.components.RoundIconButton
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.R
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
+import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
+import xyz.ksharma.krail.trip.planner.ui.components.timeLineBottom
+import xyz.ksharma.krail.trip.planner.ui.components.timeLineTop
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
@@ -54,40 +54,62 @@ fun TimeTableScreen(
     expandedJourneyId: String?,
     onEvent: (TimeTableUiEvent) -> Unit,
     modifier: Modifier = Modifier,
+    themeColor: Color = TransportMode.Train().colorCode.hexToComposeColor(), // TODO - theming
 ) {
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(color = KrailTheme.colors.surface),
     ) {
-        TitleBar(
-            title = {
-                Text(text = stringResource(R.string.time_table_screen_title))
-            },
-            actions = {
-                RoundIconButton(
-                    onClick = { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
-                ) {
-                    Image(
-                        imageVector = ImageVector.vectorResource(
-                            if (timeTableState.isTripSaved) {
-                                DesignSystemR.drawable.star_filled
-                            } else {
-                                DesignSystemR.drawable.star_outline
-                            },
-                        ),
-                        contentDescription = null,
-                        colorFilter = ColorFilter.tint(LocalOnContentColor.current),
-                    )
-                }
-            },
-        )
-
-        timeTableState.trip?.let { trip ->
-            JourneyRoute(trip)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(color = themeColor),
+        ) {
+            TitleBar(
+                title = {
+                    Text(text = stringResource(R.string.time_table_screen_title))
+                },
+                actions = {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .clickable { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Image(
+                            imageVector = ImageVector.vectorResource(
+                                if (timeTableState.isTripSaved) {
+                                    DesignSystemR.drawable.star_filled
+                                } else {
+                                    DesignSystemR.drawable.star_outline
+                                },
+                            ),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                },
+            )
         }
 
-        LazyColumn(contentPadding = PaddingValues(vertical = 16.dp)) {
+        LazyColumn(contentPadding = PaddingValues(bottom = 16.dp)) {
+            item {
+                timeTableState.trip?.let { trip ->
+                    OriginDestination(
+                        trip,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(
+                                shape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp),
+                            )
+                            .background(color = themeColor),
+                    )
+                }
+            }
+
             if (timeTableState.isLoading) {
                 item {
                     Text("Loading...", modifier = Modifier.padding(horizontal = 16.dp))
@@ -137,57 +159,48 @@ fun TimeTableScreen(
 }
 
 @Composable
-private fun JourneyRoute(trip: Trip) {
-    val (showFirstText, setShowFirstText) = remember { mutableStateOf(false) }
-    val (showSecondText, setShowSecondText) = remember { mutableStateOf(false) }
-    val textStyle = KrailTheme.typography.titleMedium
-
-    LaunchedEffect(Unit) {
-        setShowFirstText(true)
-        delay(500) // Delay for half a second before showing the second text
-        setShowSecondText(true)
-    }
-
+private fun OriginDestination(
+    trip: Trip,
+    modifier: Modifier = Modifier,
+) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
-            .padding(bottom = 20.dp)
-            .clip(RoundedCornerShape(8.dp)),
+            .padding(bottom = 12.dp),
     ) {
-        val density = LocalDensity.current
-
-        Row(Modifier.height(with(density) { textStyle.fontSize.toDp() })) {
-            AnimatedVisibility(
-                visible = showFirstText,
-                enter = fadeIn(animationSpec = tween(500)) + slideInVertically(
-                    animationSpec = tween(
-                        600,
-                    ),
-                ) { it },
-            ) {
-                Text(
-                    text = trip.fromStopName,
-                    style = textStyle.copy(fontWeight = FontWeight.Normal),
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .timeLineTop(
+                    color = KrailTheme.colors.onSurface,
+                    strokeWidth = 2.dp,
+                    circleRadius = 4.dp,
                 )
-            }
+                .padding(start = 12.dp, bottom = 4.dp),
+        ) {
+            Text(
+                text = trip.fromStopName,
+                style = KrailTheme.typography.bodyLarge,
+            )
         }
-        Spacer(modifier = Modifier.height(8.dp))
 
-        Row(Modifier.height(with(density) { textStyle.fontSize.toDp() })) {
-            AnimatedVisibility(
-                visible = showSecondText,
-                enter = fadeIn(animationSpec = tween(500)) + slideInVertically(
-                    animationSpec = tween(
-                        600,
-                    ),
-                ) { it },
-            ) {
-                Text(
-                    text = trip.toStopName,
-                    style = textStyle.copy(fontWeight = FontWeight.Normal),
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .timeLineBottom(
+                    color = KrailTheme.colors.onSurface,
+                    strokeWidth = 2.dp,
+                    circleRadius = 4.dp,
                 )
-            }
+                .padding(start = 12.dp, top = 4.dp),
+        ) {
+            Text(
+                text = trip.toStopName,
+                style = KrailTheme.typography.bodyLarge,
+            )
         }
     }
 }
@@ -219,6 +232,22 @@ fun JourneyCardItem(
             legList = legList,
             onClick = onClick,
             modifier = modifier,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewOriginDestination() {
+    KrailTheme {
+        OriginDestination(
+            modifier = Modifier.background(color = KrailTheme.colors.background),
+            trip = Trip(
+                fromStopName = "From Stop a really long stop name here, test multiline",
+                toStopName = "To Stop",
+                fromStopId = "123",
+                toStopId = "456",
+            ),
         )
     }
 }


### PR DESCRIPTION
### TL;DR
Redesigned the time table screen header with improved styling and animations.
Making trip info at top scrollable because for large font size it will take lot of space. Could make it adaptive so only scrolls when large font size, but too complicated UX for MVP, when things are changing so often

### What changed?
- Added text layout callback support to the Text component
- Increased stroke width of star outline icon from 1 to 2
- Replaced animated journey route with a new origin-destination component
- Updated title bar styling with a themed background color
- Implemented a new timeline-based design for origin and destination display
- Added preview functionality for the origin-destination component
- Modified the save button to use a circle background with improved touch target

### Why make this change?
The new design improves visual hierarchy and user experience by:
- Making the origin-destination more visually distinct
- Providing better touch targets for interactive elements
- Creating a more cohesive and polished appearance with themed colors
- Improving readability with timeline-based station display

### Screenshots

https://github.com/user-attachments/assets/94746776-230d-44a2-a0cb-d86214ea9c86

