### PR TITLE
UI: Update TextField colors and SearchStopScreen styling

### DIFF
--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TextField.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TextField.kt
@@ -61,8 +61,8 @@ fun TextField(
 
     val textFieldState = rememberTextFieldState(initialText.orEmpty())
     val textSelectionColors = TextSelectionColors(
-        handleColor = KrailTheme.colors.tertiary,
-        backgroundColor = KrailTheme.colors.tertiary.copy(alpha = TextSelectionBackgroundOpacity),
+        handleColor = KrailTheme.colors.onSurface,
+        backgroundColor = KrailTheme.colors.onSurface.copy(alpha = TextSelectionBackgroundOpacity),
     )
 
     LaunchedEffect(textFieldState.text) {
@@ -70,7 +70,7 @@ fun TextField(
     }
 
     CompositionLocalProvider(
-        LocalTextColor provides KrailTheme.colors.onSecondaryContainer,
+        LocalTextColor provides KrailTheme.colors.onSurface,
         LocalTextStyle provides KrailTheme.typography.titleLarge,
         LocalTextSelectionColors provides textSelectionColors,
         LocalContentAlpha provides contentAlpha,
@@ -96,13 +96,13 @@ fun TextField(
             lineLimits = TextFieldLineLimits.SingleLine,
             readOnly = readOnly,
             interactionSource = interactionSource,
-            cursorBrush = SolidColor(KrailTheme.colors.onSecondaryContainer),
+            cursorBrush = SolidColor(KrailTheme.colors.onSurface),
             decorator = { innerTextField ->
                 Row(
                     modifier = Modifier
                         .background(
                             shape = RoundedCornerShape(TextFieldHeight.div(2)),
-                            color = KrailTheme.colors.secondaryContainer,
+                            color = KrailTheme.colors.surface,
                         )
                         .padding(horizontal = 16.dp, vertical = 4.dp),
                     horizontalArrangement = Arrangement.Start,

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -19,6 +20,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -34,6 +37,8 @@ import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TextField
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.StopSearchListItem
+import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -45,6 +50,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 fun SearchStopScreen(
     searchStopState: SearchStopState,
     modifier: Modifier = Modifier,
+    themeColor: Color = TransportMode.Train().colorCode.hexToComposeColor(), // TODO theming
     onStopSelect: (StopItem) -> Unit = {},
     onEvent: (SearchStopUiEvent) -> Unit = {},
 ) {
@@ -74,13 +80,19 @@ fun SearchStopScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KrailTheme.colors.surface)
-            .statusBarsPadding()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(themeColor, KrailTheme.colors.surface),
+                ),
+            )
             .imePadding(),
     ) {
         TextField(
             placeholder = "Search station / stop",
             modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(vertical = 12.dp)
                 .focusRequester(focusRequester)
                 .padding(horizontal = 16.dp),
         ) { value ->


### PR DESCRIPTION
### TL;DR
Updated text field styling and search stop screen UI to improve visual consistency and user experience.

### What changed?
- Modified text field colors to use `onSurface` instead of `tertiary` and `onSecondaryContainer`
- Updated search stop screen background to use a vertical gradient with theme color
- Added status bar padding and vertical spacing to the search field
- Made search field expand to full width with proper padding

### Why make this change?
The updates create a more cohesive visual experience by:
- Using consistent color tokens that better align with Material Design principles
- Adding visual hierarchy through the gradient background
- Improving the layout and spacing of the search field for better usability
- Ensuring proper contrast for text selection and cursor visibility

### Screenshots

https://github.com/user-attachments/assets/90ae667a-0c1f-42e9-8427-6e87dd03d595


