### PR TITLE
Integrate Firebase Crashlytics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
 
     // Test
     androidTestImplementation(libs.test.androidxTestExtJunit)

--- a/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/ApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/ApplicationConventionPlugin.kt
@@ -27,6 +27,7 @@ class ApplicationConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
                 apply("org.jetbrains.kotlin.plugin.compose")
                 apply("com.google.gms.google-services")
+                apply("com.google.firebase.crashlytics")
             }
             extensions.configure<ApplicationExtension> {
                 compileSdk = compileSdkVersion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlyticsPlugin) apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ compose-material3 = { group = "androidx.compose.material3", name = "material3", 
 #Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 
 #Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
@@ -108,6 +109,7 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 wire = { id = "com.squareup.wire", version.ref = "wire" }
 cash-sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.2" }
+firebase-crashlyticsPlugin = { id = "com.google.firebase.crashlytics", version = "3.0.2" }
 
 #Convention Plugins
 krail-android-application = { id = "krail.android.application", version = "unspecified" }


### PR DESCRIPTION
### TL;DR
Added Firebase Crashlytics integration to the Android application.

### What changed?
- Added Firebase Crashlytics dependency to the app module
- Configured Crashlytics Gradle plugin in build configuration
- Added necessary plugin declarations in build files
- Updated version catalog with Crashlytics dependencies and plugin versions

### How to test?
1. Build and run the application
2. Force a crash in the app
3. Verify crash reports appear in Firebase Console under Crashlytics section
4. Confirm crash data includes proper stack traces and device information

### Why make this change?
Adding Crashlytics enables better crash reporting and monitoring capabilities, helping identify and fix issues in production. This will improve app stability by providing detailed crash reports, stack traces, and user impact metrics through the Firebase Console.