### PR TITLE
Add Debug Firebase App Distribution workflow

### DIFF
--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -1,0 +1,54 @@
+name: Firebase App Distribution
+
+on:
+  pull_request:
+    branches:
+      - debug-alpha
+
+jobs:
+  distribute:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Setup environment variables
+        env:
+          NSW_TRANSPORT_API_KEY: ${{ secrets.NSW_TRANSPORT_API_KEY }}
+          run: |
+            echo "::set-env name=NSW_TRANSPORT_API_KEY::${{ secrets.NSW_TRANSPORT_API_KEY }}"
+
+      - name: set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Firebase (Debug) - Google Services.json file
+        env:
+          DATA: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON_DEBUG }}
+        run: echo $DATA | base64 -di > app/src/debug/google-services.json
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Build APK
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Upload to Firebase App Distribution
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_KEY }}
+        run: |
+          firebase appdistribution:distribute app/build/outputs/apk/debug/app-debug.apk \
+            --app ${{ secrets.FIREBASE_APP_ID_DEBUG }} \
+            --groups "Friends" \
+            --release-notes "Automated release"


### PR DESCRIPTION
### TL;DR
Added Firebase App Distribution workflow for automated app deployment

### What changed?
- Created new GitHub Actions workflow for Firebase App Distribution
- Configured workflow to trigger on pull requests to debug-alpha branch
- Set up environment with JDK 21 and necessary API keys
- Implemented Gradle caching for faster builds
- Added Firebase configuration for debug builds
- Configured automated APK distribution to "Friends" testing group


### Why make this change?
To streamline the app testing process by automatically distributing debug builds to testers whenever changes are made to the debug-alpha branch, reducing manual deployment steps and ensuring consistent testing procedures.