### PR TITLE
UI: Update journey duration display format

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -60,7 +60,7 @@ data class TimeTableState(
                 val displayText: String, // "towards X via X"
 
                 // leg.stopSequence.size  (leg.duration seconds)
-                val totalDuration: String, // "4 stops (12 min)"
+                val totalDuration: String, // 12 min"
 
                 val stops: ImmutableList<Stop>,
 


### PR DESCRIPTION
### TL;DR
Updated duration formatting in the trip planner to display cleaner time strings

### What changed?
- Removed stop count from total duration string, now only shows time (e.g., "12 min" instead of "4 stops (12 min)")
- Improved duration handling for walking legs and transport legs
- Added null safety checks for duration fields
- Replaced manual duration string formatting with a dedicated formatter method

### How to test?
1. Open the trip planner
2. Search for a journey with multiple legs (including walking segments)
3. Verify duration displays show only time values
4. Confirm walking segments and interchanges show correct duration formats
5. Verify all transport legs display proper duration strings

### Why make this change?
The previous duration format included redundant information about stops, making the UI more cluttered. This change simplifies the duration display to focus on the time information, making it clearer and more consistent across different journey types.