### PR TITLE
UI: Add reverse trip functionality to TimeTableScreen

### DIFF
--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TitleBar.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TitleBar.kt
@@ -3,18 +3,22 @@ package xyz.ksharma.krail.design.system.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.design.system.LocalContentColor
 import xyz.ksharma.krail.design.system.LocalTextColor
@@ -33,8 +37,8 @@ fun TitleBar(
         modifier = modifier
             .statusBarsPadding()
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .heightIn(min = 56.dp),
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -47,7 +51,10 @@ fun TitleBar(
             }
         }
         actions?.let {
-            Row(modifier = Modifier.padding(start = 16.dp)) {
+            Row(
+                modifier = Modifier.padding(start = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 CompositionLocalProvider(
                     LocalContentColor provides KrailTheme.colors.onBackground,
                 ) {
@@ -75,6 +82,47 @@ private fun TitleBarPreview() {
                     modifier = Modifier.size(24.dp),
                     colorFilter = ColorFilter.tint(LocalContentColor.current),
                 )
+            },
+            modifier = Modifier.background(color = KrailTheme.colors.background),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TitleBarPreviewMultipleActions() {
+    KrailTheme {
+        TitleBar(
+            title = {
+                Text(text = "Saved Trips Screen Title")
+            },
+            actions = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.star_outline),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        colorFilter = ColorFilter.tint(LocalContentColor.current),
+                    )
+                }
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.star_outline),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp),
+                        colorFilter = ColorFilter.tint(LocalContentColor.current),
+                    )
+                }
             },
             modifier = Modifier.background(color = KrailTheme.colors.background),
         )

--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -4,4 +4,5 @@ sealed interface TimeTableUiEvent {
     data object SaveTripButtonClicked : TimeTableUiEvent
     data class LoadTimeTable(val trip: Trip) : TimeTableUiEvent
     data class JourneyCardClicked(val journeyId: String) : TimeTableUiEvent
+    data object ReverseTripButtonClicked : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,6 +29,9 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -74,12 +79,26 @@ fun TimeTableScreen(
                     Text(text = stringResource(R.string.time_table_screen_title))
                 },
                 actions = {
-                    Box(
-                        modifier = Modifier
-                            .size(40.dp)
-                            .clip(CircleShape)
-                            .clickable { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
-                        contentAlignment = Alignment.Center,
+                    ActionButton(
+                        onClick = {
+                            onEvent(TimeTableUiEvent.ReverseTripButtonClicked)
+                        },
+                        contentDescription = "Reverse Trip Search",
+                    ) {
+                        Image(
+                            imageVector = ImageVector.vectorResource(R.drawable.ic_reverse),
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                    ActionButton(
+                        onClick = { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
+                        contentDescription = if (timeTableState.isTripSaved) {
+                            "Remove Saved Trip"
+                        } else {
+                            "Save Trip"
+                        },
                     ) {
                         Image(
                             imageVector = ImageVector.vectorResource(
@@ -305,5 +324,26 @@ private fun PreviewTimeTableScreen() {
             expandedJourneyId = null,
             onEvent = {},
         )
+    }
+}
+
+@Composable
+fun ActionButton(
+    onClick: () -> Unit,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .clickable(role = Role.Button) { onClick() }
+            .semantics(mergeDescendants = true) {
+                this.contentDescription = contentDescription
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -68,7 +68,23 @@ class TimeTableViewModel @Inject constructor(
             is TimeTableUiEvent.LoadTimeTable -> onLoadTimeTable(event.trip)
             is TimeTableUiEvent.JourneyCardClicked -> onJourneyCardClicked(event.journeyId)
             TimeTableUiEvent.SaveTripButtonClicked -> onSaveTripButtonClicked()
+            TimeTableUiEvent.ReverseTripButtonClicked -> onReverseTripButtonClicked()
         }
+    }
+
+    private fun onReverseTripButtonClicked() {
+        Timber.d("Reverse Trip Button Clicked")
+        require(tripInfo != null) { "Trip Info is null" }
+        tripInfo?.let { trip ->
+            val reveredTrip = Trip(
+                fromStopId = trip.toStopId,
+                fromStopName = trip.toStopName,
+                toStopId = trip.fromStopId,
+                toStopName = trip.fromStopName,
+            )
+            updateUiState { copy(trip = reveredTrip) }
+            onLoadTimeTable(reveredTrip)
+        } ?: run { Timber.e("Trip Info is null") }
     }
 
     private fun onSaveTripButtonClicked() {


### PR DESCRIPTION
### TL;DR
Added a reverse trip button to the TimeTable screen and improved the TitleBar component's action buttons layout.

### What changed?
- Added a new reverse trip button in the TimeTable screen's title bar
- Created a reusable `ActionButton` component with proper accessibility support
- Enhanced TitleBar to support multiple action buttons with proper spacing
- Added handling for reverse trip functionality in the ViewModel
- Improved action buttons' visual appearance with proper padding and spacing
- Added semantic descriptions for better accessibility

### Why make this change?
To improve user experience by allowing quick reversal of trip searches without manually re-entering station information. This is a common use case for commuters who want to check return journey times. The changes also improve accessibility and touch interaction for action buttons.