### PR TITLE
UI: Add UsualRideScreen with transport mode selection

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
@@ -90,5 +90,18 @@ sealed class TransportMode {
         fun toTransportModeType(productClass: Int): TransportMode? = productClassMap[productClass]
 
         fun values(): Set<TransportMode> = productClassMap.values.toSet()
+
+        fun sortedValues(sortOrder: TransportModeSortOrder = TransportModeSortOrder.NAME): List<TransportMode> =
+            when (sortOrder) {
+                TransportModeSortOrder.NAME -> values().sortedBy { it.name }
+                TransportModeSortOrder.PRIORITY -> values().sortedBy { it.priority }
+                TransportModeSortOrder.PRODUCT_CLASS -> values().sortedBy { it.productClass }
+            }
     }
+}
+
+enum class TransportModeSortOrder {
+    NAME,
+    PRIORITY,
+    PRODUCT_CLASS,
 }

--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/UsualRideEvent.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/UsualRideEvent.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.trip.planner.ui.state.usualride
+
+sealed interface UsualRideEvent {
+    data class TransportModeSelected(val productClass: Int) : UsualRideEvent
+}

--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/UsualRideState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/UsualRideState.kt
@@ -1,0 +1,3 @@
+package xyz.ksharma.krail.trip.planner.ui.state.usualride
+
+data class UsualRideState(val x: Int = 0)

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -51,9 +51,7 @@ fun SearchStopRow(
             .padding(
                 bottom = with(LocalDensity.current) {
                     WindowInsets.navigationBars
-                        .getBottom(
-                            this,
-                        )
+                        .getBottom(this)
                         .toDp()
                 },
             ),

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import xyz.ksharma.krail.design.system.components.Text
@@ -25,14 +26,16 @@ fun TransportModeIcon(
     backgroundColor: Color,
     modifier: Modifier = Modifier,
     borderEnabled: Boolean = false,
+    iconSize: TextUnit = 18.sp,
+    fontSize: TextUnit? = null,
 ) {
     val density = LocalDensity.current
-    val size = with(density) { 18.sp.toDp() }
+    val textStyle = KrailTheme.typography.labelLarge.copy(fontWeight = FontWeight.Medium)
 
     Box(
         modifier = modifier
             .clip(shape = CircleShape)
-            .requiredSize(size)
+            .requiredSize(with(density) { iconSize.toDp() })
             .aspectRatio(1f)
             .background(color = backgroundColor)
             .borderIfEnabled(enabled = borderEnabled),
@@ -42,7 +45,10 @@ fun TransportModeIcon(
             text = "$letter",
             color = Color.White,
             // todo - need concrete token for style, meanwhile keep same as TransportModeBadge,
-            style = KrailTheme.typography.labelMedium.copy(fontWeight = FontWeight.Medium),
+            style = textStyle.copy(
+                fontWeight = FontWeight.Medium,
+                fontSize = fontSize ?: textStyle.fontSize,
+            ),
         )
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -13,7 +13,6 @@ object LoadingEmojiManager {
         "🛶",
         "\uD83C\uDFC2", // Snowboarder
         "☃\uFE0F", // Lollipop
-        "\uD83C\uDF7A", // Beer
         "\uD83C\uDF7A", // Shopping Cart
         "\uD83E\uDD21", // Clown
         "\uD83E\uDD21", // Dolphin

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.savedTripsDestination
 import xyz.ksharma.krail.trip.planner.ui.searchstop.searchStopDestination
 import xyz.ksharma.krail.trip.planner.ui.timetable.timeTableDestination
+import xyz.ksharma.krail.trip.planner.ui.usualride.usualRideDestination
 
 /**
  * Nested navigation graph for the trip planner feature.
@@ -22,6 +23,8 @@ fun NavGraphBuilder.tripPlannerDestinations(
         searchStopDestination(navController)
 
         timeTableDestination()
+
+        usualRideDestination()
     }
 }
 
@@ -46,3 +49,6 @@ internal data class TimeTableRoute(
 
 @Serializable
 internal data class SearchStopRoute(val fieldType: SearchStopFieldType)
+
+@Serializable
+data object UsualRideRoute

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
@@ -1,0 +1,24 @@
+package xyz.ksharma.krail.trip.planner.ui.usualride
+
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import kotlinx.collections.immutable.toImmutableSet
+import xyz.ksharma.krail.trip.planner.ui.navigation.UsualRideRoute
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
+import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideEvent
+
+internal fun NavGraphBuilder.usualRideDestination() {
+    composable<UsualRideRoute> {
+        val viewModel = hiltViewModel<UsualRideViewModel>()
+
+        UsualRideScreen(
+            transportModes = TransportMode.sortedValues(TransportModeSortOrder.PRODUCT_CLASS)
+                .toImmutableSet(),
+            transportModeSelected = { productClass ->
+                viewModel.onEvent(UsualRideEvent.TransportModeSelected(productClass))
+            },
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
@@ -1,0 +1,181 @@
+package xyz.ksharma.krail.trip.planner.ui.usualride
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
+import xyz.ksharma.krail.design.system.components.Text
+import xyz.ksharma.krail.design.system.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.TransportModeIcon
+import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
+import xyz.ksharma.krail.trip.planner.ui.components.transportModeBackgroundColor
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
+
+private val TransportMode.tagLine: String
+    get() {
+        // TODO - read from remote config
+        return when (this) {
+            is TransportMode.Bus -> "Hoppin' the concrete jungle!"
+            is TransportMode.Coach -> "Coachin' it!"
+            is TransportMode.Ferry -> "Just floatin!"
+            is TransportMode.LightRail -> "Mah city, mah rules!"
+            is TransportMode.Metro -> "Surf the sub, no cap!"
+            is TransportMode.Train -> "On the track, no lookin' back!"
+        }
+    }
+
+@Composable
+fun UsualRideScreen(
+    transportModes: ImmutableSet<TransportMode>,
+    transportModeSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = KrailTheme.colors.surface)
+            .statusBarsPadding(),
+    ) {
+        var selectedProductClass: Int? by rememberSaveable { mutableStateOf(null) }
+
+        LazyColumn(contentPadding = PaddingValues(top = 24.dp, bottom = 102.dp)) {
+            item {
+                Text(
+                    text = "What's your usual ride mate?",
+                    style = KrailTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Normal),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                )
+            }
+
+            items(items = transportModes.toImmutableList(), key = { it.productClass }) { mode ->
+                TransportModeRadioButton(
+                    mode = mode,
+                    selected = selectedProductClass == mode.productClass,
+                    onClick = { clickedMode ->
+                        selectedProductClass = clickedMode.productClass
+                    },
+                )
+            }
+        }
+
+        Text(
+            text = if (selectedProductClass != null) "Let's Go, Yeah!" else "Let's Go",
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+                .background(color = KrailTheme.colors.surface)
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .clip(RoundedCornerShape(50))
+                .padding(vertical = 24.dp, horizontal = 24.dp)
+                .border(
+                    width = 5.dp,
+                    color = selectedProductClass?.let {
+                        TransportMode.toTransportModeType(it)
+                    }?.colorCode?.hexToComposeColor() ?: KrailTheme.colors.surface,
+                    shape = RoundedCornerShape(50),
+                )
+                .clickable(
+                    role = Role.Button,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) {
+                    selectedProductClass?.let { productClass ->
+                        transportModeSelected(productClass)
+                    }
+                }
+                .padding(vertical = 12.dp),
+            textAlign = TextAlign.Center,
+            style = KrailTheme.typography.titleMedium,
+        )
+    }
+}
+
+@Composable
+private fun TransportModeRadioButton(
+    mode: TransportMode,
+    onClick: (TransportMode) -> Unit,
+    modifier: Modifier = Modifier,
+    selected: Boolean = false,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 1.dp)
+            .background(color = if (selected) transportModeBackgroundColor(mode) else Color.Transparent)
+            .padding(vertical = 16.dp, horizontal = 24.dp)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                role = Role.Button,
+            ) { onClick(mode) },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TransportModeIcon(
+            letter = mode.name.first(),
+            backgroundColor = mode.colorCode.hexToComposeColor(),
+            iconSize = 32.sp,
+            fontSize = 18.sp,
+        )
+
+        Column(
+            modifier = Modifier.padding(start = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(
+                text = mode.name,
+                style = KrailTheme.typography.titleMedium,
+            )
+
+            Text(
+                text = mode.tagLine,
+                style = KrailTheme.typography.body.copy(fontWeight = FontWeight.Normal),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewUsualRideScreen() {
+    KrailTheme {
+        UsualRideScreen(
+            TransportMode.sortedValues(sortOrder = TransportModeSortOrder.PRODUCT_CLASS)
+                .toImmutableSet(),
+            transportModeSelected = {},
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideViewModel.kt
@@ -1,0 +1,45 @@
+package xyz.ksharma.krail.trip.planner.ui.usualride
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import xyz.ksharma.krail.di.AppDispatchers
+import xyz.ksharma.krail.di.Dispatcher
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.di.SandookFactory
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideEvent
+import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideState
+import javax.inject.Inject
+
+@HiltViewModel
+class UsualRideViewModel @Inject constructor(
+    sandookFactory: SandookFactory,
+    @Dispatcher(AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val sandook: Sandook = sandookFactory.create(SandookFactory.SandookKey.THEME)
+
+    private val _uiState: MutableStateFlow<UsualRideState> = MutableStateFlow(UsualRideState())
+    val uiState: StateFlow<UsualRideState> = _uiState
+
+    fun onEvent(event: UsualRideEvent) {
+        when (event) {
+            is UsualRideEvent.TransportModeSelected -> onTransportModeSelected(event.productClass)
+        }
+    }
+
+    private fun onTransportModeSelected(productClass: Int) {
+        viewModelScope.launch(ioDispatcher) {
+            TransportMode.toTransportModeType(productClass)?.let { mode ->
+                Timber.d("onTransportModeSelected: $mode")
+                sandook.putInt("selectedMode", mode.productClass)
+            }
+        }
+    }
+}

--- a/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/di/SandookFactory.kt
+++ b/sandook/real/src/main/kotlin/xyz/ksharma/krail/sandook/di/SandookFactory.kt
@@ -18,5 +18,6 @@ class SandookFactory @Inject constructor(
 
     enum class SandookKey(val fileName: String) {
         SAVED_TRIP("saved_trip"),
+        THEME("theme"),
     }
 }


### PR DESCRIPTION
### TL;DR
Added a new "Usual Ride" screen allowing users to select their preferred transport mode with a fun, engaging interface.

### What changed?
- Created a new `UsualRideScreen` component with an interactive transport mode selection interface
- Added sorting capabilities to `TransportMode` with a new `TransportModeSortOrder` enum
- Enhanced `TransportModeIcon` component with customizable icon and font sizes
- Added playful taglines for each transport mode type
- Implemented a styled selection UI with visual feedback and a confirmation button

### How to test?
1. Navigate to the Usual Ride screen
2. Verify all transport modes are displayed with their respective icons and taglines
3. Select different transport modes and confirm the selection is visually highlighted
4. Check that the confirmation button updates its border color based on the selected mode
5. Verify the transport mode sorting works in both name and priority order

### Why make this change?
To provide users with a personalized experience by allowing them to set their preferred transport mode, making subsequent journey planning more relevant to their usual travel habits. The playful interface and engaging copy help create a more enjoyable user experience.