### PR TITLE
UI: Add navigation handling for transport mode selection

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -24,7 +24,7 @@ fun NavGraphBuilder.tripPlannerDestinations(
 
         timeTableDestination()
 
-        usualRideDestination()
+        usualRideDestination(navController)
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -9,6 +9,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import timber.log.Timber
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
@@ -62,7 +63,10 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
             },
             toButtonClick = {
                 Timber.d("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
-                navController.navigate(SearchStopRoute(fieldType = SearchStopFieldType.TO))
+                navController.navigate(
+                    route = SearchStopRoute(fieldType = SearchStopFieldType.TO),
+                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                )
             },
             onReverseButtonClick = {
                 Timber.d("onReverseButtonClick:")
@@ -78,21 +82,23 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
             onSearchButtonClick = { fromStop, toStop ->
                 if (fromStop != null && toStop != null) {
                     navController.navigate(
-                        TimeTableRoute(
+                        route = TimeTableRoute(
                             fromStopId = fromStop.stopId,
                             fromStopName = fromStop.stopName,
                             toStopId = toStop.stopId,
                             toStopName = toStop.stopName,
                         ),
+                        navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
                 } else if (fromStopItem != null && toStopItem != null) {
                     navController.navigate(
-                        TimeTableRoute(
+                        route = TimeTableRoute(
                             fromStopId = fromStopItem?.stopId!!,
                             fromStopName = fromStopItem?.stopName!!,
                             toStopId = toStopItem?.stopId!!,
                             toStopName = toStopItem?.stopName!!,
                         ),
+                        navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
                 } else {
                     // TODO - show message - to select both stops

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
@@ -1,15 +1,19 @@
 package xyz.ksharma.krail.trip.planner.ui.usualride
 
+import android.window.SplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.collections.immutable.toImmutableSet
+import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.UsualRideRoute
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideEvent
 
-internal fun NavGraphBuilder.usualRideDestination() {
+internal fun NavGraphBuilder.usualRideDestination(navController: NavHostController) {
     composable<UsualRideRoute> {
         val viewModel = hiltViewModel<UsualRideViewModel>()
 
@@ -18,6 +22,13 @@ internal fun NavGraphBuilder.usualRideDestination() {
                 .toImmutableSet(),
             transportModeSelected = { productClass ->
                 viewModel.onEvent(UsualRideEvent.TransportModeSelected(productClass))
+                navController.navigate(
+                    route = SavedTripsRoute,
+                    navOptions = NavOptions.Builder()
+                        .setLaunchSingleTop(true)
+                        .setPopUpTo<SplashScreen>(inclusive = true)
+                        .build(),
+                )
             },
         )
     }


### PR DESCRIPTION
### TL;DR
Added navigation handling for the usual ride screen and implemented single-top launch behavior across trip planner destinations.

### What changed?
- Added navigation from usual ride screen to saved trips screen after transport mode selection
- Implemented `setLaunchSingleTop(true)` for navigation actions in saved trips destination
- Added pop-up-to behavior when navigating from usual ride to saved trips
- Passed NavController to usual ride destination for navigation handling

### How to test?
1. Navigate to the usual ride screen and select a transport mode
2. Verify navigation to saved trips screen occurs
3. Test navigation between saved trips and search stops
4. Verify back stack behavior is correct and duplicate screens aren't created
5. Test that reverse navigation works as expected

### Why make this change?
To prevent multiple instances of the same screen from being created in the back stack and to implement proper navigation flow from the usual ride screen to saved trips. This improves the overall user experience by maintaining a cleaner navigation state and preventing unintended screen duplications.