### PR TITLE
UI: Add UsualRideScreen with theme persistence

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,12 +80,14 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.timber)
+    implementation(libs.hilt.navigation.compose)
 
     // Firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics)
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.perf)
+    implementation(project(":feature:trip-planner:state"))
 
     // Test
     androidTestImplementation(libs.test.androidxTestExtJunit)

--- a/app/src/main/kotlin/xyz/ksharma/krail/navigation/KrailNavHost.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/navigation/KrailNavHost.kt
@@ -1,47 +1,23 @@
 package xyz.ksharma.krail.navigation
 
-import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.keyframes
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.delay
 import kotlinx.serialization.Serializable
-import xyz.ksharma.krail.design.system.components.Text
-import xyz.ksharma.krail.design.system.theme.KrailTheme
+import xyz.ksharma.krail.splash.SplashScreen
+import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.UsualRideRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.tripPlannerDestinations
 
 /**
@@ -67,113 +43,27 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
         tripPlannerDestinations(navController = navController)
 
         composable<SplashScreen> {
-            SplashScreen(onSplashComplete = {
-                navController.navigate(
-                    route = SavedTripsRoute,
-                    navOptions = NavOptions.Builder()
-                        .setLaunchSingleTop(true)
-                        .setPopUpTo<SplashScreen>(inclusive = true)
-                        .build(),
-                )
-            })
-        }
-    }
-}
+            val viewModel = hiltViewModel<SplashViewModel>()
+            var isThemeAvailable by remember { mutableStateOf(false) }
 
-@Composable
-private fun SplashScreen(onSplashComplete: () -> Unit, modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(color = KrailTheme.colors.background),
-        contentAlignment = Alignment.Center,
-    ) {
-        AnimatedKrailLogo()
-
-        val splashComplete by rememberUpdatedState(onSplashComplete)
-        LaunchedEffect(key1 = Unit) {
-            delay(1100)
-            splashComplete()
-        }
-    }
-}
-
-@Composable
-fun AnimatedKrailLogo(modifier: Modifier = Modifier) {
-    var animationStarted by remember { mutableStateOf(false) }
-
-    // Trigger animation after a delay (e.g., when the splash screen is displayed)
-    LaunchedEffect(key1 = Unit) {
-        animationStarted = true
-    }
-
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentSize(),
-        horizontalArrangement = Arrangement.Center,
-    ) {
-        AnimatedLetter("K", animationStarted)
-        AnimatedLetter("R", animationStarted)
-        AnimatedLetter("A", animationStarted)
-        AnimatedLetter("I", animationStarted)
-        AnimatedLetter("L", animationStarted)
-    }
-}
-
-@Composable
-fun AnimatedLetter(letter: String, animationStarted: Boolean, modifier: Modifier = Modifier) {
-    val infiniteTransition = rememberInfiniteTransition(label = "animeAnimation")
-
-    // Scale animation with anticipation and squash/stretch
-    val scale by infiniteTransition.animateFloat(
-        initialValue = 1f,
-        targetValue = 1.2f,
-        animationSpec = infiniteRepeatable(
-            animation = keyframes {
-                durationMillis = 1100
-                0.0f at 0 using LinearEasing // Hold initial scale
-                0.7f at 200 using FastOutSlowInEasing // Anticipation (quick shrink)
-                1.2f at 500 using FastOutSlowInEasing // Squash/stretch (overshoot)
-                1.0f at 1000 using FastOutSlowInEasing // Settle back to normal scale
-                1.0f at 1100 using LinearEasing // Keep at normal scale
-            },
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = "animeAnimation",
-    )
-
-    val letterScale = if (animationStarted) scale else 1f
-
-    Text(
-        text = letter,
-        color = if (isSystemInDarkTheme()) Color(0xFFFFFF33) else Color(0xFFFF69B4),
-        style = KrailTheme.typography.displayLarge.copy(
-            fontSize = 80.sp,
-            letterSpacing = 4.sp,
-            fontWeight = FontWeight.ExtraBold,
-            drawStyle = Stroke(
-                width = 8f, // Adjust stroke width for desired thickness
-            ),
-        ),
-        modifier = modifier
-            .graphicsLayer {
-                scaleX = letterScale
-                scaleY = letterScale
+            LaunchedEffect(Unit) {
+                isThemeAvailable = viewModel.isThemeAvailable()
             }
-            .padding(4.dp),
-    )
+
+            SplashScreen(
+                onSplashComplete = {
+                    navController.navigate(
+                        route = if (isThemeAvailable) SavedTripsRoute else UsualRideRoute,
+                        navOptions = NavOptions.Builder()
+                            .setLaunchSingleTop(true)
+                            .setPopUpTo<SplashScreen>(inclusive = true)
+                            .build(),
+                    )
+                },
+            )
+        }
+    }
 }
 
 @Serializable
-data object SplashScreen
-
-@PreviewLightDark
-@Composable
-private fun PreviewSplashScreen() {
-    KrailTheme {
-        Column(modifier = Modifier.background(color = KrailTheme.colors.background)) {
-            AnimatedKrailLogo()
-        }
-    }
-}
+private data object SplashScreen

--- a/app/src/main/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
@@ -1,0 +1,133 @@
+package xyz.ksharma.krail.splash
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import xyz.ksharma.krail.design.system.components.Text
+import xyz.ksharma.krail.design.system.theme.KrailTheme
+
+@Composable
+fun SplashScreen(onSplashComplete: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = KrailTheme.colors.background),
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedKrailLogo()
+
+        val splashComplete by rememberUpdatedState(onSplashComplete)
+        LaunchedEffect(key1 = Unit) {
+            delay(1100)
+            splashComplete()
+        }
+    }
+}
+
+@Composable
+private fun AnimatedKrailLogo(modifier: Modifier = Modifier) {
+    var animationStarted by remember { mutableStateOf(false) }
+
+    // Trigger animation after a delay (e.g., when the splash screen is displayed)
+    LaunchedEffect(key1 = Unit) {
+        animationStarted = true
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentSize(),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        AnimatedLetter("K", animationStarted)
+        AnimatedLetter("R", animationStarted)
+        AnimatedLetter("A", animationStarted)
+        AnimatedLetter("I", animationStarted)
+        AnimatedLetter("L", animationStarted)
+    }
+}
+
+@Composable
+private fun AnimatedLetter(letter: String, animationStarted: Boolean, modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "animeAnimation")
+
+    // Scale animation with anticipation and squash/stretch
+    val scale by infiniteTransition.animateFloat(
+        initialValue = 1f,
+        targetValue = 1.2f,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                durationMillis = 1100
+                0.0f at 0 using LinearEasing // Hold initial scale
+                0.7f at 200 using FastOutSlowInEasing // Anticipation (quick shrink)
+                1.2f at 500 using FastOutSlowInEasing // Squash/stretch (overshoot)
+                1.0f at 1000 using FastOutSlowInEasing // Settle back to normal scale
+                1.0f at 1100 using LinearEasing // Keep at normal scale
+            },
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "animeAnimation",
+    )
+
+    val letterScale = if (animationStarted) scale else 1f
+
+    Text(
+        text = letter,
+        color = if (isSystemInDarkTheme()) Color(0xFFFFFF33) else Color(0xFFFF69B4),
+        style = KrailTheme.typography.displayLarge.copy(
+            fontSize = 80.sp,
+            letterSpacing = 4.sp,
+            fontWeight = FontWeight.ExtraBold,
+            drawStyle = Stroke(
+                width = 8f, // Adjust stroke width for desired thickness
+            ),
+        ),
+        modifier = modifier
+            .graphicsLayer {
+                scaleX = letterScale
+                scaleY = letterScale
+            }
+            .padding(4.dp),
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun PreviewSplashScreen() {
+    KrailTheme {
+        Column(modifier = Modifier.background(color = KrailTheme.colors.background)) {
+            AnimatedKrailLogo()
+        }
+    }
+}

--- a/app/src/main/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -1,0 +1,27 @@
+package xyz.ksharma.krail.splash
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.di.AppDispatchers
+import xyz.ksharma.krail.di.Dispatcher
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.di.SandookFactory
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+import javax.inject.Inject
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    sandookFactory: SandookFactory,
+    @Dispatcher(AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val sandook: Sandook = sandookFactory.create(SandookFactory.SandookKey.THEME)
+
+    suspend fun isThemeAvailable(): Boolean = withContext(ioDispatcher) {
+        val productClass = sandook.getInt("selectedMode")
+        val mode = TransportMode.toTransportModeType(productClass)
+        !(productClass == 0 || mode == null)
+    }
+}

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.usualride
 
-import android.window.SplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -26,7 +25,7 @@ internal fun NavGraphBuilder.usualRideDestination(navController: NavHostControll
                     route = SavedTripsRoute,
                     navOptions = NavOptions.Builder()
                         .setLaunchSingleTop(true)
-                        .setPopUpTo<SplashScreen>(inclusive = true)
+                        .setPopUpTo<UsualRideRoute>(inclusive = true)
                         .build(),
                 )
             },


### PR DESCRIPTION
### TL;DR

Added a new onboarding screen for users to select their preferred transport mode, which determines the app's theme.

### What changed?

- Created a new `UsualRideScreen` that displays transport mode options with animated icons and taglines
- Added transport mode persistence using `Sandook` storage
- Implemented navigation logic to direct users to either the usual ride screen or saved trips based on theme availability
- Enhanced the splash screen to check for existing theme preferences
- Added new sort options for transport modes (by name, priority, or product class)

### How to test?

1. Launch the app fresh (clear storage if needed)
2. Observe the splash screen animation
3. Verify you're directed to the usual ride selection screen
4. Select a transport mode and confirm the "Let's Go" button updates
5. Tap "Let's Go" and verify navigation to saved trips screen
6. Restart app to confirm it remembers your selection

### Why make this change?

To provide a personalized experience by allowing users to set their preferred transport mode during first launch, which influences the app's theme and creates a more engaging onboarding flow.