### PR TITLE
UI: Add theme color support via CompositionLocal

### DIFF
--- a/app/src/main/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -2,10 +2,6 @@ package xyz.ksharma.krail.splash
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
-import xyz.ksharma.krail.di.AppDispatchers
-import xyz.ksharma.krail.di.Dispatcher
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.di.SandookFactory
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -14,14 +10,13 @@ import javax.inject.Inject
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     sandookFactory: SandookFactory,
-    @Dispatcher(AppDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val sandook: Sandook = sandookFactory.create(SandookFactory.SandookKey.THEME)
 
-    suspend fun isThemeAvailable(): Boolean = withContext(ioDispatcher) {
+    fun getThemeColor(): String? {
         val productClass = sandook.getInt("selectedMode")
         val mode = TransportMode.toTransportModeType(productClass)
-        !(productClass == 0 || mode == null)
+        return mode?.colorCode
     }
 }

--- a/config/detekt/detekt.yaml
+++ b/config/detekt/detekt.yaml
@@ -12,7 +12,7 @@ Compose:
   CompositionLocalAllowlist:
     active: true
     # -- You can optionally define a list of CompositionLocals that are allowed here
-    allowedCompositionLocals: LocalTextColor,LocalContentAlpha, LocalTextStyle,LocalContentColor,LocalOnContentColor,LocalKrailTypography,LocalKrailColors
+    allowedCompositionLocals: LocalTextColor,LocalContentAlpha, LocalTextStyle,LocalContentColor,LocalOnContentColor,LocalKrailTypography,LocalKrailColors,LocalThemeColor
   CompositionLocalNaming:
     active: true
   ContentEmitterReturningValues:

--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/CompositionLocals.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/CompositionLocals.kt
@@ -1,12 +1,16 @@
 package xyz.ksharma.krail.design.system
 
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+
+const val unspecifiedColor = "#FF000000"
 
 val LocalTextStyle = compositionLocalOf { TextStyle.Default }
 val LocalTextColor = compositionLocalOf { Color.Unspecified }
 val LocalContentAlpha = compositionLocalOf { 1f }
+val LocalThemeColor = compositionLocalOf { mutableStateOf(unspecifiedColor) }
 
 internal val LocalContentColor = compositionLocalOf { Color.Unspecified }
 val LocalOnContentColor = compositionLocalOf { Color.Unspecified }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 /**
@@ -18,7 +19,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
  *
  * @return A Compose Color object representing the provided hex color code.
  */
-internal fun String.hexToComposeColor(): Color {
+fun String.hexToComposeColor(): Color {
     require(this.isValidHexColorCode()) { "Invalid hex color code: $this" }
     return Color(android.graphics.Color.parseColor(this))
 }
@@ -52,5 +53,15 @@ internal fun transportModeBackgroundColor(transportMode: TransportMode): Color {
         transportMode.colorCode.hexToComposeColor().copy(alpha = 0.45f)
     } else {
         transportMode.colorCode.hexToComposeColor().copy(alpha = 0.15f)
+    }
+}
+
+@Composable
+internal fun themeBackgroundColor(): Color {
+    val themeColor = LocalThemeColor.current
+    return if (isSystemInDarkTheme()) {
+        themeColor.value.hexToComposeColor().copy(alpha = 0.45f)
+    } else {
+        themeColor.value.hexToComposeColor().copy(alpha = 0.15f)
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -13,6 +13,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +27,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.preview.PreviewComponent
 import xyz.ksharma.krail.design.system.theme.KrailTheme
@@ -34,19 +38,17 @@ import xyz.ksharma.krail.design.system.R as DSR
 @Composable
 fun SavedTripCard(
     trip: Trip,
+    primaryTransportMode: TransportMode?,
     onStarClick: () -> Unit,
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
-    primaryTransportMode: TransportMode? = TransportMode.Train(), // TODO - theme color
 ) {
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(12.dp))
             .background(
-                color = primaryTransportMode?.let {
-                    transportModeBackgroundColor(primaryTransportMode)
-                } ?: KrailTheme.colors.surfaceVariant,
-                // TODO -  needs to be common logic for background color
+                color = primaryTransportMode?.let { transportModeBackgroundColor(it) }
+                    ?: themeBackgroundColor(),
             )
             .clickable(
                 role = Role.Button,
@@ -92,7 +94,7 @@ fun SavedTripCard(
                 contentDescription = "Save Trip",
                 colorFilter = ColorFilter.tint(
                     primaryTransportMode?.colorCode
-                        ?.hexToComposeColor() ?: KrailTheme.colors.onSecondaryContainer,
+                        ?.hexToComposeColor() ?: LocalThemeColor.current.value.hexToComposeColor(),
                 ),
             )
         }
@@ -105,18 +107,21 @@ fun SavedTripCard(
 @Composable
 private fun SavedTripCardPreview() {
     KrailTheme {
-        SavedTripCard(
-            trip = Trip(
-                fromStopId = "1",
-                fromStopName = "Edmondson Park Station",
-                toStopId = "2",
-                toStopName = "Harris Park Station",
-            ),
-            primaryTransportMode = TransportMode.Train(),
-            onCardClick = {},
-            onStarClick = {},
-            modifier = Modifier.background(color = KrailTheme.colors.background),
-        )
+        val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
+        CompositionLocalProvider(LocalThemeColor provides themeColor) {
+            SavedTripCard(
+                trip = Trip(
+                    fromStopId = "1",
+                    fromStopName = "Edmondson Park Station",
+                    toStopId = "2",
+                    toStopName = "Harris Park Station",
+                ),
+                primaryTransportMode = TransportMode.Train(),
+                onCardClick = {},
+                onStarClick = {},
+                modifier = Modifier.background(color = KrailTheme.colors.background),
+            )
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
@@ -20,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.design.system.LocalOnContentColor
+import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.design.system.components.RoundIconButton
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TextFieldButton
@@ -31,7 +34,6 @@ import xyz.ksharma.krail.trip.planner.ui.R as TripPlannerUiR
 
 @Composable
 fun SearchStopRow(
-    themeColor: Color,
     fromButtonClick: () -> Unit,
     toButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -40,11 +42,13 @@ fun SearchStopRow(
     onReverseButtonClick: () -> Unit = {},
     onSearchButtonClick: () -> Unit = {},
 ) {
+    val themeColor = LocalThemeColor.current
+
     Row(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = themeColor,
+                color = themeColor.value.hexToComposeColor(),
                 shape = RoundedCornerShape(topStart = 36.dp, topEnd = 36.dp),
             )
             .padding(vertical = 24.dp, horizontal = 16.dp)
@@ -113,11 +117,13 @@ fun SearchStopRow(
 @Composable
 private fun SearchStopColumnPreview() {
     KrailTheme {
-        SearchStopRow(
-            fromButtonClick = {},
-            toButtonClick = {},
-            themeColor = TransportMode.Train().colorCode.hexToComposeColor(),
-        )
+        val themeColor = remember { mutableStateOf(TransportMode.Train().colorCode) }
+        CompositionLocalProvider(LocalThemeColor provides themeColor) {
+            SearchStopRow(
+                fromButtonClick = {},
+                toButtonClick = {},
+            )
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -24,8 +24,6 @@ import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.R
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
-import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
-import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -80,6 +78,7 @@ fun SavedTripsScreen(
                                 ),
                             )
                         },
+                        primaryTransportMode = null, // TODO
                         modifier = Modifier
                             .padding(horizontal = 16.dp)
                             .animateItem(fadeOutSpec = tween(durationMillis = 500)),
@@ -98,7 +97,6 @@ fun SavedTripsScreen(
             toButtonClick = toButtonClick,
             onReverseButtonClick = onReverseButtonClick,
             onSearchButtonClick = { onSearchButtonClick(null, null) },
-            themeColor = TransportMode.Train().colorCode.hexToComposeColor(), // TODO - theme color
         )
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -21,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.mapLatest
 import timber.log.Timber
+import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.design.system.components.Divider
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TextField
@@ -50,10 +51,10 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 fun SearchStopScreen(
     searchStopState: SearchStopState,
     modifier: Modifier = Modifier,
-    themeColor: Color = TransportMode.Train().colorCode.hexToComposeColor(), // TODO theming
     onStopSelect: (StopItem) -> Unit = {},
     onEvent: (SearchStopUiEvent) -> Unit = {},
 ) {
+    val themeColor = LocalThemeColor.current
     var textFieldText: String by remember { mutableStateOf("") }
     val keyboard = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
@@ -82,7 +83,10 @@ fun SearchStopScreen(
             .fillMaxSize()
             .background(
                 brush = Brush.verticalGradient(
-                    colors = listOf(themeColor, KrailTheme.colors.surface),
+                    colors = listOf(
+                        themeColor.value.hexToComposeColor(),
+                        KrailTheme.colors.surface,
+                    ),
                 ),
             )
             .imePadding(),
@@ -151,7 +155,10 @@ fun SearchStopScreen(
 @Composable
 private fun SearchStopScreenPreview() {
     KrailTheme {
-        SearchStopScreen(searchStopState = SearchStopState())
+        val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
+        CompositionLocalProvider(LocalThemeColor provides themeColor) {
+            SearchStopScreen(searchStopState = SearchStopState())
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -19,12 +19,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
 import xyz.ksharma.krail.design.system.theme.KrailTheme
@@ -62,8 +63,9 @@ fun TimeTableScreen(
     expandedJourneyId: String?,
     onEvent: (TimeTableUiEvent) -> Unit,
     modifier: Modifier = Modifier,
-    themeColor: Color = TransportMode.Train().colorCode.hexToComposeColor(), // TODO - theming
 ) {
+    val themeColor = LocalThemeColor.current
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -72,7 +74,7 @@ fun TimeTableScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(color = themeColor),
+                .background(color = themeColor.value.hexToComposeColor()),
         ) {
             TitleBar(
                 title = {
@@ -124,7 +126,7 @@ fun TimeTableScreen(
                         trip,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(color = themeColor),
+                            .background(color = themeColor.value.hexToComposeColor()),
                     )
                 }
             }
@@ -295,35 +297,38 @@ private fun PreviewOriginDestination() {
 @Composable
 private fun PreviewTimeTableScreen() {
     KrailTheme {
-        TimeTableScreen(
-            timeTableState = TimeTableState(
-                trip = Trip(
-                    fromStopName = "From Stop",
-                    toStopName = "To Stop",
-                    fromStopId = "123",
-                    toStopId = "456",
-                ),
-                journeyList = listOf(
-                    TimeTableState.JourneyCardInfo(
-                        timeText = "12:00",
-                        platformText = 'A',
-                        originTime = "12:00",
-                        destinationTime = "12:30",
-                        travelTime = "30 mins",
-                        transportModeLines = persistentListOf(
-                            TransportModeLine(
-                                transportMode = TransportMode.Bus(),
-                                lineName = "123",
-                            ),
-                        ),
-                        legs = persistentListOf(),
-                        originUtcDateTime = "2024-11-01T12:00:00Z",
+        val themeColor = remember { mutableStateOf(TransportMode.Ferry().colorCode) }
+        CompositionLocalProvider(LocalThemeColor provides themeColor) {
+            TimeTableScreen(
+                timeTableState = TimeTableState(
+                    trip = Trip(
+                        fromStopName = "From Stop",
+                        toStopName = "To Stop",
+                        fromStopId = "123",
+                        toStopId = "456",
                     ),
-                ).toImmutableList(),
-            ),
-            expandedJourneyId = null,
-            onEvent = {},
-        )
+                    journeyList = listOf(
+                        TimeTableState.JourneyCardInfo(
+                            timeText = "12:00",
+                            platformText = 'A',
+                            originTime = "12:00",
+                            destinationTime = "12:30",
+                            travelTime = "30 mins",
+                            transportModeLines = persistentListOf(
+                                TransportModeLine(
+                                    transportMode = TransportMode.Bus(),
+                                    lineName = "123",
+                                ),
+                            ),
+                            legs = persistentListOf(),
+                            originUtcDateTime = "2024-11-01T12:00:00Z",
+                        ),
+                    ).toImmutableList(),
+                ),
+                expandedJourneyId = null,
+                onEvent = {},
+            )
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.collections.immutable.toImmutableSet
+import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.UsualRideRoute
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -15,12 +16,19 @@ import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideEvent
 internal fun NavGraphBuilder.usualRideDestination(navController: NavHostController) {
     composable<UsualRideRoute> {
         val viewModel = hiltViewModel<UsualRideViewModel>()
+        val themeColor = LocalThemeColor.current
 
         UsualRideScreen(
             transportModes = TransportMode.sortedValues(TransportModeSortOrder.PRODUCT_CLASS)
                 .toImmutableSet(),
             transportModeSelected = { productClass ->
+                val mode = TransportMode.toTransportModeType(productClass)
+                check(mode != null) {
+                    "Transport mode not found for product class $productClass"
+                }
+
                 viewModel.onEvent(UsualRideEvent.TransportModeSelected(productClass))
+                themeColor.value = mode.colorCode
                 navController.navigate(
                     route = SavedTripsRoute,
                     navOptions = NavOptions.Builder()


### PR DESCRIPTION
### TL;DR
Introduces a theme color system using CompositionLocal to maintain consistent styling across the app based on selected transport mode.

### What changed?
- Added `LocalThemeColor` CompositionLocal to manage theme colors across the app
- Modified splash screen to retrieve and set initial theme color
- Updated UI components (SavedTripCard, SearchStopRow, TimeTableScreen) to use theme color
- Refactored color management in navigation and transport mode selection
- Added `themeBackgroundColor()` helper function for consistent background styling
- Updated detekt configuration to allow `LocalThemeColor`

### How to test?
1. Launch the app and verify initial theme color is set correctly
2. Select different transport modes and confirm theme color updates appropriately
3. Verify theme color consistency across:
   - Saved trip cards
   - Search stop screens
   - Time table views
4. Check dark/light mode transitions maintain proper color alpha values

### Why make this change?
To establish a centralized theming system that maintains visual consistency throughout the app based on the user's selected transport mode. This improves the user experience by providing clear visual feedback and maintaining a cohesive design language.