### PR TITLE
UI: Improve edge-to-edge navigation bar handling

### DIFF
--- a/app/src/main/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/app/src/main/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail
 
 import android.os.Bundle
-import android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -14,10 +13,6 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        // Required because https://issuetracker.google.com/issues/298296168
-        // Edge-to-edge does not draw behind 3-button nav
-        window.setFlags(FLAG_LAYOUT_NO_LIMITS, FLAG_LAYOUT_NO_LIMITS)
-
         setContent {
             KrailTheme {
                 KrailApp()

--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/theme/A11yColors.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/theme/A11yColors.kt
@@ -26,3 +26,7 @@ fun getForegroundColor(backgroundColor: Color): Color {
         darkForegroundColor
     }
 }
+
+fun shouldUseDarkIcons(backgroundColor: Color): Boolean {
+    return getForegroundColor(backgroundColor) == md_theme_dark_onSurface
+}

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/ContextExt.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/ContextExt.kt
@@ -1,0 +1,16 @@
+package xyz.ksharma.krail.trip.planner.ui
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+// TODO - Can be removed once updated to AndroidX Activity starting from
+//  androidx.activity:activity-compose:1.10.0-alpha03
+fun Context.getActivityOrNull(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
+}

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
@@ -80,3 +80,15 @@ fun Color.toHex(): String {
     val alpha = (this.alpha * 255).toInt()
     return String.format("#%02X%02X%02X%02X", alpha, red, green, blue)
 }
+
+/**
+ * The default light scrim, as defined by androidx and the platform:
+ * https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/EdgeToEdge.kt;l=35-38;drc=27e7d52e8604a080133e8b842db10c89b4482598
+ */
+val lightScrim = android.graphics.Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
+
+/**
+ * The default dark scrim, as defined by androidx and the platform:
+ * https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/EdgeToEdge.kt;l=40-44;drc=27e7d52e8604a080133e8b842db10c89b4482598
+ */
+val darkScrim = android.graphics.Color.argb(0x80, 0x1b, 0x1b, 0x1b)

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,5 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -13,17 +16,24 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.design.system.LocalThemeContentColor
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.R
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
+import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
+import xyz.ksharma.krail.trip.planner.ui.getActivityOrNull
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -40,6 +50,20 @@ fun SavedTripsScreen(
     onSearchButtonClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     onEvent: (SavedTripUiEvent) -> Unit = {},
 ) {
+    val themeContentColor by LocalThemeContentColor.current
+    val context = LocalContext.current
+    DisposableEffect(themeContentColor) {
+        context.getActivityOrNull()?.let { activity ->
+            (activity as ComponentActivity).enableEdgeToEdge(
+                navigationBarStyle = SystemBarStyle.auto(
+                    lightScrim = themeContentColor.hexToComposeColor().toArgb(),
+                    darkScrim = themeContentColor.hexToComposeColor().toArgb(),
+                ),
+            )
+        }
+        onDispose {}
+    }
+
     Box(
         modifier = modifier
             .fillMaxSize()

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -1,9 +1,11 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,7 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,7 +32,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
@@ -43,12 +47,12 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import timber.log.Timber
 import xyz.ksharma.krail.design.system.LocalThemeColor
 import xyz.ksharma.krail.design.system.LocalThemeContentColor
 import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TitleBar
 import xyz.ksharma.krail.design.system.theme.KrailTheme
+import xyz.ksharma.krail.design.system.theme.shouldUseDarkIcons
 import xyz.ksharma.krail.trip.planner.ui.R
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
@@ -56,6 +60,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiAnim
 import xyz.ksharma.krail.trip.planner.ui.components.timeLineBottom
 import xyz.ksharma.krail.trip.planner.ui.components.timeLineTop
+import xyz.ksharma.krail.trip.planner.ui.getActivityOrNull
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
@@ -74,10 +79,22 @@ fun TimeTableScreen(
     val themeContentColorHex by LocalThemeContentColor.current
     val themeColor by remember { mutableStateOf(themeColorHex.hexToComposeColor()) }
     val themeContentColor by remember { mutableStateOf(themeContentColorHex.hexToComposeColor()) }
-
-    val dark = isSystemInDarkTheme()
-    LaunchedEffect(themeContentColorHex) {
-        Timber.d("themeContentColorHex(dark: $dark): ${themeContentColorHex.drop(3)}")
+    val context = LocalContext.current
+    val darkIcons = shouldUseDarkIcons(themeColor)
+    DisposableEffect(darkIcons) {
+        context.getActivityOrNull()?.let { activity ->
+            (activity as ComponentActivity).enableEdgeToEdge(
+                statusBarStyle = SystemBarStyle.auto(
+                    android.graphics.Color.TRANSPARENT,
+                    android.graphics.Color.TRANSPARENT,
+                ) { darkIcons },
+                navigationBarStyle = SystemBarStyle.auto(
+                    lightScrim = themeContentColor.toArgb(),
+                    darkScrim = themeContentColor.toArgb(),
+                ),
+            )
+        }
+        onDispose {}
     }
 
     Column(


### PR DESCRIPTION
### TL;DR
Improved system bar handling across the app by implementing proper edge-to-edge support and dynamic color adaptation.

### What changed?
- Removed manual `FLAG_LAYOUT_NO_LIMITS` flag from MainActivity
- Added new utility functions for scrim colors and dark icon detection
- Implemented dynamic system bar styling in SavedTripsScreen and TimeTableScreen
- Added context extension function to safely retrieve Activity instances
- Introduced proper edge-to-edge support with dynamic navigation and status bar colors

### How to test?
1. Launch the app and verify system bars (status and navigation) properly adapt to the theme
2. Switch between light and dark themes to ensure proper color transitions
3. Navigate between SavedTripsScreen and TimeTableScreen to verify consistent system bar behavior
4. Test on devices with different navigation bar styles (gesture, 3-button)

### Why make this change?
The previous implementation had inconsistent system bar handling and didn't properly support edge-to-edge display. This change provides a more polished user experience with proper system bar integration that adapts to the app's theme and content.

### Screenshots 

<details><summary>3 Button Navigation</summary>
<p>

| Dark | Light |
|--------|--------|
| <img width="343" alt="SavedTrips" src="https://github.com/user-attachments/assets/23d5d49e-42cf-478e-9062-d472780ac5c1"> | <img width="343" alt="Screenshot 2024-11-05 at 11 47 24 pm" src="https://github.com/user-attachments/assets/7464cc06-7c92-424a-aebf-1de01e1ff392"> |
| <img width="343" alt="Screenshot 2024-11-05 at 11 40 09 pm" src="https://github.com/user-attachments/assets/78777c3e-7b4f-4962-a2c3-d3dc7fb4c5db"> | <img width="343" alt="Screenshot 2024-11-05 at 11 47 35 pm" src="https://github.com/user-attachments/assets/0c54d9e0-900a-4fea-a4ca-5b6c1816767e"> |
| <img width="343" alt="Screenshot 2024-11-05 at 11 40 23 pm" src="https://github.com/user-attachments/assets/61426179-4e2f-47e7-9b6f-904388acd6fd"> | <img width="343" alt="Screenshot 2024-11-05 at 11 48 09 pm" src="https://github.com/user-attachments/assets/537ec0fe-7e55-40ce-aaee-e8057ccf9fe2"> | 


</p>
</details> 

<details><summary>Gesture Navigation</summary>
<p>

| Dark | Light |
|--------|--------|
| <img width="283" alt="Screenshot 2024-11-05 at 11 52 16 pm" src="https://github.com/user-attachments/assets/6607f376-bff1-4555-a568-22476e7801fc"> | <img width="283" alt="Screenshot 2024-11-05 at 11 54 39 pm" src="https://github.com/user-attachments/assets/6d852a1d-18b9-419d-a281-c8136b41b17b"> |
| <img width="283" alt="Screenshot 2024-11-05 at 11 52 26 pm" src="https://github.com/user-attachments/assets/a3bdc8f8-ce92-47be-9386-00d950b9eefe"> | <img width="283" alt="Screenshot 2024-11-05 at 11 54 55 pm" src="https://github.com/user-attachments/assets/352fd096-806e-4e8b-90b3-8d61f031e8d9"> |
| <img width="283" alt="Screenshot 2024-11-05 at 11 52 39 pm" src="https://github.com/user-attachments/assets/f5e0bc19-19cb-4176-b0fb-4b086566730e"> | <img width="283" alt="Screenshot 2024-11-05 at 11 55 05 pm" src="https://github.com/user-attachments/assets/c5991316-a732-4cff-b705-1c57124694bc"> | 

</p>
</details> 

