### PR TITLE
UI: Adjust bottom padding in UsualRideScreen

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
@@ -71,7 +71,7 @@ fun UsualRideScreen(
     ) {
         var selectedProductClass: Int? by rememberSaveable { mutableStateOf(null) }
 
-        LazyColumn(contentPadding = PaddingValues(top = 24.dp, bottom = 102.dp)) {
+        LazyColumn(contentPadding = PaddingValues(top = 24.dp, bottom = 152.dp)) {
             item {
                 Text(
                     text = "What's your usual ride mate?",


### PR DESCRIPTION
### TL;DR
Increased bottom padding in the UsualRide screen's LazyColumn from 102dp to 152dp.

### What changed?
Modified the bottom padding value in the UsualRideScreen's LazyColumn component from 102.dp to 152.dp while maintaining the top padding at 24.dp.

### How to test?
1. Navigate to the UsualRide screen
2. Scroll to the bottom of the content
3. Verify there is sufficient padding at the bottom of the screen
4. Ensure no content is cut off or obscured

### Why make this change?
To provide more space at the bottom of the screen, ensuring better visibility and preventing any content from being hidden behind system UI elements or navigation components.