### PR TITLE
A11y: Improve JourneyCard layout and accessibility at high font scales

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/A11yExt.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/A11yExt.kt
@@ -1,0 +1,12 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+
+@Composable
+fun WithDensityCheck(fontScaleThreshold: Float = 1.8f, content: @Composable () -> Unit) {
+    val density = LocalDensity.current
+    if (density.fontScale < fontScaleThreshold) {
+        content()
+    }
+}

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -87,7 +87,11 @@ fun JourneyCard(
     val iconSize = with(density) { 14.sp.toDp() }
 
     val horizontalCardPadding by animateDpAsState(
-        if (cardState == JourneyCardState.DEFAULT) { 12.dp } else { 0.dp },
+        if (cardState == JourneyCardState.DEFAULT) {
+            12.dp
+        } else {
+            0.dp
+        },
         label = "cardPadding",
     )
 
@@ -322,32 +326,38 @@ fun DefaultJourneyCardContent(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        FlowRow(
+        Row(
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalArrangement = Arrangement.Center,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Text(
-                text = timeToDeparture,
-                style = KrailTheme.typography.titleMedium,
-                color = themeColor,
-                modifier = Modifier
-                    .padding(end = 8.dp)
-                    .align(Alignment.CenterVertically),
-            )
-            Row(
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .weight(1f),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
+            FlowRow(
+                horizontalArrangement = Arrangement.Start,
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
-                transportModeList.forEachIndexed { index, mode ->
-                    TransportModeIcon(
-                        letter = mode.name.first(),
-                        backgroundColor = mode.colorCode.hexToComposeColor(),
-                    )
-                    if (index != transportModeList.lastIndex) {
-                        SeparatorIcon(modifier = Modifier.align(Alignment.CenterVertically))
+                Text(
+                    text = timeToDeparture,
+                    style = KrailTheme.typography.titleMedium,
+                    color = themeColor,
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .align(Alignment.CenterVertically),
+                )
+                WithDensityCheck {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.CenterVertically),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        transportModeList.forEachIndexed { index, mode ->
+                            TransportModeIcon(
+                                letter = mode.name.first(),
+                                backgroundColor = mode.colorCode.hexToComposeColor(),
+                            )
+                            if (index != transportModeList.lastIndex) {
+                                SeparatorIcon(modifier = Modifier.align(Alignment.CenterVertically))
+                            }
+                        }
                     }
                 }
             }
@@ -355,6 +365,7 @@ fun DefaultJourneyCardContent(
             platformNumber?.let { platform -> // todo - extract
                 Box(
                     modifier = Modifier
+                        .padding(start = 8.dp)
                         .align(Alignment.CenterVertically)
                         .size(28.dp.toAdaptiveDecorativeIconSize())
                         .border(
@@ -377,6 +388,7 @@ fun DefaultJourneyCardContent(
             text = originTime,
             style = KrailTheme.typography.titleMedium,
             color = KrailTheme.colors.onSurface,
+            modifier = Modifier.padding(top = 4.dp),
         )
 
         FlowRow(


### PR DESCRIPTION
### TL;DR
Added font scale threshold check and improved journey card layout for better accessibility

### What changed?
- Created new `WithDensityCheck` composable to conditionally render content based on font scale
- Restructured journey card layout using `FlowRow` and `Row` components
- Added padding adjustments for better spacing
- Implemented conditional rendering of transport mode icons based on font scale
- Platform number display now has consistent spacing

### How to test?
1. Open the trip planner screen
2. Verify journey card layout at default font scale
3. Increase device font scale above 1.8x
4. Confirm transport mode icons hide appropriately
5. Check that text remains readable and properly spaced
6. Verify platform number maintains proper alignment

### Why make this change?
To improve accessibility for users with larger font scales by preventing layout issues and maintaining readability. The changes ensure the UI remains functional and aesthetically pleasing across different font sizes while preserving essential information.

### Screenshots

**Worst Case Scenario**

https://github.com/user-attachments/assets/b3d577ba-fa92-49e9-bc2d-eae3f0998df1


