### PR TITLE
UI: Update JourneyCard padding and add festival emoji support

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -251,7 +251,7 @@ fun JourneyCardContent(
                     WalkingLeg(
                         duration = leg.duration,
                         modifier = Modifier
-                            .padding(horizontal = 16.dp),
+                            .padding(vertical = 2.dp),
                     )
                 }
 
@@ -260,8 +260,7 @@ fun JourneyCardContent(
                         leg.walkInterchange?.duration?.let { duration ->
                             WalkingLeg(
                                 duration = duration,
-                                modifier = Modifier
-                                    .padding(horizontal = 16.dp),
+                                modifier = Modifier.padding(vertical = 2.dp),
                             )
                         }
                     }
@@ -276,8 +275,7 @@ fun JourneyCardContent(
                         leg.walkInterchange?.duration?.let { duration ->
                             WalkingLeg(
                                 duration = duration,
-                                modifier = Modifier
-                                    .padding(horizontal = 16.dp),
+                                modifier = Modifier.padding(vertical = 2.dp),
                             )
                         }
                     } else {
@@ -301,8 +299,7 @@ fun JourneyCardContent(
                         leg.walkInterchange?.duration?.let { duration ->
                             WalkingLeg(
                                 duration = duration,
-                                modifier = Modifier
-                                    .padding(horizontal = 16.dp),
+                                modifier = Modifier.padding(vertical = 2.dp),
                             )
                         }
                     }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -1,6 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.components.loading
 
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.todayIn
+import java.time.MonthDay
 import kotlin.random.Random
 
 object LoadingEmojiManager {
@@ -9,20 +13,19 @@ object LoadingEmojiManager {
         "🛴",
         "🛹",
         "🚀",
-        "🚢",
         "🛶",
         "\uD83C\uDFC2", // Snowboarder
-        "☃\uFE0F", // Lollipop
-        "\uD83C\uDF7A", // Shopping Cart
-        "\uD83E\uDD21", // Clown
-        "\uD83E\uDD21", // Dolphin
+        "\uD83D\uDC2C", // Dolphin
+        "\uD83E\uDD21", // Clown,
+        "\uD83D\uDEFA", // Auto
+        "\uD83D\uDEB2", // Bicycle
     )
 
     private val festivalEmojiMap = mapOf(
         FestivalType.AUSTRALIA_DAY to listOf("🇦🇺"),
-        FestivalType.CHRISTMAS to listOf("🎄", "🎅", "🎁"),
+        FestivalType.CHRISTMAS to listOf("🎄", "🎅", "🎁", "☃\uFE0F"),
         FestivalType.NEW_YEAR to listOf("🎉", "🎆"),
-        FestivalType.ANZAC_DAY to listOf("🌺", "🎖️"),
+        FestivalType.ANZAC_DAY to listOf("🌺", "🇦🇺"),
         FestivalType.MOTHERS_DAY to listOf("💐", "💕"),
         FestivalType.FATHERS_DAY to listOf("👔", "🍻"),
         FestivalType.EASTER to listOf("🐰", "🐣", "🥚"),
@@ -32,10 +35,24 @@ object LoadingEmojiManager {
         FestivalType.CHINESE_NEW_YEAR to listOf("🧧"),
     )
 
+    private val knownFestivalDates = mapOf(
+        FestivalType.CHRISTMAS to MonthDay.of(12, 25),
+        FestivalType.NEW_YEAR to MonthDay.of(1, 1),
+        FestivalType.VALENTINES_DAY to MonthDay.of(2, 14),
+        FestivalType.AUSTRALIA_DAY to MonthDay.of(1, 26),
+        FestivalType.ANZAC_DAY to MonthDay.of(4, 25),
+    )
+
     internal fun getRandomEmoji(overrideEmoji: String? = null): String {
         if (overrideEmoji != null) return overrideEmoji
 
-        val commonEmojis = listOf("🛴", "🛹", "🚀", "🚢", "🛶", "\uD83E\uDD21")
+        val today = Clock.System.todayIn(TimeZone.currentSystemDefault())
+        val festivalEmoji = knownFestivalDates.entries
+            .firstOrNull { it.value.month == today.month && it.value.dayOfMonth == today.dayOfMonth }
+            ?.let { festivalEmojiMap[it.key]?.randomOrNull() }
+        if (festivalEmoji != null) return festivalEmoji
+
+        val commonEmojis = listOf("🛴", "🛹", "🚀", "🛶", "\uD83E\uDD21", "\uD83D\uDC2C")
         val rareEmoji = "🐦‍🔥"
         val otherEmojis = emojiList - commonEmojis - rareEmoji
 
@@ -46,6 +63,4 @@ object LoadingEmojiManager {
             else -> rareEmoji // 1% chance for the rare emoji
         }
     }
-
-    private fun FestivalType.getRandomEmoji(): String? = festivalEmojiMap[this]?.randomOrNull()
 }


### PR DESCRIPTION
### TL;DR
Updated emoji loading system with festival dates and adjusted journey card padding

### What changed?
- Added date-based festival emoji selection using `MonthDay` comparisons
- Implemented automatic festival emoji display on specific dates (Christmas, New Year, Valentine's Day, etc.)
- Modified padding in JourneyCard from horizontal to vertical (2.dp) for walking leg components
- Refined emoji list by removing redundant entries and adding new transportation options
- Added bicycle and auto rickshaw emojis to the selection pool

### How to test?
1. Check walking leg spacing in journey cards appears with correct vertical padding
2. Test emoji loading on different dates:
   - Set system date to December 25 to verify Christmas emojis
   - Set system date to January 1 to verify New Year emojis
   - Set system date to regular days to verify standard transport emojis
3. Verify random emoji distribution still works as expected

### Why make this change?
To enhance the user experience by providing contextually relevant emojis based on special dates and improve the visual spacing of walking segments in journey cards. The date-aware emoji system creates a more engaging and seasonally appropriate interface.