### PR TITLE
UI: Add walking time indicator to JourneyCard

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -29,6 +29,11 @@ data class TimeTableState(
         val travelTime: String, // "(10 min)"
 
         /**
+         * Total walking time in the journey.
+         */
+        val totalWalkTime: String? = null, // "10 mins"
+
+        /**
          * transportation.disassembledName -> lineName
          * transportation.product.class -> TransportModeType
          */

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -74,6 +74,7 @@ fun JourneyCard(
     transportModeList: ImmutableList<TransportMode>,
     onClick: () -> Unit,
     cardState: JourneyCardState,
+    totalWalkTime: String?,
     modifier: Modifier = Modifier,
     platformNumber: Char? = null,
 ) {
@@ -127,6 +128,7 @@ fun JourneyCard(
                 themeColor = themeColor,
                 transportModeList = transportModeList,
                 platformNumber = platformNumber,
+                totalWalkTime = totalWalkTime,
                 modifier = Modifier.clickable(
                     role = Role.Button,
                     onClick = onClick,
@@ -320,6 +322,7 @@ fun DefaultJourneyCardContent(
     themeColor: Color,
     transportModeList: ImmutableList<TransportMode>,
     platformNumber: Char?,
+    totalWalkTime: String?,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
@@ -399,23 +402,22 @@ fun DefaultJourneyCardContent(
                 text = destinationTime,
                 style = KrailTheme.typography.titleMedium,
                 color = KrailTheme.colors.onSurface,
+                modifier = Modifier.padding(end = 10.dp),
             )
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.align(Alignment.CenterVertically),
-            ) {
-                Image(
-                    painter = painterResource(R.drawable.ic_clock),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
+            TextWithIcon(
+                icon = R.drawable.ic_clock,
+                text = totalTravelTime,
+                modifier = Modifier
+                    .align(Alignment.CenterVertically)
+                    .padding(end = 10.dp),
+            )
+            totalWalkTime?.let {
+                TextWithIcon(
+                    icon = R.drawable.ic_walk,
+                    text = totalWalkTime,
                     modifier = Modifier
-                        .padding(horizontal = 4.dp)
                         .align(Alignment.CenterVertically)
-                        .size(14.dp.toAdaptiveSize()),
-                )
-                Text(
-                    text = totalTravelTime,
-                    style = KrailTheme.typography.bodyMedium,
+                        .padding(end = 10.dp),
                 )
             }
             Spacer(modifier = Modifier.weight(1f))
@@ -430,6 +432,28 @@ fun DefaultJourneyCardContent(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun TextWithIcon(icon: Int, text: String, modifier: Modifier = Modifier) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Image(
+            painter = painterResource(icon),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
+            modifier = Modifier
+                .padding(end = 4.dp)
+                .align(Alignment.CenterVertically)
+                .size(14.dp.toAdaptiveSize()),
+        )
+        Text(
+            text = text,
+            style = KrailTheme.typography.bodyMedium,
+        )
     }
 }
 
@@ -472,6 +496,7 @@ private fun PreviewJourneyCard() {
             ).toImmutableList(),
             legList = persistentListOf(),
             cardState = JourneyCardState.DEFAULT,
+            totalWalkTime = null,
             onClick = {},
         )
     }
@@ -518,6 +543,7 @@ private fun PreviewJourneyCardCollapsed() {
 
             ),
             cardState = JourneyCardState.COLLAPSED,
+            totalWalkTime = "10 mins",
             onClick = {},
         )
     }
@@ -564,6 +590,7 @@ private fun PreviewJourneyCardExpanded() {
 
             ),
             cardState = JourneyCardState.EXPANDED,
+            totalWalkTime = null,
             onClick = {},
         )
     }
@@ -605,6 +632,7 @@ private fun PreviewJourneyCardLongData() {
             ).toImmutableList(),
             legList = persistentListOf(),
             cardState = JourneyCardState.DEFAULT,
+            totalWalkTime = "15 mins",
             onClick = {},
         )
     }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -33,7 +33,7 @@ internal fun OriginDestination(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
-            .padding(bottom = 16.dp),
+            .padding(bottom = 16.dp, top = 4.dp),
     ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -193,6 +193,7 @@ fun TimeTableScreen(
                         originTime = journey.originTime,
                         destinationTime = journey.destinationTime,
                         durationText = journey.travelTime,
+                        totalWalkTime = journey.totalWalkTime,
                         transportModeLineList = journey.transportModeLines.map {
                             TransportModeLine(
                                 transportMode = it.transportMode,
@@ -235,6 +236,7 @@ fun JourneyCardItem(
     departureLocationNumber: Char?,
     originTime: String,
     durationText: String,
+    totalWalkTime: String?,
     destinationTime: String,
     onClick: () -> Unit,
     cardState: JourneyCardState,
@@ -254,6 +256,7 @@ fun JourneyCardItem(
             transportModeList = transportModeLineList.map { it.transportMode }
                 .toImmutableList(),
             legList = legList,
+            totalWalkTime = totalWalkTime,
             onClick = onClick,
             modifier = modifier,
         )


### PR DESCRIPTION
### TL;DR
Added total walking time indicator to journey cards in the trip planner

### What changed?
- Added a new `totalWalkTime` field to `TimeTableState`
- Implemented walking time calculation in `TripResponseMapper`
- Added walking time indicator with icon to journey cards
- Adjusted padding in the Origin/Destination component
- Updated journey card previews with walking time examples

### Why make this change?
To provide users with clear visibility of the total walking time required for their journey, helping them make more informed decisions when choosing between different route options. This is particularly important for users with mobility considerations or when planning trips in unfamiliar areas.

### Screenshots

<img width="367" alt="Screenshot 2024-11-06 at 10 51 56 pm" src="https://github.com/user-attachments/assets/fcb19e85-0ff5-4fdf-b087-987ab9265148">