### PR TITLE
UI: Refactor color utilities and add background color helper

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
@@ -108,7 +108,7 @@ val darkScrim = android.graphics.Color.argb(0x80, 0x1b, 0x1b, 0x1b)
  *
  * @return The brightened color in ARGB format
  */
-fun brightenColor(color: Int, factor: Float = 0.2f): Int {
+private fun brightenColor(color: Int, factor: Float = 0.2f): Int {
     // Convert the color to RGB components
     val red = android.graphics.Color.red(color) / 255f
     val green = android.graphics.Color.green(color) / 255f
@@ -116,7 +116,12 @@ fun brightenColor(color: Int, factor: Float = 0.2f): Int {
 
     // Convert RGB to HSL
     val hsl = FloatArray(3)
-    android.graphics.Color.RGBToHSV((red * 255).toInt(), (green * 255).toInt(), (blue * 255).toInt(), hsl)
+    android.graphics.Color.RGBToHSV(
+        (red * 255).toInt(),
+        (green * 255).toInt(),
+        (blue * 255).toInt(),
+        hsl,
+    )
 
     // Adjust lightness (value) within bounds
     hsl[2] = (hsl[2] + factor).coerceIn(0f, 1f)
@@ -135,13 +140,13 @@ fun brightenColor(color: Int, factor: Float = 0.2f): Int {
  *
  * @return The brightened Compose [Color].
  */
-fun Color.brighten(factor: Float = 0.2f): Color {
+private fun Color.brighten(factor: Float = 0.2f): Color {
     val argb = this.toArgb()
     val brightenedArgb = brightenColor(argb, factor)
     return Color(brightenedArgb)
 }
 
-fun darkenColor(color: Int, factor: Float = 0.2f): Int {
+private fun darkenColor(color: Int, factor: Float = 0.2f): Int {
     // Convert the color to RGB components
     val red = android.graphics.Color.red(color) / 255f
     val green = android.graphics.Color.green(color) / 255f
@@ -149,7 +154,12 @@ fun darkenColor(color: Int, factor: Float = 0.2f): Int {
 
     // Convert RGB to HSL
     val hsl = FloatArray(3)
-    android.graphics.Color.RGBToHSV((red * 255).toInt(), (green * 255).toInt(), (blue * 255).toInt(), hsl)
+    android.graphics.Color.RGBToHSV(
+        (red * 255).toInt(),
+        (green * 255).toInt(),
+        (blue * 255).toInt(),
+        hsl,
+    )
 
     // Adjust lightness (value) within bounds
     hsl[2] = (hsl[2] - factor).coerceIn(0f, 1f)
@@ -158,8 +168,17 @@ fun darkenColor(color: Int, factor: Float = 0.2f): Int {
     return android.graphics.Color.HSVToColor(hsl)
 }
 
-fun Color.darken(factor: Float = 0.2f): Color {
+private fun Color.darken(factor: Float = 0.2f): Color {
     val argb = this.toArgb()
     val darkArgb = darkenColor(argb, factor)
     return Color(darkArgb)
+}
+
+@Composable
+fun backgroundColorOf(color: Color): Color {
+    return if (isSystemInDarkTheme()) {
+        color.darken()
+    } else {
+        color.brighten()
+    }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -40,8 +39,7 @@ import xyz.ksharma.krail.design.system.components.Text
 import xyz.ksharma.krail.design.system.components.TextField
 import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.StopSearchListItem
-import xyz.ksharma.krail.trip.planner.ui.components.brighten
-import xyz.ksharma.krail.trip.planner.ui.components.darken
+import xyz.ksharma.krail.trip.planner.ui.components.backgroundColorOf
 import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
@@ -85,15 +83,7 @@ fun SearchStopScreen(
             .background(
                 brush = Brush.verticalGradient(
                     colors = listOf(
-                        if (isSystemInDarkTheme()) {
-                            themeColor
-                                .hexToComposeColor()
-                                .darken()
-                        } else {
-                            themeColor
-                                .hexToComposeColor()
-                                .brighten()
-                        },
+                        backgroundColorOf(themeColor.hexToComposeColor()),
                         KrailTheme.colors.surface,
                     ),
                 ),


### PR DESCRIPTION
### TL;DR
Improved color handling in the trip planner UI by introducing a new composable function for background colors and making color utility functions private.

### What changed?
- Added new `backgroundColorOf` composable function to handle theme-aware color adjustments
- Made color utility functions (`brightenColor`, `brighten`, `darkenColor`, `darken`) private
- Simplified color gradient logic in `SearchStopScreen` by using the new `backgroundColorOf` function
- Improved code formatting in color conversion functions

### How to test?
1. Launch the app and navigate to the trip planner
2. Toggle between light and dark themes
3. Verify that background colors adjust appropriately based on the theme
4. Check that color gradients in the search stop screen appear correctly in both themes

### Why make this change?
To encapsulate color manipulation logic and provide a more maintainable, theme-aware approach to handling background colors. This change reduces code duplication and improves the consistency of color handling across the app.