### PR TITLE
UI: Enhance service alerts display and journey card layout

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -41,6 +41,8 @@ data class TimeTableState(
         val transportModeLines: ImmutableList<TransportModeLine>,
 
         val legs: ImmutableList<Leg>,
+
+        val totalUniqueServiceAlerts: Int,
     ) {
         val journeyId: String
             get() = buildString {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
@@ -48,13 +48,13 @@ fun CollapsibleAlert(
                 color = if (collapsed) KrailTheme.colors.surface else themeBackgroundColor(),
                 shape = RoundedCornerShape(12.dp),
             )
-            .padding(vertical = 8.dp)
-            .padding(horizontal = 8.dp)
             .clickable(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = onClick,
             )
+            .padding(vertical = 8.dp)
+            .padding(horizontal = 8.dp)
             .animateContentSize(),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
@@ -48,7 +48,7 @@ fun ServiceAlertScreen(
 
         LazyColumn(
             modifier = Modifier,
-            contentPadding = PaddingValues(top = 32.dp, bottom = 104.dp),
+            contentPadding = PaddingValues(top = 20.dp, bottom = 104.dp),
         ) {
             itemsIndexed(
                 items = serviceAlerts.toImmutableList(),

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -53,6 +53,7 @@ fun LegView(
     routeText: String, // AVC via XYZ
     transportModeLine: TransportModeLine,
     stops: ImmutableList<TimeTableState.JourneyCardInfo.Stop>,
+    displayDuration: Boolean,
     modifier: Modifier = Modifier,
     displayAllStops: Boolean = false,
 ) {
@@ -81,7 +82,12 @@ fun LegView(
             )
             .padding(vertical = 12.dp, horizontal = 12.dp),
     ) {
-        RouteSummary(routeText = routeText, iconSize = iconSize, duration = duration)
+        RouteSummary(
+            routeText = routeText,
+            iconSize = iconSize,
+            duration = duration,
+            displayDuration = displayDuration,
+        )
 
         Spacer(modifier = Modifier.height(12.dp))
         Column(modifier = Modifier.fillMaxWidth()) {
@@ -171,6 +177,7 @@ private fun RouteSummary(
     routeText: String,
     iconSize: Dp,
     duration: String,
+    displayDuration: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -188,21 +195,23 @@ private fun RouteSummary(
                     .align(Alignment.CenterVertically),
             )
         }
-        Row(horizontalArrangement = Arrangement.End) {
-            Image(
-                painter = painterResource(R.drawable.ic_clock),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
-                modifier = Modifier
-                    .padding(end = 4.dp)
-                    .align(Alignment.CenterVertically)
-                    .size(iconSize),
-            )
-            Text(
-                text = duration,
-                style = KrailTheme.typography.bodySmall,
-                textAlign = TextAlign.End,
-            )
+        if (displayDuration) {
+            Row(horizontalArrangement = Arrangement.End) {
+                Image(
+                    painter = painterResource(R.drawable.ic_clock),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
+                    modifier = Modifier
+                        .padding(end = 4.dp)
+                        .align(Alignment.CenterVertically)
+                        .size(iconSize),
+                )
+                Text(
+                    text = duration,
+                    style = KrailTheme.typography.bodySmall,
+                    textAlign = TextAlign.End,
+                )
+            }
         }
     }
 }
@@ -290,6 +299,7 @@ private fun PreviewLegView() {
                 ),
             ).toImmutableList(),
             modifier = Modifier.background(KrailTheme.colors.surface),
+            displayDuration = true,
         )
     }
 }
@@ -317,6 +327,7 @@ private fun PreviewLegViewTwoStops() {
                 ),
             ).toImmutableList(),
             modifier = Modifier.background(KrailTheme.colors.surface),
+            displayDuration = true,
         )
     }
 }
@@ -343,6 +354,7 @@ private fun PreviewLegViewMetro() {
                 ),
             ).toImmutableList(),
             modifier = Modifier.background(KrailTheme.colors.surface),
+            displayDuration = true,
         )
     }
 }
@@ -369,6 +381,7 @@ private fun PreviewLegViewFerry() {
                 ),
             ).toImmutableList(),
             modifier = Modifier.background(KrailTheme.colors.surface),
+            displayDuration = false,
         )
     }
 }
@@ -395,6 +408,7 @@ private fun PreviewLegViewLightRail() {
                 ),
             ).toImmutableList(),
             modifier = Modifier.background(KrailTheme.colors.surface),
+            displayDuration = false,
         )
     }
 }
@@ -436,6 +450,7 @@ private fun PreviewRouteSummary() {
             iconSize = 14.dp,
             duration = "1h 30m",
             modifier = Modifier.background(KrailTheme.colors.surface),
+            displayDuration = true,
         )
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -210,6 +210,7 @@ fun TimeTableScreen(
                         onClick = {
                             onEvent(TimeTableUiEvent.JourneyCardClicked(journey.journeyId))
                         },
+                        totalUniqueServiceAlerts = journey.totalUniqueServiceAlerts,
                         onAlertClick = {
                             onAlertClick(journey.journeyId)
                         },
@@ -235,7 +236,7 @@ fun TimeTableScreen(
 }
 
 @Composable
-fun JourneyCardItem(
+private fun JourneyCardItem(
     timeToDeparture: String,
     departureLocationNumber: Char?,
     originTime: String,
@@ -246,6 +247,7 @@ fun JourneyCardItem(
     cardState: JourneyCardState,
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
     onAlertClick: () -> Unit,
+    totalUniqueServiceAlerts: Int,
     modifier: Modifier = Modifier,
     transportModeLineList: ImmutableList<TransportModeLine>? = null,
 ) {
@@ -264,6 +266,7 @@ fun JourneyCardItem(
             totalWalkTime = totalWalkTime,
             onClick = onClick,
             onAlertClick = onAlertClick,
+            totalUniqueServiceAlerts = totalUniqueServiceAlerts,
             modifier = modifier,
         )
     }
@@ -297,6 +300,7 @@ private fun PreviewTimeTableScreen() {
                                 ),
                             ),
                             legs = persistentListOf(),
+                            totalUniqueServiceAlerts = 3,
                             originUtcDateTime = "2024-11-01T12:00:00Z",
                         ),
                     ).toImmutableList(),
@@ -310,7 +314,7 @@ private fun PreviewTimeTableScreen() {
 }
 
 @Composable
-fun ActionButton(
+private fun ActionButton(
     onClick: () -> Unit,
     contentDescription: String,
     modifier: Modifier = Modifier,

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -87,7 +87,7 @@ class TimeTableViewModel @Inject constructor(
 
     private fun fetchTrip() {
         Timber.d("fetchTrip API Call")
-        viewModelScope.launch {
+        viewModelScope.launch(ioDispatcher) {
             // TODO - silent refresh here, UI to display loading but silent one.
             rateLimiter.rateLimitFlow {
                 Timber.d("rateLimitFlow block")

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -66,6 +66,7 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
                 totalWalkTime = walkingDurationStr,
                 transportModeLines = transportModeLines,
                 legs = legsList,
+                totalUniqueServiceAlerts = legs.flatMap { leg -> leg.infos.orEmpty() }.toSet().size,
             ).also {
                 Timber.d("\tJourneyId: ${it.journeyId}")
             }

--- a/feature/trip-planner/ui/src/main/res/values/strings.xml
+++ b/feature/trip-planner/ui/src/main/res/values/strings.xml
@@ -8,4 +8,8 @@
         <item quantity="one">%d stop</item>
         <item quantity="other">%d stops</item>
     </plurals>
+    <plurals name="alerts">
+        <item quantity="one">%d Alert</item>
+        <item quantity="other">%d Alerts</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
### TL;DR

**Enhanced service alert visibility in journey cards and improved UI interactions**
**Only display journey leg duration when there are multiple transport legs**


### What changed?

- Added a counter for unique service alerts in the journey card
- Redesigned alert button to show count and use a pill-shaped background
- Adjusted padding and click areas for better touch targets
- Only display journey leg duration when there are multiple transport legs
- Added pluralization support for alert count messaging
- Moved API call to IO dispatcher for better performance
- Fixed padding in service alert screen

### Why make this change?

To improve user awareness of service disruptions and make the interface more intuitive. The changes make it easier to identify journeys with alerts and provide better visual feedback for interactive elements.


### Screenshots


https://github.com/user-attachments/assets/7c80d64b-d5fc-4b9c-84eb-c2f3239eb914


