### PR TITLE
UI: Update alert link color in HTML text

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/HtmlText.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/HtmlText.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.text.HtmlCompat
 import xyz.ksharma.krail.design.system.theme.KrailTheme
-import xyz.ksharma.krail.trip.planner.ui.components.themeContentColor
 
 /**
  * Reference - https://developer.android.com/codelabs/jetpack-compose-migration#8
@@ -30,7 +29,7 @@ fun HtmlText(html: String, modifier: Modifier = Modifier, onClick: () -> Unit = 
     val textColor = KrailTheme.colors.label.toArgb()
     val textStyle = KrailTheme.typography.bodyLarge
     val resolver: FontFamily.Resolver = LocalFontFamilyResolver.current
-    val urlColor = themeContentColor().toArgb()
+    val urlColor = KrailTheme.colors.alert.toArgb()
 
     val textTypeface: Typeface = remember(resolver, textStyle) {
         resolver.resolve(


### PR DESCRIPTION
### TL;DR
Updated the URL color in HtmlText component to use the alert color from KrailTheme.

### What changed?
Modified the `urlColor` value in HtmlText.kt to use `KrailTheme.colors.alert.toArgb()` instead of `themeContentColor().toArgb()`.

### How to test?
1. Navigate to any screen using the HtmlText component
2. Verify that URLs are now displayed in the alert color from the theme
3. Confirm the color matches other alert elements in the app

### Why make this change?
To maintain consistency in the UI by using the designated alert color for clickable links, making them more distinguishable from regular text while adhering to the app's design system.