### PR TITLE
UI: Refactor platform text handling in journey cards

### DIFF
--- a/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -14,7 +14,8 @@ data class TimeTableState(
     data class JourneyCardInfo(
         val timeText: String, // "in x mins"
 
-        val platformText: Char? = null, // "on Platform X" or Stand A etc.
+        val platformText: String? = null, // "on Platform X" or Stand A etc.
+        val platformNumber: String? = null, // "1, 2, A etc
 
         // If first leg is not walking then,
         //      leg.first.origin.departureTimeEstimated ?: leg.first.origin.departureTimePlanned

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -73,6 +73,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 @Composable
 fun JourneyCard(
     timeToDeparture: String,
+    platformNumber: String?,
+    platformText: String?,
     originTime: String,
     destinationTime: String,
     totalTravelTime: String,
@@ -85,7 +87,6 @@ fun JourneyCard(
     totalUniqueServiceAlerts: Int,
     modifier: Modifier = Modifier,
     onAlertClick: () -> Unit = {},
-    platformNumber: Char? = null,
 ) {
     val onSurface: Color = KrailTheme.colors.onSurface
     val borderColors = remember(transportModeList) { transportModeList.toColors(onSurface) }
@@ -163,7 +164,7 @@ fun JourneyCard(
                     displayAllStops = false,
                     timeToDeparture = timeToDeparture,
                     themeColor = themeColor,
-                    platformNumber = platformNumber,
+                    platformText = platformText,
                     iconSize = iconSize,
                     totalTravelTime = totalTravelTime,
                     legList = legList,
@@ -187,7 +188,7 @@ fun ExpandedJourneyCardContent(
     displayAllStops: Boolean,
     timeToDeparture: String,
     themeColor: Color,
-    platformNumber: Char?,
+    platformText: String?,
     iconSize: Dp,
     totalTravelTime: String,
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
@@ -195,16 +196,13 @@ fun ExpandedJourneyCardContent(
     onAlertClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val firstTransportLeg = remember(legList) {
-        legList.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>().firstOrNull()
-    }
     val context = LocalContext.current
 
     Column(modifier = modifier) {
         FlowRow(
             modifier = Modifier
                 .fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            horizontalArrangement = if (platformText != null) Arrangement.SpaceBetween else Arrangement.Start,
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Text(
@@ -213,15 +211,12 @@ fun ExpandedJourneyCardContent(
                 color = themeColor,
             )
 
-            platformNumber?.let { platform ->
-                firstTransportLeg?.transportModeLine?.transportMode?.buildPlatformText(platform)
-                    ?.let { platformText ->
-                        Text(
-                            text = platformText,
-                            style = KrailTheme.typography.titleLarge,
-                            color = themeColor,
-                        )
-                    }
+            platformText?.let { text ->
+                Text(
+                    text = text,
+                    style = KrailTheme.typography.titleLarge,
+                    color = themeColor,
+                )
             }
         }
         FlowRow(
@@ -330,7 +325,7 @@ fun DefaultJourneyCardContent(
     isWheelchairAccessible: Boolean,
     themeColor: Color,
     transportModeList: ImmutableList<TransportMode>,
-    platformNumber: Char?,
+    platformNumber: String?,
     totalWalkTime: String?,
     modifier: Modifier = Modifier,
 ) {
@@ -533,15 +528,6 @@ internal fun List<TransportMode>?.toColors(onSurface: Color): List<Color> = when
     }
 }
 
-internal fun TransportMode.buildPlatformText(platformNumber: Char): String? {
-    return when (this) {
-        is TransportMode.Train, is TransportMode.Metro -> "Platform $platformNumber"
-        is TransportMode.Bus -> "Stand $platformNumber"
-        is TransportMode.Ferry -> "Wharf $platformNumber"
-        else -> null
-    }
-}
-
 // region Previews
 
 @PreviewLightDark
@@ -554,7 +540,8 @@ private fun PreviewJourneyCard() {
             originTime = "8:25am",
             destinationTime = "8:40am",
             totalTravelTime = "15 mins",
-            platformNumber = '1',
+            platformNumber = "18",
+            platformText = "Platform 18",
             isWheelchairAccessible = true,
             transportModeList = listOf(
                 TransportMode.Train(),
@@ -579,7 +566,8 @@ private fun PreviewJourneyCardCollapsed() {
             originTime = "8:25am",
             destinationTime = "8:40am",
             totalTravelTime = "15 mins",
-            platformNumber = '1',
+            platformNumber = "1",
+            platformText = "Platform 1",
             isWheelchairAccessible = true,
             transportModeList = listOf(
                 TransportMode.Train(),
@@ -627,7 +615,8 @@ private fun PreviewJourneyCardExpanded() {
             originTime = "8:25am",
             destinationTime = "8:40am",
             totalTravelTime = "15 mins",
-            platformNumber = '1',
+            platformNumber = "3",
+            platformText = "Platform 3",
             isWheelchairAccessible = true,
             transportModeList = listOf(
                 TransportMode.Train(),
@@ -692,7 +681,8 @@ private fun PreviewJourneyCardLongData() {
             originTime = "12:25am",
             destinationTime = "12:40am",
             totalTravelTime = "45h 15minutes",
-            platformNumber = 'A',
+            platformNumber = "A",
+            platformText = "Stand A",
             isWheelchairAccessible = true,
             transportModeList = listOf(
                 TransportMode.Ferry(),

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -190,7 +190,8 @@ fun TimeTableScreen(
                 items(timeTableState.journeyList) { journey ->
                     JourneyCardItem(
                         timeToDeparture = journey.timeText,
-                        departureLocationNumber = journey.platformText,
+                        platformNumber = journey.platformNumber,
+                        platformText = journey.platformText,
                         originTime = journey.originTime,
                         destinationTime = journey.destinationTime,
                         durationText = journey.travelTime,
@@ -235,10 +236,11 @@ fun TimeTableScreen(
     }
 }
 
-@Composable
+@Composable // todo - probably don't need this
 private fun JourneyCardItem(
     timeToDeparture: String,
-    departureLocationNumber: Char?,
+    platformNumber: String?,
+    platformText: String?,
     originTime: String,
     durationText: String,
     totalWalkTime: String?,
@@ -257,7 +259,8 @@ private fun JourneyCardItem(
             originTime = originTime,
             destinationTime = destinationTime,
             totalTravelTime = durationText,
-            platformNumber = departureLocationNumber,
+            platformNumber = platformNumber,
+            platformText = platformText,
             isWheelchairAccessible = false,
             cardState = cardState,
             transportModeList = transportModeLineList.map { it.transportMode }
@@ -289,7 +292,8 @@ private fun PreviewTimeTableScreen() {
                     journeyList = listOf(
                         TimeTableState.JourneyCardInfo(
                             timeText = "12:00",
-                            platformText = 'A',
+                            platformText = "Stand A",
+                            platformNumber = "A",
                             originTime = "12:00",
                             destinationTime = "12:30",
                             travelTime = "30 mins",

--- a/feature/trip-planner/ui/src/test/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/PlatformTextTest.kt
+++ b/feature/trip-planner/ui/src/test/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/PlatformTextTest.kt
@@ -1,0 +1,60 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+
+class PlatformTextTest {
+
+    @Test
+    fun testGetPlatformText() {
+        val disassembledNameSamples = listOf(
+            "Central Station, Platform 16" to "Platform 16",
+            "Central Station, Platform 24" to "Platform 24",
+            "Central Station, Platform 17" to "Platform 17",
+            null to null,
+            "Central Station" to null,
+            "Erskineville Station, Platform 1" to "Platform 1",
+            "Circular Quay, Wharf 2, Side A" to "Wharf 2, Side A",
+            "M2 Motorway, Barclay Rd" to null,
+            "Wynyard Station, Platform 3" to "Platform 3",
+            "Seven Hills Station, Stand A" to "Stand A",
+            "Circular Quay, Wharf 2" to "Wharf 2"
+        )
+
+        disassembledNameSamples.forEach { (input, expected) ->
+            val leg = TripResponse.Leg(
+                origin = TripResponse.StopSequence(
+                    disassembledName = input
+                )
+            )
+
+            assertEquals(expected, leg.getPlatformText())
+        }
+    }
+
+
+    @Test
+    fun testGetPlatformValue() {
+        val disassembledNameSamples = listOf(
+            "Central Station, Platform 16" to "16",
+            "Central Station" to null,
+            "Erskineville Station, Platform 1" to "1",
+            "Circular Quay, Wharf 2, Side A" to "2",
+            "M2 Motorway, Barclay Rd" to null,
+            "Wynyard Station, Platform 3" to "3",
+            "Seven Hills Station, Stand A" to "A",
+            "Circular Quay, Wharf 2" to "2"
+        )
+
+        disassembledNameSamples.forEach { (input, expected) ->
+            val leg = TripResponse.Leg(
+                origin = TripResponse.StopSequence(
+                    disassembledName = input
+                )
+            )
+
+            assertEquals(expected, leg.getPlatformNumber())
+        }
+    }
+}


### PR DESCRIPTION
### TL;DR
Improved platform number display by extracting information from stop names instead of relying on platform property.

### What changed?
- Changed `platformText` type from `Char` to `String` to support full platform descriptions
- Added new `platformNumber` field to store standalone platform values
- Created regex patterns to extract platform information from stop names
- Added unit tests to verify platform text and number extraction
- Updated UI components to handle both platform text and number separately
- Removed the `buildPlatformText` helper function as it's no longer needed

### Screenshots

No platform info for Bus, there fore it's skipped.

#### Journey Card 
| Default | Expanded |
|--------|--------|
| <img width="416" alt="Screenshot 2024-11-09 at 3 33 07 pm" src="https://github.com/user-attachments/assets/3df41b56-bc9a-4aa0-b444-3a0c73f77896"> | <img width="416" alt="Screenshot 2024-11-09 at 3 33 28 pm" src="https://github.com/user-attachments/assets/f638aea2-704c-4173-af90-da42e8486af5"> |

#### Ferry , Train

Train with platform no. 18
Ferry with Wharf and Side, siaplyed correctly.

| Train | Ferry |
|--------|--------|
| ![18](https://github.com/user-attachments/assets/44b1558d-1042-4cac-9e4d-2d500470d2d0) | ![wharf_number](https://github.com/user-attachments/assets/eb6ac61b-34a8-4106-ad38-0e5d8f825d7a) |


### Why make this change?
The previous implementation relied on a single character platform property which was often incomplete or missing. By extracting platform information from stop names, we can provide more accurate and detailed platform information to users, improving their journey planning experience.