### PR TITLE
UI: Add error and empty states to stop search

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -52,7 +52,7 @@ class SearchStopViewModel @Inject constructor(
     )
 
     private fun SearchStopState.displayLoading() =
-        copy(isLoading = true, stops = persistentListOf(), isError = false)
+        copy(isLoading = true, isError = false)
 
     private fun SearchStopState.displayError() = copy(
         isLoading = false,


### PR DESCRIPTION
### TL;DR
Enhanced the search stop screen with improved error handling, loading states, and empty state messaging.

### What changed?
- Added a "No match found" message with contextual hints based on search length
- Implemented error messages with user-friendly copy
- Introduced animation for list items and error states
- Removed loading text in favor of a cleaner loading state
- Added preview compositions for loading, error, and empty states
- Preserved the stop list during loading states instead of clearing it
- Added a delay before showing the "No match found" message to prevent flickering

### How to test?
1. Enter a search query with less than 4 characters to see the "throw in more chars" message
2. Enter a longer search query with no results to see the "try tweaking your search" message
3. Trigger an error state to verify the error message
4. Verify animations when list items appear
5. Check that the loading state doesn't clear existing results

### Why make this change?
To provide a more polished and user-friendly search experience with clear feedback and smooth transitions between states. The changes help users understand when their search isn't yielding results and guides them toward successful searches.