### PR TITLE
UI: Add text filtering and length limits to search input

### DIFF
--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TextField.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TextField.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.runtime.Composable
@@ -53,6 +54,8 @@ fun TextField(
     textStyle: TextStyle? = null,
     readOnly: Boolean = false,
     imeAction: ImeAction = ImeAction.Default,
+    filter: (CharSequence) -> CharSequence = { it },
+    maxLength: Int = Int.MAX_VALUE,
     onTextChange: (CharSequence) -> Unit = {},
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -66,7 +69,11 @@ fun TextField(
     )
 
     LaunchedEffect(textFieldState.text) {
-        onTextChange(textFieldState.text)
+        val filteredText = filter(textFieldState.text).take(maxLength)
+        if (textFieldState.text != filteredText) {
+            textFieldState.setTextAndPlaceCursorAtEnd(filteredText.toString())
+        }
+        onTextChange(filteredText)
     }
 
     CompositionLocalProvider(

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -69,7 +69,10 @@ fun SearchStopScreen(
     val trimmedText by remember(textFieldText) { derivedStateOf { textFieldText.trim() } }
 
     LaunchedEffect(trimmedText) {
-        snapshotFlow { trimmedText }.distinctUntilChanged().debounce(250).filter { it.isNotBlank() }
+        snapshotFlow { trimmedText }
+            .distinctUntilChanged()
+            .debounce(250)
+            .filter { it.isNotBlank() }
             .mapLatest { text ->
                 Timber.d("Query - $text")
                 onEvent(SearchStopUiEvent.SearchTextChanged(text))
@@ -107,6 +110,10 @@ fun SearchStopScreen(
                 .padding(vertical = 12.dp)
                 .focusRequester(focusRequester)
                 .padding(horizontal = 16.dp),
+            maxLength = 30,
+            filter = { input ->
+                input.filter { it.isLetterOrDigit() || it.isWhitespace() }
+            },
         ) { value ->
             Timber.d("value: $value")
             textFieldText = value.toString()


### PR DESCRIPTION
### TL;DR
Added text filtering and max length support to TextField component and implemented these features in SearchStopScreen.

### What changed?
- Added `filter` and `maxLength` parameters to TextField component
- Implemented text filtering in TextField to process input before triggering changes
- Updated SearchStopScreen to limit input to 30 characters
- Added filtering in SearchStopScreen to only allow letters, digits, and whitespace
- Improved code readability in SearchStopScreen by formatting the reactive flow chain

### How to test?
1. Open SearchStopScreen
2. Try entering more than 30 characters - verify it's truncated
3. Attempt to enter special characters - verify only alphanumeric and spaces are accepted
4. Verify that the search functionality still works as expected with filtered input

### Why make this change?
To improve input validation and user experience by:
- Preventing excessive text input length
- Ensuring only valid characters are entered
- Reducing potential for invalid search queries
- Making the code more maintainable with clear input processing