### PR TITLE
UI: Improve stop search results handling and animations

### DIFF
--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -38,7 +38,8 @@ class SearchStopViewModel @Inject constructor(
         viewModelScope.launch {
             tripPlanningRepository.stopFinder(stopSearchQuery = query)
                 .onSuccess { response: StopFinderResponse ->
-                    updateUiState { displayData(response.toStopResults()) }
+                    val results = response.toStopResults()
+                    updateUiState { displayData(results) }
                 }.onFailure {
                     updateUiState { displayError() }
                 }


### PR DESCRIPTION
### TL;DR
Enhanced the stop search functionality with improved error handling and smoother UI transitions.

### What changed?
- Added key-based list item rendering for better performance
- Implemented a 1-second delay before showing "No match found" message
- Added tracking of query timestamps to prevent false "No match found" displays
- Improved error state handling with distinct keys for error messages
- Removed redundant Unit placeholder for empty state

### How to test?
1. Open the stop search screen
2. Enter a search query
3. Verify that "No match found" appears after 1 second if no results
4. Enter a valid stop name and confirm results appear
5. Clear the search and verify smooth transitions
6. Test with network errors to verify error message display


### Screenshots

https://github.com/user-attachments/assets/881f2270-fe2b-4645-b2c5-7d4ba6a648c5


### Why make this change?
To provide a more polished user experience by eliminating UI flicker, improving state transitions, and ensuring more reliable error handling when searching for stops.