### PR TITLE
Update app version to 1.0-alpha02 and add ProGuard rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ google-services.json
 # MAC OS specific
 .DS_Store
 **/.DS_Store
+
+# Ignore Android App Bundle files
+*.aab
+
+# Ignore Download Manager files
+*.dm

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 5
-        versionName = "1.0-alpha01"
+        versionCode = 11
+        versionName = "1.0-alpha02"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -23,30 +23,24 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             isDebuggable = true
+            ndk {
+                isDebuggable = true
+                debugSymbolLevel = "FULL"
+            }
         }
 
         release {
             isMinifyEnabled = true
             isDebuggable = false
-
-            // Enables resource shrinking, which is performed by the
-            // Android Gradle plugin.
             isShrinkResources = true
-
             ndk {
                 isDebuggable = false
                 debugSymbolLevel = "FULL"
             }
-
-            proguardFiles(
-                // Includes the default ProGuard rules files that are packaged with
-                // the Android Gradle plugin. To learn more, go to the section about
-                // R8 configuration files.
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-
-                // Includes a local, custom Proguard rules file
-                "proguard-rules.pro"
-            )
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            firebaseCrashlytics {
+                nativeSymbolUploadEnabled = true
+            }
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,47 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+#Need this to keep serializable members as is
+-keepclassmembers class * implements java.io.Serializable {
+    static final long serialVersionUID;
+    private static final java.io.ObjectStreamField[] serialPersistentFields;
+    private void writeObject(java.io.ObjectOutputStream);
+    private void readObject(java.io.ObjectInputStream);
+    java.lang.Object writeReplace();
+    java.lang.Object readResolve();
+}
+
+
+# For native methods, see http://proguard.sourceforge.net/manual/examples.html#native
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+
+#This will print mappings - very useful for troubleshooting.
+-printseeds ./build/seeds.txt
+-printusage ./build/unused.txt
+-printmapping ./build/mapping.txt
+
+#Some recommended settings for running with Android
+-keep public class * extends android.app.Activity
+-keep public class * extends android.app.Application
+
+-keep public enum * {}
+-keep public interface * {}
+
+-keepattributes *Annotation*
+
+-keepclassmembers,allowobfuscation class * {
+    @javax.inject.* *;
+    @dagger.* *;
+    <init>();
+}
+
+
+-keepattributes *Annotation*,Signature
+-dontwarn retrofit.**
+-keep class retrofit.** { *; }
+-keepclasseswithmembers class * {
+    @retrofit.* <methods>;
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
### TL;DR
Updated app version to alpha02 and enhanced ProGuard configuration for better release builds.

### What changed?
- Bumped version code from 5 to 11 and version name to 1.0-alpha02
- Added new file extensions (*.aab, *.dm) to .gitignore
- Enhanced ProGuard rules to better handle serialization, native methods, and Retrofit
- Added Firebase Crashlytics native symbol upload for release builds
- Configured NDK debugging settings for both debug and release builds
- Streamlined build.gradle configuration for release builds

### How to test?
1. Build the app in release mode
2. Verify the app launches and functions correctly
3. Check Firebase Crashlytics dashboard for proper native crash reporting
4. Verify ProGuard mapping files are generated in ./build directory

### Why make this change?
To improve app stability and crash reporting capabilities while preparing for the next alpha release. The enhanced ProGuard configuration provides better code optimization and protection while maintaining necessary functionality for serialization and native methods.