### PR TITLE
Build: Remove SQLDelight dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,6 @@ opencsv = "5.9"
 paparazzi = "1.3.5"
 retrofit = "2.11.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
-sqldelight = "2.0.2"
-sqliteAndroidDriver = "2.0.2"
 timber = "5.0.1"
 wire = "5.1.0"
 
@@ -96,9 +94,6 @@ android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", ver
 detektFormat = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
 detektCompose = { group = "io.nlopez.compose.rules", name = "detekt", version.ref = "detektCompose" }
 
-#Database
-sqlite-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqliteAndroidDriver" }
-
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -109,7 +104,6 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
-cash-sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 google-services = { id = "com.google.gms.google-services", version = "4.4.2" }
 firebase-crashlyticsPlugin = { id = "com.google.firebase.crashlytics", version = "3.0.2" }
 firebase-performancePlugin = { id = "com.google.firebase.firebase-perf", version = "1.4.2" }


### PR DESCRIPTION
### TL;DR
Removed SQLDelight dependencies and configurations from the project

### What changed?
- Removed SQLDelight version definitions (`sqldelight` and `sqliteAndroidDriver`)
- Removed SQLite Android driver dependency
- Removed SQLDelight Gradle plugin configuration

### How to test?
1. Build the project and verify it compiles successfully
2. Ensure no SQLDelight-related build errors are present
3. Verify that database functionality is handled by alternative implementations

### Why make this change?
SQLDelight is being phased out in favor of a different database solution, requiring the removal of these unused dependencies to maintain a clean project configuration and reduce potential conflicts.