### PR TITLE
Build: Update Android SDK targets and core-ktx version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 java = "17"
 agp = "8.7.2" # Android Gradle Plugin
 kotlin = "2.0.21"
-core-ktx = "1.13.1"
+core-ktx = "1.15.0"
 junit = "4.13.2"
 androidx-test = "1.6.1"
 androidx-test-ext-junit = "1.2.1"
@@ -28,8 +28,8 @@ wire = "5.1.0"
 
 #SDK
 minSdk = "26"
-compileSdk = "34"
-targetSdk = "34"
+compileSdk = "35"
+targetSdk = "35"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }


### PR DESCRIPTION
### TL;DR
Updated Android SDK targets and core-ktx library version

### What changed?
- Upgraded `core-ktx` from 1.13.1 to 1.15.0
- Increased `compileSdk` from 34 to 35
- Increased `targetSdk` from 34 to 35

### Why make this change?
Keeping dependencies up-to-date ensures we have access to the latest Android features, bug fixes, and security patches. The SDK target update allows the app to take advantage of the latest Android platform capabilities while maintaining backward compatibility.