### PR TITLE
UI: Add back navigation to alerts and timetable screens

### DIFF
--- a/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TitleBar.kt
+++ b/core/design-system/src/main/kotlin/xyz/ksharma/krail/design/system/components/TitleBar.kt
@@ -31,6 +31,7 @@ import xyz.ksharma.krail.design.system.theme.KrailTheme
 fun TitleBar(
     title: @Composable () -> Unit,
     modifier: Modifier = Modifier,
+    navAction: @Composable (() -> Unit)? = null,
     actions: @Composable (() -> Unit)? = null,
 ) {
     Row(
@@ -38,11 +39,19 @@ fun TitleBar(
             .statusBarsPadding()
             .fillMaxWidth()
             .heightIn(min = 56.dp)
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(end = 16.dp, start = 8.dp)
+            .padding(vertical = 4.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(modifier = Modifier.weight(1f)) {
+        navAction?.let {
+            navAction()
+        }
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 10.dp),
+        ) {
             CompositionLocalProvider(
                 LocalTextColor provides KrailTheme.colors.onSurface,
                 LocalTextStyle provides KrailTheme.typography.headlineMedium,

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.kotlinx.datetime)
     implementation(projects.sandook.real)
+    implementation(libs.compose.material3)
 
     testImplementation(libs.test.composeUiTestJunit4)
     testImplementation(libs.test.kotlin)

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.alerts
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import kotlinx.collections.immutable.toImmutableSet
@@ -9,7 +10,7 @@ import timber.log.Timber
 import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
-internal fun NavGraphBuilder.alertsDestination() {
+internal fun NavGraphBuilder.alertsDestination(navController: NavHostController) {
     composable<ServiceAlertRoute> { backStackEntry ->
 
         val route = backStackEntry.toRoute<ServiceAlertRoute>()
@@ -26,6 +27,8 @@ internal fun NavGraphBuilder.alertsDestination() {
             }
         }
 
-        ServiceAlertScreen(serviceAlerts = serviceAlerts)
+        ServiceAlertScreen(serviceAlerts = serviceAlerts, onBackClick = {
+            navController.popBackStack()
+        })
     }
 }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
@@ -1,20 +1,25 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
@@ -26,11 +31,13 @@ import xyz.ksharma.krail.design.system.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.DefaultSystemBarColors
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertPriority
+import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 
 @Composable
 fun ServiceAlertScreen(
     serviceAlerts: ImmutableSet<ServiceAlert>,
     modifier: Modifier = Modifier,
+    onBackClick: () -> Unit = {},
 ) {
     DefaultSystemBarColors()
 
@@ -41,7 +48,22 @@ fun ServiceAlertScreen(
             .statusBarsPadding(),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            TitleBar(title = { Text(text = "Service Alerts") })
+            TitleBar(
+                navAction = {
+                    ActionButton(
+                        onClick = onBackClick,
+                        contentDescription = "Back",
+                    ) {
+                        Image(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                },
+                title = { Text(text = "Service Alerts") },
+            )
         }
 
         var expandedAlertId by rememberSaveable { mutableStateOf<Int?>(null) }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -27,7 +27,7 @@ fun NavGraphBuilder.tripPlannerDestinations(
 
         usualRideDestination(navController)
 
-        alertsDestination()
+        alertsDestination(navController)
     }
 }
 

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -31,6 +31,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             timeTableState = timeTableState,
             expandedJourneyId = expandedJourneyId,
             onEvent = { viewModel.onEvent(it) },
+            onBackClick = { navController.popBackStack() },
             onAlertClick = { journeyId ->
                 Timber.d("journeyId: $journeyId")
                 viewModel.fetchAlertsForJourney(journeyId) { alerts ->

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -71,6 +73,7 @@ fun TimeTableScreen(
     expandedJourneyId: String?,
     onEvent: (TimeTableUiEvent) -> Unit,
     onAlertClick: (String) -> Unit,
+    onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val themeColorHex by LocalThemeColor.current
@@ -106,6 +109,19 @@ fun TimeTableScreen(
                 .background(color = themeColor),
         ) {
             TitleBar(
+                navAction = {
+                    ActionButton(
+                        onClick = onBackClick,
+                        contentDescription = "Back",
+                    ) {
+                        Image(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = null,
+                            colorFilter = ColorFilter.tint(themeContentColor),
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                },
                 title = {
                     Text(
                         text = stringResource(R.string.time_table_screen_title),
@@ -298,7 +314,7 @@ private fun JourneyCardItem(
 }
 
 @Composable
-private fun ActionButton(
+fun ActionButton(
     onClick: () -> Unit,
     contentDescription: String,
     modifier: Modifier = Modifier,
@@ -357,6 +373,7 @@ private fun PreviewTimeTableScreen() {
                 expandedJourneyId = null,
                 onEvent = {},
                 onAlertClick = {},
+                onBackClick = {},
             )
         }
     }
@@ -382,6 +399,7 @@ private fun PreviewTimeTableScreenError() {
                 expandedJourneyId = null,
                 onEvent = {},
                 onAlertClick = {},
+                onBackClick = {},
             )
         }
     }
@@ -407,6 +425,7 @@ private fun PreviewTimeTableScreenNoResults() {
                 expandedJourneyId = null,
                 onEvent = {},
                 onAlertClick = {},
+                onBackClick = {},
             )
         }
     }

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
@@ -78,7 +78,7 @@ fun UsualRideScreen(
                     style = KrailTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Normal),
                     modifier = Modifier
                         .padding(horizontal = 24.dp)
-                        .padding(bottom = 8.dp, top = 16.dp),
+                        .padding(bottom = 8.dp, top = 24.dp),
                 )
             }
 


### PR DESCRIPTION
### TL;DR
Added back navigation functionality to the Service Alerts and Time Table screens with a consistent UI treatment.

### What changed?
- Added a back arrow navigation button to the TitleBar component
- Implemented back navigation in Service Alerts and Time Table screens
- Updated TitleBar padding and layout to accommodate the new navigation button
- Adjusted the UsualRideScreen top padding for better visual hierarchy
- Added material3 dependency to the trip-planner module

### Why make this change?
To provide users with a clear and consistent way to navigate back from detail screens, improving the overall navigation experience and adhering to platform navigation patterns.