### PR TITLE
Update app version to 1.0-alpha03

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,8 +9,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 11
-        versionName = "1.0-alpha02"
+        versionCode = 12
+        versionName = "1.0-alpha03"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
### TL;DR
Bump version code to 12 and version name to 1.0-alpha03

### What changed?
- Incremented version code from 11 to 12
- Updated version name from 1.0-alpha02 to 1.0-alpha03

### Why make this change?
Preparing for the next alpha release of the application by incrementing version identifiers to maintain proper versioning sequence.