### PR TITLE
UI: Fix text capitalization and styling in UsualRideScreen

### DIFF
--- a/core/date-time/src/main/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/main/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -77,9 +77,9 @@ object DateTimeHelper {
                     "${if (totalMinutes.absoluteValue == 1L) "min" else "mins"} ago"
 
             totalMinutes == 0L -> "Now"
-            hours == 1L -> "In ${hours.absoluteValue}h ${partialMinutes.absoluteValue}m"
-            hours >= 2 -> "In ${hours.absoluteValue}h"
-            else -> "In ${totalMinutes.absoluteValue} ${if (totalMinutes.absoluteValue == 1L) "min" else "mins"}"
+            hours == 1L -> "in ${hours.absoluteValue}h ${partialMinutes.absoluteValue}m"
+            hours >= 2 -> "in ${hours.absoluteValue}h"
+            else -> "in ${totalMinutes.absoluteValue} ${if (totalMinutes.absoluteValue == 1L) "min" else "mins"}"
         }
         Timber.d("\t minutes: $partialMinutes, hours: $hours, formattedDifference: $formattedDifference -> originTime")
         return formattedDifference

--- a/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
+++ b/feature/trip-planner/ui/src/main/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
@@ -84,7 +84,7 @@ fun UsualRideScreen(
 
             item {
                 Text(
-                    text = "What's your favourite color, mate?",
+                    text = "What's your favourite colour, mate?",
                     style = KrailTheme.typography.bodyMedium,
                     modifier = Modifier
                         .padding(horizontal = 24.dp)
@@ -104,7 +104,7 @@ fun UsualRideScreen(
         }
 
         Text(
-            text = if (selectedProductClass != null) "Let's Go, Yeah!" else "Pick one.",
+            text = if (selectedProductClass != null) "Let's Go, Yeah!" else "Pick a colour.",
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
@@ -131,7 +131,11 @@ fun UsualRideScreen(
                 }
                 .padding(vertical = 12.dp),
             textAlign = TextAlign.Center,
-            style = KrailTheme.typography.titleMedium,
+            style = if (selectedProductClass != null) {
+                KrailTheme.typography.titleMedium
+            } else {
+                KrailTheme.typography.bodyLarge
+            },
         )
     }
 }


### PR DESCRIPTION
### TL;DR
Updated text formatting and styling in the usual ride screen and datetime helper

### What changed?
- Changed capitalization of "In" to lowercase "in" for time differences in DateTimeHelper
- Updated text from "color" to "colour" in UsualRideScreen
- Changed "Pick one" to "Pick a colour" in selection prompt
- Modified text style to use bodyLarge instead of titleMedium when no product class is selected

### How to test?
1. Navigate to the usual ride screen and verify text changes
2. Check that the selection prompt displays "Pick a colour" before selection
3. Verify text style changes when no product class is selected
4. Test datetime formatting to ensure "in" appears lowercase in time differences

### Why make this change?
To maintain consistent text formatting across the app and improve user experience with more specific prompts and appropriate text styling based on selection state