### PR TITLE
Add CI build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Build Status
+
+[![Krail App CI](https://github.com/ksharma-xyz/Krail/actions/workflows/build.yml/badge.svg)](https://github.com/ksharma-xyz/Krail/actions/workflows/build.yml)
+
 # Krail - Making travel simple and fun.
 
 ### Tag Lines


### PR DESCRIPTION
### TL;DR
Added CI build status badge to README.md

### What changed?
Added a GitHub Actions build status badge at the top of the README.md file, which links to the Krail App CI workflow

### How to test?
1. View the README.md file on GitHub
2. Verify the build status badge is visible
3. Click the badge to ensure it links to the correct GitHub Actions workflow

### Why make this change?
Provides immediate visibility of the project's build status to repository visitors and contributors, making it easier to monitor the health of the codebase