### PR TITLE
UI: Add color animations to CollapsibleAlert

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
@@ -1,6 +1,9 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -21,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
@@ -39,11 +43,23 @@ fun CollapsibleAlert(
     modifier: Modifier = Modifier,
     collapsed: Boolean = true,
 ) {
+    val indexBackgroundColor by animateColorAsState(
+        targetValue = if (collapsed) themeBackgroundColor() else Color.Transparent,
+        label = "indexBackgroundColor",
+        animationSpec = tween(durationMillis = 300, easing = LinearEasing)
+    )
+
+    val parentBackgroundColor by animateColorAsState(
+        targetValue = if (collapsed) KrailTheme.colors.surface else themeBackgroundColor(),
+        label = "parentBackgroundColor",
+        animationSpec = tween(durationMillis = 300, easing = LinearEasing)
+    )
+
     Column(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                color = if (collapsed) KrailTheme.colors.surface else themeBackgroundColor(),
+                color = parentBackgroundColor,
                 shape = RoundedCornerShape(12.dp),
             )
             .clickable(
@@ -65,7 +81,7 @@ fun CollapsibleAlert(
                     .size(24.dp.toAdaptiveSize())
                     .clip(CircleShape)
                     .background(
-                        color = if (collapsed) themeBackgroundColor() else KrailTheme.colors.surface,
+                        color = indexBackgroundColor,
                     ),
                 contentAlignment = Alignment.Center,
             ) {


### PR DESCRIPTION
### TL;DR
Added smooth color transition animations to the CollapsibleAlert component

### What changed?
- Introduced color animations for background transitions in the CollapsibleAlert
- Added `animateColorAsState` for both the index and parent background colors
- Set animation duration to 300ms with linear easing
- Replaced direct color assignments with animated color states

### How to test?
1. Navigate to any screen containing the CollapsibleAlert component
2. Tap the alert to expand/collapse it
3. Verify that the background colors transition smoothly between states
4. Confirm the animation duration feels natural and matches the existing content size animation

### Why make this change?
The previous implementation had abrupt color changes when expanding/collapsing the alert, which created a jarring user experience. Adding smooth color transitions creates a more polished and cohesive interaction that better aligns with material design principles.


### Screenshots



https://github.com/user-attachments/assets/3985589f-69ba-44ed-8e6d-863731bd838c

