### PR TITLE
UI: Add HTML text support for Android and iOS

### DIFF
--- a/feature/trip-planner/ui/src/androidMain/kotlin/HtmlText.kt
+++ b/feature/trip-planner/ui/src/androidMain/kotlin/HtmlText.kt
@@ -1,0 +1,63 @@
+package xyz.ksharma.krail.trip.planner.ui.alerts
+
+import android.graphics.Typeface
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontSynthesis
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.text.HtmlCompat
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+/**
+ * Reference - https://developer.android.com/codelabs/jetpack-compose-migration#8
+ */
+@Composable
+actual fun HtmlText(text: String, modifier: Modifier, onClick: () -> Unit) {
+    // Remembers the HTML formatted description. Re-executes on a new description
+    val htmlDescription = remember(text) {
+        HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_COMPACT)
+    }
+
+    val textColor = KrailTheme.colors.label.toArgb()
+    val textStyle = KrailTheme.typography.bodyLarge
+    val resolver: FontFamily.Resolver = LocalFontFamilyResolver.current
+    val urlColor = KrailTheme.colors.alert.toArgb()
+
+    val textTypeface: Typeface = remember(resolver, textStyle) {
+        resolver.resolve(
+            fontFamily = textStyle.fontFamily,
+            fontWeight = textStyle.fontWeight ?: FontWeight.Normal,
+            fontStyle = textStyle.fontStyle ?: FontStyle.Normal,
+            fontSynthesis = textStyle.fontSynthesis ?: FontSynthesis.All,
+        )
+    }.value as Typeface
+
+    // Displays the TextView on the screen and updates with the HTML description when inflated
+    // Updates to htmlDescription will make AndroidView recompose and update the text
+    AndroidView(
+        factory = { context ->
+            TextView(context).apply {
+                movementMethod = LinkMovementMethod.getInstance()
+                setTextColor(textColor)
+                setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, textStyle.fontSize.value)
+                typeface = textTypeface
+                setLinkTextColor(urlColor)
+                setOnClickListener {
+                    onClick()
+                }
+            }
+        },
+        update = {
+            it.text = htmlDescription
+        },
+        modifier = modifier,
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.content.MediaType.Companion.HtmlText
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -105,8 +106,7 @@ fun CollapsibleAlert(
                 )
             }
             if (isHtml) {
-                // TODO - Html  Text Component
-                Text(text = serviceAlert.message) // , onClick = onClick
+                HtmlText(text = serviceAlert.message, onClick = onClick)
             } else {
                 Text(
                     text = serviceAlert.message,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/HtmlText.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/HtmlText.kt
@@ -1,67 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
-/*
 
-import android.graphics.Typeface
-import android.text.method.LinkMovementMethod
-import android.widget.TextView
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalFontFamilyResolver
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontSynthesis
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.text.HtmlCompat
-import xyz.ksharma.krail.taj.theme.KrailTheme
-
-*/
-/**
- * Reference - https://developer.android.com/codelabs/jetpack-compose-migration#8
- *//*
 
 @Composable
-fun HtmlText(html: String, modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
-    // Remembers the HTML formatted description. Re-executes on a new description
-    val htmlDescription = remember(html) {
-        HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_COMPACT)
-    }
-
-    val textColor = KrailTheme.colors.label.toArgb()
-    val textStyle = KrailTheme.typography.bodyLarge
-    val resolver: FontFamily.Resolver = LocalFontFamilyResolver.current
-    val urlColor = KrailTheme.colors.alert.toArgb()
-
-    val textTypeface: Typeface = remember(resolver, textStyle) {
-        resolver.resolve(
-            fontFamily = textStyle.fontFamily,
-            fontWeight = textStyle.fontWeight ?: FontWeight.Normal,
-            fontStyle = textStyle.fontStyle ?: FontStyle.Normal,
-            fontSynthesis = textStyle.fontSynthesis ?: FontSynthesis.All,
-        )
-    }.value as Typeface
-
-    // Displays the TextView on the screen and updates with the HTML description when inflated
-    // Updates to htmlDescription will make AndroidView recompose and update the text
-    AndroidView(
-        factory = { context ->
-            TextView(context).apply {
-                movementMethod = LinkMovementMethod.getInstance()
-                setTextColor(textColor)
-                setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, textStyle.fontSize.value)
-                typeface = textTypeface
-                setLinkTextColor(urlColor)
-                setOnClickListener {
-                    onClick()
-                }
-            }
-        },
-        update = {
-            it.text = htmlDescription
-        },
-        modifier = modifier,
-    )
-}
-*/
+expect fun HtmlText(text: String, modifier: Modifier = Modifier, onClick: () -> Unit)

--- a/feature/trip-planner/ui/src/iosMain/kotlin/HtmlText.kt
+++ b/feature/trip-planner/ui/src/iosMain/kotlin/HtmlText.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.krail.trip.planner.ui.alerts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import xyz.ksharma.krail.taj.components.Text
+
+@Composable
+actual fun HtmlText(text: String, modifier: Modifier, onClick: () -> Unit) {
+    Text(text = replaceHtmlTags(text), modifier = Modifier.clickable { onClick() })
+}
+
+// TODO - A workaround for iOS until https://issuetracker.google.com/issues/139326648 is fixed.
+private fun replaceHtmlTags(html: String): String {
+    return html
+        .replace("</div>", "\n")
+        .replace("</li>", "\n")
+        .replace("<ul>", "\n")
+        .replace(Regex("<a href=\"[^\"]*\">"), " ")
+        .replace("&nbsp;", " ")
+        .replace(Regex("<[^>]*>"), "") // Remove all other HTML tags
+        .replace(Regex("\n{3,}"), "\n\n")  // Replace multiple new lines with a single new line
+}


### PR DESCRIPTION
### TL;DR
Added HTML text support for service alerts across Android and iOS platforms.

### What changed?
- Created a new `HtmlText` composable that handles HTML-formatted text differently for Android and iOS
- Android implementation uses `AndroidView` with `TextView` to properly render HTML content with clickable links
- iOS implementation includes a temporary workaround that strips HTML tags and formats text appropriately
- Integrated the `HtmlText` component into the `CollapsibleAlert` composable

### Why make this change?
Service alerts often contain HTML-formatted content including links and formatting. This change enables proper rendering of HTML content while maintaining platform-specific best practices. The Android implementation follows official guidance for HTML in Compose, while the iOS solution provides a temporary workaround until the platform fully supports HTML rendering.

### Screenshots

| Android | iOS |
|--------|--------|
| <img width="267" alt="Screenshot 2024-11-24 at 2 17 40 pm" src="https://github.com/user-attachments/assets/37f9fe44-2075-416f-a331-4cdcdd6ac394"> | <img width="277" alt="Screenshot 2024-11-24 at 2 16 11 pm" src="https://github.com/user-attachments/assets/f0b8a0aa-8b3d-4fbd-9986-4ef25751d7ec"> |


PS - Compose multiplatform does not support Html Text markdown
Issue - https://issuetracker.google.com/issues/139326648