### PR TITLE
UI: Add loading state to saved trips screen

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -4,4 +4,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
-data class SavedTripsState(val savedTrips: ImmutableList<Trip> = persistentListOf())
+data class SavedTripsState(
+    val savedTrips: ImmutableList<Trip> = persistentListOf(),
+    val isLoading: Boolean = true,
+)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -94,7 +94,7 @@ fun SavedTripsScreen(
                     Spacer(modifier = Modifier.height(12.dp))
                 }
 
-                if (savedTripsState.savedTrips.isEmpty()) {
+                if (savedTripsState.savedTrips.isEmpty() && savedTripsState.isLoading.not()) {
                     item(key = "empty_state") {
                         ErrorMessage(
                             emoji = "🌟",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -25,6 +25,7 @@ class SavedTripsViewModel(
 
     private fun loadSavedTrips() {
         viewModelScope.launch(context = Dispatchers.IO) {
+            updateUiState { copy(isLoading = true) }
             val trips = mutableSetOf<Trip>()
 
             val savedTrips = sandook.selectAllTrips()
@@ -42,7 +43,7 @@ class SavedTripsViewModel(
                 println("\t SavedTrip: #$index ${trip.fromStopName} -> ${trip.toStopName}")
             }
 
-            updateUiState { copy(savedTrips = trips.toImmutableList()) }
+            updateUiState { copy(savedTrips = trips.toImmutableList(), isLoading = false) }
         }
     }
 


### PR DESCRIPTION
### TL;DR
Added loading state to the Saved Trips screen to prevent premature display of empty state message

### What changed?
- Added `isLoading` boolean flag to `SavedTripsState`
- Updated `SavedTripsViewModel` to manage loading state during trip fetching
- Modified empty state visibility logic in `SavedTripsScreen` to consider loading status

### How to test?
1. Navigate to the Saved Trips screen
2. Verify that the empty state message doesn't appear immediately while trips are loading
3. Confirm empty state message appears only after loading completes with no saved trips
4. Save a trip and verify the empty state message is replaced with the saved trip

### Why make this change?
Previously, the empty state message would flash briefly while trips were being loaded from storage, creating a jarring user experience. This change ensures the empty state message only appears when we're certain there are no saved trips to display.