### PR TITLE
UI: Add rosemary emoji for ANZAC Day loading screen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -27,7 +27,12 @@ object LoadingEmojiManager {
         FestivalType.CHRISTMAS to listOf("🎁"),
         FestivalType.NEW_YEAR to listOf("🎉"),
         FestivalType.NEW_YEAR_EVE to listOf("🎆"),
-        FestivalType.ANZAC_DAY to listOf("🌺", "🇦🇺", "\uD83C\uDF96\uFE0F"),
+        FestivalType.ANZAC_DAY to listOf(
+            "🌺", // Flower
+            "🇦🇺", // Australia Flag
+            "\uD83C\uDF96\uFE0F", // Military Medal
+            "\uD83C\uDF3F" // Herb Rosemary
+        ),
         FestivalType.EASTER to listOf("🐰", "🐣", "🥚"),
         FestivalType.VALENTINES_DAY to listOf("❤️", "🌹"),
         FestivalType.HALLOWEEN to listOf("🎃", "👻"),


### PR DESCRIPTION
### TL;DR
Added Rosemary emoji to ANZAC Day loading animations

### What changed?
Added the Rosemary herb emoji (🌿) to the ANZAC Day emoji collection and included descriptive comments for each emoji's significance

### Why make this change?
Rosemary is a significant symbol of remembrance for ANZAC Day, traditionally worn as a symbol of remembrance and commemoration. Adding this emoji makes the ANZAC Day loading animations more culturally authentic and meaningful.