### PR TITLE
Fix display name for Leg

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -155,7 +155,7 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
             ?.let { TransportMode.toTransportModeType(productClass = it) }
     val lineName = transportation?.disassembledName
 
-    val displayText = transportation?.description
+    val displayText = transportation?.destination?.name
     val numberOfStops = stopSequence?.size
     val displayDuration = duration?.seconds?.toFormattedDurationTimeString()
     val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()


### PR DESCRIPTION
### TL;DR
Updated journey card display text to show destination name instead of transportation description

### What changed?
Modified the `toUiModel()` function in `TripResponseMapper.kt` to use `transportation?.destination?.name` instead of `transportation?.description` for the `displayText` property

### How to test?
1. Open the trip planner
2. Search for and select a journey
3. Verify that journey cards now display the destination name
4. Compare with previous behavior where transportation description was shown

### Why make this change?
Displaying the destination name provides more relevant information to users when viewing journey details, making it easier to identify where each leg of their trip ends