### PR TITLE
UI: Redesign search stop screen and improve text field layout

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -52,13 +52,14 @@ fun SearchStopRow(
                 color = themeColor.hexToComposeColor(),
                 shape = RoundedCornerShape(topStart = 36.dp, topEnd = 36.dp),
             )
-            .padding(vertical = 24.dp, horizontal = 16.dp)
+            .padding(vertical = 20.dp, horizontal = 16.dp)
             .padding(
                 bottom = with(LocalDensity.current) {
                     WindowInsets.navigationBars
                         .getBottom(this)
                         .toDp()
                 },
+                top = 8.dp
             ),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
@@ -26,6 +26,9 @@ fun NavGraphBuilder.searchStopDestination(navController: NavHostController) {
                 )
                 navController.popBackStack()
             },
+            onBackClick = {
+                navController.popBackStack()
+            },
         ) { event -> viewModel.onEvent(event) }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -1,15 +1,23 @@
 package xyz.ksharma.krail.trip.planner.ui.searchstop
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -20,10 +28,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
@@ -56,6 +67,7 @@ fun SearchStopScreen(
     searchStopState: SearchStopState,
     modifier: Modifier = Modifier,
     searchQuery: String = "",
+    onBackClick: () -> Unit = {},
     onStopSelect: (StopItem) -> Unit = {},
     onEvent: (SearchStopUiEvent) -> Unit = {},
 ) {
@@ -77,7 +89,7 @@ fun SearchStopScreen(
             .debounce(250)
             .filter { it.isNotBlank() }
             .mapLatest { text ->
-               // Timber.d("Query - $text")
+                // Timber.d("Query - $text")
                 onEvent(SearchStopUiEvent.SearchTextChanged(text))
             }.collectLatest {}
     }
@@ -119,7 +131,7 @@ fun SearchStopScreen(
             .imePadding(),
     ) {
         TextField(
-            placeholder = "Search station / stop",
+            placeholder = "Search here",
             modifier = Modifier
                 .fillMaxWidth()
                 .statusBarsPadding()
@@ -130,6 +142,28 @@ fun SearchStopScreen(
             filter = { input ->
                 input.filter { it.isLetterOrDigit() || it.isWhitespace() }
             },
+            leadingIcon = {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() },
+                        ) {
+                            keyboard?.hide()
+                            onBackClick()
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back",
+                        colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
+            }
         ) { value ->
             //Timber.d("value: $value")
             textFieldText = value.toString()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -62,7 +62,7 @@ fun SettingsScreen(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = null,
                             colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                            modifier = Modifier.size(24.dp),
+                            modifier = Modifier.size(32.dp),
                         )
                     }
                 },
@@ -102,7 +102,6 @@ fun SettingsScreen(
                 }
                 Divider()
             }
-
         }
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -53,6 +55,7 @@ fun TextField(
     enabled: Boolean = true,
     textStyle: TextStyle? = null,
     readOnly: Boolean = false,
+    leadingIcon: (@Composable () -> Unit)? = null,
     imeAction: ImeAction = ImeAction.Default,
     filter: (CharSequence) -> CharSequence = { it },
     maxLength: Int = Int.MAX_VALUE,
@@ -98,7 +101,7 @@ fun TextField(
                 autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Text,
                 imeAction = imeAction,
-                hintLocales = LocaleList.current, // todo - required?
+                hintLocales = LocaleList.current,
             ),
             lineLimits = TextFieldLineLimits.SingleLine,
             readOnly = readOnly,
@@ -111,10 +114,15 @@ fun TextField(
                             shape = RoundedCornerShape(TextFieldHeight.div(2)),
                             color = KrailTheme.colors.surface,
                         )
-                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                        .padding(vertical = 4.dp)
+                        .padding(end = 16.dp, start = if (leadingIcon != null) 0.dp else 16.dp),
                     horizontalArrangement = Arrangement.Start,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    leadingIcon?.let { icon ->
+                        icon.invoke()
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
                     if (textFieldState.text.isEmpty() && isFocused) {
                         /* Using a Box ensures that cursor and placeholder are displayed on top of
                      each other, so the cursor is always displayed at the start if the TextField.
@@ -126,7 +134,6 @@ fun TextField(
                     } else if (textFieldState.text.isEmpty()) {
                         TextFieldPlaceholder(placeholder = placeholder)
                     } else {
-                        // add leading icon here - todo
                         innerTextField()
                         // add trailing icon here / Clear - todo
                     }
@@ -138,12 +145,12 @@ fun TextField(
 
 @Composable
 private fun TextFieldPlaceholder(placeholder: String? = null) {
-    val color = LocalTextColor.current
-    Text(
-        text = placeholder.orEmpty(),
-        maxLines = 1,
-        color = color.copy(alpha = PlaceholderOpacity),
-    )
+    CompositionLocalProvider(LocalContentAlpha provides PlaceholderOpacity) {
+        Text(
+            text = placeholder.orEmpty(),
+            maxLines = 1,
+        )
+    }
 }
 
 // region Previews


### PR DESCRIPTION
### TL;DR
Added a back button to the search stop screen and refined UI spacing across multiple components.

### What changed?
- Added a back button with arrow icon to the search stop screen
- Updated the search placeholder text to "Search here"
- Adjusted padding and spacing in SearchStopRow component
- Modified TextField component to support leading icons
- Increased the back arrow size in Settings screen to 32dp
- Refined placeholder text opacity handling in TextField component

### Screenshots

| Dark | Light |
|--------|--------|
| ![Screenshot_20241126_230809](https://github.com/user-attachments/assets/11ad924e-55ce-42a4-a177-56c72de9d525) | ![Screenshot_20241126_230657](https://github.com/user-attachments/assets/da843433-cdb7-40a0-8f56-078cceb0b5a2) | 


### Why make this change?
To improve navigation consistency and user experience by providing clear ways to exit the search screen and ensuring UI elements are properly sized and spaced throughout the application.