### PR TITLE
UI: Clear focus when exiting search stop screen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -152,6 +152,7 @@ fun SearchStopScreen(
                             interactionSource = remember { MutableInteractionSource() },
                         ) {
                             keyboard?.hide()
+                            focusRequester.freeFocus()
                             onBackClick()
                         },
                     contentAlignment = Alignment.Center,
@@ -194,6 +195,7 @@ fun SearchStopScreen(
                         textColor = KrailTheme.colors.label,
                         onClick = { stopItem ->
                             keyboard?.hide()
+                            focusRequester.freeFocus()
                             onStopSelect(stopItem)
                         },
                         modifier = Modifier


### PR DESCRIPTION
### TL;DR
Added focus management when navigating away from the search stop screen

### What changed?
Added `focusRequester.freeFocus()` calls when:
- Clicking the back button
- Selecting a stop from the search results

### How to test?
1. Open the search stop screen
2. Type in the search field
3. Click back button or select a stop
4. Verify keyboard is dismissed and focus is cleared

### Why make this change?
Improves the user experience by properly managing keyboard focus when navigating away from the search screen, preventing any lingering focus states that could affect the next screen.