### PR TITLE
UI: SavedTripCard - update button colors and improve spacing

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,7 +58,7 @@ fun SavedTripCard(
                 onClickLabel = "Open Trip Details",
                 onClick = onCardClick,
             )
-            .padding(12.dp),
+            .padding(vertical = 16.dp, horizontal = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         primaryTransportMode?.let {
@@ -71,7 +72,7 @@ fun SavedTripCard(
             modifier = Modifier
                 .padding(horizontal = 16.dp)
                 .weight(1f),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text(text = trip.fromStopName, style = KrailTheme.typography.bodyMedium)
             Text(text = trip.toStopName, style = KrailTheme.typography.bodyMedium)
@@ -95,8 +96,10 @@ fun SavedTripCard(
                 painter = painterResource(Res.drawable.ic_star_filled),
                 contentDescription = "Save Trip",
                 colorFilter = ColorFilter.tint(
-                    primaryTransportMode?.colorCode
-                        ?.hexToComposeColor() ?: themeColor.hexToComposeColor(),
+                    if (isSystemInDarkTheme().not()) {
+                        primaryTransportMode?.colorCode
+                            ?.hexToComposeColor() ?: themeColor.hexToComposeColor()
+                    } else KrailTheme.colors.onSurface,
                 ),
             )
         }


### PR DESCRIPTION
### TL;DR
Enhanced the visual appearance of the SavedTripCard component with improved spacing and dark theme support.

### What changed?
- Increased vertical padding from 12dp to 16dp in the main card container
- Adjusted spacing between stop names from 8dp to 16dp
- Added dark theme support for the star icon, using onSurface color instead of transport mode color
- Maintained horizontal padding at 12dp for consistency

### How to test?
1. Open the trip planner screen with saved trips
2. Verify card spacing looks balanced in light mode
3. Switch to dark mode and confirm the star icon is visible
4. Check that the spacing between origin and destination stations is comfortable

### Why make this change?
The adjustments improve readability and visual hierarchy while ensuring the star icon remains visible in dark mode. The increased spacing provides better visual separation between elements, making the card more scannable for users.