### PR TITLE
Add Loading Animation for Search StopScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/AnimatedDots.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/AnimatedDots.kt
@@ -1,0 +1,71 @@
+package xyz.ksharma.krail.trip.planner.ui.components.loading
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+@Composable
+fun AnimatedDots(color: Color = KrailTheme.colors.onSurface) {
+    val infiniteTransition = rememberInfiniteTransition()
+
+    // Animating the offset for each dot
+    val dot1Offset by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = -30f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+    val dot2Offset by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = -30f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600, easing = LinearEasing, delayMillis = 200),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+    val dot3Offset by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = -30f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600, easing = LinearEasing, delayMillis = 400),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        val dotRadius = 10f
+        val centerY = size.height / 2
+        val centerX = size.width / 2
+        val spacing = 40f
+
+        // Draw the three dots with their animated offsets
+        drawCircle(
+            color = color,
+            radius = dotRadius,
+            center = Offset(centerX - spacing, centerY + dot1Offset)
+        )
+        drawCircle(
+            color = color,
+            radius = dotRadius,
+            center = Offset(centerX, centerY + dot2Offset)
+        )
+        drawCircle(
+            color = color,
+            radius = dotRadius,
+            center = Offset(centerX + spacing, centerY + dot3Offset)
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -29,6 +30,8 @@ class SearchStopViewModel(private val tripPlanningService: TripPlanningService) 
         updateUiState { displayLoading() }
 
         viewModelScope.launch {
+
+            delay(300)
             runCatching {
                 val response = tripPlanningService.stopFinder(stopSearchQuery = query)
                 println("response VM: $response")


### PR DESCRIPTION
### TL;DR
Added loading animation with animated dots to the stop search screen

### What changed?
- Created a new `AnimatedDots` composable that displays three animated dots
- Integrated loading animation into the `SearchStopScreen`
- Added a 300ms delay to search operations to ensure loading state is visible
- Improved error state handling to prevent overlap with loading animation

### How to test?
1. Navigate to the stop search screen
2. Enter text in the search field
3. Verify that animated dots appear while search is in progress
4. Confirm that error states and no results messages appear after loading completes
5. Ensure loading animation smoothly transitions in and out

### Why make this change?
To provide better visual feedback during search operations, helping users understand when the app is actively processing their request. The animated dots create a more polished and professional user experience compared to a static loading state.