### PR TITLE
UI: Add DateTime support to trip planning API

### DIFF
--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -17,6 +17,9 @@ class RealTripPlanningService(private val httpClient: HttpClient) : TripPlanning
     override suspend fun trip(
         originStopId: String,
         destinationStopId: String,
+        depArr: DepArr,
+        date: String?,
+        time: String?,
     ): TripResponse = withContext(Dispatchers.IO) {
 
         httpClient.get("$NSW_TRANSPORT_BASE_URL/v1/tp/trip") {
@@ -24,7 +27,10 @@ class RealTripPlanningService(private val httpClient: HttpClient) : TripPlanning
                 parameters.append(TripRequestParams.nameOrigin, originStopId)
                 parameters.append(TripRequestParams.nameDestination, destinationStopId)
 
-                parameters.append(TripRequestParams.depArrMacro, "dep")
+                parameters.append(TripRequestParams.depArrMacro, depArr.macro)
+                date?.let { parameters.append(TripRequestParams.itdDate, date) }
+                time?.let { parameters.append(TripRequestParams.itdTime, time) }
+
                 parameters.append(TripRequestParams.typeDestination, "any")
                 parameters.append(TripRequestParams.calcNumberOfTrips, "6")
                 parameters.append(TripRequestParams.typeOrigin, "any")
@@ -56,5 +62,9 @@ class RealTripPlanningService(private val httpClient: HttpClient) : TripPlanning
             }
         }.body()
     }
+}
 
+enum class DepArr(val macro: String) {
+    DEP("dep"),
+    ARR("arr")
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
@@ -11,7 +11,23 @@ internal const val NSW_TRANSPORT_BASE_URL = "https://api.transport.nsw.gov.au"
 
 interface TripPlanningService {
 
-    suspend fun trip(originStopId: String, destinationStopId: String): TripResponse
+    suspend fun trip(
+        originStopId: String,
+        destinationStopId: String,
+        depArr: DepArr = DepArr.DEP,
+
+        /**
+         * YYYYMMDD format.
+         * E.g. 20160901 refers to 1 September 2016.
+         */
+        date: String? = null,
+
+        /**
+         * HHMM 24-hour format.
+         * E.g. 0830 means 8:30am and 2030 means 8:30pm.
+         */
+        time: String? = null,
+    ): TripResponse
 
     suspend fun stopFinder(
         stopSearchQuery: String,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -55,8 +55,6 @@ import xyz.ksharma.krail.trip.planner.ui.components.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.themeContentColor
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.JourneyTimeOptions.ARRIVE
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.JourneyTimeOptions.LEAVE
-import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
-import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem.Companion
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -233,6 +231,19 @@ data class DateTimeSelectionItem(
     }
 
     fun toJsonString() = Json.encodeToString(serializer(), this)
+
+    fun toHHMM(): String {
+        val hh = hour.toString().padStart(2, '0')
+        val mm = minute.toString().padStart(2, '0')
+        return "$hh$mm"
+    }
+
+    fun toYYYYMMDD(): String {
+        val yyyy = date.year.toString()
+        val mm = date.monthNumber.toString().padStart(2, '0')
+        val dd = date.dayOfMonth.toString().padStart(2, '0')
+        return "$yyyy$mm$dd"
+    }
 
     @Suppress("ConstPropertyName")
     companion object {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -22,7 +22,11 @@ import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeStri
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.ratelimit.RateLimiter
+import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
+import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectionItem
+import xyz.ksharma.krail.trip.planner.ui.datetimeselector.JourneyTimeOptions
+import xyz.ksharma.krail.trip.planner.ui.datetimeselector.JourneyTimeOptions.*
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
@@ -67,6 +71,7 @@ class TimeTableViewModel(
     val expandedJourneyId: StateFlow<String?> = _expandedJourneyId
 
     private var tripInfo: Trip? = null
+    private var dateTimeSelectionItem: DateTimeSelectionItem? = null
 
     fun onEvent(event: TimeTableUiEvent) {
         when (event) {
@@ -116,6 +121,13 @@ class TimeTableViewModel(
             val tripResponse = tripPlanningService.trip(
                 originStopId = tripInfo!!.fromStopId,
                 destinationStopId = tripInfo!!.toStopId,
+                date = dateTimeSelectionItem?.toYYYYMMDD(),
+                time = dateTimeSelectionItem?.toHHMM(),
+                depArr = when (dateTimeSelectionItem?.option) {
+                    LEAVE -> DepArr.DEP
+                    ARRIVE -> DepArr.ARR
+                    else -> DepArr.DEP
+                }
             )
             Result.success(tripResponse)
         }.getOrElse { error ->


### PR DESCRIPTION
### TL;DR
Added support for departure/arrival time selection in trip planning

### What changed?
- Extended the trip planning API to support departure and arrival time preferences
- Added new parameters for date (YYYYMMDD) and time (HHMM) in the trip planning service
- Introduced a DepArr enum to handle departure/arrival preferences
- Added utility functions in DateTimeSelectionItem to format date and time
- Updated TimeTableViewModel to incorporate user-selected date/time preferences

### How to test?
1. Set a departure or arrival time in the date/time selector
2. Plan a trip between two stops
3. Verify that the returned journeys respect the selected time preference
4. Test both departure and arrival scenarios
5. Verify date/time formatting matches the required format (YYYYMMDD for date, HHMM for time)

### Why make this change?
To provide users with more control over their journey planning by allowing them to specify whether they want to arrive by or depart at a specific time, rather than only showing current departure times.