### PR TITLE
UI: Improve search and loading states in trip planner

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -97,6 +97,7 @@ class TimeTableViewModel(
     private fun fetchTrip() {
         println("fetchTrip API Call")
         fetchTripJob?.cancel()
+        updateUiState { copy(silentLoading = true) }
         fetchTripJob = viewModelScope.launch(Dispatchers.IO) {
             rateLimiter.rateLimitFlow {
                 println("rateLimitFlow block obj:$rateLimiter and coroutine: $this")


### PR DESCRIPTION
### TL;DR
Added error handling and loading states for trip planner search functionality

### What changed?
- Added job cancellation for search queries to prevent race conditions
- Introduced a 1.5-second delay before showing error states in search results
- Added silent loading state during trip fetching operations
- Implemented proper cleanup of previous search operations

### How to test?
1. Enter text in the stop search field and verify that rapid typing doesn't cause flickering
2. Test error scenarios by triggering API failures and verify the error state appears after 1.5 seconds
3. Verify loading indicators appear appropriately during trip fetches
4. Confirm that rapid searches don't stack or cause race conditions

### Why make this change?
To improve the user experience by preventing UI flickering, managing loading states more effectively, and ensuring proper error handling during search operations. The changes also help prevent potential race conditions when users perform rapid searches.