### PR TITLE
UI: Persist DateTime selection across navigation

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
@@ -6,14 +6,19 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
+import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 
 internal fun NavGraphBuilder.dateTimeSelectorDestination(navController: NavHostController) {
     composable<DateTimeSelectorRoute> { backStackEntry ->
         val viewModel: DateTimeSelectorViewModel = koinViewModel<DateTimeSelectorViewModel>()
+        val route: DateTimeSelectorRoute = backStackEntry.toRoute()
 
         // TODO - If arguments have data, then display that data in the Screen else display current date time.
 
         DateTimeSelectorScreen(
+            dateTimeSelection = route.dateTimeSelectionItemJson?.let{
+                DateTimeSelectionItem.fromJsonString(it)
+            },
             onBackClick = {
                 navController.popBackStack()
             },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -87,7 +87,7 @@ data object SettingsRoute
 @Serializable
 data class DateTimeSelectorRoute(
     // Noop, need x coz it's data class, need to put keys in companion obj rather than elsewhere.
-    val x: String = "",
+    val dateTimeSelectionItemJson: String? = null,
 ) {
     companion object {
         const val DATE_TIME_TEXT_KEY = "DateTimeSelectionKey"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -70,7 +70,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             dateTimeSelectionItem = dateTimeSelectionItem,
             dateTimeSelectorClicked = {
                 navController.navigate(
-                    route = DateTimeSelectorRoute(),
+                    route = DateTimeSelectorRoute(dateTimeSelectionItem?.toJsonString()),
                     navOptions = NavOptions.Builder().setLaunchSingleTop(singleTop = true).build(),
                 )
             },


### PR DESCRIPTION
### TL;DR
Added support for persisting and restoring date/time selection state when navigating between screens in the trip planner.

### What changed?
- Added ability to pass DateTimeSelectionItem through navigation route
- DateTimeSelectorScreen now initializes with previously selected date/time values
- Reset functionality now properly resets all fields to current date/time
- Updated reset state logic to accurately track when values match current time

### Screenshots

https://github.com/user-attachments/assets/01fb4edb-c0cc-4b04-b6d7-98652176b2a6


### Why make this change?
Improves user experience by maintaining selected date/time values during navigation, preventing users from having to re-enter their selections when returning to the screen. This is particularly useful when users need to temporarily navigate away while planning their journey.