### PR TITLE
UI: Extract SecondaryButton component and standardize usage

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SecondaryButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SecondaryButton.kt
@@ -1,0 +1,32 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+@Composable
+fun SecondaryButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = KrailTheme.typography.titleSmall.copy(fontWeight = FontWeight.Normal),
+        modifier = modifier.padding(10.dp)
+            .background(color = themeBackgroundColor(), shape = RoundedCornerShape(50))
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+            .clickable(
+                role = Role.Button,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            )
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.Clock
@@ -47,8 +46,8 @@ import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.SecondaryButton
 import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
-import xyz.ksharma.krail.trip.planner.ui.components.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.themeContentColor
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
@@ -134,24 +133,16 @@ fun DateTimeSelectorScreen(
                 )
             }
         }, actions = {
-            Text(text = "Reset",
-                style = KrailTheme.typography.titleSmall.copy(fontWeight = FontWeight.Normal),
-                modifier = Modifier.padding(10.dp)
-                    .background(color = themeBackgroundColor(), shape = RoundedCornerShape(50))
-                    .padding(horizontal = 12.dp, vertical = 6.dp)
-                    .clickable(
-                        role = Role.Button,
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                    ) {
-                        val now: LocalDateTime =
-                            Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-                        selectedDateStr = now.date.toString()
-                        timePickerState.hour = now.time.hour
-                        timePickerState.minute = now.time.minute
-                        journeyTimeOption = JourneyTimeOptions.LEAVE
-                        reset = true
-                    })
+            SecondaryButton(text = "Reset",
+                onClick = {
+                    val now: LocalDateTime =
+                        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+                    selectedDateStr = now.date.toString()
+                    timePickerState.hour = now.time.hour
+                    timePickerState.minute = now.time.minute
+                    journeyTimeOption = JourneyTimeOptions.LEAVE
+                    reset = true
+                })
         })
 
         LazyColumn(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,7 +21,6 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
@@ -56,10 +54,10 @@ import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
 import xyz.ksharma.krail.trip.planner.ui.components.OriginDestination
+import xyz.ksharma.krail.trip.planner.ui.components.SecondaryButton
 import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
 import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiAnim
-import xyz.ksharma.krail.trip.planner.ui.components.themeContentColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
@@ -105,7 +103,10 @@ fun TimeTableScreen(
                     }
                 },
                 title = {
-                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
                         Text(
                             text = "TimeTable",
                             color = KrailTheme.colors.onSurface,
@@ -116,7 +117,10 @@ fun TimeTableScreen(
                             enter = fadeIn(),
                             exit = fadeOut(),
                         ) {
-                            AnimatedDots(color = themeColor, modifier = Modifier.padding(start = 24.dp))
+                            AnimatedDots(
+                                color = themeColor,
+                                modifier = Modifier.padding(start = 24.dp)
+                            )
                         }
                     }
                 },
@@ -172,21 +176,9 @@ fun TimeTableScreen(
             }
 
             item {
-                Text(
+                SecondaryButton(
                     text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
-                    style = KrailTheme.typography.titleMedium,
-                    color = themeContentColor(),
-                    modifier = Modifier
-                        .padding(horizontal = 16.dp, vertical = 12.dp)
-                        .background(color = themeColor, shape = RoundedCornerShape(50))
-                        .padding(horizontal = 12.dp, vertical = 6.dp)
-                        .clickable(
-                            role = Role.Button,
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                        ) {
-                            dateTimeSelectorClicked()
-                        },
+                    onClick = dateTimeSelectorClicked,
                 )
             }
 


### PR DESCRIPTION
### TL;DR
Created a reusable SecondaryButton component and implemented it across date/time selector screens.

### What changed?
- Created a new `SecondaryButton` composable that encapsulates common button styling and behavior
- Replaced custom button implementations in `DateTimeSelectorScreen` and `TimeTableScreen` with the new `SecondaryButton` component
- The button maintains consistent styling with rounded corners, background color, and padding across all implementations

### Screenshots

https://github.com/user-attachments/assets/563bfceb-8c10-4c7a-945c-79c3191ee9ca


### Why make this change?
Reduces code duplication and ensures consistent button styling across the trip planner interface. This change improves maintainability by centralizing button styling logic and makes it easier to update the design system in the future.