### PR TITLE
Release: Bump version to 1.0-beta01 and disable logging

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,8 +6,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 16
-        versionName = "1.0-alpha05"
+        versionCode = 21
+        versionName = "1.0-beta01"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,7 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
@@ -23,7 +22,7 @@ actual fun httpClient(): HttpClient {
         }
         install(Logging) {
 //            if(debug) - TODO
-            level = LogLevel.BODY
+//            level = LogLevel.BODY
         }
 
         defaultRequest {

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,7 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
@@ -23,7 +22,7 @@ actual fun httpClient(): HttpClient {
         }
         install(Logging) {
 //            if(debug) - TODO
-            level = LogLevel.BODY
+//            level = LogLevel.BODY
         }
 
         defaultRequest {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,11 +28,6 @@ sqlDelight = "2.0.2"
 koin = "4.0.1-Beta1"
 slf4jSimple = "2.0.16"
 
-#SDK
-minSdk = "26"
-compileSdk = "35"
-targetSdk = "35"
-
 [libraries]
 buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildkonfigGradlePlugin" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }


### PR DESCRIPTION
### TL;DR
Bumped version to 1.0-beta01 and disabled HTTP client logging

### What changed?
- Increased version code from 16 to 21
- Updated version name from 1.0-alpha05 to 1.0-beta01
- Disabled HTTP body logging in both Android and iOS clients
- Removed unused SDK version definitions from libs.versions.toml

### Screenshots

https://github.com/user-attachments/assets/563bfceb-8c10-4c7a-945c-79c3191ee9ca


### Why make this change?
Moving from alpha to beta release requires cleaning up debug features like verbose network logging. This change prepares the app for a more stable beta release while reducing unnecessary logging overhead in the networking layer.