### PR TITLE
UI: Add horizontal padding to alert heading text

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
@@ -80,7 +80,7 @@ fun CollapsibleAlert(
             Text(
                 text = serviceAlert.heading,
                 style = KrailTheme.typography.titleSmall,
-                modifier = Modifier.padding(start = 12.dp).alignByBaseline(),
+                modifier = Modifier.padding(horizontal = 12.dp).alignByBaseline(),
                 color = getForegroundColor(backgroundColor),
             )
         }


### PR DESCRIPTION
### TL;DR
Added horizontal padding to alert heading text

### What changed?
Modified the padding modifier for the alert heading text from `start = 12.dp` to `horizontal = 12.dp`, which adds padding to both left and right sides of the text.

### How to test?
1. Navigate to any screen displaying service alerts
2. Verify that alert headings have equal padding on both left and right sides
3. Ensure text remains properly aligned within the alert container

### Why make this change?
To improve visual consistency and readability of alert headings by maintaining equal spacing on both sides of the text, rather than just the left side.