### PR TITLE
Release: Bump version to 1.0-beta02

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,8 +6,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 21
-        versionName = "1.0-beta01"
+        versionCode = 22
+        versionName = "1.0-beta02"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
### TL;DR
Bump version code to 22 and version name to 1.0-beta02

### What changed?
- Incremented `versionCode` from 21 to 22
- Updated `versionName` from "1.0-beta01" to "1.0-beta02"

### How to test?
1. Build and install the app
2. Verify the new version appears in the app settings or system app info

### Why make this change?
Prepare for the next beta release by incrementing version numbers to maintain proper version control and release tracking in the Play Store.