### PR TITLE
Create :core:appInfo module

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -94,6 +94,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.taj)
             implementation(projects.sandook)
+            implementation(projects.core.appInfo)
             implementation(projects.feature.tripPlanner.network)
             implementation(projects.feature.tripPlanner.ui)
             implementation(projects.feature.tripPlanner.state)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -1,15 +1,20 @@
 package xyz.ksharma.krail
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import org.koin.compose.KoinApplication
+import xyz.ksharma.krail.core.appinfo.LocalPlatformTypeProvider
+import xyz.ksharma.krail.core.appinfo.getPlatform
 import xyz.ksharma.krail.di.koinConfig
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
 fun KrailApp() {
     KoinApplication(application = koinConfig) {
-        KrailTheme {
-            KrailNavHost()
+        CompositionLocalProvider(LocalPlatformTypeProvider provides getPlatform().type) {
+            KrailTheme {
+                KrailNavHost()
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/Platform.kt
@@ -1,7 +1,0 @@
-package xyz.ksharma.krail
-
-interface Platform {
-    val name: String
-}
-
-expect fun getPlatform(): Platform

--- a/core/app-info/build.gradle.kts
+++ b/core/app-info/build.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    alias(libs.plugins.krail.android.library)
+    alias(libs.plugins.krail.kotlin.multiplatform)
+    alias(libs.plugins.krail.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "xyz.ksharma.krail.core.appinfo"
+}
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    androidTarget()
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        }
+    }
+
+    sourceSets {
+        androidMain {
+            dependencies {
+            }
+        }
+
+        commonMain {
+            dependencies {
+                implementation(libs.kotlinx.serialization.json)
+
+                implementation(compose.runtime)
+            }
+        }
+
+        iosMain.dependencies {
+        }
+    }
+}

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.android.kt
@@ -1,9 +1,10 @@
-package xyz.ksharma.krail
+package xyz.ksharma.krail.core.appinfo
 
 import android.os.Build
 
 class AndroidPlatform : Platform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
+    override val type: PlatformType = PlatformType.ANDROID
 }
 
 actual fun getPlatform(): Platform = AndroidPlatform()

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.core.appinfo
+
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalPlatformTypeProvider = compositionLocalOf { PlatformType.UNKNOWN }

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.kt
@@ -1,0 +1,14 @@
+package xyz.ksharma.krail.core.appinfo
+
+interface Platform {
+    val name: String
+    val type: PlatformType
+}
+
+enum class PlatformType {
+    ANDROID,
+    IOS,
+    UNKNOWN,
+}
+
+expect fun getPlatform(): Platform

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.ios.kt
@@ -1,10 +1,12 @@
-package xyz.ksharma.krail
+package xyz.ksharma.krail.core.appinfo
 
 import platform.UIKit.UIDevice
 
 class IOSPlatform : Platform {
     override val name: String =
         UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+
+    override val type: PlatformType = PlatformType.IOS
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ rootProject.name = "Krail"
 //include(":android-app")
 include(":composeApp")
 include(":taj") // Design System
+include(":core:app-info")
 include(":core:date-time")
 include(":feature:trip-planner:ui")
 include(":feature:trip-planner:state")


### PR DESCRIPTION
### TL;DR
Created a new app-info module to handle platform-specific information and introduced a composition local for platform type.

### What changed?
- Created a new `:core:app-info` module to handle platform-specific functionality
- Moved platform detection code from `composeApp` to the new module
- Added a `PlatformType` enum to distinguish between Android, iOS, and Unknown platforms
- Introduced `LocalPlatformTypeProvider` composition local to access platform type throughout the app
- Updated `KrailApp` to provide platform type via composition local

### How to test?
1. Build and run the app on both Android and iOS
2. Verify that `LocalPlatformTypeProvider.current` returns the correct platform type
3. Confirm that platform-specific features still work as expected

### Why make this change?
Platform-specific code was scattered throughout the app. This change centralizes platform detection and type information into a dedicated module, making it easier to handle platform-specific behaviors and maintain platform-related code. The composition local provides a clean way to access platform information anywhere in the UI layer.