### PR TITLE
Core: Add debug flag and rename Platform to AppPlatform

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -4,14 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import org.koin.compose.KoinApplication
 import xyz.ksharma.krail.core.appinfo.LocalPlatformTypeProvider
-import xyz.ksharma.krail.core.appinfo.getPlatform
+import xyz.ksharma.krail.core.appinfo.getAppPlatform
 import xyz.ksharma.krail.di.koinConfig
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
 fun KrailApp() {
     KoinApplication(application = koinConfig) {
-        CompositionLocalProvider(LocalPlatformTypeProvider provides getPlatform().type) {
+        CompositionLocalProvider(LocalPlatformTypeProvider provides getAppPlatform()) {
             KrailTheme {
                 KrailNavHost()
             }

--- a/core/app-info/build.gradle.kts
+++ b/core/app-info/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 
 android {
     namespace = "xyz.ksharma.krail.core.appinfo"
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 kotlin {

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.android.kt
@@ -2,9 +2,10 @@ package xyz.ksharma.krail.core.appinfo
 
 import android.os.Build
 
-class AndroidPlatform : Platform {
+class AndroidAppPlatform : AppPlatform {
     override val name: String = "Android ${Build.VERSION.SDK_INT}"
     override val type: PlatformType = PlatformType.ANDROID
+    override fun isDebug(): Boolean = BuildConfig.DEBUG
 }
 
-actual fun getPlatform(): Platform = AndroidPlatform()
+actual fun getAppPlatform(): AppPlatform = AndroidAppPlatform()

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppPlatform.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppPlatform.kt
@@ -1,8 +1,10 @@
 package xyz.ksharma.krail.core.appinfo
 
-interface Platform {
+interface AppPlatform {
     val name: String
     val type: PlatformType
+
+    fun isDebug(): Boolean
 }
 
 enum class PlatformType {
@@ -11,4 +13,4 @@ enum class PlatformType {
     UNKNOWN,
 }
 
-expect fun getPlatform(): Platform
+expect fun getAppPlatform(): AppPlatform

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
@@ -1,5 +1,5 @@
 package xyz.ksharma.krail.core.appinfo
 
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 
-val LocalPlatformTypeProvider = compositionLocalOf { PlatformType.UNKNOWN }
+val LocalPlatformTypeProvider = staticCompositionLocalOf { getAppPlatform() }

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/Platform.ios.kt
@@ -1,12 +1,16 @@
 package xyz.ksharma.krail.core.appinfo
 
 import platform.UIKit.UIDevice
+import kotlin.experimental.ExperimentalNativeApi
 
-class IOSPlatform : Platform {
+class IOSAppPlatform : AppPlatform {
     override val name: String =
         UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 
     override val type: PlatformType = PlatformType.IOS
+
+    @OptIn(ExperimentalNativeApi::class)
+    override fun isDebug(): Boolean = Platform.isDebugBinary
 }
 
-actual fun getPlatform(): Platform = IOSPlatform()
+actual fun getAppPlatform(): AppPlatform = IOSAppPlatform()


### PR DESCRIPTION
### TL;DR
Added debug flag detection and improved platform-specific information handling across Android and iOS.

### What changed?
- Renamed `Platform` interface to `AppPlatform` and `getPlatform()` to `getAppPlatform()`
- Added `isDebug()` function to detect debug builds on both platforms
- Enabled BuildConfig for Android to support debug detection
- Updated `LocalPlatformTypeProvider` to use `staticCompositionLocalOf` with proper platform initialization
- Implemented platform-specific debug detection (BuildConfig.DEBUG for Android, Platform.isDebugBinary for iOS)

### How to test?
1. Build and run the app in both debug and release configurations
2. Verify that `isDebug()` returns the correct boolean value for each build type
3. Confirm platform information is correctly displayed
4. Check that platform-specific features work as expected on both Android and iOS

### Why make this change?
To provide a more robust way to detect debug builds across platforms and improve the platform-specific information architecture. This enables better debugging capabilities and platform-specific optimizations in the codebase.