### PR TITLE
iOS: Hide Alerts due to navigation issue

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -3,7 +3,7 @@ package xyz.ksharma.krail
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import org.koin.compose.KoinApplication
-import xyz.ksharma.krail.core.appinfo.LocalPlatformTypeProvider
+import xyz.ksharma.krail.core.appinfo.LocalAppPlatformProvider
 import xyz.ksharma.krail.core.appinfo.getAppPlatform
 import xyz.ksharma.krail.di.koinConfig
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -11,7 +11,7 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 @Composable
 fun KrailApp() {
     KoinApplication(application = koinConfig) {
-        CompositionLocalProvider(LocalPlatformTypeProvider provides getAppPlatform()) {
+        CompositionLocalProvider(LocalAppPlatformProvider provides getAppPlatform()) {
             KrailTheme {
                 KrailNavHost()
             }

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
@@ -2,4 +2,4 @@ package xyz.ksharma.krail.core.appinfo
 
 import androidx.compose.runtime.staticCompositionLocalOf
 
-val LocalPlatformTypeProvider = staticCompositionLocalOf { getAppPlatform() }
+val LocalAppPlatformProvider = staticCompositionLocalOf { getAppPlatform() }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/alerts/ServiceAlert.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/alerts/ServiceAlert.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.json.Json
 data class ServiceAlert(
     val heading: String,
     val message: String,
-    val priority: ServiceAlertPriority,
 ) {
 
     fun toJsonString() = Json.encodeToString(serializer(), this)

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -24,11 +24,12 @@ kotlin {
     sourceSets {
         commonMain  {
             dependencies {
-                implementation(projects.taj)
-                implementation(projects.feature.tripPlanner.state)
                 implementation(projects.core.dateTime)
-                implementation(projects.sandook)
+                implementation(projects.core.appInfo)
                 implementation(projects.feature.tripPlanner.network)
+                implementation(projects.feature.tripPlanner.state)
+                implementation(projects.sandook)
+                implementation(projects.taj)
 
                 implementation(compose.foundation)
                 implementation(compose.animation)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
@@ -10,12 +10,10 @@ import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
 internal fun NavGraphBuilder.alertsDestination(navController: NavHostController) {
     composable<ServiceAlertRoute> { backStackEntry ->
-
         val route = backStackEntry.toRoute<ServiceAlertRoute>()
         val serviceAlerts = route.alertsJsonList.mapNotNull { alertJson ->
             ServiceAlert.fromJsonString(alertJson)
         }.toImmutableSet()
-
         ServiceAlertScreen(serviceAlerts = serviceAlerts, onBackClick = {
             navController.popBackStack()
         })

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
@@ -30,7 +30,6 @@ import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.toAdaptiveSize
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
-import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertPriority
 
 @Composable
 fun CollapsibleAlert(
@@ -141,7 +140,6 @@ private fun PreviewCollapsibleAlertCollapsed() {
                 serviceAlert = ServiceAlert(
                     heading = "Sample Alert",
                     message = "This is a sample alert message.",
-                    priority = ServiceAlertPriority.HIGH,
                 ),
                 index = 1,
                 onClick = {},
@@ -161,7 +159,6 @@ private fun PreviewCollapsibleAlertExpanded() {
                 serviceAlert = ServiceAlert(
                     heading = "Sample Alert",
                     message = "This is a sample alert message.",
-                    priority = ServiceAlertPriority.HIGH,
                 ),
                 collapsed = false,
                 onClick = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
@@ -24,12 +24,10 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
-import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
-import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertPriority
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 
 @Composable
@@ -103,17 +101,14 @@ private fun PreviewServiceAlertScreen() {
                 ServiceAlert(
                     heading = "Service Alert 1",
                     message = "This is a service alert 1",
-                    priority = ServiceAlertPriority.HIGH,
                 ),
                 ServiceAlert(
                     heading = "Service Alert 2",
                     message = "This is a service alert 2",
-                    priority = ServiceAlertPriority.MEDIUM,
                 ),
                 ServiceAlert(
                     heading = "Service Alert 3",
                     message = "This is a service alert 3",
-                    priority = ServiceAlertPriority.LOW,
                 ),
             ),
         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -49,6 +49,8 @@ import krail.feature.trip_planner.ui.generated.resources.ic_a11y
 import krail.feature.trip_planner.ui.generated.resources.ic_clock
 import krail.feature.trip_planner.ui.generated.resources.ic_walk
 import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.core.appinfo.LocalAppPlatformProvider
+import xyz.ksharma.krail.core.appinfo.PlatformType
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.SeparatorIcon
 import xyz.ksharma.krail.taj.components.Text
@@ -196,6 +198,8 @@ fun ExpandedJourneyCardContent(
     onAlertClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val appInfo = LocalAppPlatformProvider.current
+
     Column(modifier = modifier) {
         FlowRow(
             modifier = Modifier
@@ -228,7 +232,11 @@ fun ExpandedJourneyCardContent(
             },
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            if (totalUniqueServiceAlerts > 0) {
+            // TODO - display alerts only on Android as of now - ComposeNavigation
+            //    to support iOS, we need to store them in db and use some id to fetch them and display.
+            //    Current approach of passing them as json string does not work on iOS devices.
+            //    See - https://youtrack.jetbrains.com/issue/CMP-7180/iOS-App-Crashes-when-navigating-with-html-content-as-string-argument.
+            if (totalUniqueServiceAlerts > 0 && appInfo.type == PlatformType.ANDROID) {
                 Box(
                     modifier = Modifier
                         .padding()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -9,6 +9,7 @@ import xyz.ksharma.krail.trip.planner.ui.datetimeselector.dateTimeSelectorDestin
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.savedTripsDestination
 import xyz.ksharma.krail.trip.planner.ui.searchstop.searchStopDestination
 import xyz.ksharma.krail.trip.planner.ui.settings.settingsDestination
+import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.timetable.timeTableDestination
 import xyz.ksharma.krail.trip.planner.ui.usualride.usualRideDestination
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -243,22 +243,22 @@ class TimeTableViewModel(
         _uiState.update(block)
     }
 
-    fun fetchAlertsForJourney(journeyId: String, onResult: (Set<ServiceAlert>) -> Unit) {
+    fun fetchAlertsForJourney(journeyId: String, onResult: (List<ServiceAlert>) -> Unit) {
         viewModelScope.launch {
             val alerts = withContext(Dispatchers.IO) {
                 runCatching {
                     _uiState.value.journeyList.find { it.journeyId == journeyId }?.let { journey ->
                         getAlertsFromJourney(journey)
                     }.orEmpty()
-                }.getOrElse { emptySet() }
+                }.getOrElse { emptyList() }
             }
             onResult(alerts)
         }
     }
 
-    private fun getAlertsFromJourney(journey: TimeTableState.JourneyCardInfo): Set<ServiceAlert> {
+    private fun getAlertsFromJourney(journey: TimeTableState.JourneyCardInfo): List<ServiceAlert> {
         return journey.legs.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
-            .flatMap { it.serviceAlertList.orEmpty() }.toSet()
+            .flatMap { it.serviceAlertList.orEmpty() }
     }
 
     companion object {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseExt.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseExt.kt
@@ -13,7 +13,6 @@ fun TripResponse.Info.toAlert(): ServiceAlert? {
         ServiceAlert(
             heading = heading,
             message = alertContent,
-            priority = alertPriority,
         )
     } else {
         null


### PR DESCRIPTION
### TL;DR
Removed service alert priority and restricted alert display to Android platform only.

### What changed?
- Renamed `LocalPlatformTypeProvider` to `LocalAppPlatformProvider` for clarity
- Removed `priority` field from `ServiceAlert` data class
- Added platform check to only show alerts on Android devices
- Modified alert-related functions to handle alerts as List instead of Set
- Added TODO comment explaining the iOS limitation with ComposeNavigation

### How to test?
1. Verify alerts are only visible on Android devices
2. Confirm alerts still display correctly with heading and message
3. Navigate through journey cards and check alert functionality
4. Verify iOS app doesn't crash when handling alerts

### Why make this change?
The service alert priority was unused and added unnecessary complexity. Additionally, iOS devices were crashing when navigating with HTML content as string arguments (see JetBrains issue CMP-7180). This change provides a temporary solution by limiting alerts to Android while maintaining app stability on iOS.