### PR TITLE
AndroidRelease: Bump version to 1.0-beta04

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,8 +6,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 22
-        versionName = "1.0-beta02"
+        versionCode = 23
+        versionName = "1.0-beta04"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
### TL;DR
Bumped version code to 23 and version name to 1.0-beta04

### What changed?
- Incremented version code from 22 to 23
- Updated version name from 1.0-beta02 to 1.0-beta04

### Changelog
- Auto refresh time table every 30 seconds
