### PR TITLE
TimeTable: Add auto-refresh and trip ID tracking

### DIFF
--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/model/TripResponse.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/model/TripResponse.kt
@@ -355,7 +355,14 @@ data class TripResponse(
 
         @SerialName("operator") val operator: OperatorClass? = null,
 
-        // @SerialName("properties") val properties: TransportationProperties? = null, Not required
+        @SerialName("properties") val properties: TransportationProperties? = null,
+    )
+
+    @Serializable
+    data class TransportationProperties(
+        @SerialName("tripCode") val tripCode: String? = null,
+
+        @SerialName("RealtimeTripId") val realtimeTripId: String? = null,
     )
 
     @Serializable

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -82,7 +82,7 @@ data class TimeTableState(
                 // Service Alerts for the leg.
                 val serviceAlertList: ImmutableList<ServiceAlert>? = null,
 
-                val tripId: String?= null,
+                val tripId: String,
             ) : Leg()
         }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -49,11 +49,13 @@ data class TimeTableState(
     ) {
         val journeyId: String
             get() = buildString {
-                append(originUtcDateTime)
-                append(destinationTime)
                 append(
-                    transportModeLines.joinToString { it.lineName }
-                        .filter { it.isLetterOrDigit() },
+                    legs.joinToString { leg ->
+                        when (leg) {
+                            is Leg.WalkingLeg -> "W"
+                            is Leg.TransportLeg -> leg.tripId ?: "T"
+                        }
+                    },
                 )
             }
 
@@ -79,6 +81,8 @@ data class TimeTableState(
 
                 // Service Alerts for the leg.
                 val serviceAlertList: ImmutableList<ServiceAlert>? = null,
+
+                val tripId: String?= null,
             ) : Leg()
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -565,6 +565,7 @@ private fun PreviewJourneyCardCollapsed() {
                         lineName = "T1",
                     ),
                     totalDuration = "20 mins",
+                    tripId = "T1",
                 ),
                 TimeTableState.JourneyCardInfo.Leg.WalkingLeg(
                     duration = "15 mins",
@@ -577,6 +578,7 @@ private fun PreviewJourneyCardCollapsed() {
                         transportMode = TransportMode.Bus(),
                         lineName = "700",
                     ),
+                    tripId = "700",
                 ),
 
                 ),
@@ -612,6 +614,7 @@ private fun PreviewJourneyCardExpanded() {
                         lineName = "T1",
                     ),
                     totalDuration = "20 mins",
+                    tripId = "T1",
                 ),
                 TimeTableState.JourneyCardInfo.Leg.WalkingLeg(
                     duration = "15 mins",
@@ -624,6 +627,7 @@ private fun PreviewJourneyCardExpanded() {
                         transportMode = TransportMode.Bus(),
                         lineName = "700",
                     ),
+                    tripId = "700",
                 ),
             ),
             cardState = JourneyCardState.EXPANDED,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -31,6 +31,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
         }
         // Subscribe to the isActive state flow - for updating the TimeText periodically.
         val isActive by viewModel.isActive.collectAsStateWithLifecycle()
+        val autoRefreshTimeTable by viewModel.autoRefreshTimeTable.collectAsStateWithLifecycle()
         val expandedJourneyId: String? by viewModel.expandedJourneyId.collectAsStateWithLifecycle()
 
         // Arguments

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -193,6 +193,7 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
                         duration?.seconds?.toFormattedDurationTimeString()
                             ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
                     },
+                    tripId = (transportation?.properties?.tripCode + transportation?.properties?.realtimeTripId),
                 )
             } else {
                 null


### PR DESCRIPTION
### TL;DR
Added trip ID tracking and auto-refresh functionality for real-time journey updates in the trip planner.

Update `tripID` logic and save past journey in a map, so that we can still see it as long as the user is on the screen, even though new data can keep coming in and add to the list.

### What changed?
- Added `TransportationProperties` data class to capture `tripCode` and `realtimeTripId`
- Modified journey ID generation to use leg-specific identifiers
- Implemented trip tracking using a mutable map to store and update journey information
- Added auto-refresh mechanism to periodically update journey times and information
- Enhanced time text updates for journey cards to show accurate timing information

### Screenshots

https://github.com/user-attachments/assets/53de78a1-b36c-4135-81f4-e431ef3669df

### Why make this change?
To improve real-time tracking of journeys and provide more accurate, up-to-date information to users. The addition of trip IDs and auto-refresh functionality ensures that users always see the most current journey status and timing information.