### PR TITLE
TimeTable: Improve journey caching and cleanup past trips

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -52,10 +52,10 @@ data class TimeTableState(
                 append(
                     legs.joinToString { leg ->
                         when (leg) {
-                            is Leg.WalkingLeg -> "W"
+                            is Leg.WalkingLeg -> ""
                             is Leg.TransportLeg -> leg.tripId ?: "T"
                         }
-                    },
+                    }.filter { it.isLetterOrDigit() },
                 )
             }
 
@@ -82,7 +82,7 @@ data class TimeTableState(
                 // Service Alerts for the leg.
                 val serviceAlertList: ImmutableList<ServiceAlert>? = null,
 
-                val tripId: String,
+                val tripId: String? = null,
             ) : Leg()
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -100,7 +100,7 @@ fun JourneyCard(
         )
     }
     val pastJourneyColor = KrailTheme.colors.onSurface.copy(alpha = 0.5f)
-    val themeColor = if (!isPastJourney) {
+    val themeColor = if (!isPastJourney) { // TODO - animate
         transportModeList.firstOrNull()?.colorCode?.hexToComposeColor()
             ?: KrailTheme.colors.onSurface
     } else {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -3,6 +3,8 @@ package xyz.ksharma.krail.trip.planner.ui.timetable
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -80,13 +82,10 @@ fun TimeTableScreen(
     val themeColor = themeColorHex.hexToComposeColor()
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(color = KrailTheme.colors.surface),
+        modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
         ) {
             TitleBar(
                 navAction = {
@@ -118,8 +117,7 @@ fun TimeTableScreen(
                             exit = fadeOut(),
                         ) {
                             AnimatedDots(
-                                color = themeColor,
-                                modifier = Modifier.padding(start = 24.dp)
+                                color = themeColor, modifier = Modifier.padding(start = 24.dp)
                             )
                         }
                     }
@@ -167,8 +165,7 @@ fun TimeTableScreen(
                     OriginDestination(
                         trip = trip,
                         timeLineColor = KrailTheme.colors.onSurface,
-                        modifier = Modifier
-                            .fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp)
                             .background(color = KrailTheme.colors.surface),
                     )
@@ -195,18 +192,14 @@ fun TimeTableScreen(
                             actionText = "Retry",
                             onActionClick = { onEvent(TimeTableUiEvent.RetryButtonClicked) },
                         ),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .animateItem(),
+                        modifier = Modifier.fillMaxWidth().animateItem(),
                     )
                 }
             } else if (timeTableState.isLoading) {
                 item {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         LoadingEmojiAnim(
-                            modifier = Modifier
-                                .padding(vertical = 60.dp)
-                                .animateItem(),
+                            modifier = Modifier.padding(vertical = 60.dp).animateItem(),
                         )
 
                         Text(
@@ -214,14 +207,15 @@ fun TimeTableScreen(
                             style = KrailTheme.typography.bodyLarge,
                             textAlign = TextAlign.Center,
                             color = KrailTheme.colors.onSurface,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                         )
                     }
                 }
             } else if (timeTableState.journeyList.isNotEmpty()) {
-                items(timeTableState.journeyList) { journey ->
+                items(
+                    items = timeTableState.journeyList,
+                    key = { it.journeyId },
+                ) { journey ->
                     JourneyCardItem(
                         timeToDeparture = journey.timeText,
                         platformNumber = journey.platformNumber,
@@ -249,8 +243,7 @@ fun TimeTableScreen(
                         onAlertClick = {
                             onAlertClick(journey.journeyId)
                         },
-                        modifier = Modifier
-                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
                     )
                 }
             } else { // Journey list is empty or null
@@ -258,18 +251,14 @@ fun TimeTableScreen(
                     ErrorMessage(
                         title = "No route found!",
                         message = "Search for another stop or check back later.",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .animateItem(),
+                        modifier = Modifier.fillMaxWidth().animateItem(),
                     )
                 }
             }
 
             item {
                 Spacer(
-                    modifier = Modifier
-                        .height(96.dp)
-                        .systemBarsPadding(),
+                    modifier = Modifier.height(96.dp).systemBarsPadding(),
                 )
             }
         }
@@ -323,11 +312,8 @@ fun ActionButton(
     content: @Composable () -> Unit,
 ) {
     Box(
-        modifier = modifier
-            .size(40.dp)
-            .clip(CircleShape)
-            .clickable(role = Role.Button) { onClick() }
-            .semantics(mergeDescendants = true) {
+        modifier = modifier.size(40.dp).clip(CircleShape)
+            .clickable(role = Role.Button) { onClick() }.semantics(mergeDescendants = true) {
                 this.contentDescription = contentDescription
             },
         contentAlignment = Alignment.Center,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -193,7 +193,7 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
                         duration?.seconds?.toFormattedDurationTimeString()
                             ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
                     },
-                    tripId = (transportation?.properties?.tripCode + transportation?.properties?.realtimeTripId),
+                    tripId = transportation?.id + transportation?.properties?.realtimeTripId,
                 )
             } else {
                 null


### PR DESCRIPTION
### TL;DR
Improved journey tracking and trip management in the time table feature, with optimizations for past trips and journey identification.

### What changed?
- Modified journey identification to use more reliable IDs instead of trip codes
- Implemented cache cleanup for past trips beyond a threshold of 3 entries
- Removed walking leg indicators ("W") from journey IDs
- Made trip IDs nullable in transport legs
- Added key-based journey list rendering for better performance
- Enhanced trip cache management with proper cleanup on reverse trip actions

### How to test?
1. Open the time table screen and observe journey listings
2. Check that past journeys are properly managed and limited
3. Verify that reverse trip functionality clears the cache correctly
4. Confirm that walking segments are not showing "W" indicators
5. Test journey updates and verify smooth animations with keyed items

### Why make this change?
To improve the reliability and performance of journey tracking while maintaining a cleaner user interface. The changes optimize memory usage by managing past trips more efficiently and ensure more accurate journey identification through better ID handling.