### PR TITLE
Theming Screen - Update copy and icons

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/UsualRideState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/UsualRideState.kt
@@ -1,3 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.state.usualride
 
-data class UsualRideState(val x: Int = 0)
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+
+data class UsualRideState(val selectedTransportMode: TransportMode? = null)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideDestination.kt
@@ -1,9 +1,11 @@
 package xyz.ksharma.krail.trip.planner.ui.usualride
 
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
@@ -24,13 +26,20 @@ import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideEvent
 internal fun NavGraphBuilder.usualRideDestination(navController: NavHostController) {
     composable<UsualRideRoute> {
         val viewModel: UsualRideViewModel = koinViewModel<UsualRideViewModel>()
+        val isUiStateLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
         var themeColor by LocalThemeColor.current
         var themeContentColor by LocalThemeContentColor.current
         var mode: TransportMode? by remember { mutableStateOf(null) }
         themeContentColor =
             getForegroundColor(backgroundColor = themeColor.hexToComposeColor()).toHex()
 
+        LaunchedEffect(state.selectedTransportMode){
+            println("selectedTransportMode: ${state.selectedTransportMode}")
+        }
+
         UsualRideScreen(
+            selectedTransportMode = state.selectedTransportMode,
             transportModes = TransportMode.sortedValues(TransportModeSortOrder.PRODUCT_CLASS)
                 .toImmutableSet(),
             transportModeSelected = { productClass ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -38,7 +39,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
@@ -46,7 +46,6 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
-import xyz.ksharma.krail.trip.planner.ui.components.TransportModeIcon
 import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.transportModeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -68,6 +67,7 @@ private val TransportMode.tagLine: String
 
 @Composable
 fun UsualRideScreen(
+    selectedTransportMode: TransportMode?,
     transportModes: ImmutableSet<TransportMode>,
     transportModeSelected: (Int) -> Unit,
     onBackClick: () -> Unit,
@@ -79,7 +79,9 @@ fun UsualRideScreen(
             .background(color = KrailTheme.colors.surface)
             .statusBarsPadding(),
     ) {
-        var selectedProductClass: Int? by rememberSaveable { mutableStateOf(null) }
+        var selectedProductClass: Int? by rememberSaveable(selectedTransportMode) {
+            mutableStateOf(selectedTransportMode?.productClass)
+        }
         val buttonBackgroundColor by animateColorAsState(
             targetValue = selectedProductClass?.let { productClass ->
                 TransportMode.toTransportModeType(productClass)?.colorCode?.hexToComposeColor()
@@ -200,11 +202,11 @@ private fun TransportModeRadioButton(
             ) { onClick(mode) },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        TransportModeIcon(
-            letter = mode.name.first(),
-            backgroundColor = mode.colorCode.hexToComposeColor(),
-            iconSize = 32.sp,
-            fontSize = 18.sp,
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(color = mode.colorCode.hexToComposeColor()),
         )
 
         Column(
@@ -212,12 +214,12 @@ private fun TransportModeRadioButton(
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             Text(
-                text = mode.name,
+                text = mode.tagLine,
                 style = KrailTheme.typography.titleMedium,
             )
 
             Text(
-                text = mode.tagLine,
+                text = mode.name,
                 style = KrailTheme.typography.body.copy(fontWeight = FontWeight.Normal),
             )
         }
@@ -228,10 +230,12 @@ private fun TransportModeRadioButton(
 private fun PreviewUsualRideScreen() {
     KrailTheme {
         UsualRideScreen(
-            TransportMode.sortedValues(sortOrder = TransportModeSortOrder.PRODUCT_CLASS)
+            selectedTransportMode = null,
+            transportModes = TransportMode.sortedValues(sortOrder = TransportModeSortOrder.PRODUCT_CLASS)
                 .toImmutableSet(),
             transportModeSelected = {},
             onBackClick = {},
-        )
+
+            )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/usualride/UsualRideViewModel.kt
@@ -5,9 +5,14 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideEvent
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.UsualRideState
 
@@ -16,16 +21,40 @@ class UsualRideViewModel(private val sandook: Sandook) : ViewModel() {
     private val _uiState: MutableStateFlow<UsualRideState> = MutableStateFlow(UsualRideState())
     val uiState: StateFlow<UsualRideState> = _uiState
 
+    private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+        .onStart { getThemeTransportMode() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANR_TIMEOUT), true)
+
     fun onEvent(event: UsualRideEvent) {
         when (event) {
             is UsualRideEvent.TransportModeSelected -> onTransportModeSelected(event.productClass)
         }
     }
 
-    private fun onTransportModeSelected(productClass: Int) {
+   private fun onTransportModeSelected(productClass: Int) {
         viewModelScope.launch(Dispatchers.IO) {
             sandook.clearTheme() // Only one entry should exist at a time
             sandook.insertOrReplaceTheme(productClass.toLong())
         }
+    }
+
+    private fun getThemeTransportMode() {
+        viewModelScope.launch(Dispatchers.IO) {
+            // First app launch there will be no product class, so use default transport mode theme.
+            val productClass = sandook.getProductClass()?.toInt()
+            val mode = productClass?.let { TransportMode.toTransportModeType(it) }
+            updateUiState {
+                copy(selectedTransportMode = mode)
+            }
+        }
+    }
+
+    private inline fun updateUiState(block: UsualRideState.() -> UsualRideState) {
+        _uiState.update(block)
+    }
+
+    companion object {
+        const val ANR_TIMEOUT = 5000L
     }
 }


### PR DESCRIPTION
Remove transport mode icons and replace with colored circles

- Replace `TransportModeIcon` with a simple colored circle background
- Swap name and tagline positions in transport mode list items
- Add state handling for selected transport mode
- Add loading state management with 5 second timeout
- Persist transport mode selection to storage

### Screenshots

<img width="290" alt="Screenshot 2024-12-06 at 5 02 46 pm" src="https://github.com/user-attachments/assets/32d8a8d8-259f-47aa-862e-16b149a02790">
