### PR TITLE
Release: Bump Android to beta08 and iOS build to 2

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,8 +6,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 26
-        versionName = "1.0-beta07"
+        versionCode = 27
+        versionName = "1.0-beta08"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR
Bumped version numbers for both Android and iOS apps

### What changed?
- Android version updated from `1.0-beta07` (26) to `1.0-beta08` (27)
- iOS build number increased from `1` to `2`

- Releasing firebase analytics  / Crashlytics and performance

### Why make this change?
Preparing for a new release by incrementing version numbers to maintain proper versioning across platforms and ensure accurate tracking of app releases in their respective stores.