### PR TITLE
TimeTable: Optimize date selection and auto-refresh logic

### DIFF
--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.core.datetime
 
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -91,5 +92,14 @@ object DateTimeHelper {
         val instant1 = Instant.parse(utcDateString1)
         val instant2 = Instant.parse(utcDateString2)
         return (instant1 - instant2).absoluteValue
+    }
+
+    /**
+     * Returns true if the given date is in the future, false otherwise.
+     */
+    fun LocalDate?.isFuture(): Boolean {
+        return this?.let {
+            it > Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+        } ?: false
     }
 }


### PR DESCRIPTION
Do not poll trip api when future date and time is selected. Poll only when current date and time is selcted