### PR TITLE
TimeTable: Improve journey cleanup and started/ended states

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -23,11 +23,12 @@ data class TimeTableState(
         //      leg.first.origin.departureTimeEstimated ?: leg.first.origin.departureTimePlanned
         // else leg.first.destination.arrivalTimeEstimated ?: leg.first.destination.arrivalTimePlanned
         val originTime: String, // "11:30pm" stopSequence.arrivalTimeEstimated ?: stopSequence.arrivalTimePlanned
-
         val originUtcDateTime: String, // "2024-09-24T19:00:00Z"
 
         // legs.last.destination.arrivalTimeEstimated ?: legs.last.destination.arrivalTimePlanned
         val destinationTime: String, // "11:40pm"
+        val destinationUtcDateTime: String, // "2024-09-24T19:00:00Z" Use for calculations.
+
 
         // legs.sumBy { it.duration } - seconds
         val travelTime: String, // "(10 min)"

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -2,6 +2,8 @@ package xyz.ksharma.krail.trip.planner.ui.state.timetable
 
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
@@ -59,6 +61,18 @@ data class TimeTableState(
                     }.filter { it.isLetterOrDigit() },
                 )
             }
+
+        /**
+         * If the origin time is in the past.
+         */
+        val hasJourneyStarted: Boolean
+            get() = Instant.parse(originUtcDateTime) < Clock.System.now()
+
+        /**
+         * If the destination time is in the past.
+         */
+        val hasJourneyEnded: Boolean
+            get() = Instant.parse(destinationUtcDateTime) < Clock.System.now()
 
         sealed class Leg {
             data class WalkingLeg(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -354,6 +354,7 @@ private fun PreviewTimeTableScreen() {
                             legs = persistentListOf(),
                             totalUniqueServiceAlerts = 3,
                             originUtcDateTime = "2024-11-01T12:00:00Z",
+                            destinationUtcDateTime = "2024-11-01T12:30:00Z",
                         ),
                     ).toImmutableList(),
                 ),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -168,6 +168,12 @@ class TimeTableViewModel(
             }
         }
 
+        // Check if past trips have destination time passed, then remove them from cache.
+        val pastTripsWithDestinationTimePassed = pastTrips.filter { pastTrip ->
+            Instant.parse(pastTrip.destinationUtcDateTime) < now
+        }
+        pastTripsWithDestinationTimePassed.forEach { trips.remove(it.journeyId) }
+
         println("Trips in cache:")
         trips.forEach {
             println("tripCode: [${it.value.journeyId}], Time: ${it.value.originTime}")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -17,15 +17,9 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.toHHMM
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
@@ -98,7 +92,13 @@ class TimeTableViewModel(
 
     private var fetchTripJob: Job? = null
 
-    private val trips: MutableMap<String, TimeTableState.JourneyCardInfo> = mutableMapOf()
+    /**
+     * Cache of trips. Key is [TimeTableState.JourneyCardInfo.journeyId] and value is
+     * [TimeTableState.JourneyCardInfo].
+     *
+     * This list will be displayed in the UI.
+     */
+    private val journeys: MutableMap<String, TimeTableState.JourneyCardInfo> = mutableMapOf()
 
     fun onEvent(event: TimeTableUiEvent) {
         when (event) {
@@ -119,7 +119,7 @@ class TimeTableViewModel(
         if (dateTimeSelectionItem != item) {
             updateUiState { copy(isLoading = true) }
             dateTimeSelectionItem = item
-            trips.clear() // Clear cache trips when date time selection changed.
+            journeys.clear() // Clear cache trips when date time selection changed.
             rateLimiter.triggerEvent()
         }
     }
@@ -147,35 +147,34 @@ class TimeTableViewModel(
         }
     }
 
+    // TODO - Write UT for this method
     private suspend fun updateTripsCache(response: TripResponse) = withContext(Dispatchers.IO) {
         // Convert api response to UI Model and add all to cache. Will be unique always because of key
         response.buildJourneyList()?.forEach { journeyCardInfo ->
             println("API TRIP: tripCode: [${journeyCardInfo.journeyId}], Time: ${journeyCardInfo.originTime}")
-            trips[journeyCardInfo.journeyId] = journeyCardInfo
+            journeys[journeyCardInfo.journeyId] = journeyCardInfo
         }
 
-        // Make sure the cache is not growing infinitely. Clean up past trips beyond a threshold.
-        val now = Clock.System.now()
-        val pastTrips = trips.values
-            .filter { Instant.parse(it.originUtcDateTime) < now }
-        if (pastTrips.size > PAST_TRIPS_COUNT_THRESHOLD) {
-            println("Past Trip: ${pastTrips.size} is greater than threshold: $PAST_TRIPS_COUNT_THRESHOLD")
-            val tripIdsToRemove =
-                pastTrips.dropLast(PAST_TRIPS_COUNT_THRESHOLD).map { it.journeyId }
-            tripIdsToRemove.forEach {
-                println("Trip removed from cache: $it")
-                trips.remove(it)
-            }
+        // Make sure the cache is not growing infinitely. Clean up started trips beyond a threshold.
+        val startedJourneyList = journeys.values.filter { it.hasJourneyStarted }
+        if (startedJourneyList.size > MAX_STARTED_JOURNEY_DISPLAY_THRESHOLD) {
+            println("Past Trip: ${startedJourneyList.size} is greater than threshold: $MAX_STARTED_JOURNEY_DISPLAY_THRESHOLD")
+            startedJourneyList
+                .dropLast(MAX_STARTED_JOURNEY_DISPLAY_THRESHOLD)
+                .map { it.journeyId }
+                .forEach {
+                    println("Trip removed from cache: $it")
+                    journeys.remove(it)
+                }
         }
 
-        // Check if past trips have destination time passed, then remove them from cache.
-        val pastTripsWithDestinationTimePassed = pastTrips.filter { pastTrip ->
-            Instant.parse(pastTrip.destinationUtcDateTime) < now
-        }
-        pastTripsWithDestinationTimePassed.forEach { trips.remove(it.journeyId) }
+        // Check if past journeys have destination time passed, then remove them from cache.
+        startedJourneyList
+            .filter { it.hasJourneyEnded }
+            .forEach { journeys.remove(it.journeyId) }
 
         println("Trips in cache:")
-        trips.forEach {
+        journeys.forEach {
             println("tripCode: [${it.value.journeyId}], Time: ${it.value.originTime}")
         }
     }
@@ -184,7 +183,7 @@ class TimeTableViewModel(
         updateUiState {
             copy(
                 isLoading = false,
-                journeyList = updateJourneyCardInfoTimeText(trips.values.toList())
+                journeyList = updateJourneyCardInfoTimeText(journeys.values.toList())
                     .sortedBy { it.originUtcDateTime.utcToLocalDateTimeAEST() }
                     .toImmutableList(),
                 isError = false,
@@ -272,7 +271,7 @@ class TimeTableViewModel(
             toStopName = tripInfo!!.fromStopName,
         )
         tripInfo = reverseTrip
-        trips.clear() // Clear cache trips when reverse trip is clicked.
+        journeys.clear() // Clear cache trips when reverse trip is clicked.
 
         val savedTrip = sandook.selectTripById(tripId = reverseTrip.tripId)
         updateUiState {
@@ -341,6 +340,10 @@ class TimeTableViewModel(
         private val REFRESH_TIME_TEXT_DURATION = 10.seconds
         private val AUTO_REFRESH_TIME_TABLE_DURATION = 30.seconds
         private val STOP_TIME_TEXT_UPDATES_THRESHOLD = 3.seconds
-        private const val PAST_TRIPS_COUNT_THRESHOLD = 3
+
+        /**
+         * Maximum number of started journeys to display.
+         */
+        private const val MAX_STARTED_JOURNEY_DISPLAY_THRESHOLD = 3
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -58,6 +58,7 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
                 platformNumber = firstPublicTransportLeg.getPlatformNumber(),
                 originTime = originTimeUTC.fromUTCToDisplayTimeString(),
                 originUtcDateTime = originTimeUTC,
+                destinationUtcDateTime = arrivalTimeUTC,
                 destinationTime = arrivalTimeUTC.fromUTCToDisplayTimeString(),
                 travelTime = calculateTimeDifference(
                     originTimeUTC,


### PR DESCRIPTION
# Improve journey cache management and cleanup

Adds logic to remove completed journeys from the cache and introduces a new threshold to limit the number of started journeys displayed. Previously, started journeys would remain in the cache indefinitely.

- Added `hasJourneyStarted` and `hasJourneyEnded` properties to determine journey status
- Removes journeys that have reached their destination time
- Limits displayed started journeys to a maximum of 3
- Renames internal `trips` map to `journeys` for better clarity

These changes ensure the cache stays clean and only shows relevant journey information to users.