### PR TITLE
TimeTable: Add journey cache cleanup and Instant helpers

### DIFF
--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -102,4 +102,7 @@ object DateTimeHelper {
             it > Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
         } ?: false
     }
+
+    fun Instant.isBefore(other: Instant): Boolean = this < other
+    fun Instant.isAfter(other: Instant): Boolean = this > other
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/model/TripResponse.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/model/TripResponse.kt
@@ -3,6 +3,9 @@ package xyz.ksharma.krail.trip.planner.network.api.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Swagger: https://opendata.transport.nsw.gov.au/dataset/trip-planner-apis/resource/917c66c3-8123-4a0f-b1b1-b4220f32585d
+ */
 @Serializable
 data class TripResponse(
     @SerialName("systemMessages") val systemMessages: List<SystemMessages>? = null,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isBefore
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
@@ -173,7 +174,10 @@ class TimeTableViewModel(
 
         // Check if past journeys have destination time passed, then remove them from cache.
         startedJourneyList
-            .filter {  Instant.parse(it.destinationUtcDateTime) < Clock.System.now().plus(10.minutes) }
+            .filter {
+                val thresholdTime = Clock.System.now().minus(JOURNEY_ENDED_CACHE_THRESHOLD_TIME)
+                Instant.parse(it.destinationUtcDateTime).isBefore(thresholdTime)
+            }
             .forEach {
                 println("Trip removed from cache as destination time passed: ${it.journeyId}")
                 journeys.remove(it.journeyId)
@@ -351,5 +355,6 @@ class TimeTableViewModel(
          * Maximum number of started journeys to display.
          */
         private const val MAX_STARTED_JOURNEY_DISPLAY_THRESHOLD = 3
+        private val JOURNEY_ENDED_CACHE_THRESHOLD_TIME = 10.minutes
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
@@ -33,6 +35,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.business.buildJourneyList
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class TimeTableViewModel(
@@ -170,8 +173,11 @@ class TimeTableViewModel(
 
         // Check if past journeys have destination time passed, then remove them from cache.
         startedJourneyList
-            .filter { it.hasJourneyEnded }
-            .forEach { journeys.remove(it.journeyId) }
+            .filter {  Instant.parse(it.destinationUtcDateTime) < Clock.System.now().plus(10.minutes) }
+            .forEach {
+                println("Trip removed from cache as destination time passed: ${it.journeyId}")
+                journeys.remove(it.journeyId)
+            }
 
         println("Trips in cache:")
         journeys.forEach {


### PR DESCRIPTION
Add buffer of 10 minutes before removing ended trips

- Added extension functions `isBefore` and `isAfter` for `Instant` comparisons
- Added swagger documentation link for trip planner API
- Updated journey cache cleanup to wait 10 minutes after destination time before removal
- Added logging for when trips are removed from cache