### PR TITLE
UI: Fix stops count display in LegView component

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -118,9 +119,10 @@ fun LegView(
                         )
                         .padding(start = 16.dp, top = 12.dp),
                 ) {
-                    if (stops.size > 2) {
+                    val stopsCount by rememberSaveable(stops) { mutableIntStateOf(stops.size - 1) }
+                    if (stopsCount > 1) {
                         StopsRow(
-                            stops = if (stops.size == 1) "${stops.size} stop" else "${stops.size} stops",
+                            stops = "$stopsCount stops",
                             line = transportModeLine,
                         )
                     } else {


### PR DESCRIPTION
### TL;DR
Updated stop count display logic in LegView component to show accurate intermediate stop counts

### What changed?
- Modified the stop count calculation to show the number of intermediate stops (total stops - 1)
- Simplified the stop count text to always use plural form "stops"
- Added state management using `mutableIntStateOf` for the stops count
- Adjusted the visibility threshold to show stops count when there are more than 1 intermediate stops


### Why make this change?
To provide more accurate information about intermediate stops in a journey. The previous implementation showed the total number of stops, which included both origin and destination, potentially confusing users about the number of intermediate stops in their journey.