### PR TITLE
Release: Bump Android to beta09 and iOS to 1.0.1

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,8 +6,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 27
-        versionName = "1.0-beta08"
+        versionCode = 28
+        versionName = "1.0-beta09"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Required for Firebase -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
     <application
         android:name=".KrailApplication"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR
Version bump and Firebase permission addition for Android and iOS apps

### What changed?
- Android: Bumped version from 1.0-beta08 (27) to 1.0-beta09 (28)
- Android: Added Google Play Services Advertising ID permission for Firebase
- iOS: Bumped version from 1.0 (2) to 1.0.1 (3)

### How to test?
1. Build and install the app on Android and iOS devices
2. Verify Firebase functionality works correctly
3. Confirm version numbers are displayed correctly in app stores

### Why make this change?
The version bump is needed for a new release, and the addition of the Advertising ID permission ensures proper Firebase functionality on Android devices.