### PR TITLE
MainActivity: Remove unused code and comments

### DIFF
--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -4,35 +4,14 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import xyz.ksharma.krail.KrailApp
 
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-/*
-        val applicationComponent = AndroidApplicationComponent.from(this)
-*/
-
         setContent {
             KrailApp()
         }
     }
-
-    /*
-        private val koinConfig1 = koinConfiguration {
-            androidContext(androidContext = this@MainActivity.applicationContext)
-            modules(androidDbModule)
-            includes(koinConfig)
-        }
-    */
 }
-
-/*
-private fun AndroidApplicationComponent.Companion.from(context: Context): AndroidApplicationComponent {
-    return (context.applicationContext as KrailApplication).component
-}
-*/


### PR DESCRIPTION
### TL;DR
Cleaned up MainActivity by removing unused code and comments

### What changed?
- Removed commented-out code related to Koin configuration and Android application components
- Simplified the MainActivity class to only contain essential functionality
- Maintained core functionality with `enableEdgeToEdge()` and `KrailApp()` setup

### How to test?
1. Launch the application
2. Verify that the app starts and runs normally
3. Confirm that edge-to-edge display still functions correctly

### Why make this change?
Improves code maintainability by removing dead code and unused comments that were likely remnants from previous implementations. This makes the codebase cleaner and easier to understand while reducing technical debt.