### PR TITLE
TransportMode: Swap Bus and Light Rail priorities

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
@@ -50,7 +50,7 @@ sealed class TransportMode {
         override val name: String = "Bus",
         override val colorCode: String = "#00B5EF",
         override val productClass: Int = 5,
-        override val priority: Int = 4444,
+        override val priority: Int = 5555,
     ) : TransportMode()
 
     @Serializable
@@ -58,7 +58,7 @@ sealed class TransportMode {
         override val name: String = "Light Rail",
         override val colorCode: String = "#EE343F",
         override val productClass: Int = 4,
-        override val priority: Int = 5555,
+        override val priority: Int = 4444,
     ) : TransportMode()
 
     @Serializable


### PR DESCRIPTION
### TL;DR
Swapped priority values between Bus and Light Rail transport modes.

### What changed?
- Changed Bus transport mode priority from 4444 to 5555
- Changed Light Rail transport mode priority from 5555 to 4444

### How to test?
1. Open the trip planner
2. Search for a route that includes both bus and light rail options
3. Verify that light rail options are now prioritized over bus options in the results

### Why make this change?
Light rail transport should have higher priority than bus transport in route planning as it typically offers faster and more reliable service. This change ensures the trip planner appropriately prioritizes light rail connections when available.