### PR TITLE
GTFS: Add file storage for gtfs static data downloads

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -101,6 +101,7 @@ kotlin {
             implementation(projects.feature.tripPlanner.network)
             implementation(projects.feature.tripPlanner.ui)
             implementation(projects.feature.tripPlanner.state)
+            implementation(projects.gtfsStatic)
 
             implementation(libs.navigation.compose)
 

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
@@ -6,6 +6,8 @@ import org.koin.dsl.includes
 import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
+import xyz.ksharma.krail.gtfs_static.di.fileStorageModule
+import xyz.ksharma.krail.gtfs_static.di.gtfsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.networkModule
@@ -19,6 +21,8 @@ val koinConfig = koinConfiguration {
         sandookModule,
         splashModule,
         appInfoModule,
+        gtfsModule,
+        fileStorageModule,
     )
 }
 

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
                 implementation(projects.feature.tripPlanner.state)
                 implementation(projects.sandook)
                 implementation(projects.taj)
+                implementation(projects.gtfsStatic)
 
                 implementation(compose.foundation)
                 implementation(compose.animation)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -2,7 +2,6 @@ package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -10,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.gtfs_static.NswGtfsService
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -18,13 +18,17 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 class SavedTripsViewModel(
     private val sandook: Sandook,
+    private val nswGtfsService: NswGtfsService,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
 
     private fun loadSavedTrips() {
+
         viewModelScope.launch(context = Dispatchers.IO) {
+            nswGtfsService.getSydneyTrains()
+
             updateUiState { copy(isLoading = true) }
             val trips = mutableSetOf<Trip>()
 

--- a/gtfs-static/build.gradle.kts
+++ b/gtfs-static/build.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
-import com.codingfeline.buildkonfig.compiler.FieldSpec
-
 android {
     namespace = "xyz.ksharma.krail.gtfs_static"
 
@@ -18,7 +15,6 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
-    alias(libs.plugins.buildkonfig)
 }
 
 kotlin {
@@ -71,24 +67,5 @@ kotlin {
                 implementation(libs.test.kotlinxCoroutineTest)
             }
         }
-    }
-}
-
-// READ API KEY
-val localProperties = gradleLocalProperties(rootProject.rootDir, providers)
-val nswTransportApiKey: String = localProperties.getProperty("NSW_TRANSPORT_API_KEY")
-    ?: System.getenv("NSW_TRANSPORT_API_KEY")
-require(nswTransportApiKey.isNotEmpty()) {
-    "Register API key and put in local.properties as `NSW_TRANSPORT_API_KEY`"
-}
-buildkonfig {
-    packageName = "xyz.ksharma.krail.trip.planner.network"
-
-    require(nswTransportApiKey.isNotEmpty()) {
-        "Register API key and put in local.properties as `NSW_TRANSPORT_API_KEY`"
-    }
-
-    defaultConfigs {
-        buildConfigField(FieldSpec.Type.STRING, "NSW_TRANSPORT_API_KEY", nswTransportApiKey)
     }
 }

--- a/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.android.kt
+++ b/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.android.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.gtfs_static
+
+import android.content.Context
+import java.io.File
+
+class AndroidFileStorage(private val context: Context) : FileStorage {
+    override suspend fun saveFile(fileName: String, data: ByteArray) {
+        val file = File(context.filesDir, fileName)
+        file.writeBytes(data)
+    }
+}

--- a/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/di/FileStorageModule.android.kt
+++ b/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/di/FileStorageModule.android.kt
@@ -1,0 +1,12 @@
+package xyz.ksharma.krail.gtfs_static.di
+
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+import xyz.ksharma.krail.gtfs_static.AndroidFileStorage
+import xyz.ksharma.krail.gtfs_static.FileStorage
+
+actual val fileStorageModule = module {
+    single<FileStorage> {
+        AndroidFileStorage(context = androidContext())
+    }
+}

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.gtfs_static
+
+interface FileStorage {
+    suspend fun saveFile(fileName: String, data: ByteArray)
+}

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/NswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/NswGtfsService.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.krail.gtfs_static.di
+package xyz.ksharma.krail.gtfs_static
 
 /**
  * All other transport modes:

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
@@ -1,17 +1,30 @@
-package xyz.ksharma.krail.gtfs_static.di
+package xyz.ksharma.krail.gtfs_static
 
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 
-class RealNswGtfsService(private val httpClient: HttpClient) : NswGtfsService {
+class RealNswGtfsService(
+    private val httpClient: HttpClient,
+    private val fileStorage: FileStorage,
+) : NswGtfsService {
 
     override suspend fun getSydneyTrains() = withContext(Dispatchers.IO) {
         val response: HttpResponse =
             httpClient.get("$NSW_TRANSPORT_BASE_URL/$GTFS_SCHEDULE_V1/sydneytrains")
+
+        if (response.status.value == 200) {
+            println("Downloading file: ")
+            val data = response.readRawBytes()
+            fileStorage.saveFile("sydneytrains.zip", data)
+            println("File downloaded")
+        } else {
+            throw Exception("Failed to download file: ${response.status}")
+        }
     }
 
     override suspend fun getSydneyMetro() {

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/di/GtfsModule.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/di/GtfsModule.kt
@@ -1,7 +1,14 @@
 package xyz.ksharma.krail.gtfs_static.di
 
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import xyz.ksharma.krail.gtfs_static.NswGtfsService
+import xyz.ksharma.krail.gtfs_static.RealNswGtfsService
 
 val gtfsModule = module {
-
+    singleOf(::RealNswGtfsService) { bind<NswGtfsService>() }
 }
+
+expect val fileStorageModule: Module

--- a/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
+++ b/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
@@ -1,0 +1,33 @@
+package xyz.ksharma.krail.gtfs_static
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.dataWithBytes
+import platform.Foundation.writeToFile
+
+class IosFileStorage : FileStorage {
+    @OptIn(ExperimentalForeignApi::class)
+    override suspend fun saveFile(fileName: String, data: ByteArray) {
+        println("Saving file: $fileName")
+        val fileManager = NSFileManager.defaultManager
+        val directory = fileManager.URLForDirectory(
+            directory = NSDocumentDirectory,
+            inDomain = NSUserDomainMask,
+            appropriateForURL = null,
+            create = true,
+            error = null,
+        )?.path
+
+        val filePath = "$directory/$fileName"
+        data.usePinned { pinned ->
+            NSData.dataWithBytes(pinned.addressOf(0), data.size.toULong())
+                .writeToFile(filePath, true)
+        }
+        println("File saved: $filePath")
+    }
+}

--- a/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/di/FileStorageModule.ios.kt
+++ b/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/di/FileStorageModule.ios.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.gtfs_static.di
+
+import org.koin.dsl.module
+import xyz.ksharma.krail.gtfs_static.FileStorage
+import xyz.ksharma.krail.gtfs_static.IosFileStorage
+
+actual val fileStorageModule = module {
+    single<FileStorage> {
+        IosFileStorage()
+    }
+}


### PR DESCRIPTION
### TL;DR
Added GTFS static file download functionality for Sydney Trains data with platform-specific file storage implementations.

### What changed?
- Created a FileStorage interface with platform-specific implementations for Android and iOS
- Implemented GTFS file downloading functionality in RealNswGtfsService
- Added dependency injection modules for GTFS and file storage services
- Integrated GTFS service into SavedTripsViewModel for initial testing
- Removed BuildKonfig plugin and related API key configuration as it was duplicate

### How to test?
1. Launch the app and navigate to the Saved Trips screen
2. The app should attempt to download Sydney Trains GTFS data
3. Verify that a "sydneytrains.zip" file is created in the app's files directory
4. Check logs for "Downloading file" and "File downloaded" messages

### Why make this change?
To enable offline access to transit schedule data by implementing the infrastructure needed to download and store GTFS static files locally on both Android and iOS platforms. This is a foundational step towards providing reliable trip planning functionality without constant network connectivity.