### PR TITLE
Alerts: Add service alerts caching and state management

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
@@ -11,6 +11,7 @@ import xyz.ksharma.krail.gtfs_static.di.gtfsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.networkModule
+import xyz.ksharma.krail.trip.planner.ui.di.alertsCacheModule
 import xyz.ksharma.krail.trip.planner.ui.di.viewModelsModule
 
 val koinConfig = koinConfiguration {
@@ -23,6 +24,7 @@ val koinConfig = koinConfiguration {
         appInfoModule,
         gtfsModule,
         fileStorageModule,
+        alertsCacheModule,
     )
 }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/alerts/ServiceAlertState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/alerts/ServiceAlertState.kt
@@ -1,0 +1,8 @@
+package xyz.ksharma.krail.trip.planner.ui.state.alerts
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+data class ServiceAlertState(
+    val serviceAlerts: ImmutableList<ServiceAlert> = persistentListOf(),
+)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
@@ -1,21 +1,31 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import kotlinx.collections.immutable.toImmutableSet
+import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
 internal fun NavGraphBuilder.alertsDestination(navController: NavHostController) {
     composable<ServiceAlertRoute> { backStackEntry ->
         val route = backStackEntry.toRoute<ServiceAlertRoute>()
-        val serviceAlerts = route.alertsJsonList.mapNotNull { alertJson ->
-            ServiceAlert.fromJsonString(alertJson)
-        }.toImmutableSet()
-        ServiceAlertScreen(serviceAlerts = serviceAlerts, onBackClick = {
-            navController.popBackStack()
-        })
+        val viewModel: ServiceAlertsViewModel = koinViewModel<ServiceAlertsViewModel>()
+        val serviceAlertState by viewModel.uiState.collectAsStateWithLifecycle()
+
+        /*
+                val serviceAlerts = route.alertsJsonList.mapNotNull { alertJson ->
+                    ServiceAlert.fromJsonString(alertJson)
+                }.toImmutableSet()
+        */
+        ServiceAlertScreen(
+            serviceAlerts = serviceAlertState.serviceAlerts.toImmutableSet(),
+            onBackClick = {
+                navController.popBackStack()
+            })
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/AlertsDestination.kt
@@ -1,29 +1,29 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableSet
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
-import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
 internal fun NavGraphBuilder.alertsDestination(navController: NavHostController) {
     composable<ServiceAlertRoute> { backStackEntry ->
         val route = backStackEntry.toRoute<ServiceAlertRoute>()
         val viewModel: ServiceAlertsViewModel = koinViewModel<ServiceAlertsViewModel>()
         val serviceAlertState by viewModel.uiState.collectAsStateWithLifecycle()
-
-        /*
-                val serviceAlerts = route.alertsJsonList.mapNotNull { alertJson ->
-                    ServiceAlert.fromJsonString(alertJson)
-                }.toImmutableSet()
-        */
-        ServiceAlertScreen(
-            serviceAlerts = serviceAlertState.serviceAlerts.toImmutableSet(),
+        val alerts by remember(route.journeyId) {
+            mutableStateOf(
+                viewModel.fetchAlerts(journeyId = route.journeyId)
+            )
+        }
+        ServiceAlertScreen(serviceAlerts = alerts?.toImmutableSet() ?: persistentSetOf(),
             onBackClick = {
                 navController.popBackStack()
             })

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
@@ -1,0 +1,27 @@
+package xyz.ksharma.krail.trip.planner.ui.alerts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import xyz.ksharma.krail.trip.planner.ui.alerts.cache.ServiceAlertsCache
+import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertState
+
+class ServiceAlertsViewModel(
+    private val alertsCache: ServiceAlertsCache,
+) : ViewModel() {
+
+    private val _uiState: MutableStateFlow<ServiceAlertState> =
+        MutableStateFlow(ServiceAlertState())
+    val uiState: StateFlow<ServiceAlertState> = _uiState
+        .onStart {
+            _uiState.value = ServiceAlertState(alertsCache.getAlerts("journeyId").toImmutableList())
+        }
+        .stateIn(
+            viewModelScope, SharingStarted.WhileSubscribed(5000), ServiceAlertState()
+        )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
@@ -1,14 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
 import xyz.ksharma.krail.trip.planner.ui.alerts.cache.ServiceAlertsCache
+import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertState
 
 class ServiceAlertsViewModel(
@@ -18,10 +14,14 @@ class ServiceAlertsViewModel(
     private val _uiState: MutableStateFlow<ServiceAlertState> =
         MutableStateFlow(ServiceAlertState())
     val uiState: StateFlow<ServiceAlertState> = _uiState
-        .onStart {
-            _uiState.value = ServiceAlertState(alertsCache.getAlerts("journeyId").toImmutableList())
-        }
-        .stateIn(
-            viewModelScope, SharingStarted.WhileSubscribed(5000), ServiceAlertState()
-        )
+
+    fun fetchAlerts(journeyId: String): List<ServiceAlert>? {
+        // get alerts here and save to ui state.
+        val alerts = alertsCache.getAlerts(journeyId)
+        return alerts
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+    }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/cache/ServiceAlertsCache.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/cache/ServiceAlertsCache.kt
@@ -1,0 +1,30 @@
+package xyz.ksharma.krail.trip.planner.ui.alerts.cache
+
+import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
+
+interface ServiceAlertsCache {
+
+    fun getAlerts(journeyId: String): List<ServiceAlert>?
+
+    fun setAlerts(journeyId: String, alerts: List<ServiceAlert>)
+
+    fun clearAlerts()
+}
+
+class RealServiceAlertsCache : ServiceAlertsCache {
+
+    private val serviceAlerts: MutableMap<String, List<ServiceAlert>> = mutableMapOf()
+
+    override fun getAlerts(journeyId: String): List<ServiceAlert>? {
+        return serviceAlerts[journeyId]
+    }
+
+    override fun setAlerts(journeyId: String, alerts: List<ServiceAlert>) {
+        serviceAlerts.clear()
+        serviceAlerts[journeyId] = alerts
+    }
+
+    override fun clearAlerts() {
+        serviceAlerts.clear()
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/cache/ServiceAlertsCache.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/cache/ServiceAlertsCache.kt
@@ -13,6 +13,10 @@ interface ServiceAlertsCache {
 
 class RealServiceAlertsCache : ServiceAlertsCache {
 
+    init {
+        println("RealServiceAlertsCache created $this")
+    }
+
     private val serviceAlerts: MutableMap<String, List<ServiceAlert>> = mutableMapOf()
 
     override fun getAlerts(journeyId: String): List<ServiceAlert>? {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -236,7 +236,7 @@ fun ExpandedJourneyCardContent(
             //    to support iOS, we need to store them in db and use some id to fetch them and display.
             //    Current approach of passing them as json string does not work on iOS devices.
             //    See - https://youtrack.jetbrains.com/issue/CMP-7180/iOS-App-Crashes-when-navigating-with-html-content-as-string-argument.
-            if (totalUniqueServiceAlerts > 0 && appPlatformType == AppPlatformType.ANDROID) {
+            if (totalUniqueServiceAlerts > 0) {
                 Box(
                     modifier = Modifier
                         .padding()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/AlertsCacheModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/AlertsCacheModule.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.trip.planner.ui.di
+
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+import xyz.ksharma.krail.trip.planner.ui.alerts.cache.ServiceAlertsCache
+import xyz.ksharma.krail.trip.planner.ui.alerts.cache.RealServiceAlertsCache
+
+val alertsCacheModule = module {
+    singleOf(::RealServiceAlertsCache) { bind<ServiceAlertsCache>() }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -6,6 +6,7 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
+import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 
 val viewModelsModule = module {
@@ -14,4 +15,5 @@ val viewModelsModule = module {
     viewModelOf(::TimeTableViewModel)
     viewModelOf(::ThemeSelectionViewModel)
     viewModelOf(::SettingsViewModel)
+    viewModelOf(::ServiceAlertsViewModel)
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -1,6 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation
 
-import androidx.navigation.NavGraphBuilder
+import    androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.navigation
 import kotlinx.serialization.Serializable
@@ -78,7 +78,7 @@ data object ThemeSelectionRoute
 
 @Serializable
 internal data class ServiceAlertRoute(
-    val alertsJsonList: List<String>,
+    val journeyId: String,
 )
 
 @Serializable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -57,11 +57,11 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             onEvent = { viewModel.onEvent(it) },
             onBackClick = { navController.popBackStack() },
             onAlertClick = { journeyId ->
-                println("journeyId: $journeyId")
+                println("AlertClicked for journeyId: $journeyId")
                 viewModel.fetchAlertsForJourney(journeyId) { alerts ->
                     if (alerts.isNotEmpty()) {
                         navController.navigate(
-                            route = ServiceAlertRoute(alertsJsonList = alerts.map { it.toJsonString() }),
+                            route = ServiceAlertRoute(journeyId = journeyId),
                             navOptions = NavOptions.Builder().setLaunchSingleTop(singleTop = true)
                                 .build(),
                         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -127,6 +127,7 @@ class TimeTableViewModel(
             updateUiState { copy(isLoading = true) }
             dateTimeSelectionItem = item
             journeys.clear() // Clear cache trips when date time selection changed.
+            alertsCache.clearAlerts()
             rateLimiter.triggerEvent()
         }
     }
@@ -293,6 +294,7 @@ class TimeTableViewModel(
         )
         tripInfo = reverseTrip
         journeys.clear() // Clear cache trips when reverse trip is clicked.
+        alertsCache.clearAlerts() // Clear alerts cache when reverse trip is clicked.
 
         val savedTrip = sandook.selectTripById(tripId = reverseTrip.tripId)
         updateUiState {
@@ -352,10 +354,18 @@ class TimeTableViewModel(
     }
 
     private fun getAlertsFromJourney(journey: TimeTableState.JourneyCardInfo): List<ServiceAlert> {
-        val alerts = journey.legs.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
-            .flatMap { it.serviceAlertList.orEmpty() }
-        alertsCache.setAlerts(alerts)
+        val alerts =
+            journey.legs.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                .flatMap { it.serviceAlertList.orEmpty() }
+        alertsCache.setAlerts(journeyId = journey.journeyId, alerts = alerts)
         return alerts
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        // TODO - ideally AlertsCache should be scoped to TimeTableDestination and object must be deleted itself.
+        //   so we do not need to manually clear.
+        alertsCache.clearAlerts()
     }
 
     companion object {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -30,6 +30,7 @@ import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.ratelimit.RateLimiter
 import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
+import xyz.ksharma.krail.trip.planner.ui.alerts.cache.ServiceAlertsCache
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
@@ -44,6 +45,7 @@ class TimeTableViewModel(
     private val tripPlanningService: TripPlanningService,
     private val rateLimiter: RateLimiter,
     private val sandook: Sandook,
+    private val alertsCache: ServiceAlertsCache,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<TimeTableState> = MutableStateFlow(TimeTableState())
@@ -350,8 +352,10 @@ class TimeTableViewModel(
     }
 
     private fun getAlertsFromJourney(journey: TimeTableState.JourneyCardInfo): List<ServiceAlert> {
-        return journey.legs.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+        val alerts = journey.legs.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
             .flatMap { it.serviceAlertList.orEmpty() }
+        alertsCache.setAlerts(alerts)
+        return alerts
     }
 
     companion object {

--- a/feature/trip-planner/ui/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/HtmlText.kt
+++ b/feature/trip-planner/ui/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/HtmlText.kt
@@ -1,9 +1,11 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
 
 @Composable
@@ -14,12 +16,16 @@ actual fun HtmlText(
     color: Color,
     urlColor: Color,
 ) {
-    Text(text = replaceHtmlTags(text), modifier = Modifier.clickable { onClick() }, color = color)
+    Text(
+        text = replaceHtmlTags(text),
+        color = color,
+        modifier = Modifier.clickable { onClick() }.padding(horizontal = 16.dp),
+    )
 }
 
 // TODO - A workaround for iOS until https://issuetracker.google.com/issues/139326648 is fixed.
 fun replaceHtmlTags(html: String): String {
-   return runCatching {
+    return runCatching {
         html
             .replace("</div>", "\n")
             .replace("</li>", "\n")

--- a/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/di/FileStorageModule.ios.kt
+++ b/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/di/FileStorageModule.ios.kt
@@ -5,7 +5,5 @@ import xyz.ksharma.krail.gtfs_static.FileStorage
 import xyz.ksharma.krail.gtfs_static.IosFileStorage
 
 actual val fileStorageModule = module {
-    single<FileStorage> {
-        IosFileStorage()
-    }
+    single<FileStorage> { IosFileStorage() }
 }


### PR DESCRIPTION
Create ServiceAlertsCache

- Implement ServiceAlertsCache interface with RealServiceAlertsCache implementation
- Add alertsCacheModule for dependency injection
- Create ServiceAlertsViewModel to manage alerts state
- Update AlertsDestination to fetch alerts using journeyId instead of json strings
- Update TimeTableViewModel to cache alerts when fetched and clear cache when needed