### PR TITLE
UI: Rename UsualRideScreen to ThemeSelectionScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -198,7 +198,7 @@ private fun TransportModeRadioButton(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
-            .background(color = backgroundColor, shape = RoundedCornerShape(24.dp))
+            .background(color = backgroundColor, shape = RoundedCornerShape(12.dp))
             .clickable(
                 role = Role.Button,
                 indication = null,


### PR DESCRIPTION
### TL;DR
Updated corner radius of transport mode selection buttons from 24dp to 12dp

### What changed?
Modified the `RoundedCornerShape` value in the `TransportModeRadioButton` composable from 24dp to 12dp, resulting in less rounded corners for the transport mode selection buttons.

### How to test?
1. Navigate to the theme selection screen
2. Verify that transport mode buttons have a subtler corner radius
3. Confirm the visual appearance matches the updated design specifications

### Why make this change?
To create a more refined and modern appearance that better aligns with the overall design language of the application. The reduced corner radius provides a better balance between visual interest and usability.