### PR TITLE
Release: Bump iOS version to 1.0.2

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Bumped iOS app version from 1.0.1 to 1.0.2

### What changed?
Updated the CFBundleShortVersionString in Info.plist from 1.0.1 to 1.0.2 while maintaining the existing build number of 4.

### How to test?
1. Build and run the iOS app
2. Navigate to Settings > General > About on your device
3. Verify the app version shows as 1.0.2

### Why make this change?
Version bump needed to prepare for next App Store release while maintaining proper semantic versioning.