### PR TITLE
GTFS: Remove static module dependencies

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -101,7 +101,6 @@ kotlin {
             implementation(projects.feature.tripPlanner.network)
             implementation(projects.feature.tripPlanner.ui)
             implementation(projects.feature.tripPlanner.state)
-            implementation(projects.gtfsStatic)
 
             implementation(libs.navigation.compose)
 

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
@@ -6,8 +6,6 @@ import org.koin.dsl.includes
 import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
-import xyz.ksharma.krail.gtfs_static.di.fileStorageModule
-import xyz.ksharma.krail.gtfs_static.di.gtfsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.networkModule
@@ -22,8 +20,6 @@ val koinConfig = koinConfiguration {
         sandookModule,
         splashModule,
         appInfoModule,
-        gtfsModule,
-        fileStorageModule,
         alertsCacheModule,
     )
 }

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -30,7 +30,6 @@ kotlin {
                 implementation(projects.feature.tripPlanner.state)
                 implementation(projects.sandook)
                 implementation(projects.taj)
-                implementation(projects.gtfsStatic)
 
                 implementation(compose.foundation)
                 implementation(compose.animation)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import xyz.ksharma.krail.gtfs_static.NswGtfsService
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -18,7 +17,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 class SavedTripsViewModel(
     private val sandook: Sandook,
-    private val nswGtfsService: NswGtfsService,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())


### PR DESCRIPTION
### TL;DR
Removed GTFS static module dependencies and references from the trip planner feature

### What changed?
- Removed GTFS static module dependency from compose app and trip planner UI build files
- Removed GTFS module and file storage module from app's Koin configuration
- Removed NswGtfsService dependency from SavedTripsViewModel

### How to test?
1. Build and run the app
2. Navigate to the saved trips screen
3. Verify that saved trips functionality continues to work as expected
4. Ensure no build errors occur due to missing GTFS dependencies

### Why make this change?
The GTFS static module was no longer being utilized in the trip planner feature, making it an unnecessary dependency. Removing it helps reduce the app's complexity and build dependencies while maintaining all existing functionality.