### PR TITLE
Core: Add analytics module

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -64,7 +64,6 @@ plugins {
 kotlin {
     applyDefaultHierarchyTemplate()
     androidTarget {
-        @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
         }
@@ -95,6 +94,7 @@ kotlin {
         }
 
         commonMain.dependencies {
+            implementation(projects.core.analytics)
             implementation(projects.taj)
             implementation(projects.sandook)
             implementation(projects.core.appInfo)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
@@ -5,6 +5,7 @@ import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.includes
 import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
+import xyz.ksharma.krail.core.analytics.di.analyticsModule
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
@@ -21,6 +22,7 @@ val koinConfig = koinConfiguration {
         splashModule,
         appInfoModule,
         alertsCacheModule,
+        analyticsModule,
     )
 }
 

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    alias(libs.plugins.krail.android.library)
+    alias(libs.plugins.krail.kotlin.multiplatform)
+    alias(libs.plugins.krail.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "xyz.ksharma.krail.core.analytics"
+}
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    androidTarget()
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        }
+    }
+
+    sourceSets {
+        androidMain {
+            dependencies {
+                api(libs.di.koinAndroid)
+            }
+        }
+
+        commonMain {
+            dependencies {
+                implementation(libs.kotlinx.serialization.json)
+                implementation(compose.runtime)
+                api(libs.di.koinComposeViewmodel)
+                implementation(libs.slf4j.simple)
+                implementation(libs.firebase.gitLiveAnalytics)
+            }
+        }
+
+        iosMain.dependencies {
+        }
+    }
+}

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/Analytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/Analytics.kt
@@ -1,0 +1,10 @@
+package xyz.ksharma.krail.core.analytics
+
+interface Analytics {
+
+    fun track(eventName: String, properties: Map<String, Any>? = null)
+
+    fun setUserId(userId: String)
+
+    fun setUserProperty(name: String, value: String)
+}

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.core.analytics
+
+import dev.gitlive.firebase.analytics.FirebaseAnalytics
+
+class RealAnalytics(private val firebaseAnalytics: FirebaseAnalytics) : Analytics {
+
+    override fun track(eventName: String, properties: Map<String, Any>?) {
+        firebaseAnalytics.logEvent(eventName, properties)
+    }
+
+    override fun setUserId(userId: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun setUserProperty(name: String, value: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/di/AnalyticsModule.kt
@@ -1,0 +1,15 @@
+package xyz.ksharma.krail.core.analytics.di
+
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.analytics.analytics
+import org.koin.dsl.module
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.RealAnalytics
+
+val analyticsModule = module {
+    single<Analytics> {
+        RealAnalytics(
+            firebaseAnalytics = Firebase.analytics
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ rootProject.name = "Krail"
 //include(":android-app")
 include(":composeApp")
 include(":taj") // Design System
+include(":core:analytics")
 include(":core:app-info")
 include(":core:date-time")
 include(":feature:trip-planner:ui")


### PR DESCRIPTION
### TL;DR
Added a new analytics module to support cross-platform analytics tracking

### What changed?
- Created a new `:core:analytics` module with Kotlin Multiplatform support
- Configured the module with necessary dependencies including Firebase Analytics, Koin for DI, and Kotlin Serialization
- Added the module to the project's settings.gradle.kts file

### How to test?
1. Sync the project in Android Studio
2. Verify the new analytics module appears in the project structure
3. Confirm the module builds successfully

### Why make this change?
To establish a dedicated analytics infrastructure that can be shared across Android and iOS platforms, enabling consistent tracking and reporting of user interactions and app events.