### PR TITLE
Analytics: Add screen view tracking

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/Analytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/Analytics.kt
@@ -4,7 +4,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 
 interface Analytics {
 
-    fun track(event: AnalyticsEvent, properties: Map<String, Any>?)
+    fun track(event: AnalyticsEvent, properties: Map<String, Any>? = null)
 
     fun setUserId(userId: String)
 

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.core.analytics
+
+sealed class AnalyticsScreen(val name: String) {
+    data object Settings : AnalyticsScreen(name = "Settings")
+    data object SavedTrips : AnalyticsScreen(name = "SavedTrips")
+    data object TimeTable : AnalyticsScreen(name = "TimeTable")
+    data object PlanTrip : AnalyticsScreen(name = "PlanTrip")
+    data object ThemeSelection : AnalyticsScreen(name = "ThemeSelection")
+    data object SearchStop : AnalyticsScreen(name = "SearchStop")
+    data object ServiceAlerts : AnalyticsScreen(name = "ServiceAlerts")
+}

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -1,10 +1,12 @@
 package xyz.ksharma.krail.core.analytics.event
 
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
 
-    data class ScreenViewEvent(val screenName: String) : AnalyticsEvent(
+    data class ScreenViewEvent(val screen: AnalyticsScreen) : AnalyticsEvent(
         name = "screen_view",
-        properties = mapOf("name" to screenName)
+        properties = mapOf("name" to screen.name)
     )
 
     data class SavedTripCardClickEvent(val fromStopId: Int, val toStopId: Int) : AnalyticsEvent(

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/EventHelper.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/EventHelper.kt
@@ -1,0 +1,8 @@
+package xyz.ksharma.krail.core.analytics.event
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+
+fun Analytics.trackScreenViewEvent(screen: AnalyticsScreen) {
+    track(event = AnalyticsEvent.ScreenViewEvent(screen),)
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
@@ -1,19 +1,31 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.trip.planner.ui.alerts.cache.ServiceAlertsCache
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertState
+import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
 
 class ServiceAlertsViewModel(
     private val alertsCache: ServiceAlertsCache,
+    private val analytics: Analytics,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<ServiceAlertState> =
         MutableStateFlow(ServiceAlertState())
     val uiState: StateFlow<ServiceAlertState> = _uiState
+        .onStart {
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.ServiceAlerts)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ServiceAlertState())
 
     fun fetchAlerts(journeyId: String): List<ServiceAlert>? {
         // get alerts here and save to ui state.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
@@ -1,15 +1,20 @@
 package xyz.ksharma.krail.trip.planner.ui.datetimeselector
 
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 
 internal fun NavGraphBuilder.dateTimeSelectorDestination(navController: NavHostController) {
     composable<DateTimeSelectorRoute> { backStackEntry ->
         val route: DateTimeSelectorRoute = backStackEntry.toRoute()
+        val viewModel: DateTimeSelectorViewModel = koinViewModel<DateTimeSelectorViewModel>()
+        val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
         DateTimeSelectorScreen(
             dateTimeSelection = route.dateTimeSelectionItemJson?.let{

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorViewModel.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.krail.trip.planner.ui.datetimeselector
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+
+class DateTimeSelectorViewModel(
+    private val analytics: Analytics,
+) : ViewModel() {
+
+    private val _uiState: MutableStateFlow<Unit> = MutableStateFlow(Unit)
+    val uiState: StateFlow<Unit> = _uiState
+        .onStart {
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.PlanTrip)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Unit)
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -7,6 +7,7 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
+import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewModel
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 
 val viewModelsModule = module {
@@ -16,4 +17,5 @@ val viewModelsModule = module {
     viewModelOf(::ThemeSelectionViewModel)
     viewModelOf(::SettingsViewModel)
     viewModelOf(::ServiceAlertsViewModel)
+    viewModelOf(::DateTimeSelectorViewModel)
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -6,9 +6,15 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -17,10 +23,14 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 class SavedTripsViewModel(
     private val sandook: Sandook,
+    private val analytics: Analytics,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
+        .onStart {
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
 
     private fun loadSavedTrips() {
         viewModelScope.launch(context = Dispatchers.IO) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -7,18 +7,31 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultMapper.toStopResults
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
 
-class SearchStopViewModel(private val tripPlanningService: TripPlanningService) : ViewModel() {
+class SearchStopViewModel(
+    private val tripPlanningService: TripPlanningService,
+    private val analytics: Analytics,
+) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SearchStopState> = MutableStateFlow(SearchStopState())
     val uiState: StateFlow<SearchStopState> = _uiState
+        .onStart {
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.SearchStop)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SearchStopState())
 
     private var searchJob: Job? = null
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -7,15 +7,22 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
 
-class SettingsViewModel(private val appInfoProvider: AppInfoProvider) : ViewModel() {
+class SettingsViewModel(
+    private val appInfoProvider: AppInfoProvider,
+    private val analytics: Analytics,
+) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SettingsState> = MutableStateFlow(SettingsState())
     val uiState: StateFlow<SettingsState> = _uiState
         .onStart {
             fetchAppVersion()
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.Settings)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SettingsState())
 
     private fun fetchAppVersion() {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -12,19 +12,29 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionEvent
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionState
 
-class ThemeSelectionViewModel(private val sandook: Sandook) : ViewModel() {
+class ThemeSelectionViewModel(
+    private val sandook: Sandook,
+    private val analytics: Analytics,
+) : ViewModel() {
 
-    private val _uiState: MutableStateFlow<ThemeSelectionState> = MutableStateFlow(ThemeSelectionState())
+    private val _uiState: MutableStateFlow<ThemeSelectionState> =
+        MutableStateFlow(ThemeSelectionState())
     val uiState: StateFlow<ThemeSelectionState> = _uiState
 
     private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
-        .onStart { getThemeTransportMode() }
+        .onStart {
+            getThemeTransportMode()
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.ThemeSelection)
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANR_TIMEOUT), true)
 
     private var transportSelectionJob: Job? = null

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isBefore
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
@@ -46,6 +49,7 @@ class TimeTableViewModel(
     private val rateLimiter: RateLimiter,
     private val sandook: Sandook,
     private val alertsCache: ServiceAlertsCache,
+    private val analytics: Analytics,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<TimeTableState> = MutableStateFlow(TimeTableState())
@@ -59,6 +63,7 @@ class TimeTableViewModel(
         .onStart {
             println("onStart: Fetching Trip")
             fetchTrip()
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.TimeTable)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANR_TIMEOUT), true)
 
     private val _isActive: MutableStateFlow<Boolean> = MutableStateFlow(false)


### PR DESCRIPTION
### TL;DR
Added screen view analytics tracking across the app's various screens.

### What changed?
- Created a new `AnalyticsScreen` sealed class to standardize screen names
- Added a helper function `trackScreenViewEvent` to simplify analytics tracking
- Integrated screen view tracking in ViewModels for:
  - Settings
  - Saved Trips
  - Time Table
  - Plan Trip
  - Theme Selection
  - Search Stop
  - Service Alerts
- Made properties parameter optional in Analytics interface

### How to test?
1. Navigate through different screens in the app
2. Verify screen view events are being tracked in your analytics dashboard
3. Confirm correct screen names are being logged
4. Check that analytics events contain the proper screen name property

### Why make this change?
To implement consistent screen view tracking across the application, enabling better understanding of user navigation patterns and screen usage analytics.