### PR TITLE
Analytics: Add saved trip and theme selection events

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -5,41 +5,60 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
 
     data class ScreenViewEvent(val screen: AnalyticsScreen) : AnalyticsEvent(
-        name = "screen_view",
+        name = "view_screen",
         properties = mapOf("name" to screen.name)
     )
 
-    data class SavedTripCardClickEvent(val fromStopId: Int, val toStopId: Int) : AnalyticsEvent(
-        name = "saved_trip_card_click",
-        properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
-    )
+    // region SavedTrips
 
-    data class ThemeSelectedEvent(val productClass: Int) : AnalyticsEvent(
-        name = "theme_selected",
-        properties = mapOf("productClass" to productClass),
-    )
-
-    data object ReverseStopClickEvent : AnalyticsEvent(name = "reverse_stop_click")
-
-    data class LoadJourneyClickEvent(val fromStopId: Int, val toStopId: Int) :
+    data class SavedTripCardClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
-            name = "load_journey_click",
+            name = "saved_trip_card_click",
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
         )
 
-    data class ReverseTimeTableClickEvent(val fromStopId: Int, val toStopId: Int) :
+    data class DeleteSavedTripClickEvent(val fromStopId: String, val toStopId: String) :
+        AnalyticsEvent(
+            name = "delete_saved_trip_card_click",
+            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+        )
+
+    data object ReverseStopClickEvent : AnalyticsEvent(name = "reverse_stop_click")
+
+    data class LoadTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
+        AnalyticsEvent(
+            name = "load_timetable_click",
+            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+        )
+
+    data object SettingsClickEvent : AnalyticsEvent(name = "settings_click")
+
+    // endregion
+
+    // region Theme
+
+    data class ThemeSelectedEvent(val transportMode: String) : AnalyticsEvent(
+        name = "theme_selected",
+        properties = mapOf("transportMode" to transportMode),
+    )
+
+    // endregion
+
+    // region TimeTable Screen
+
+    data class ReverseTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "reverse_time_table_click",
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId)
         )
 
-    data class SaveTripClickEvent(val fromStopId: Int, val toStopId: Int) :
+    data class SaveTripClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "save_trip_click",
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
         )
 
-    data class PlanTripClickEvent(val fromStopId: Int, val toStopId: Int) :
+    data class PlanTripClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "plan_trip_click",
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
@@ -63,17 +82,20 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     data object JourneyLegClickEvent : AnalyticsEvent(name = "journey_leg_click")
 
-    data class JourneyAlertClickEvent(val fromStopId: Int, val toStopId: Int) :
+    data class JourneyAlertClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "journey_alert_click",
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
         )
 
+    // endregion
+
+    // region Generic Events
     data class BackClickEvent(val fromScreen: String) :
         AnalyticsEvent(
             name = "back_click",
             properties = mapOf("fromScreen" to fromScreen),
         )
 
-    data object SettingsClickEvent : AnalyticsEvent(name = "settings_click")
+    // endregion
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -3,6 +3,18 @@ package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 sealed interface SavedTripUiEvent {
+
     data object LoadSavedTrips : SavedTripUiEvent
+
     data class DeleteSavedTrip(val trip: Trip) : SavedTripUiEvent
+
+    data class AnalyticsSavedTripCardClick(val fromStopId: String, val toStopId: String) :
+        SavedTripUiEvent
+
+    data class AnalyticsLoadTimeTableClick(val fromStopId: String, val toStopId: String) :
+        SavedTripUiEvent
+
+    data object AnalyticsReverseSavedTrip : SavedTripUiEvent
+
+    data object AnalyticsSettingsButtonClick : SavedTripUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripAnalytics.kt
@@ -1,0 +1,21 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+
+internal fun Analytics.trackDeleteSavedTrip(fromStopId: String, toStopId: String) {
+    track(
+        AnalyticsEvent.DeleteSavedTripClickEvent(
+            fromStopId = fromStopId,
+            toStopId = toStopId,
+        )
+    )
+}
+
+internal fun Analytics.trackSavedTripCardClick(fromStopId: String, toStopId: String) {
+    track(AnalyticsEvent.SavedTripCardClickEvent(fromStopId = fromStopId, toStopId = toStopId))
+}
+
+internal fun Analytics.trackLoadTimeTableClick(fromStopId: String, toStopId: String) {
+    track(AnalyticsEvent.LoadTimeTableClickEvent(fromStopId = fromStopId, toStopId = toStopId))
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -58,18 +58,18 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
             fromStopItem = fromStopItem,
             toStopItem = toStopItem,
             fromButtonClick = {
-  //              Timber.d("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
+                //              Timber.d("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
                 navController.navigate(SearchStopRoute(fieldTypeKey = SearchStopFieldType.FROM.key))
             },
             toButtonClick = {
-  //              Timber.d("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
+                //              Timber.d("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
                 navController.navigate(
                     route = SearchStopRoute(fieldTypeKey = SearchStopFieldType.TO.key),
                     navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                 )
             },
             onReverseButtonClick = {
-  //              Timber.d("onReverseButtonClick:")
+                //              Timber.d("onReverseButtonClick:")
                 val bufferStop = fromStopItem
                 backStackEntry.savedStateHandle[SearchStopFieldType.FROM.key] =
                     toStopItem?.toJsonString()
@@ -78,9 +78,15 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
 
                 fromStopItem = toStopItem
                 toStopItem = bufferStop
+                viewModel.onEvent(SavedTripUiEvent.AnalyticsReverseSavedTrip)
             },
-            onSearchButtonClick = { fromStop, toStop ->
-                if (fromStop != null && toStop != null) {
+            onSavedTripCardClick = { fromStop, toStop ->
+                if (fromStop?.stopId != null && toStop?.stopId != null) {
+                    val fromStopId = fromStop.stopId
+                    val toStopId = toStop.stopId
+                    viewModel.onEvent(
+                        SavedTripUiEvent.AnalyticsSavedTripCardClick(fromStopId, toStopId)
+                    )
                     navController.navigate(
                         route = TimeTableRoute(
                             fromStopId = fromStop.stopId,
@@ -90,22 +96,35 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                         ),
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
-                } else if (fromStopItem != null && toStopItem != null) {
+                } else {
+                    // TODO - show message - to select both stops
+                    // Timber.e("Select both stops")
+                }
+            },
+            onSearchButtonClick = { fromStop, toStop ->
+                if (fromStop != null && toStop != null) {
+                    viewModel.onEvent(
+                        SavedTripUiEvent.AnalyticsLoadTimeTableClick(
+                            fromStopId = fromStop.stopId,
+                            toStopId = toStop.stopId,
+                        )
+                    )
                     navController.navigate(
                         route = TimeTableRoute(
-                            fromStopId = fromStopItem?.stopId!!,
-                            fromStopName = fromStopItem?.stopName!!,
-                            toStopId = toStopItem?.stopId!!,
-                            toStopName = toStopItem?.stopName!!,
+                            fromStopId = fromStop.stopId,
+                            fromStopName = fromStop.stopName,
+                            toStopId = toStop.stopId,
+                            toStopName = toStop.stopName,
                         ),
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
                 } else {
                     // TODO - show message - to select both stops
- //                   Timber.e("Select both stops")
+                    // Timber.e("Select both stops")
                 }
             },
             onSettingsButtonClick = {
+                viewModel.onEvent(SavedTripUiEvent.AnalyticsSettingsButtonClick)
                 navController.navigate(
                     route = SettingsRoute,
                     navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -44,6 +44,7 @@ fun SavedTripsScreen(
     fromButtonClick: () -> Unit = {},
     toButtonClick: () -> Unit = {},
     onReverseButtonClick: () -> Unit = {},
+    onSavedTripCardClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     onSearchButtonClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     onSettingsButtonClick: () -> Unit = {},
     onEvent: (SavedTripUiEvent) -> Unit = {},
@@ -115,6 +116,16 @@ fun SavedTripsScreen(
                             trip = trip,
                             onStarClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
                             onCardClick = {
+                                onSavedTripCardClick(
+                                    StopItem(
+                                        stopId = trip.fromStopId,
+                                        stopName = trip.fromStopName,
+                                    ),
+                                    StopItem(
+                                        stopId = trip.toStopId,
+                                        stopName = trip.toStopName,
+                                    ),
+                                )
                                 onSearchButtonClick(
                                     StopItem(
                                         stopId = trip.fromStopId,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
@@ -60,6 +61,27 @@ class SavedTripsViewModel(
         when (event) {
             is SavedTripUiEvent.DeleteSavedTrip -> onDeleteSavedTrip(event.trip)
             SavedTripUiEvent.LoadSavedTrips -> loadSavedTrips()
+            is SavedTripUiEvent.AnalyticsSavedTripCardClick -> {
+                analytics.trackSavedTripCardClick(
+                    fromStopId = event.fromStopId,
+                    toStopId = event.toStopId,
+                )
+            }
+
+            SavedTripUiEvent.AnalyticsReverseSavedTrip -> {
+                analytics.track(AnalyticsEvent.ReverseStopClickEvent)
+            }
+
+            is SavedTripUiEvent.AnalyticsLoadTimeTableClick -> {
+                analytics.trackLoadTimeTableClick(
+                    fromStopId = event.fromStopId,
+                    toStopId = event.toStopId,
+                )
+            }
+
+            SavedTripUiEvent.AnalyticsSettingsButtonClick -> {
+                analytics.track(AnalyticsEvent.SettingsClickEvent)
+            }
         }
     }
 
@@ -68,6 +90,10 @@ class SavedTripsViewModel(
         viewModelScope.launch(context = Dispatchers.IO) {
             sandook.deleteTrip(tripId = savedTrip.tripId)
             loadSavedTrips()
+            analytics.trackDeleteSavedTrip(
+                fromStopId = savedTrip.fromStopId,
+                toStopId = savedTrip.toStopId,
+            )
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionAnalytics.kt
@@ -1,0 +1,13 @@
+package xyz.ksharma.krail.trip.planner.ui.themeselection
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+
+internal fun Analytics.trackThemeSelectionEvent(productClass: Int) {
+    productClass.let { TransportMode.toTransportModeType(it) }?.let {
+        track(AnalyticsEvent.ThemeSelectedEvent(transportMode = it.name))
+    } ?: run {
+        track(AnalyticsEvent.ThemeSelectedEvent(transportMode = productClass.toString()))
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -53,6 +54,7 @@ class ThemeSelectionViewModel(
             updateUiState {
                 copy(themeSelected = true)
             }
+            analytics.trackThemeSelectionEvent(productClass)
         }
     }
 


### PR DESCRIPTION
### TL;DR
Added analytics tracking for saved trips and theme selection features.

### What changed?
- Renamed `screen_view` event to `view_screen`
- Changed stop ID type from `Int` to `String`
- Added new analytics events for saved trips:
  - Delete saved trip
  - Load timetable
  - Reverse trip
  - Settings button click
- Added theme selection analytics with transport mode tracking
- Organized analytics events into logical regions
- Implemented analytics tracking in SavedTripsViewModel and ThemeSelectionViewModel

### How to test?
1. Navigate to saved trips screen and perform actions:
   - Delete a saved trip
   - Click on a saved trip card
   - Load timetable
   - Reverse trip direction
   - Access settings
2. Change theme selection and verify transport mode is tracked
3. Verify analytics events are properly logged with correct parameters

### Why make this change?
To improve analytics tracking capabilities and gain better insights into user behavior and feature usage patterns. The structured analytics events will help understand how users interact with saved trips and theme selection features.