### PR TITLE
Analytics: Add journey and trip tracking events

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/Analytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/Analytics.kt
@@ -4,7 +4,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 
 interface Analytics {
 
-    fun track(event: AnalyticsEvent, properties: Map<String, Any>? = null)
+    fun track(event: AnalyticsEvent)
 
     fun setUserId(userId: String)
 

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
@@ -5,8 +5,8 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 
 class RealAnalytics(private val firebaseAnalytics: FirebaseAnalytics) : Analytics {
 
-    override fun track(event: AnalyticsEvent, properties: Map<String, Any>?) {
-        firebaseAnalytics.logEvent(event.name, properties)
+    override fun track(event: AnalyticsEvent) {
+        firebaseAnalytics.logEvent(event.name, event.properties)
     }
 
     override fun setUserId(userId: String) {

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -44,6 +44,12 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // endregion
 
+    // region PlanTripScreen / DateTimeSelection Screen
+
+    data object ResetTimeClickEvent : AnalyticsEvent("reset_time_click")
+
+    // endregion
+
     // region TimeTable Screen
 
     data class ReverseTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
@@ -64,13 +70,14 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
         )
 
-    data class DateTimeSelectEvent(val dayOfWeek: String, val time: String, val type: String) :
-        AnalyticsEvent(
-            name = "date_time_select",
-            properties = mapOf("dayOfWeek" to dayOfWeek, "time" to time, "type" to type),
-        )
-
-    data object ResetTimeClickEvent : AnalyticsEvent("reset_time_click")
+    data class DateTimeSelectEvent(
+        val dayOfWeek: String,
+        val time: String,
+        val journeyOption: String,
+    ) : AnalyticsEvent(
+        name = "date_time_select",
+        properties = mapOf("dayOfWeek" to dayOfWeek, "time" to time, "option" to journeyOption),
+    )
 
     data class JourneyCardExpandEvent(val hasStarted: Boolean) :
         AnalyticsEvent(
@@ -78,9 +85,15 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             properties = mapOf("hasStarted" to hasStarted),
         )
 
-    data object JourneyCardCollapseEvent : AnalyticsEvent(name = "journey_card_collapse")
+    data class JourneyCardCollapseEvent(val hasStarted: Boolean) : AnalyticsEvent(
+        name = "journey_card_collapse",
+        properties = mapOf("hasStarted" to hasStarted),
+    )
 
-    data object JourneyLegClickEvent : AnalyticsEvent(name = "journey_leg_click")
+    data class JourneyLegClickEvent(val expanded: Boolean) : AnalyticsEvent(
+        name = "journey_leg_click",
+        properties = mapOf("expanded" to expanded),
+    )
 
     data class JourneyAlertClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -3,12 +3,21 @@ package xyz.ksharma.krail.trip.planner.ui.state.timetable
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 
 sealed interface TimeTableUiEvent {
+
     data object SaveTripButtonClicked : TimeTableUiEvent
+
     data class LoadTimeTable(val trip: Trip) : TimeTableUiEvent
+
     data class JourneyCardClicked(val journeyId: String) : TimeTableUiEvent
+
     data class DateTimeSelectionChanged(val dateTimeSelectionItem: DateTimeSelectionItem?) :
         TimeTableUiEvent
 
     data object ReverseTripButtonClicked : TimeTableUiEvent
+
     data object RetryButtonClicked : TimeTableUiEvent
+
+    data object AnalyticsDateTimeSelectorClicked : TimeTableUiEvent
+
+    data class JourneyLegClicked(val expanded: Boolean) : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -91,6 +91,7 @@ fun JourneyCard(
     totalUniqueServiceAlerts: Int,
     modifier: Modifier = Modifier,
     onAlertClick: () -> Unit = {},
+    onLegClick: (Boolean) -> Unit = {},
 ) {
     val onSurface: Color = KrailTheme.colors.onSurface
     val borderColors = remember(transportModeList) { transportModeList.toColors(onSurface) }
@@ -173,6 +174,7 @@ fun JourneyCard(
                     legList = legList,
                     totalUniqueServiceAlerts = totalUniqueServiceAlerts,
                     onAlertClick = onAlertClick,
+                    onLegClick = onLegClick,
                     modifier = Modifier.clickable(
                         role = Role.Button,
                         onClick = onClick,
@@ -196,6 +198,7 @@ fun ExpandedJourneyCardContent(
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
     totalUniqueServiceAlerts: Int,
     onAlertClick: () -> Unit,
+    onLegClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val appPlatformType: AppPlatformType = LocalAppPlatformProvider.current
@@ -319,6 +322,7 @@ fun ExpandedJourneyCardContent(
                                     lastLeg = legList[(index - 1).coerceAtLeast(0)]
                                 ) else 0.dp
                             ),
+                            onClick = onLegClick,
                         )
                     }
 
@@ -535,6 +539,7 @@ private fun PreviewJourneyCard() {
             totalWalkTime = null,
             totalUniqueServiceAlerts = 0,
             onClick = {},
+            onLegClick = {},
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -59,6 +59,7 @@ fun LegView(
     displayDuration: Boolean,
     modifier: Modifier = Modifier,
     displayAllStops: Boolean = false,
+    onClick: (Boolean) -> Unit = {},
 ) {
     val circleRadius = 8.dp
     val strokeWidth = 4.dp
@@ -83,7 +84,10 @@ fun LegView(
                 .clickable(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
-                    onClick = { showIntermediateStops = !showIntermediateStops },
+                    onClick = {
+                        showIntermediateStops = !showIntermediateStops
+                        onClick(showIntermediateStops)
+                    },
                     role = Role.Button,
                 )
                 .padding(vertical = 12.dp, horizontal = 12.dp),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -101,20 +101,23 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                     // Timber.e("Select both stops")
                 }
             },
-            onSearchButtonClick = { fromStop, toStop ->
-                if (fromStop != null && toStop != null) {
+            onSearchButtonClick = {
+                if (fromStopItem != null && toStopItem != null) {
+                    val fromStopId = fromStopItem!!.stopId
+                    val toStopId = toStopItem!!.stopId
+
                     viewModel.onEvent(
                         SavedTripUiEvent.AnalyticsLoadTimeTableClick(
-                            fromStopId = fromStop.stopId,
-                            toStopId = toStop.stopId,
+                            fromStopId = fromStopId,
+                            toStopId = toStopId,
                         )
                     )
                     navController.navigate(
                         route = TimeTableRoute(
-                            fromStopId = fromStop.stopId,
-                            fromStopName = fromStop.stopName,
-                            toStopId = toStop.stopId,
-                            toStopName = toStop.stopName,
+                            fromStopId = fromStopId,
+                            fromStopName = fromStopItem!!.stopName,
+                            toStopId = toStopId,
+                            toStopName = toStopItem!!.stopName,
                         ),
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -45,7 +45,7 @@ fun SavedTripsScreen(
     toButtonClick: () -> Unit = {},
     onReverseButtonClick: () -> Unit = {},
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
-    onSearchButtonClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
+    onSearchButtonClick: () -> Unit = {},
     onSettingsButtonClick: () -> Unit = {},
     onEvent: (SavedTripUiEvent) -> Unit = {},
 ) {
@@ -126,16 +126,6 @@ fun SavedTripsScreen(
                                         stopName = trip.toStopName,
                                     ),
                                 )
-                                onSearchButtonClick(
-                                    StopItem(
-                                        stopId = trip.fromStopId,
-                                        stopName = trip.fromStopName,
-                                    ),
-                                    StopItem(
-                                        stopId = trip.toStopId,
-                                        stopName = trip.toStopName,
-                                    ),
-                                )
                             },
                             primaryTransportMode = null, // TODO
                             modifier = Modifier
@@ -155,7 +145,7 @@ fun SavedTripsScreen(
             fromButtonClick = fromButtonClick,
             toButtonClick = toButtonClick,
             onReverseButtonClick = onReverseButtonClick,
-            onSearchButtonClick = { onSearchButtonClick(null, null) },
+            onSearchButtonClick = { onSearchButtonClick() },
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAnalytics.kt
@@ -1,0 +1,12 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+
+internal fun Analytics.trackJourneyCardExpandEvent(hasStarted: Boolean) {
+    track(AnalyticsEvent.JourneyCardExpandEvent(hasStarted = hasStarted))
+}
+
+internal fun Analytics.trackJourneyCardCollapseEvent(hasStarted: Boolean) {
+    track(AnalyticsEvent.JourneyCardCollapseEvent(hasStarted = hasStarted))
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -70,10 +70,14 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             },
             dateTimeSelectionItem = dateTimeSelectionItem,
             dateTimeSelectorClicked = {
+                viewModel.onEvent(TimeTableUiEvent.AnalyticsDateTimeSelectorClicked)
                 navController.navigate(
                     route = DateTimeSelectorRoute(dateTimeSelectionItem?.toJsonString()),
                     navOptions = NavOptions.Builder().setLaunchSingleTop(singleTop = true).build(),
                 )
+            },
+            onJourneyLegClick = { journeyId ->
+                viewModel.onEvent(TimeTableUiEvent.JourneyLegClicked(journeyId))
             },
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -3,8 +3,6 @@ package xyz.ksharma.krail.trip.planner.ui.timetable
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
-import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -75,6 +73,7 @@ fun TimeTableScreen(
     onEvent: (TimeTableUiEvent) -> Unit,
     onAlertClick: (String) -> Unit,
     onBackClick: () -> Unit,
+    onJourneyLegClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     dateTimeSelectorClicked: () -> Unit = {},
 ) {
@@ -243,6 +242,7 @@ fun TimeTableScreen(
                         onAlertClick = {
                             onAlertClick(journey.journeyId)
                         },
+                        onLegClick = onJourneyLegClick,
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
                             .animateItem(),
                     )
@@ -282,6 +282,7 @@ private fun JourneyCardItem(
     totalUniqueServiceAlerts: Int,
     modifier: Modifier = Modifier,
     transportModeLineList: ImmutableList<TransportModeLine>? = null,
+    onLegClick: (Boolean) -> Unit,
 ) {
     if (!transportModeLineList.isNullOrEmpty() && legList.isNotEmpty()) {
         JourneyCard(
@@ -300,6 +301,7 @@ private fun JourneyCardItem(
             onClick = onClick,
             onAlertClick = onAlertClick,
             totalUniqueServiceAlerts = totalUniqueServiceAlerts,
+            onLegClick = onLegClick,
             modifier = modifier,
         )
     }
@@ -364,6 +366,7 @@ private fun PreviewTimeTableScreen() {
                 onAlertClick = {},
                 onBackClick = {},
                 dateTimeSelectionItem = null,
+                onJourneyLegClick = {},
             )
         }
     }
@@ -390,6 +393,7 @@ private fun PreviewTimeTableScreenError() {
                 onAlertClick = {},
                 onBackClick = {},
                 dateTimeSelectionItem = null,
+                onJourneyLegClick = {},
             )
         }
     }
@@ -416,6 +420,7 @@ private fun PreviewTimeTableScreenNoResults() {
                 onEvent = {},
                 onAlertClick = {},
                 onBackClick = {},
+                onJourneyLegClick = {},
             )
         }
     }


### PR DESCRIPTION
### TL;DR
Refactored analytics tracking to include more detailed event properties and improved event handling across journey interactions.

### What changed?
- Modified `Analytics` interface to handle event properties directly through `AnalyticsEvent`
- Added new analytics events for journey card expand/collapse with `hasStarted` property
- Updated `DateTimeSelectEvent` to use `journeyOption` instead of `type`
- Added analytics tracking for journey alerts, save trip actions, and date/time selections
- Created dedicated `TimeTableAnalytics.kt` file for journey card tracking functions
- Added analytics tracking when accessing the date/time selector

### How to test?
1. Navigate through the time table screen and verify analytics events are fired:
   - Expand/collapse journey cards
   - Select different dates/times
   - Save trips
   - View journey alerts
2. Check Firebase Analytics dashboard to confirm events are logged with correct properties
3. Verify reverse trip functionality triggers appropriate analytics events

### Why make this change?
To provide more comprehensive analytics data for user interactions, making it easier to track user behavior and improve the journey planning experience. The standardized event tracking will help better understand how users interact with time tables and journey planning features.