### PR TITLE
Analytics: Add reset time click tracking

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/datetimeselector/DateTimeSelectorEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/datetimeselector/DateTimeSelectorEvent.kt
@@ -1,0 +1,6 @@
+package xyz.ksharma.krail.trip.planner.ui.state.datetimeselector
+
+sealed interface DateTimeSelectorEvent {
+
+    data object ResetDateTimeClick : DateTimeSelectorEvent
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
@@ -9,6 +9,7 @@ import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
+import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectorEvent
 
 internal fun NavGraphBuilder.dateTimeSelectorDestination(navController: NavHostController) {
     composable<DateTimeSelectorRoute> { backStackEntry ->
@@ -29,7 +30,10 @@ internal fun NavGraphBuilder.dateTimeSelectorDestination(navController: NavHostC
                     value = dateTimeSelection?.toJsonString(),
                 )
                 navController.popBackStack()
-            }
+            },
+            onResetClick = {
+                viewModel.onEvent(DateTimeSelectorEvent.ResetDateTimeClick)
+            },
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -60,6 +60,7 @@ fun DateTimeSelectorScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
     onDateTimeSelected: (DateTimeSelectionItem?) -> Unit = {},
+    onResetClick: () -> Unit = {},
 ) {
     // Colors
     val themeColorHex by LocalThemeColor.current
@@ -142,6 +143,7 @@ fun DateTimeSelectorScreen(
                     timePickerState.minute = now.time.minute
                     journeyTimeOption = JourneyTimeOptions.LEAVE
                     reset = true
+                    onResetClick()
                 })
         })
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorViewModel.kt
@@ -9,7 +9,9 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectorEvent
 
 class DateTimeSelectorViewModel(
     private val analytics: Analytics,
@@ -20,4 +22,14 @@ class DateTimeSelectorViewModel(
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.PlanTrip)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), Unit)
+
+    fun onEvent(event: DateTimeSelectorEvent) {
+        when (event) {
+            is DateTimeSelectorEvent.ResetDateTimeClick -> onResetDateTimeClick()
+        }
+    }
+
+    private fun onResetDateTimeClick() {
+        analytics.track(AnalyticsEvent.ResetTimeClickEvent)
+    }
 }


### PR DESCRIPTION
### TL;DR
Added analytics tracking for the reset date/time button in the trip planner.

### What changed?
- Created a new `DateTimeSelectorEvent` sealed interface for handling UI events
- Added tracking for when users click the reset date/time button
- Connected the reset button click in the UI to the ViewModel
- Implemented analytics tracking through the `Analytics` interface

### How to test?
1. Open the trip planner
2. Navigate to the date/time selector screen
3. Click the reset button
4. Verify that the analytics event `ResetTimeClickEvent` is being tracked

### Why make this change?
To better understand how users interact with the date/time selector, specifically tracking when they reset their selections to the current time. This data will help inform future improvements to the trip planning experience.