### PR TITLE
Analytics: Add app start event tracking

### DIFF
--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -38,6 +38,8 @@ kotlin {
                 implementation(compose.runtime)
                 api(libs.di.koinComposeViewmodel)
                 implementation(libs.firebase.gitLiveAnalytics)
+
+                implementation(projects.core.appInfo)
             }
         }
 

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
@@ -2,11 +2,18 @@ package xyz.ksharma.krail.core.analytics
 
 import dev.gitlive.firebase.analytics.FirebaseAnalytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 
-class RealAnalytics(private val firebaseAnalytics: FirebaseAnalytics) : Analytics {
+class RealAnalytics(
+    private val firebaseAnalytics: FirebaseAnalytics,
+    private val appInfoProvider: AppInfoProvider,
+) : Analytics {
 
     override fun track(event: AnalyticsEvent) {
-        firebaseAnalytics.logEvent(event.name, event.properties)
+        // Only track prod builds analytics events
+        if (appInfoProvider.getAppInfo().isDebug().not()) {
+            firebaseAnalytics.logEvent(event.name, event.properties)
+        }
     }
 
     override fun setUserId(userId: String) {

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/di/AnalyticsModule.kt
@@ -9,7 +9,8 @@ import xyz.ksharma.krail.core.analytics.RealAnalytics
 val analyticsModule = module {
     single<Analytics> {
         RealAnalytics(
-            firebaseAnalytics = Firebase.analytics
+            firebaseAnalytics = Firebase.analytics,
+            appInfoProvider = get(),
         )
     }
 }

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -110,5 +110,14 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             properties = mapOf("fromScreen" to fromScreen),
         )
 
+    data class AppStart(
+        val deviceType: String,
+        val appVersion: String,
+        val osVersion: String,
+        val deviceModel: String,
+        val fontSize: String,
+        val isDarkTheme: Boolean,
+    ) : AnalyticsEvent(name = "app_start", properties = mapOf("app_start" to "app_start"))
+
     // endregion
 }

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -2,10 +2,9 @@ package xyz.ksharma.krail.core.appinfo
 
 import android.content.Context
 import android.os.Build
+import android.content.res.Configuration
 
 class AndroidAppInfo(private val context: Context) : AppInfo {
-
-    override val name: String = "Android ${Build.VERSION.SDK_INT}"
 
     override val type: AppPlatformType = AppPlatformType.ANDROID
 
@@ -17,6 +16,31 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             return packageInfo.versionName ?: "Unknown"
         }
+    override val osVersion: String
+        get() = Build.VERSION.SDK_INT.toString()
+
+    override val fontSize: String
+        get() {
+            val configuration = context.resources.configuration
+            return configuration.fontScale.toString()
+        }
+
+    override val isDarkTheme: Boolean
+        get() {
+            val uiMode = context.resources.configuration.uiMode
+            return (uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        }
+
+    override val deviceModel: String
+        get() = Build.MODEL
+
+    override val deviceManufacturer: String
+        get() = Build.BRAND
+
+    override fun toString() =
+        "AndroidAppInfo(type=$type, isDebug=${isDebug()}, version=$version, osVersion=$osVersion, " +
+                "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
+                "deviceManufacturer=$deviceManufacturer)"
 }
 
 class AndroidAppInfoProvider(private val context: Context) : AppInfoProvider {

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -1,13 +1,24 @@
 package xyz.ksharma.krail.core.appinfo
 
+/**
+ * Inject [AppInfoProvider] to get instance of [AppInfo].
+ */
 interface AppInfo {
-    val name: String
-
     val type: AppPlatformType
 
     fun isDebug(): Boolean
 
     val version: String
+
+    val osVersion: String
+
+    val fontSize: String
+
+    val isDarkTheme: Boolean
+
+    val deviceModel: String
+
+    val deviceManufacturer: String
 }
 
 enum class AppPlatformType {

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -1,13 +1,13 @@
 package xyz.ksharma.krail.core.appinfo
 
 import platform.Foundation.NSBundle
+import platform.UIKit.UIApplication
 import platform.UIKit.UIDevice
+import platform.UIKit.UIScreen
+import platform.UIKit.UIUserInterfaceStyle
 import kotlin.experimental.ExperimentalNativeApi
 
 class IOSAppInfo : AppInfo {
-
-    override val name: String =
-        UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 
     override val type: AppPlatformType = AppPlatformType.IOS
 
@@ -23,6 +23,32 @@ class IOSAppInfo : AppInfo {
                 NSBundle.mainBundle.infoDictionary?.get("CFBundleVersion") as? String ?: "Unknown"
             return "$shortVersion ($buildVersion)"
         }
+
+    override val osVersion: String
+        get() = UIDevice.currentDevice.systemVersion
+
+    override val fontSize: String
+        get() {
+            val contentSizeCategory = UIApplication.sharedApplication.preferredContentSizeCategory
+            return contentSizeCategory.toString()
+        }
+
+    override val isDarkTheme: Boolean
+        get() {
+            val userInterfaceStyle = UIScreen.mainScreen.traitCollection.userInterfaceStyle
+            return userInterfaceStyle == UIUserInterfaceStyle.UIUserInterfaceStyleDark
+        }
+
+    override val deviceModel: String
+        get() = UIDevice.currentDevice.model
+
+    override val deviceManufacturer: String
+        get() = "Apple"
+
+    override fun toString() =
+        "AndroidAppInfo(type=$type, isDebug=${isDebug()}, version=$version, osVersion=$osVersion, " +
+                "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
+                "deviceManufacturer=$deviceManufacturer)"
 }
 
 


### PR DESCRIPTION
### TL;DR
Added app start analytics event tracking with device and app information

### What changed?
- Created new `AppStart` analytics event to capture device and app information
- Enhanced `AppInfo` interface with additional properties (OS version, font size, theme, device model)
- Implemented platform-specific (iOS/Android) app information collection
- Added analytics tracking to the splash screen
- Configured analytics to only track events in production builds

### How to test?
1. Launch the app in debug mode and verify no analytics events are sent
2. Launch the app in release mode and confirm the app_start event is tracked
3. Verify the following properties are captured:
   - Device type
   - OS version
   - App version
   - Font size
   - Theme setting
   - Device model

### Why make this change?
To gather essential analytics data about app usage across different devices and configurations, helping understand user behavior and app performance across various platforms and settings.