### PR TITLE
Core: Rename AppPlatformType to DevicePlatformType and refactor AppInfo

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.launch
 import xyz.ksharma.krail.DEFAULT_THEME_TRANSPORT_MODE
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
-import xyz.ksharma.krail.core.appinfo.AppInfo
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -38,9 +37,9 @@ class SplashViewModel(
     private fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {
         analytics.track(
             AnalyticsEvent.AppStart(
-                deviceType = type.name,
+                deviceType = devicePlatformType.name,
                 osVersion = osVersion,
-                appVersion = version,
+                appVersion = appVersion,
                 fontSize = fontSize,
                 isDarkTheme = isDarkTheme,
                 deviceModel = deviceModel,

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
@@ -11,7 +11,7 @@ class RealAnalytics(
 
     override fun track(event: AnalyticsEvent) {
         // Only track prod builds analytics events
-        if (appInfoProvider.getAppInfo().isDebug().not()) {
+        if (appInfoProvider.getAppInfo().isDebug.not()) {
             firebaseAnalytics.logEvent(event.name, event.properties)
         }
     }

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -6,12 +6,13 @@ import android.content.res.Configuration
 
 class AndroidAppInfo(private val context: Context) : AppInfo {
 
-    override val type: AppPlatformType = AppPlatformType.ANDROID
+    override val devicePlatformType: DevicePlatformType = DevicePlatformType.ANDROID
 
-    override fun isDebug(): Boolean =
-        context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE != 0
+    override val isDebug: Boolean
+        get() =
+            context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE != 0
 
-    override val version: String
+    override val appVersion: String
         get() {
             val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             return packageInfo.versionName ?: "Unknown"
@@ -38,7 +39,7 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
         get() = Build.BRAND
 
     override fun toString() =
-        "AndroidAppInfo(type=$type, isDebug=${isDebug()}, version=$version, osVersion=$osVersion, " +
+        "AndroidAppInfo(type=$devicePlatformType, isDebug=${isDebug}, version=$appVersion, osVersion=$osVersion, " +
                 "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
                 "deviceManufacturer=$deviceManufacturer)"
 }
@@ -49,4 +50,4 @@ class AndroidAppInfoProvider(private val context: Context) : AppInfoProvider {
     }
 }
 
-actual fun getAppPlatformType() = AppPlatformType.ANDROID
+actual fun getAppPlatformType() = DevicePlatformType.ANDROID

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -4,11 +4,14 @@ package xyz.ksharma.krail.core.appinfo
  * Inject [AppInfoProvider] to get instance of [AppInfo].
  */
 interface AppInfo {
-    val type: AppPlatformType
+    val devicePlatformType: DevicePlatformType
 
-    fun isDebug(): Boolean
+    val isDebug: Boolean
 
-    val version: String
+    /**
+     * App version.
+     */
+    val appVersion: String
 
     val osVersion: String
 
@@ -21,7 +24,7 @@ interface AppInfo {
     val deviceManufacturer: String
 }
 
-enum class AppPlatformType {
+enum class DevicePlatformType {
     ANDROID,
     IOS,
     UNKNOWN,

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
@@ -4,4 +4,4 @@ import androidx.compose.runtime.staticCompositionLocalOf
 
 val LocalAppPlatformProvider = staticCompositionLocalOf { getAppPlatformType() }
 
-expect fun getAppPlatformType(): AppPlatformType
+expect fun getAppPlatformType(): DevicePlatformType

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -9,12 +9,13 @@ import kotlin.experimental.ExperimentalNativeApi
 
 class IOSAppInfo : AppInfo {
 
-    override val type: AppPlatformType = AppPlatformType.IOS
+    override val devicePlatformType: DevicePlatformType = DevicePlatformType.IOS
 
     @OptIn(ExperimentalNativeApi::class)
-    override fun isDebug(): Boolean = Platform.isDebugBinary
+    override val isDebug: Boolean
+        get() = Platform.isDebugBinary
 
-    override val version: String
+    override val appVersion: String
         get() {
             val shortVersion =
                 NSBundle.mainBundle.infoDictionary?.get("CFBundleShortVersionString") as? String
@@ -30,7 +31,8 @@ class IOSAppInfo : AppInfo {
     override val fontSize: String
         get() {
             val contentSizeCategory = UIApplication.sharedApplication.preferredContentSizeCategory
-            return contentSizeCategory.toString()
+            return contentSizeCategory?.substring(startIndex = "UICTContentSizeCategory".length)
+                ?: contentSizeCategory.toString()
         }
 
     override val isDarkTheme: Boolean
@@ -39,6 +41,10 @@ class IOSAppInfo : AppInfo {
             return userInterfaceStyle == UIUserInterfaceStyle.UIUserInterfaceStyleDark
         }
 
+    /**
+     * TODO - what a hack! This is not the device model.
+     *    There needs to be a better way to do it without using 3rd party libraries.
+     */
     override val deviceModel: String
         get() = UIDevice.currentDevice.model
 
@@ -46,11 +52,10 @@ class IOSAppInfo : AppInfo {
         get() = "Apple"
 
     override fun toString() =
-        "AndroidAppInfo(type=$type, isDebug=${isDebug()}, version=$version, osVersion=$osVersion, " +
+        "AndroidAppInfo(type=$devicePlatformType, isDebug=${isDebug}, version=$appVersion, osVersion=$osVersion, " +
                 "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
                 "deviceManufacturer=$deviceManufacturer)"
 }
-
 
 class IosAppInfoProvider : AppInfoProvider {
     override fun getAppInfo(): AppInfo {
@@ -58,4 +63,4 @@ class IosAppInfoProvider : AppInfoProvider {
     }
 }
 
-actual fun getAppPlatformType() = AppPlatformType.IOS
+actual fun getAppPlatformType() = DevicePlatformType.IOS

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -49,7 +49,7 @@ import krail.feature.trip_planner.ui.generated.resources.ic_a11y
 import krail.feature.trip_planner.ui.generated.resources.ic_clock
 import krail.feature.trip_planner.ui.generated.resources.ic_walk
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.core.appinfo.AppPlatformType
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
 import xyz.ksharma.krail.core.appinfo.LocalAppPlatformProvider
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.SeparatorIcon
@@ -201,7 +201,7 @@ fun ExpandedJourneyCardContent(
     onLegClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val appPlatformType: AppPlatformType = LocalAppPlatformProvider.current
+    val devicePlatformType: DevicePlatformType = LocalAppPlatformProvider.current
 
     Column(modifier = modifier) {
         FlowRow(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -26,7 +26,7 @@ class SettingsViewModel(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SettingsState())
 
     private fun fetchAppVersion() {
-        val appVersion = appInfoProvider.getAppInfo().version
+        val appVersion = appInfoProvider.getAppInfo().appVersion
         _uiState.value = _uiState.value.copy(appVersion = appVersion)
     }
 }


### PR DESCRIPTION
Refactors app info interface and implementations:
- Converts `isDebug()` from a function to a property
- Renames `AppPlatformType` to `DevicePlatformType` for clarity
- Renames `type` property to `devicePlatformType`
- Renames `version` property to `appVersion`