### PR TITLE
Analytics: Add stop selection and field click events

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -33,6 +33,19 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     data object SettingsClickEvent : AnalyticsEvent(name = "settings_click")
 
+    data object FromFieldClickEvent : AnalyticsEvent(name = "from_field_click")
+
+    data object ToFieldClickEvent : AnalyticsEvent(name = "to_field_click")
+
+    // endregion
+
+    // region SearchStop
+
+    data class StopSelectedEvent(val stopId: String) : AnalyticsEvent(
+        name = "stop_selected",
+        properties = mapOf("stopId" to stopId),
+    )
+
     // endregion
 
     // region Theme

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -17,4 +17,6 @@ sealed interface SavedTripUiEvent {
     data object AnalyticsReverseSavedTrip : SavedTripUiEvent
 
     data object AnalyticsSettingsButtonClick : SavedTripUiEvent
+    data object AnalyticsFromButtonClick : SavedTripUiEvent
+    data object AnalyticsToButtonClick : SavedTripUiEvent
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
@@ -1,5 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.state.searchstop
 
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
 sealed interface SearchStopUiEvent {
     data class SearchTextChanged(val query: String) : SearchStopUiEvent
+    data class StopSelected(val stopItem: StopItem) : SearchStopUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -58,11 +58,13 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
             fromStopItem = fromStopItem,
             toStopItem = toStopItem,
             fromButtonClick = {
-                //              log(("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
+                viewModel.onEvent(SavedTripUiEvent.AnalyticsFromButtonClick)
+                //              Timber.d("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
                 navController.navigate(SearchStopRoute(fieldTypeKey = SearchStopFieldType.FROM.key))
             },
             toButtonClick = {
-                //              log(("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
+                viewModel.onEvent(SavedTripUiEvent.AnalyticsToButtonClick)
+                //              Timber.d("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
                 navController.navigate(
                     route = SearchStopRoute(fieldTypeKey = SearchStopFieldType.TO.key),
                     navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -83,6 +83,14 @@ class SavedTripsViewModel(
             SavedTripUiEvent.AnalyticsSettingsButtonClick -> {
                 analytics.track(AnalyticsEvent.SettingsClickEvent)
             }
+
+            SavedTripUiEvent.AnalyticsFromButtonClick -> {
+                analytics.track(AnalyticsEvent.FromFieldClickEvent)
+            }
+
+            SavedTripUiEvent.AnalyticsToButtonClick -> {
+                analytics.track(AnalyticsEvent.ToFieldClickEvent)
+            }
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopRoute
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 
 fun NavGraphBuilder.searchStopDestination(navController: NavHostController) {
     composable<SearchStopRoute> { backStackEntry ->
@@ -19,6 +20,7 @@ fun NavGraphBuilder.searchStopDestination(navController: NavHostController) {
             searchStopState = searchStopState,
             onStopSelect = { stopItem ->
                 //log(("onStopSelected: fieldTypeKey=${route.fieldType.key} and stopItem: $stopItem")
+                viewModel.onEvent(SearchStopUiEvent.StopSelected(stopItem))
 
                 navController.previousBackStackEntry?.savedStateHandle?.set(
                     route.fieldType.key,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultMapper.toStopResults
@@ -39,6 +40,10 @@ class SearchStopViewModel(
     fun onEvent(event: SearchStopUiEvent) {
         when (event) {
             is SearchStopUiEvent.SearchTextChanged -> onSearchTextChanged(event.query)
+
+            is SearchStopUiEvent.StopSelected -> {
+                analytics.track(AnalyticsEvent.StopSelectedEvent(stopId = event.stopItem.stopId))
+            }
         }
     }
 


### PR DESCRIPTION
### TL;DR
Added analytics tracking for stop selection and field interactions in the trip planner.

### What changed?
- Added new analytics events for tracking:
  - From field clicks
  - To field clicks
  - Stop selection with stop ID
- Integrated analytics tracking in the SavedTrips and SearchStop screens
- Added UI events to handle analytics tracking for field interactions
- Connected stop selection analytics to the search flow

### How to test?
1. Open the trip planner
2. Click the "From" field and verify FromFieldClickEvent is tracked
3. Click the "To" field and verify ToFieldClickEvent is tracked
4. Select a stop from the search results and verify StopSelectedEvent is tracked with the correct stop ID

### Why make this change?
To gather usage data about how users interact with the trip planner's field selection and stop search functionality, enabling better understanding of user behavior and feature optimization.