### PR TITLE
Release: Bump version codes for Android and iOS

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 29
+        versionCode = 30
         versionName = "1.0.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.2</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR
Increment version codes for both Android and iOS apps

### What changed?
- Android version code bumped from 29 to 30
- iOS build number increased from 4 to 5
- Version name remains at 1.0.2 for both platforms

### How to test?
1. Build the Android app and verify the version code is 30
2. Build the iOS app and verify the build number is 5
3. Verify both apps display version 1.0.2

### Why make this change?
Prepare for next app store release by incrementing the build numbers while maintaining the same version name