### PR TITLE
Core: Replace println/Timber with unified logging system

### DIFF
--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/NetworkRateLimiter.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/NetworkRateLimiter.kt
@@ -35,14 +35,14 @@ class NetworkRateLimiter : RateLimiter {
             .debounce {
                 // First time the block should be executed immediately and subsequent must be rate limited.
                 val interval = if (isFirstTime.value) rateLimitInterval else 0.milliseconds
-                // Timber.d("state: ${isFirstTime.value} and interval: $interval")
+                // log(("state: ${isFirstTime.value} and interval: $interval")
                 interval
             }
             .flatMapLatest {
-                //Timber.d("flatmapLatest: Triggered")
+                //log(("flatmapLatest: Triggered")
                 isFirstTime.update { true } // Mark the first trigger
                 flow {
-                    //   Timber.d("Inside flow -emitting block")
+                    //   log(("Inside flow -emitting block")
                     emit(block())
                 }
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/cache/ServiceAlertsCache.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/cache/ServiceAlertsCache.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.alerts.cache
 
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
 interface ServiceAlertsCache {
@@ -14,7 +15,7 @@ interface ServiceAlertsCache {
 class RealServiceAlertsCache : ServiceAlertsCache {
 
     init {
-        println("RealServiceAlertsCache created $this")
+        log("RealServiceAlertsCache created $this")
     }
 
     private val serviceAlerts: MutableMap<String, List<ServiceAlert>> = mutableMapOf()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -45,12 +45,12 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
 
         LaunchedEffect(fromArg) {
             fromArg?.let { fromStopItem = fromJsonString(it) }
-//            Timber.d("Change fromStopItem: $fromStopItem")
+//            log(("Change fromStopItem: $fromStopItem")
         }
 
         LaunchedEffect(toArg) {
             toArg?.let { toStopItem = fromJsonString(it) }
-//            Timber.d("Change toStopItem: $toStopItem")
+//            log(("Change toStopItem: $toStopItem")
         }
 
         SavedTripsScreen(
@@ -58,18 +58,18 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
             fromStopItem = fromStopItem,
             toStopItem = toStopItem,
             fromButtonClick = {
-                //              Timber.d("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
+                //              log(("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
                 navController.navigate(SearchStopRoute(fieldTypeKey = SearchStopFieldType.FROM.key))
             },
             toButtonClick = {
-                //              Timber.d("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
+                //              log(("toButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.TO)}")
                 navController.navigate(
                     route = SearchStopRoute(fieldTypeKey = SearchStopFieldType.TO.key),
                     navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                 )
             },
             onReverseButtonClick = {
-                //              Timber.d("onReverseButtonClick:")
+                //              log(("onReverseButtonClick:")
                 val bufferStop = fromStopItem
                 backStackEntry.savedStateHandle[SearchStopFieldType.FROM.key] =
                     toStopItem?.toJsonString()
@@ -98,7 +98,7 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                     )
                 } else {
                     // TODO - show message - to select both stops
-                    // Timber.e("Select both stops")
+                    // logError(("Select both stops")
                 }
             },
             onSearchButtonClick = {
@@ -123,7 +123,7 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                     )
                 } else {
                     // TODO - show message - to select both stops
-                    // Timber.e("Select both stops")
+                    // logError(("Select both stops")
                 }
             },
             onSettingsButtonClick = {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
@@ -18,7 +18,7 @@ fun NavGraphBuilder.searchStopDestination(navController: NavHostController) {
         SearchStopScreen(
             searchStopState = searchStopState,
             onStopSelect = { stopItem ->
-                //Timber.d("onStopSelected: fieldTypeKey=${route.fieldType.key} and stopItem: $stopItem")
+                //log(("onStopSelected: fieldTypeKey=${route.fieldType.key} and stopItem: $stopItem")
 
                 navController.previousBackStackEntry?.savedStateHandle?.set(
                     route.fieldType.key,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -68,6 +68,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import xyz.ksharma.krail.core.log.log
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @Composable
@@ -97,7 +98,7 @@ fun SearchStopScreen(
             .debounce(250)
             .filter { it.isNotBlank() }
             .mapLatest { text ->
-                // Timber.d("Query - $text")
+                // log(("Query - $text")
                 onEvent(SearchStopUiEvent.SearchTextChanged(text))
             }.collectLatest {}
     }
@@ -237,8 +238,8 @@ fun SearchStopScreen(
                 }
             }
         ) { value ->
-            //Timber.d("value: $value")
-            println("value: $value")
+            //log(("value: $value")
+            log("value: $value")
             if(value.isNotBlank()) runPlaceholderAnimation = false
             textFieldText = value.toString()
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -21,6 +21,7 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultMapper.toStopResul
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
+import xyz.ksharma.krail.core.log.log
 
 class SearchStopViewModel(
     private val tripPlanningService: TripPlanningService,
@@ -42,7 +43,7 @@ class SearchStopViewModel(
     }
 
     private fun onSearchTextChanged(query: String) {
-        //Timber.d("onSearchTextChanged: $query")
+        //log(("onSearchTextChanged: $query")
         updateUiState { displayLoading() }
         searchJob?.cancel()
         // TODO - cancel previous flow before starting new one.
@@ -50,10 +51,10 @@ class SearchStopViewModel(
             delay(300)
             runCatching {
                 val response = tripPlanningService.stopFinder(stopSearchQuery = query)
-                println("response VM: $response")
+                log("response VM: $response")
 
                 val results = response.toStopResults()
-                println("results: $results")
+                log("results: $results")
 
                 updateUiState { displayData(results) }
             }.getOrElse {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultMapper.kt
@@ -4,6 +4,7 @@ import kotlinx.collections.immutable.toPersistentList
 import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.core.log.log
 
 object StopResultMapper {
 
@@ -19,7 +20,7 @@ object StopResultMapper {
     fun StopFinderResponse.toStopResults(
         selectedModes: Set<TransportMode> = TransportMode.values(),
     ): List<SearchStopState.StopResult> {
-        println( "selectedModes: " + selectedModes)
+        log( "selectedModes: " + selectedModes)
 
         return locations.orEmpty().mapNotNull { location ->
             val stopName = location.disassembledName ?: return@mapNotNull null // Skip if stop name is null
@@ -27,7 +28,7 @@ object StopResultMapper {
             val modes = location.productClasses.orEmpty()
                 .mapNotNull { productClass -> TransportMode.toTransportModeType(productClass) }
 
-            println("productClasses [${location.name}]: ${location.productClasses}")
+            log("productClasses [${location.name}]: ${location.productClasses}")
 
             // Filter based on selected mode types
             if (selectedModes.isNotEmpty() && !modes.any { it in selectedModes }) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
@@ -22,6 +22,7 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionEvent
+import xyz.ksharma.krail.core.log.log
 
 internal fun NavGraphBuilder.themeSelectionDestination(navController: NavHostController) {
     composable<ThemeSelectionRoute> {
@@ -37,7 +38,7 @@ internal fun NavGraphBuilder.themeSelectionDestination(navController: NavHostCon
             getForegroundColor(backgroundColor = themeColor.hexToComposeColor()).toHex()
 
         LaunchedEffect(state.selectedTransportMode) {
-            println("selectedTransportMode: ${state.selectedTransportMode}")
+            log("selectedTransportMode: ${state.selectedTransportMode}")
         }
         LaunchedEffect(state.themeSelected) {
             if(state.themeSelected) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import xyz.ksharma.krail.core.log.log
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
@@ -46,7 +47,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
 
         // Lookout for new updates
         LaunchedEffect(dateTimeSelectionJson) {
-            println("Changed dateTimeSelectionItem: $dateTimeSelectionItem")
+            log("Changed dateTimeSelectionItem: $dateTimeSelectionItem")
             dateTimeSelectionItem = dateTimeSelectionJson?.let { fromJsonString(it) }
             viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(dateTimeSelectionItem))
         }
@@ -57,7 +58,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             onEvent = { viewModel.onEvent(it) },
             onBackClick = { navController.popBackStack() },
             onAlertClick = { journeyId ->
-                println("AlertClicked for journeyId: $journeyId")
+                log("AlertClicked for journeyId: $journeyId")
                 viewModel.fetchAlertsForJourney(journeyId) { alerts ->
                     if (alerts.isNotEmpty()) {
                         navController.navigate(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -17,6 +17,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
+import xyz.ksharma.krail.core.log.log
 
 @Suppress("ComplexCondition")
 internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.JourneyCardInfo>? =
@@ -69,7 +70,7 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
                 legs = legsList,
                 totalUniqueServiceAlerts = legs.flatMap { leg -> leg.infos.orEmpty() }.toSet().size,
             ).also {
-                println("\tJourneyId: ${it.journeyId}")
+                log("\tJourneyId: ${it.journeyId}")
             }
         } else {
             null
@@ -114,8 +115,8 @@ fun TripResponse.Leg?.getPlatformNumber(): String? {
 private fun List<TripResponse.Leg>.logTransportModes() = forEachIndexed { index, leg ->
 
     // log origin's disassembledName
-    println("Origin #$index: ${leg.origin?.disassembledName}")
-    println(
+    log("Origin #$index: ${leg.origin?.disassembledName}")
+    log(
         "TransportMode #$index: ${leg.transportation?.product?.productClass}, " +
             "name: ${leg.transportation?.product?.name}, " +
             "stops: ${leg.stopSequence?.size}, " +
@@ -138,14 +139,14 @@ private fun List<TripResponse.Leg>.getTransportModeLines() = mapNotNull { leg ->
 private fun List<TripResponse.Leg>.getLegsList() = mapNotNull { it.toUiModel() }.toImmutableList()
 
 private fun String.getTimeText() = let {
-   // println("originTime: $it :- ${calculateTimeDifferenceFromNow(utcDateString = it)}")
+   // log("originTime: $it :- ${calculateTimeDifferenceFromNow(utcDateString = it)}")
     calculateTimeDifferenceFromNow(utcDateString = it).toGenericFormattedTimeString()
 }
 
 @Suppress("ComplexCondition")
 private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
 /*
-    println(
+    log(
         "\tFFF Leg: ${this.duration}, " +
             "leg: ${this.origin?.name} TO ${this.destination?.name}" +
             " - isWalk:${this.isWalkingLeg()}, " +
@@ -164,9 +165,9 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
     val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
     val alerts = infos?.mapNotNull { it.toAlert() }?.toImmutableList()
     alerts?.forEach {
-        //println("\t Alert: ${it.heading.take(5)}, ${it.message.take(5)}, ${it.priority}")
+        //log("\t Alert: ${it.heading.take(5)}, ${it.message.take(5)}, ${it.priority}")
     }
-   // println("Alert---")
+   // log("Alert---")
 
     return when {
         // Walking Leg - Always check before public transport leg
@@ -177,7 +178,7 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
         }
 
         else -> { // Public Transport Leg
-//            println("FFF PTLeg: $displayDuration, leg: ${this.destination?.name} ")
+//            log("FFF PTLeg: $displayDuration, leg: ${this.destination?.name} ")
             if (transportMode != null && lineName != null && displayText != null &&
                 numberOfStops != null && stops != null && displayDuration != null
             ) {
@@ -253,19 +254,19 @@ private fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInf
 }
 
 internal fun TripResponse.logForUnderstandingData() {
-    println("Journeys: ${journeys?.size}")
+    log("Journeys: ${journeys?.size}")
     journeys?.mapIndexed { jindex, j ->
-        println("JOURNEY #${jindex + 1}")
+        log("JOURNEY #${jindex + 1}")
         j.legs?.forEachIndexed { index, leg ->
 
             val transportationProductClass =
                 leg.transportation?.product?.productClass
 
-            println(
+            log(
                 " LEG#${index + 1} -- Duration: ${leg.duration} -- " +
                     "productClass:${transportationProductClass?.toInt()}",
             )
-            println(
+            log(
                 "\t\t ORG: ${
                     leg.origin?.departureTimeEstimated?.utcToAEST()
                         ?.formatTo12HourTime()

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorsTest.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.components
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import xyz.ksharma.krail.core.log.log
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -31,7 +32,7 @@ fun getForegroundColor(backgroundColor: Color, isDarkMode: Boolean): Color {
     val whiteContrast = whiteColor.contrastRatio(backgroundColor)
     val blackContrast = blackColor.contrastRatio(backgroundColor)
 
-    println("Background: ${backgroundColor.toHex()}, White Contrast: $whiteContrast, Black Contrast: $blackContrast")
+//    log("Background: ${backgroundColor.toHex()}, White Contrast: $whiteContrast, Black Contrast: $blackContrast")
 
     return if (whiteContrast >= 4.0f) whiteColor else blackColor
 }

--- a/gtfs-static/build.gradle.kts
+++ b/gtfs-static/build.gradle.kts
@@ -49,6 +49,8 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(compose.runtime)
 
+                implementation(projects.core.log)
+
                 api(libs.di.koinComposeViewmodel)
             }
         }

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
@@ -7,6 +7,7 @@ import io.ktor.client.statement.readRawBytes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.core.log.log
 
 class RealNswGtfsService(
     private val httpClient: HttpClient,
@@ -18,10 +19,10 @@ class RealNswGtfsService(
             httpClient.get("$NSW_TRANSPORT_BASE_URL/$GTFS_SCHEDULE_V1/sydneytrains")
 
         if (response.status.value == 200) {
-            println("Downloading file: ")
+            log("Downloading file: ")
             val data = response.readRawBytes()
             fileStorage.saveFile("sydneytrains.zip", data)
-            println("File downloaded")
+            log("File downloaded")
         } else {
             throw Exception("Failed to download file: ${response.status}")
         }

--- a/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
+++ b/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
@@ -9,11 +9,12 @@ import platform.Foundation.NSFileManager
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.dataWithBytes
 import platform.Foundation.writeToFile
+import xyz.ksharma.krail.core.log.log
 
 class IosFileStorage : FileStorage {
     @OptIn(ExperimentalForeignApi::class)
     override suspend fun saveFile(fileName: String, data: ByteArray) {
-        println("Saving file: $fileName")
+        log("Saving file: $fileName")
         val fileManager = NSFileManager.defaultManager
         val directory = fileManager.URLForDirectory(
             directory = NSDocumentDirectory,
@@ -28,6 +29,6 @@ class IosFileStorage : FileStorage {
             NSData.dataWithBytes(pinned.addressOf(0), data.size.toULong())
                 .writeToFile(filePath, true)
         }
-        println("File saved: $filePath")
+        log("File saved: $filePath")
     }
 }


### PR DESCRIPTION
### TL;DR
Replaced all `println` and `Timber` logging calls with a unified `log` function from the core module.

### What changed?
- Replaced all instances of `println` debugging statements with `log` function calls
- Removed `Timber` logging dependencies and replaced with `log` function
- Updated logging calls across trip planner, GTFS, and UI components
- Standardized error logging format
- Added imports for the new logging utility

### How to test?
1. Run the app and verify logging output appears correctly
2. Check debug logs in various scenarios:
   - Search for stops
   - View timetables
   - Save trips
   - Download GTFS data
3. Verify error messages are properly logged during failure cases

### Why make this change?
Centralizing logging through a single utility function provides:
- Consistent logging format across the codebase
- Better control over logging output
- Easier debugging and log filtering
- Removal of Android-specific Timber dependency for better multiplatform support