### PR TITLE
Core: Add debug-only logging

### DIFF
--- a/core/log/src/androidMain/kotlin/xyz/ksharma/krail/core/log/Log.android.kt
+++ b/core/log/src/androidMain/kotlin/xyz/ksharma/krail/core/log/Log.android.kt
@@ -5,11 +5,11 @@ import android.util.Log
 private const val MAX_TAG_LENGTH: Int = 23
 
 actual fun log(message: String, throwable: Throwable?) {
-    Log.d(getTag(), message)
+    if (BuildConfig.DEBUG) Log.d(getTag(), message)
 }
 
 actual fun logError(message: String, throwable: Throwable?) {
-    Log.e(getTag(), message, throwable)
+    if (BuildConfig.DEBUG) Log.e(getTag(), message, throwable)
 }
 
 private fun getTag(): String {

--- a/core/log/src/iosMain/kotlin/xyz/ksharma/krail/core/log/Log.ios.kt
+++ b/core/log/src/iosMain/kotlin/xyz/ksharma/krail/core/log/Log.ios.kt
@@ -1,11 +1,19 @@
 package xyz.ksharma.krail.core.log
 
 import platform.Foundation.NSLog
+import kotlin.experimental.ExperimentalNativeApi
 
-actual fun log(message: String, throwable: Throwable?) = NSLog("DEBUG: $message")
+@OptIn(ExperimentalNativeApi::class)
+actual fun log(message: String, throwable: Throwable?) {
+    if (Platform.isDebugBinary) NSLog("DEBUG: $message")
+}
 
-actual fun logError(message: String, throwable: Throwable?) = if (throwable != null) {
-    NSLog("ERROR: $message. Throwable: $throwable CAUSE ${throwable.cause}")
-} else {
-    NSLog("ERROR: $message")
+@OptIn(ExperimentalNativeApi::class)
+actual fun logError(message: String, throwable: Throwable?) {
+    if (!Platform.isDebugBinary) return
+    if (throwable != null) {
+        NSLog("ERROR: $message. Throwable: $throwable CAUSE ${throwable.cause}")
+    } else {
+        NSLog("ERROR: $message")
+    }
 }


### PR DESCRIPTION
Adds debug-only logging for Android and iOS targets. Logs will now only be printed when running debug builds, reducing noise in production environments.