### PR TITLE
UI: Optimize search text debouncing logic

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -90,10 +90,8 @@ fun SearchStopScreen(
         keyboard?.show()
     }
 
-    val trimmedText by remember(textFieldText) { derivedStateOf { textFieldText.trim() } }
-
-    LaunchedEffect(trimmedText) {
-        snapshotFlow { trimmedText }
+    LaunchedEffect(textFieldText) {
+        snapshotFlow { textFieldText.trim() }
             .distinctUntilChanged()
             .debounce(250)
             .filter { it.isNotBlank() }


### PR DESCRIPTION
### TL;DR
Optimized search stop screen text field state management

### What changed?
Removed unnecessary `derivedStateOf` wrapper around the text field trim operation and moved the trim directly into the `snapshotFlow` transformation

### How to test?
1. Navigate to the search stop screen
2. Enter text into the search field
3. Verify that search results appear after typing
4. Confirm there is no performance degradation or unexpected behavior

### Why make this change?
The `derivedStateOf` wrapper was redundant since the trim operation was already being performed within the `snapshotFlow`. This simplification maintains the same functionality while reducing unnecessary state calculations.