### PR TITLE
Core: Enable SQLDelight migration verification and cleanup iOS targets

### DIFF
--- a/gtfs-static/build.gradle.kts
+++ b/gtfs-static/build.gradle.kts
@@ -21,6 +21,10 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     androidTarget()
+    iosArm64()
+    iosSimulatorArm64()
+
+/*
     listOf(
         iosX64(),
         iosArm64(),
@@ -30,6 +34,7 @@ kotlin {
             baseName = "gtfsStatic"
         }
     }
+*/
 
     sourceSets {
         androidMain.dependencies {

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -31,7 +31,7 @@
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"

--- a/sandook/build.gradle.kts
+++ b/sandook/build.gradle.kts
@@ -56,6 +56,7 @@ sqldelight {
     databases {
         create("KrailSandook") {
             packageName.set("xyz.ksharma.krail.sandook")
+            verifyMigrations.set(true)
         }
     }
 }

--- a/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/AndroidSandookDriverFactory.kt
+++ b/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/AndroidSandookDriverFactory.kt
@@ -9,7 +9,7 @@ class AndroidSandookDriverFactory(private val context: Context) : SandookDriverF
         return AndroidSqliteDriver(
             schema = KrailSandook.Schema,
             context = context,
-            name = "krailSandook.db"
+            name = "krailSandook.db",
         )
     }
 }


### PR DESCRIPTION
### TL;DR
Added SQLite migration support and simplified iOS build targets

### What changed?
- Enabled SQLDelight migration verification
- Created initial migration file structure
- Simplified iOS build targets to only include arm64 architectures
- Changed iOS build configuration from Release to Debug
- Added trailing comma in Android SQLite driver configuration

### How to test?
1. Build and run the iOS app in debug mode
2. Verify SQLite database operations work on both iOS and Android
3. Confirm database migrations are properly verified during build

### Why make this change?
To establish a proper database migration system early in development, preventing potential schema evolution issues. The iOS build target simplification helps streamline the development process by focusing on currently supported architectures.