### PR TITLE
Deps: Update Ktor to 3.0.3 and consolidate auth dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,14 +11,13 @@ android-lifecycle = "2.8.7"
 activity-compose = "1.9.3"
 kotlinxCollectionsImmutable = "0.3.8"
 kotlinxDatetime = "0.6.1"
-ktorClientAuth = "2.3.13"
 lifecycleViewmodelCompose = "2.8.4"
 navigationCompose = "2.8.0-alpha10"
 kotlinxSerializationJson = "1.7.3"
 ksp = "2.1.0-1.0.29" # ksp to kotlin version mapping https://github.com/google/ksp/releases
 paparazzi = "1.3.5"
 compose-multiplatform = "1.7.3"
-ktor = "3.0.1"
+ktor = "3.0.3"
 androidx-lifecycle = "2.8.4"
 kotlinxCoroutines = "1.10.1"
 buildkonfigGradlePlugin = "0.15.2"
@@ -34,7 +33,6 @@ activity-compose = { group = "androidx.activity", name = "activity-compose", ver
 
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
-ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktorClientAuth" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "android-lifecycle" }
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
@@ -58,6 +56,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
+ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 
 #Test
 test-composeUiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
### TL;DR
Updated Ktor version to 3.0.3 and aligned Ktor client auth dependency with main Ktor version.

### What changed?
- Upgraded Ktor from 3.0.1 to 3.0.3
- Removed separate version for `ktor-client-auth` (previously 2.3.13)
- Moved `ktor-client-auth` dependency to use the main Ktor version
- Reorganized Ktor-related dependencies to be grouped together
