### PR TITLE
iOS: Add SQLite migration support for service alerts

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -201,8 +201,6 @@ fun ExpandedJourneyCardContent(
     onLegClick: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val devicePlatformType: DevicePlatformType = LocalAppPlatformProvider.current
-
     Column(modifier = modifier) {
         FlowRow(
             modifier = Modifier

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
@@ -1,13 +1,20 @@
 package xyz.ksharma.krail.sandook
 
+import app.cash.sqldelight.db.AfterVersion
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter1
 
 class IosSandookDriverFactory : SandookDriverFactory {
     override fun createDriver(): SqlDriver {
         return NativeSqliteDriver(
             schema = KrailSandook.Schema,
             name = "krailSandook.db",
+            callbacks = getMigrationCallbacks(),
         )
     }
+
+    private fun getMigrationCallbacks(): Array<AfterVersion> = arrayOf(
+        AfterVersion(1) { SandookMigrationAfter1.migrate(it) },
+    )
 }

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigration.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigration.kt
@@ -1,0 +1,8 @@
+package xyz.ksharma.krail.sandook.migrations
+
+import app.cash.sqldelight.db.SqlDriver
+
+interface SandookMigration {
+
+    fun migrate(sqlDriver: SqlDriver)
+}

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter1.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter1.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.krail.sandook.migrations
+
+import app.cash.sqldelight.db.SqlDriver
+import xyz.ksharma.krail.core.log.log
+
+internal object SandookMigrationAfter1 : SandookMigration {
+
+    override fun migrate(sqlDriver: SqlDriver) {
+        log("Upgrading database from version 1 to 2")
+        sqlDriver.execute(
+            identifier = null,
+            sql = """
+                        CREATE TABLE IF NOT EXISTS ServiceAlertsTable (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            journeyId TEXT NOT NULL,
+                            heading TEXT NOT NULL,
+                            message TEXT NOT NULL
+                        );
+                """.trimIndent(),
+            parameters = 0,
+        )
+    }
+}


### PR DESCRIPTION
### TL;DR
Added SQLite database migration support for iOS and introduced a new ServiceAlertsTable

### What changed?
- Created a new ServiceAlertsTable schema for storing journey alerts
- Implemented database migration infrastructure for iOS with `SandookMigration` interface
- Added migration logic to upgrade database from version 1 to 2
- Removed unused `devicePlatformType` variable from JourneyCard component

### How to test?
1. Install a fresh version of the app on iOS
2. Verify the database is created with the new ServiceAlertsTable
3. Update from an older version and confirm data persists
4. Check that journey alerts are properly stored and retrieved

### Why make this change?
To support storing service alerts for journeys in the iOS app's local database, enabling offline access to important journey notifications and maintaining data consistency across app updates.