### PR TITLE
API: Split NSW Transport API key for iOS and Android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment variables
         run: |
-          echo "NSW_TRANSPORT_API_KEY=${{ secrets.NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
 
       - name: set up JDK
         uses: actions/setup-java@v4
@@ -58,12 +58,12 @@ jobs:
 
       - name: Build Debug
         env:
-          NSW_TRANSPORT_API_KEY: ${{ secrets.NSW_TRANSPORT_API_KEY }}
+          ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
         run: ./gradlew :composeApp:assembleDebug test
 
       - name: Build Release
         env:
-          NSW_TRANSPORT_API_KEY: ${{ secrets.NSW_TRANSPORT_API_KEY }}
+          ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
         run: ./gradlew :composeApp:assembleRelease test
 
   iOS:
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup environment variables
         run: |
-          echo "NSW_TRANSPORT_API_KEY=${{ secrets.NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
 
       - name: Build iOS App - Debug (Without Code Signing)
         env:
-          NSW_TRANSPORT_API_KEY: ${{ secrets.NSW_TRANSPORT_API_KEY }}
+          IOS_NSW_TRANSPORT_API_KEY: ${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}
         run: |
           xcodebuild -project iosApp/iosApp.xcodeproj \
                      -scheme iosApp \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Setup environment variables
         run: |
           echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
 
       - name: set up JDK
         uses: actions/setup-java@v4
@@ -77,6 +78,7 @@ jobs:
       - name: Setup environment variables
         run: |
           echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -75,19 +75,26 @@ kotlin {
 
 // READ API KEY
 val localProperties = gradleLocalProperties(rootProject.rootDir, providers)
-val nswTransportApiKey: String = localProperties.getProperty("NSW_TRANSPORT_API_KEY")
-    ?: System.getenv("NSW_TRANSPORT_API_KEY")
-require(nswTransportApiKey.isNotEmpty()) {
-    "Register API key and put in local.properties as `NSW_TRANSPORT_API_KEY`"
+val androidNswTransportApiKey: String = localProperties.getProperty("ANDROID_NSW_TRANSPORT_API_KEY")
+    ?: System.getenv("ANDROID_NSW_TRANSPORT_API_KEY")
+require(androidNswTransportApiKey.isNotEmpty()) {
+    "Register API key and put in local.properties as `ANDROID_NSW_TRANSPORT_API_KEY`"
+}
+
+val iosNswTransportApiKey: String = localProperties.getProperty("IOS_NSW_TRANSPORT_API_KEY")
+    ?: System.getenv("IOS_NSW_TRANSPORT_API_KEY")
+require(iosNswTransportApiKey.isNotEmpty()) {
+    "Register API key and put in local.properties as `IOS_NSW_TRANSPORT_API_KEY`"
 }
 buildkonfig {
     packageName = "xyz.ksharma.krail.trip.planner.network"
 
-    require(nswTransportApiKey.isNotEmpty()) {
-        "Register API key and put in local.properties as `NSW_TRANSPORT_API_KEY`"
+    require(androidNswTransportApiKey.isNotEmpty() && iosNswTransportApiKey.isNotEmpty()) {
+        "Register API key and put in local.properties"
     }
 
     defaultConfigs {
-        buildConfigField(FieldSpec.Type.STRING, "NSW_TRANSPORT_API_KEY", nswTransportApiKey)
+        buildConfigField(FieldSpec.Type.STRING, "ANDROID_NSW_TRANSPORT_API_KEY", androidNswTransportApiKey)
+        buildConfigField(FieldSpec.Type.STRING, "IOS_NSW_TRANSPORT_API_KEY", iosNswTransportApiKey)
     }
 }

--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/AndroidNetworkComponent.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/AndroidNetworkComponent.kt
@@ -1,3 +1,0 @@
-package xyz.ksharma.krail.trip.planner.network.api
-
-//actual fun createNetworkComponent(): NetworkComponent = NetworkComponent::class.create()

--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -26,7 +26,7 @@ actual fun httpClient(): HttpClient {
         }
 
         defaultRequest {
-            headers.append(HttpHeaders.Authorization, "apikey ${BuildKonfig.NSW_TRANSPORT_API_KEY}")
+            headers.append(HttpHeaders.Authorization, "apikey ${BuildKonfig.ANDROID_NSW_TRANSPORT_API_KEY}")
         }
     }
 }

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/IosNetworkComponent.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/IosNetworkComponent.kt
@@ -1,3 +1,0 @@
-package xyz.ksharma.krail.trip.planner.network.api
-
-//actual fun createNetworkComponent(): NetworkComponent = NetworkComponent::class.create()

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -26,7 +26,7 @@ actual fun httpClient(): HttpClient {
         }
 
         defaultRequest {
-            headers.append(HttpHeaders.Authorization, "apikey ${BuildKonfig.NSW_TRANSPORT_API_KEY}")
+            headers.append(HttpHeaders.Authorization, "apikey ${BuildKonfig.IOS_NSW_TRANSPORT_API_KEY}")
         }
     }
 }


### PR DESCRIPTION
### TL;DR
Separated NSW Transport API keys for Android and iOS platforms.

### What changed?
- Renamed `NSW_TRANSPORT_API_KEY` to platform-specific versions (`ANDROID_NSW_TRANSPORT_API_KEY` and `IOS_NSW_TRANSPORT_API_KEY`)
- Updated GitHub Actions workflow to use platform-specific secrets
- Modified build configuration to require both Android and iOS API keys
- Updated HTTP client implementations to use their respective platform-specific keys
- Removed unused network component files

### Why make this change?
To support different API keys for Android and iOS platforms, allowing for better tracking and management of API usage per platform. This separation also enables platform-specific rate limiting and analytics.