### PR TITLE
Network: Add debug logging support via AppInfoProvider

### DIFF
--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
 
         commonMain {
             dependencies {
+                implementation(projects.core.appInfo)
 
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/NetworkModule.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/NetworkModule.kt
@@ -12,6 +12,6 @@ import xyz.ksharma.krail.trip.planner.network.api.service.httpClient
 
 val networkModule = module {
     singleOf(::NetworkRateLimiter) { bind<RateLimiter>() }
-    single<HttpClient> { httpClient() }
+    single<HttpClient> { httpClient(appInfoProvider = get()) }
     singleOf(::RealTripPlanningService) { bind<TripPlanningService>() }
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.network.api.service
 
 import io.ktor.client.HttpClient
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 
-expect fun httpClient(): HttpClient
+expect fun httpClient(appInfoProvider: AppInfoProvider): HttpClient

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,13 +4,16 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.trip.planner.network.BuildKonfig
 
-actual fun httpClient(): HttpClient {
+actual fun httpClient(appInfoProvider: AppInfoProvider): HttpClient {
     return HttpClient(Darwin) {
         expectSuccess = true
         install(ContentNegotiation) {
@@ -21,12 +24,24 @@ actual fun httpClient(): HttpClient {
             })
         }
         install(Logging) {
-//            if(debug) - TODO
-//            level = LogLevel.BODY
+            if (appInfoProvider.getAppInfo().isDebug) {
+                level = LogLevel.BODY
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        println(message)
+                    }
+                }
+                sanitizeHeader { header -> header == HttpHeaders.Authorization }
+            } else {
+                level = LogLevel.NONE
+            }
         }
 
         defaultRequest {
-            headers.append(HttpHeaders.Authorization, "apikey ${BuildKonfig.IOS_NSW_TRANSPORT_API_KEY}")
+            headers.append(
+                HttpHeaders.Authorization,
+                "apikey ${BuildKonfig.IOS_NSW_TRANSPORT_API_KEY}"
+            )
         }
     }
 }


### PR DESCRIPTION
### TL;DR
Added HTTP request logging for debug builds while keeping logging disabled in release builds.

### What changed?
- Added AppInfoProvider dependency to determine if app is in debug mode
- Implemented HTTP request logging configuration for both Android and iOS clients
- Added sanitization for Authorization headers in logs
- Configured logging to only show request/response bodies in debug builds

### How to test?
1. Run the app in debug mode
2. Perform any network request
3. Check the console logs for detailed HTTP request/response information
4. Verify that Authorization headers are properly sanitized in the logs
5. Switch to release mode and confirm that no network logs are visible

### Why make this change?
To improve debugging capabilities during development while maintaining security and performance in production builds. This change makes it easier to diagnose network-related issues during development without exposing sensitive information in logs.