### PR TITLE
Revert UI: Add shared element transitions while planning trip (#499)

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
@@ -1,8 +1,5 @@
 package xyz.ksharma.krail
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -14,13 +11,12 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.serialization.Serializable
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.splash.SplashScreen
 import xyz.ksharma.krail.splash.SplashViewModel
-import xyz.ksharma.krail.taj.LocalNavAnimatedVisibilityScope
-import xyz.ksharma.krail.taj.LocalSharedTransitionScope
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.LocalThemeContentColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -29,7 +25,6 @@ import xyz.ksharma.krail.taj.unspecifiedColor
 import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.toHex
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
-import xyz.ksharma.krail.trip.planner.ui.navigation.animComposable
 import xyz.ksharma.krail.trip.planner.ui.navigation.tripPlannerDestinations
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
@@ -44,58 +39,53 @@ import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
  *   so fine for now. But I will want to refactor it to something nicer e.g. using Circuit library
  *   from Slack, but that would also mean refactoring to use MVP instead of MVVM.
  */
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun KrailNavHost() {
-    SharedTransitionLayout {
-        val navController = rememberNavController()
-        val themeColorHexCode = rememberSaveable { mutableStateOf(unspecifiedColor) }
-        var productClass: Int? by rememberSaveable { mutableStateOf(null) }
-        val themeContentColorHexCode = rememberSaveable { mutableStateOf(unspecifiedColor) }
-        themeContentColorHexCode.value = getForegroundColor(
+fun KrailNavHost(modifier: Modifier = Modifier) {
+    val navController = rememberNavController()
+    val themeColorHexCode = rememberSaveable { mutableStateOf(unspecifiedColor) }
+    var productClass: Int? by rememberSaveable { mutableStateOf(null) }
+    val themeContentColorHexCode = rememberSaveable { mutableStateOf(unspecifiedColor) }
+    themeContentColorHexCode.value =
+        getForegroundColor(
             backgroundColor = themeColorHexCode.value.hexToComposeColor(),
         ).toHex()
 
-        CompositionLocalProvider(
-            LocalThemeColor provides themeColorHexCode,
-            LocalThemeContentColor provides themeContentColorHexCode,
-            LocalSharedTransitionScope provides this@SharedTransitionLayout,
+    CompositionLocalProvider(
+        LocalThemeColor provides themeColorHexCode,
+        LocalThemeContentColor provides themeContentColorHexCode,
+    ) {
+        NavHost(
+            navController = navController,
+            startDestination = SplashScreen,
+            modifier = modifier.fillMaxSize(),
         ) {
-            AnimatedContent(targetState = Unit) {
-                CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this) {
-                    NavHost(
-                        navController = navController,
-                        startDestination = SplashScreen,
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        tripPlannerDestinations(navController = navController)
+            tripPlannerDestinations(navController = navController)
 
-                        animComposable<SplashScreen> {
-                            val viewModel: SplashViewModel = koinViewModel<SplashViewModel>()
-                            val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
-                            val mode by viewModel.uiState.collectAsStateWithLifecycle()
+            composable<SplashScreen> {
+                val viewModel: SplashViewModel = koinViewModel<SplashViewModel>()
+                val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+                val mode by viewModel.uiState.collectAsStateWithLifecycle()
 
-                            productClass = mode.productClass
-                            themeColorHexCode.value = mode.colorCode
+                productClass = mode.productClass
+                themeColorHexCode.value = mode.colorCode
 
-                            SplashScreen(
-                                logoColor = if (productClass != null && themeColorHexCode.value != unspecifiedColor) {
-                                    themeColorHexCode.value.hexToComposeColor()
-                                } else {
-                                    KrailTheme.colors.onSurface
-                                },
-                                backgroundColor = KrailTheme.colors.surface,
-                                onSplashComplete = {
-                                    navController.navigate(
-                                        route = SavedTripsRoute,
-                                        navOptions = NavOptions.Builder().setLaunchSingleTop(true)
-                                            .setPopUpTo<SplashScreen>(inclusive = true).build(),
-                                    )
-                                },
-                            )
-                        }
-                    }
-                }
+                SplashScreen(
+                    logoColor = if (productClass != null && themeColorHexCode.value != unspecifiedColor) {
+                        themeColorHexCode.value.hexToComposeColor()
+                    } else {
+                        KrailTheme.colors.onSurface
+                    },
+                    backgroundColor = KrailTheme.colors.surface,
+                    onSplashComplete = {
+                        navController.navigate(
+                            route = SavedTripsRoute,
+                            navOptions = NavOptions.Builder()
+                                .setLaunchSingleTop(true)
+                                .setPopUpTo<SplashScreen>(inclusive = true)
+                                .build(),
+                        )
+                    },
+                )
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorDestination.kt
@@ -4,15 +4,15 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
-import xyz.ksharma.krail.trip.planner.ui.navigation.animComposable
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectorEvent
 
 internal fun NavGraphBuilder.dateTimeSelectorDestination(navController: NavHostController) {
-    animComposable<DateTimeSelectorRoute> { backStackEntry ->
+    composable<DateTimeSelectorRoute> { backStackEntry ->
         val route: DateTimeSelectorRoute = backStackEntry.toRoute()
         val viewModel: DateTimeSelectorViewModel = koinViewModel<DateTimeSelectorViewModel>()
         val uiState by viewModel.uiState.collectAsStateWithLifecycle()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -1,7 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.datetimeselector
 
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -44,8 +42,6 @@ import xyz.ksharma.krail.core.datetime.decrementDateByOneDay
 import xyz.ksharma.krail.core.datetime.incrementDateByOneDay
 import xyz.ksharma.krail.core.datetime.rememberCurrentDateTime
 import xyz.ksharma.krail.core.datetime.toReadableDate
-import xyz.ksharma.krail.taj.LocalNavAnimatedVisibilityScope
-import xyz.ksharma.krail.taj.LocalSharedTransitionScope
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
@@ -57,7 +53,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectio
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DateTimeSelectorScreen(
     dateTimeSelection: DateTimeSelectionItem?,
@@ -66,11 +62,6 @@ fun DateTimeSelectorScreen(
     onDateTimeSelected: (DateTimeSelectionItem?) -> Unit = {},
     onResetClick: () -> Unit = {},
 ) {
-    val sharedTransitionScope = LocalSharedTransitionScope.current
-        ?: throw IllegalStateException("No SharedElementScope found")
-    val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
-        ?: throw IllegalStateException("No AnimatedVisibility found")
-
     // Colors
     val themeColorHex by LocalThemeColor.current
     val themeColor = remember(themeColorHex) { themeColorHex.hexToComposeColor() }
@@ -199,52 +190,44 @@ fun DateTimeSelectorScreen(
             }
 
             item {
-                with(sharedTransitionScope) {
-                    Text(
-                        text = if (reset) {
-                            "Leave Now"
-                        } else {
-                            DateTimeSelectionItem(
-                                option = journeyTimeOption,
-                                hour = timePickerState.hour,
-                                minute = timePickerState.minute,
-                                date = selectedDate,
-                            ).toDateTimeText()
-                        },
-                        textAlign = TextAlign.Center,
-                        color = themeContentColor(),
-                        style = KrailTheme.typography.titleMedium,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .sharedBounds(
-                                sharedContentState = rememberSharedContentState(key = "planTripButtonKey"),
-                                animatedVisibilityScope = animatedVisibilityScope,
-                                resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds(),
-                            )
-                            .padding(horizontal = 24.dp, vertical = 16.dp)
-                            .clip(RoundedCornerShape(50))
-                            .background(color = themeColor)
-                            .clickable(
-                                role = Role.Button,
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null,
-                                onClick = {
-                                    onDateTimeSelected(
-                                        if (reset) null
-                                        else {
-                                            DateTimeSelectionItem(
-                                                option = journeyTimeOption,
-                                                hour = timePickerState.hour,
-                                                minute = timePickerState.minute,
-                                                date = selectedDate,
-                                            )
-                                        }
-                                    )
-                                },
-                            )
-                            .padding(vertical = 10.dp, horizontal = 12.dp),
-                    )
-                }
+                Text(
+                    text = if (reset) {
+                        "Leave Now"
+                    } else {
+                        DateTimeSelectionItem(
+                            option = journeyTimeOption,
+                            hour = timePickerState.hour,
+                            minute = timePickerState.minute,
+                            date = selectedDate,
+                        ).toDateTimeText()
+                    },
+                    textAlign = TextAlign.Center,
+                    color = themeContentColor(),
+                    style = KrailTheme.typography.titleMedium,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 16.dp)
+                        .clip(RoundedCornerShape(50))
+                        .background(color = themeColor)
+                        .clickable(
+                            role = Role.Button,
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = {
+                                onDateTimeSelected(
+                                    if (reset) null
+                                    else {
+                                        DateTimeSelectionItem(
+                                            option = journeyTimeOption,
+                                            hour = timePickerState.hour,
+                                            minute = timePickerState.minute,
+                                            date = selectedDate,
+                                        )
+                                    }
+                                )
+                            },
+                        ).padding(vertical = 10.dp, horizontal = 12.dp)
+                )
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -1,22 +1,16 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation
 
-import androidx.compose.animation.AnimatedContentScope
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavGraphBuilder
+import    androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import kotlinx.serialization.Serializable
-import xyz.ksharma.krail.taj.LocalNavAnimatedVisibilityScope
 import xyz.ksharma.krail.trip.planner.ui.alerts.alertsDestination
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.dateTimeSelectorDestination
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.savedTripsDestination
 import xyz.ksharma.krail.trip.planner.ui.searchstop.searchStopDestination
 import xyz.ksharma.krail.trip.planner.ui.settings.settingsDestination
-import xyz.ksharma.krail.trip.planner.ui.themeselection.themeSelectionDestination
 import xyz.ksharma.krail.trip.planner.ui.timetable.timeTableDestination
+import xyz.ksharma.krail.trip.planner.ui.themeselection.themeSelectionDestination
 
 /**
  * Nested navigation graph for the trip planner feature.
@@ -97,18 +91,5 @@ data class DateTimeSelectorRoute(
 ) {
     companion object {
         const val DATE_TIME_TEXT_KEY = "DateTimeSelectionKey"
-    }
-}
-
-/**
- * Use this when shared element transitions are required, otherwise keep using [composable] directly.
- */
-inline fun <reified T : Any> NavGraphBuilder.animComposable(
-    noinline content: @Composable AnimatedContentScope.(NavBackStackEntry) -> Unit,
-) {
-    composable<T> { backStackEntry ->
-        CompositionLocalProvider(LocalNavAnimatedVisibilityScope provides this) {
-            content(backStackEntry)
-        }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -9,20 +9,20 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
+import androidx.navigation.compose.composable
+import xyz.ksharma.krail.core.log.log
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
-import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
-import xyz.ksharma.krail.trip.planner.ui.navigation.animComposable
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem.Companion.fromJsonString
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 internal fun NavGraphBuilder.timeTableDestination(navController: NavHostController) {
-    animComposable<TimeTableRoute> { backStackEntry ->
+    composable<TimeTableRoute> { backStackEntry ->
         val viewModel: TimeTableViewModel = koinViewModel<TimeTableViewModel>()
         val timeTableState by viewModel.uiState.collectAsStateWithLifecycle()
         val route: TimeTableRoute = backStackEntry.toRoute()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -1,8 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
@@ -47,8 +45,6 @@ import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.taj.LocalNavAnimatedVisibilityScope
-import xyz.ksharma.krail.taj.LocalSharedTransitionScope
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
@@ -69,7 +65,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
-@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun TimeTableScreen(
     timeTableState: TimeTableState,
@@ -84,11 +79,6 @@ fun TimeTableScreen(
 ) {
     val themeColorHex by LocalThemeColor.current
     val themeColor = themeColorHex.hexToComposeColor()
-
-    val sharedTransitionScope = LocalSharedTransitionScope.current
-        ?: throw IllegalStateException("No SharedElementScope found")
-    val animatedVisibilityScope = LocalNavAnimatedVisibilityScope.current
-        ?: throw IllegalStateException("No AnimatedVisibility found")
 
     Column(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
@@ -182,18 +172,10 @@ fun TimeTableScreen(
             }
 
             item {
-                with(sharedTransitionScope) {
-                    SecondaryButton(
-                        text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
-                        onClick = dateTimeSelectorClicked,
-                        modifier = Modifier
-                            .sharedBounds(
-                                sharedContentState = rememberSharedContentState(key = "planTripButtonKey"),
-                                animatedVisibilityScope = animatedVisibilityScope,
-                                resizeMode = SharedTransitionScope.ResizeMode.ScaleToBounds(),
-                            ),
-                    )
-                }
+                SecondaryButton(
+                    text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
+                    onClick = dateTimeSelectorClicked,
+                )
             }
 
             item {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/CompositionLocals.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/CompositionLocals.kt
@@ -1,8 +1,5 @@
 package xyz.ksharma.krail.taj
 
-import androidx.compose.animation.AnimatedVisibilityScope
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
@@ -18,7 +15,3 @@ val LocalThemeContentColor = compositionLocalOf { mutableStateOf(unspecifiedColo
 
 internal val LocalContentColor = compositionLocalOf { Color.Unspecified }
 val LocalOnContentColor = compositionLocalOf { Color.Unspecified }
-
-val LocalNavAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }
-@OptIn(ExperimentalSharedTransitionApi::class)
-val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }


### PR DESCRIPTION
Removes shared element transitions from navigation between screens.

Reverts #499 

## Reason

The shared transition api's were also affecting the size / bounds of the other items in the LazyColumn. 

This removes the shared element transitions between screens, reverting back to standard navigation transitions. The change removes the `SharedTransitionLayout`, `AnimatedContent`, and associated composition locals that were used to coordinate the shared element animations.

### Screenshots

| Before - Has Shared Transition  | After removing Anim |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ad12669c-6442-4c68-9e40-e8da6517f75b"> |  <video src="https://github.com/user-attachments/assets/4c1bf638-8969-462e-b652-e2719f730647"> | 

