### PR TITLE
DI: Replace Dispatchers.IO with injected CoroutineDispatcher

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
@@ -1,12 +1,14 @@
 package xyz.ksharma.krail.di
 
-import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.module.dsl.viewModel
+import org.koin.core.qualifier.named
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.includes
 import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.analytics.di.analyticsModule
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
+import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.core.di.coroutineDispatchersModule
 import xyz.ksharma.krail.core.remote_config.di.remoteConfigModule
 import xyz.ksharma.krail.sandook.di.sandookModule
@@ -29,7 +31,15 @@ val koinConfig = koinConfiguration {
 }
 
 val splashModule = module {
-    viewModelOf(::SplashViewModel)
+    viewModel {
+        SplashViewModel(
+            sandook = get(),
+            analytics = get(),
+            appInfoProvider = get(),
+            remoteConfig = get(),
+            ioDispatcher = get(named(IODispatcher)),
+        )
+    }
 }
 
 expect fun nativeConfig(): KoinAppDeclaration

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -2,8 +2,7 @@ package xyz.ksharma.krail.splash
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +13,7 @@ import xyz.ksharma.krail.DEFAULT_THEME_TRANSPORT_MODE
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
-import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.remote_config.RemoteConfig
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -24,6 +23,7 @@ class SplashViewModel(
     private val analytics: Analytics,
     private val appInfoProvider: AppInfoProvider,
     private val remoteConfig: RemoteConfig,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<TransportMode> =
@@ -52,7 +52,7 @@ class SplashViewModel(
     }
 
     private fun getThemeTransportMode() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             // First app launch there will be no product class, so use default transport mode theme.
             val productClass =
                 sandook.getProductClass()?.toInt() ?: DEFAULT_THEME_TRANSPORT_MODE.productClass

--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.core.appInfo)
+                implementation(projects.core.di)
 
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/NetworkModule.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/NetworkModule.kt
@@ -3,7 +3,10 @@ package xyz.ksharma.krail.trip.planner.network.api.di
 import io.ktor.client.HttpClient
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
+import org.koin.dsl.bind
 import org.koin.dsl.module
+import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.trip.planner.network.api.ratelimit.NetworkRateLimiter
 import xyz.ksharma.krail.trip.planner.network.api.ratelimit.RateLimiter
 import xyz.ksharma.krail.trip.planner.network.api.service.RealTripPlanningService
@@ -13,5 +16,11 @@ import xyz.ksharma.krail.trip.planner.network.api.service.httpClient
 val networkModule = module {
     singleOf(::NetworkRateLimiter) { bind<RateLimiter>() }
     single<HttpClient> { httpClient(appInfoProvider = get()) }
-    singleOf(::RealTripPlanningService) { bind<TripPlanningService>() }
+
+    single {
+        RealTripPlanningService(
+            httpClient = get(),
+            ioDispatcher = get(named(IODispatcher)),
+        )
+    } bind TripPlanningService::class
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -3,16 +3,19 @@ package xyz.ksharma.krail.trip.planner.network.api.service
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.StopType
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.service.stop_finder.StopFinderRequestParams
 import xyz.ksharma.krail.trip.planner.network.api.service.trip.TripRequestParams
 
-class RealTripPlanningService(private val httpClient: HttpClient) : TripPlanningService {
+class RealTripPlanningService(
+    private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher,
+) : TripPlanningService {
 
     override suspend fun trip(
         originStopId: String,
@@ -20,7 +23,7 @@ class RealTripPlanningService(private val httpClient: HttpClient) : TripPlanning
         depArr: DepArr,
         date: String?,
         time: String?,
-    ): TripResponse = withContext(Dispatchers.IO) {
+    ): TripResponse = withContext(ioDispatcher) {
 
         httpClient.get("$NSW_TRANSPORT_BASE_URL/v1/tp/trip") {
             url {
@@ -49,7 +52,7 @@ class RealTripPlanningService(private val httpClient: HttpClient) : TripPlanning
     override suspend fun stopFinder(
         stopSearchQuery: String,
         stopType: StopType,
-    ): StopFinderResponse = withContext(Dispatchers.IO) {
+    ): StopFinderResponse = withContext(ioDispatcher) {
         httpClient.get("${NSW_TRANSPORT_BASE_URL}/v1/tp/stop_finder") {
             url {
                 parameters.append(StopFinderRequestParams.nameSf, stopSearchQuery)

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -27,6 +27,7 @@ kotlin {
                 implementation(projects.core.appInfo)
                 implementation(projects.core.analytics)
                 implementation(projects.core.dateTime)
+                implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.remoteConfig)
                 implementation(projects.feature.tripPlanner.network)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -1,7 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.di
 
+import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
@@ -11,11 +14,34 @@ import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewMo
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 
 val viewModelsModule = module {
-    viewModelOf(::SavedTripsViewModel)
     viewModelOf(::SearchStopViewModel)
-    viewModelOf(::TimeTableViewModel)
-    viewModelOf(::ThemeSelectionViewModel)
     viewModelOf(::SettingsViewModel)
     viewModelOf(::ServiceAlertsViewModel)
     viewModelOf(::DateTimeSelectorViewModel)
+
+    viewModel {
+        SavedTripsViewModel(
+            sandook = get(),
+            analytics = get(),
+            ioDispatcher = get(named(IODispatcher)),
+        )
+    }
+
+    viewModel {
+        TimeTableViewModel(
+            tripPlanningService = get(),
+            rateLimiter = get(),
+            sandook = get(),
+            analytics = get(),
+            ioDispatcher = get(named(IODispatcher)),
+        )
+    }
+
+    viewModel {
+        ThemeSelectionViewModel(
+            sandook = get(),
+            analytics = get(),
+            ioDispatcher = get(named(IODispatcher)),
+        )
+    }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.savedtrips
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,10 +13,12 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.koin.core.qualifier.named
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
@@ -26,6 +29,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 class SavedTripsViewModel(
     private val sandook: Sandook,
     private val analytics: Analytics,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
@@ -35,7 +39,7 @@ class SavedTripsViewModel(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
 
     private fun loadSavedTrips() {
-        viewModelScope.launch(context = Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             updateUiState { copy(isLoading = true) }
             val trips = mutableSetOf<Trip>()
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -2,8 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.themeselection
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -14,7 +13,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
-import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -24,6 +22,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionState
 class ThemeSelectionViewModel(
     private val sandook: Sandook,
     private val analytics: Analytics,
+    private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<ThemeSelectionState> =
@@ -48,7 +47,7 @@ class ThemeSelectionViewModel(
 
     private fun onTransportModeSelected(productClass: Int) {
         transportSelectionJob?.cancel()
-        transportSelectionJob = viewModelScope.launch(Dispatchers.IO) {
+        transportSelectionJob = viewModelScope.launch(ioDispatcher) {
             sandook.clearTheme() // Only one entry should exist at a time
             sandook.insertOrReplaceTheme(productClass.toLong())
             updateUiState {
@@ -59,7 +58,7 @@ class ThemeSelectionViewModel(
     }
 
     private fun getThemeTransportMode() {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             // First app launch there will be no product class, so use default transport mode theme.
             val productClass = sandook.getProductClass()?.toInt()
             val mode = productClass?.let { TransportMode.toTransportModeType(it) }

--- a/gtfs-static/build.gradle.kts
+++ b/gtfs-static/build.gradle.kts
@@ -24,18 +24,6 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-/*
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "gtfsStatic"
-        }
-    }
-*/
-
     sourceSets {
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
@@ -55,6 +43,7 @@ kotlin {
                 implementation(compose.runtime)
 
                 implementation(projects.core.log)
+                implementation(projects.core.di)
 
                 api(libs.di.koinComposeViewmodel)
             }

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
@@ -4,17 +4,18 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.readRawBytes
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
 
 class RealNswGtfsService(
     private val httpClient: HttpClient,
     private val fileStorage: FileStorage,
+    private val ioDispatcher: CoroutineDispatcher = DispatchersComponent().ioDispatcher,
 ) : NswGtfsService {
 
-    override suspend fun getSydneyTrains() = withContext(Dispatchers.IO) {
+    override suspend fun getSydneyTrains() = withContext(ioDispatcher) {
         val response: HttpResponse =
             httpClient.get("$NSW_TRANSPORT_BASE_URL/$GTFS_SCHEDULE_V1/sydneytrains")
 


### PR DESCRIPTION
### TL;DR
Replaced hardcoded Dispatchers.IO with injected CoroutineDispatcher across ViewModels and network services.

### What changed?
- Added CoroutineDispatcher as a constructor parameter to ViewModels and services
- Updated Koin DI modules to inject IODispatcher
- Removed direct Dispatchers.IO usage in favor of injected dispatcher
- Updated SplashViewModel, SavedTripsViewModel, ThemeSelectionViewModel, TimeTableViewModel, and RealTripPlanningService

### Why make this change?
- Improves testability by allowing dispatcher injection
- Makes coroutine context usage more consistent across the codebase
- Follows dependency injection best practices
- Makes it easier to swap dispatchers for testing purposes