### PR TITLE
DI: Move Koin Android context initialization to MainActivity

### DIFF
--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/KrailApplication.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/KrailApplication.kt
@@ -8,11 +8,13 @@ class KrailApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        instance = this
+//        instance = this
         Firebase.initialize(context = this)
     }
 
+/*
     companion object {
         var instance: Application? = null
     }
+*/
 }

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.logger.Level
 
 class MainActivity : ComponentActivity() {
 
@@ -11,7 +14,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
-            KrailApp()
+            KrailApp {
+                androidContext(this@MainActivity)
+                androidLogger(Level.DEBUG)
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/di/AppModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/di/AppModule.android.kt
@@ -1,11 +1,8 @@
 package xyz.ksharma.krail.di
 
-import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.dsl.koinConfiguration
-import xyz.ksharma.krail.KrailApplication
 
 actual fun nativeConfig() = koinConfiguration {
     androidLogger()
-    androidContext(KrailApplication.instance ?: error("No Android application context set"))
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -2,12 +2,16 @@ package xyz.ksharma.krail
 
 import androidx.compose.runtime.Composable
 import org.koin.compose.KoinApplication
+import org.koin.dsl.KoinAppDeclaration
 import xyz.ksharma.krail.di.koinConfig
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
-fun KrailApp() {
-    KoinApplication(application = koinConfig) {
+fun KrailApp(koinDeclaration: KoinAppDeclaration? = null) {
+    KoinApplication(application = {
+        koinDeclaration?.invoke(this)
+        koinConfig()
+    }) {
         KrailTheme {
             KrailNavHost()
         }


### PR DESCRIPTION
### TL;DR
Improved Koin dependency injection setup by removing static Application instance and configuring Android context directly in MainActivity.

### What changed?
- Removed static Application instance from KrailApplication
- Moved Android context configuration to MainActivity
- Updated KrailApp composable to accept optional Koin declarations
- Simplified native configuration in AppModule.android.kt

### Why make this change?
Using a static Application instance is an anti-pattern that can lead to memory leaks and makes testing more difficult. This change follows better Android practices by configuring the dependency injection context directly in MainActivity, making the code more maintainable and testable.