### PR TITLE
Test: Add LoadSavedTrips event test and replace Android logging

### DIFF
--- a/core/log/src/androidMain/kotlin/xyz/ksharma/krail/core/log/Log.android.kt
+++ b/core/log/src/androidMain/kotlin/xyz/ksharma/krail/core/log/Log.android.kt
@@ -1,15 +1,13 @@
 package xyz.ksharma.krail.core.log
 
-import android.util.Log
-
 private const val MAX_TAG_LENGTH: Int = 23
 
 actual fun log(message: String, throwable: Throwable?) {
-    if (BuildConfig.DEBUG) Log.d(getTag(), message)
+    if (BuildConfig.DEBUG) println("${getTag()}, $message")
 }
 
 actual fun logError(message: String, throwable: Throwable?) {
-    if (BuildConfig.DEBUG) Log.e(getTag(), message, throwable)
+    if (BuildConfig.DEBUG) println("${getTag()}, $message, $throwable")
 }
 
 private fun getTag(): String {

--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(projects.core.analytics)
+                implementation(projects.core.log)
                 implementation(projects.sandook)
                 implementation(projects.feature.tripPlanner.ui)
                 implementation(projects.feature.tripPlanner.state)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/helpers/FakeSandookHelper.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/helpers/FakeSandookHelper.kt
@@ -1,0 +1,6 @@
+package xyz.ksharma.core.test.helpers
+
+object FakeSandookHelper  {
+
+
+}


### PR DESCRIPTION
### TL;DR
Replaced Android Log calls with println and added new test coverage for SavedTripsViewModel

Switched from Android Log temporarily, until I figure out the issue with Turbine Tests displaying error with Mocking Log.d / e
https://developer.android.com/training/testing/local-tests#mocking-dependencies

### What changed?
- Modified Android logging implementation to use println instead of Android.util.Log
- Added new test case to verify SavedTripsViewModel behavior when loading saved trips
- Added FakeSandookHelper class (empty implementation)
- Added log dependency to core/test module
