### PR TITLE
Test: Add TimeTableViewModel unit tests and fakes

### DIFF
--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
                 implementation(projects.sandook)
                 implementation(projects.feature.tripPlanner.ui)
                 implementation(projects.feature.tripPlanner.state)
+                implementation(projects.feature.tripPlanner.network)
 
                 implementation(libs.test.kotlin)
                 implementation(libs.test.kotlinxCoroutineTest)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeRateLimiter.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeRateLimiter.kt
@@ -1,0 +1,19 @@
+package xyz.ksharma.core.test.fakes
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import xyz.ksharma.krail.trip.planner.network.api.ratelimit.RateLimiter
+
+class FakeRateLimiter : RateLimiter {
+
+    private var eventTriggered = false
+
+    override fun <T> rateLimitFlow(block: suspend () -> T): Flow<T> {
+        return flow { emit(block()) }
+    }
+
+    override fun triggerEvent(): Boolean {
+        eventTriggered = true
+        return eventTriggered
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
@@ -1,0 +1,31 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
+import xyz.ksharma.krail.trip.planner.network.api.model.StopType
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
+import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
+
+class FakeTripPlanningService : TripPlanningService {
+
+    override suspend fun trip(
+        originStopId: String,
+        destinationStopId: String,
+        depArr: DepArr,
+        date: String?,
+        time: String?,
+    ): TripResponse {
+        // Return a fake TripResponse
+        return TripResponse(
+        )
+    }
+
+    override suspend fun stopFinder(
+        stopSearchQuery: String,
+        stopType: StopType,
+    ): StopFinderResponse {
+        // Return a fake StopFinderResponse
+        return StopFinderResponse(
+        )
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -1,0 +1,45 @@
+package xyz.ksharma.core.test.viewmodels
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeRateLimiter
+import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.fakes.FakeTripPlanningService
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimeTableViewModelTest {
+
+    private val sandook: Sandook = FakeSandook()
+    private val analytics: Analytics = FakeAnalytics()
+    private val tripPlanningService = FakeTripPlanningService()
+    private val rateLimiter = FakeRateLimiter()
+    private lateinit var viewModel: TimeTableViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = TimeTableViewModel(
+            tripPlanningService = tripPlanningService,
+            rateLimiter = rateLimiter,
+            sandook = sandook,
+            analytics = analytics,
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -30,7 +30,6 @@ import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toHHMM
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
-import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId


### PR DESCRIPTION
Add fakes for FakeTripPlanningService and FakeRateLimiter and set up TimeTableViewModel test class

The PR adds test fakes for TripPlanningService and RateLimiter interfaces, along with a new TimeTableViewModel test class. The test class is configured with the necessary dependencies and test dispatchers for coroutine testing.