### PR TITLE
Test: Add SaveTrip event tests and clear analytics state

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAnalytics.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAnalytics.kt
@@ -25,4 +25,9 @@ class FakeAnalytics : Analytics {
     override fun setUserProperty(name: String, value: String) {
         println("Setting user property $name to $value")
     }
+
+    fun clear() {
+        trackedEvents.clear()
+        fakeUserId = null
+    }
 }


### PR DESCRIPTION
### TL;DR
Added trip saving functionality and analytics tracking to TimeTableViewModel with corresponding tests

### What changed?
- Added a `clear()` function to FakeAnalytics to reset tracked events and user ID
- Implemented test coverage for trip saving functionality in TimeTableViewModel
- Added verification for analytics tracking when saving/unsaving trips
- Renamed analytics variable to fakeAnalytics for better clarity in tests

### Why make this change?
To ensure proper test coverage for the trip saving functionality and analytics tracking in the TimeTableViewModel, making the codebase more reliable and maintainable. The addition of the clear() function in FakeAnalytics helps prevent test pollution between different test cases.