### PR TITLE
Test: Add ReverseTrip event test for TimeTableViewModel

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -32,6 +32,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
@@ -397,6 +398,51 @@ class TimeTableViewModelTest {
                 }
                 assertTrue(analytics.isEventTracked("save_trip_click"))
                 analytics.clear()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion
+
+    // region Test for reverse trip
+    @Test
+    fun `GIVEN trip info WHEN ReverseTripButtonClicked is triggered THEN trip should be reversed`() =
+        runTest {
+            // GIVEN
+            val initialTrip = Trip(
+                fromStopId = "stop1",
+                fromStopName = "Stop 1",
+                toStopId = "stop2",
+                toStopName = "Stop 2"
+            )
+
+            viewModel.uiState.test {
+                awaitItem().run {
+                    assertNull(trip) // trip is null initially
+                }
+
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(initialTrip))
+
+                awaitItem().run {
+                    assertNotNull(trip)
+                    assertEquals("stop1", trip?.fromStopId)
+                    assertEquals("Stop 1", trip?.fromStopName)
+                    assertEquals("stop2", trip?.toStopId)
+                    assertEquals("Stop 2", trip?.toStopName)
+                }
+
+                // WHEN ReverseTripButtonClicked is triggered
+                viewModel.onEvent(TimeTableUiEvent.ReverseTripButtonClicked)
+
+                // THEN trip should be reversed
+                awaitItem().run {
+                    assertNotNull(trip)
+                    assertEquals("stop2", trip?.fromStopId)
+                    assertEquals("Stop 2", trip?.fromStopName)
+                    assertEquals("stop1", trip?.toStopId)
+                    assertEquals("Stop 1", trip?.toStopName)
+                }
 
                 cancelAndIgnoreRemainingEvents()
             }


### PR DESCRIPTION
### TL;DR
Added functionality to reverse trip directions in the TimeTable view model

### What changed?
Added a new test case to verify the reverse trip functionality in `TimeTableViewModelTest`. The test ensures that when `ReverseTripButtonClicked` event is triggered, the origin and destination stops are properly swapped.

### How to test?
1. Initialize a trip with origin "Stop 1" and destination "Stop 2"
2. Trigger the `ReverseTripButtonClicked` event
3. Verify that the origin is now "Stop 2" and destination is "Stop 1"
4. Confirm that both stop IDs and names are correctly swapped

### Why make this change?
To ensure the reverse trip functionality works correctly, allowing users to easily plan return journeys without manually re-entering stop information.