### PR TITLE
Test: Add DateTimeSelection event tests for TimeTableViewModel

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -104,7 +104,8 @@ class TimeTableViewModel(
     val expandedJourneyId: StateFlow<String?> = _expandedJourneyId
 
     private var tripInfo: Trip? = null
-    private var dateTimeSelectionItem: DateTimeSelectionItem? = null
+    @VisibleForTesting
+    var dateTimeSelectionItem: DateTimeSelectionItem? = null
 
     private var fetchTripJob: Job? = null
 
@@ -152,6 +153,7 @@ class TimeTableViewModel(
         log("DateTimeSelectionChanged: $item")
         // Verify if date time selection has actually changed, otherwise, api will be called unnecessarily.
         if (dateTimeSelectionItem != item) {
+            println("Loading True")
             updateUiState { copy(isLoading = true) }
             dateTimeSelectionItem = item
             journeys.clear() // Clear cache trips when date time selection changed.


### PR DESCRIPTION
### TL;DR
Added date/time selection handling and analytics tracking for the TimeTable feature

### What changed?
- Added tests for `DateTimeSelectionChanged` event handling
- Implemented logic to prevent unnecessary API calls when the same date/time is selected
- Added analytics tracking for date/time selection events
- Made `dateTimeSelectionItem` visible for testing purposes

### How to test?
1. Select different date/time combinations in the TimeTable view
2. Verify analytics event "date_time_select" is tracked only when selection changes
3. Confirm that selecting the same date/time doesn't trigger additional API calls
4. Verify loading state updates correctly when date/time selection changes

### Why make this change?
To optimize API usage by preventing redundant calls when users select the same date/time and to track user interactions with the date/time selector for analytics purposes. This improves app performance and provides valuable usage data.