### PR TITLE
Test: Add analytics event tracking tests for TimeTableViewModel

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -576,4 +576,41 @@ class TimeTableViewModelTest {
         }
 
     // endregion
+
+    // region Test for Analytics
+    @Test
+    fun `GIVEN trip info WHEN AnalyticsDateTimeSelectorClicked is triggered THEN analytics event should be tracked`() =
+        runTest {
+            // GIVEN
+            val trip = Trip(
+                fromStopId = "stop1",
+                fromStopName = "Stop 1",
+                toStopId = "stop2",
+                toStopName = "Stop 2"
+            )
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+
+            // WHEN AnalyticsDateTimeSelectorClicked is triggered
+            viewModel.onEvent(TimeTableUiEvent.AnalyticsDateTimeSelectorClicked)
+
+            // THEN analytics event should be tracked
+            assertTrue(analytics.isEventTracked("plan_trip_click"))
+        }
+
+    @Test
+    fun `GIVEN expanded state WHEN JourneyLegClicked is triggered THEN analytics event should be tracked`() =
+        runTest {
+            // GIVEN
+            val expanded = true
+            val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+
+            // WHEN JourneyLegClicked is triggered
+            viewModel.onEvent(TimeTableUiEvent.JourneyLegClicked(expanded))
+
+            // THEN analytics event should be tracked
+            assertTrue(analytics.isEventTracked("journey_leg_click"))
+        }
+
+    // endregion
 }


### PR DESCRIPTION
### TL;DR
Added analytics tracking tests for date/time selector and journey leg clicks in TimeTableViewModel

### What changed?
- Added test to verify analytics tracking when date/time selector is clicked
- Added test to verify analytics tracking when journey leg expansion is toggled
- Both tests utilize FakeAnalytics to confirm proper event tracking

### How to test?
1. Run the TimeTableViewModelTest test suite
2. Verify that `plan_trip_click` event is tracked when date/time selector is clicked
3. Verify that `journey_leg_click` event is tracked when journey leg is expanded/collapsed

### Why make this change?
To ensure proper analytics tracking implementation for user interactions with the time table interface, helping us better understand user behavior and feature usage patterns