### PR TITLE
Build: Remove iosX64 target from trip planner network module

### DIFF
--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -26,7 +26,6 @@ kotlin {
 
     androidTarget()
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {


### PR DESCRIPTION
### TL;DR
Removed iOS x64 architecture support from trip planner network module

### What changed?
Removed `iosX64()` target from the Kotlin Multiplatform configuration in the trip planner network module's build file

### How to test?
1. Build the iOS app for arm64 devices and simulator
2. Verify the app builds successfully
3. Confirm the app runs on modern iOS devices and simulators

### Why make this change?
iOS x64 architecture is no longer needed as Apple has transitioned to arm64 for all modern devices and simulators. Removing this target simplifies the build process and reduces unnecessary compilation time.