### PR TITLE
Test: Add SearchStopViewModel tests and fake stop finder response builder

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAnalytics.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAnalytics.kt
@@ -5,17 +5,21 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 
 class FakeAnalytics : Analytics {
 
-    private val trackedEvents = mutableListOf<String>()
+    private val trackedEvents = mutableListOf<AnalyticsEvent>()
     private var fakeUserId: String? = null
 
-    fun isEventTracked(event: String): Boolean {
+    fun isEventTracked(eventName: String): Boolean {
         println("trackedEvents: $trackedEvents")
-        return trackedEvents.contains(event)
+        return trackedEvents.any { it.name == eventName }
+    }
+
+    fun getTrackedEvent(eventName: String): AnalyticsEvent? {
+        return trackedEvents.find { it.name == eventName }
     }
 
     override fun track(event: AnalyticsEvent) {
         println("Tracking event: $event")
-        trackedEvents.add(event.name)
+        trackedEvents.add(event)
     }
 
     override fun setUserId(userId: String) {

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeStopFinderResponseBuilder.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeStopFinderResponseBuilder.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
+
+object FakeStopFinderResponseBuilder {
+
+    fun buildStopFinderResponse(): StopFinderResponse {
+        return StopFinderResponse(
+            locations = listOf(
+                StopFinderResponse.Location(
+                    id = "1",
+                    name = "Stop 1",
+                    type = "stop",
+                    disassembledName = "Stop 1, Suburb 1",
+                    properties = StopFinderResponse.Properties("1"),
+                    productClasses = listOf(1, 5, 9),
+                ),
+                StopFinderResponse.Location(
+                    id = "2",
+                    name = "Stop 2",
+                    type = "stop",
+                    disassembledName = "Stop 2, Suburb 2",
+                    properties = StopFinderResponse.Properties("2"),
+                    productClasses = listOf(1, 2),
+                ),
+            ),
+        )
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
@@ -26,7 +26,7 @@ class FakeTripPlanningService : TripPlanningService {
         stopType: StopType,
     ): StopFinderResponse {
         // Return a fake StopFinderResponse
-        return StopFinderResponse(
-        )
+        return if (isSuccess) FakeStopFinderResponseBuilder.buildStopFinderResponse()
+        else throw IllegalStateException("Failed to fetch stops")
     }
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -1,0 +1,148 @@
+package xyz.ksharma.core.test.viewmodels
+
+import app.cash.turbine.test
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeTripPlanningService
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchStopViewModelTest {
+
+    private val fakeAnalytics: Analytics = FakeAnalytics()
+    private val tripPlanningService = FakeTripPlanningService()
+    private lateinit var viewModel: SearchStopViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = SearchStopViewModel(
+            tripPlanningService = tripPlanningService,
+            analytics = fakeAnalytics,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `GIVEN SearchStopViewModel WHEN uiState is collected THEN analytics event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                awaitItem().run {
+                    assertFalse(isLoading)
+                    assertFalse(isError)
+                    assertTrue(stops.isEmpty())
+                }
+
+                advanceUntilIdle()
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                assertTrue(fakeAnalytics.isEventTracked("view_screen"))
+                val event = fakeAnalytics.getTrackedEvent("view_screen")
+                assertIs<AnalyticsEvent.ScreenViewEvent>(event)
+                assertEquals("SearchStop", event.screen.name)
+            }
+        }
+
+    @Test
+    fun `GIVEN search query WHEN SearchTextChanged is triggered and api is success THEN uiState is updated with results`() =
+        runTest {
+            tripPlanningService.isSuccess = true
+
+            viewModel.uiState.test {
+                skipItems(1) // initial state
+
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("abcd"))
+
+                awaitItem().run {
+                    assertTrue(isLoading)
+                    assertFalse(isError)
+                    assertTrue(stops.isEmpty())
+                }
+
+
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("stop"))
+                awaitItem().run {
+                    assertFalse(isLoading)
+                    assertFalse(isError)
+                    assertEquals(2, stops.size)
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN search query WHEN SearchTextChanged and api fails THEN uiState is updated with error`() =
+        runTest {
+            val query = "test"
+
+            tripPlanningService.isSuccess = false
+
+            viewModel.uiState.test {
+                skipItems(1) // initial state
+
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged(query))
+                awaitItem().run {
+                    assertTrue(isLoading)
+                    assertFalse(isError)
+                    assertTrue(stops.isEmpty())
+                }
+
+                awaitItem().run {
+                    assertFalse(isLoading)
+                    assertTrue(isError)
+                    assertTrue(stops.isEmpty())
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN stop item WHEN StopSelected is triggered THEN analytics event is tracked`() =
+        runTest {
+
+            // WHEN
+            viewModel.onEvent(
+                SearchStopUiEvent.StopSelected(
+                    StopItem(
+                        stopName = "name",
+                        persistentSetOf(TransportMode.Train()),
+                        stopId = "stopID",
+                    )
+                )
+            )
+
+            // THEN
+            assertTrue(fakeAnalytics is FakeAnalytics)
+            assertTrue(fakeAnalytics.isEventTracked("stop_selected"))
+            val event = fakeAnalytics.getTrackedEvent("stop_selected")
+            assertIs<AnalyticsEvent.StopSelectedEvent>(event)
+            assertEquals("stopID", event.stopId)
+        }
+}


### PR DESCRIPTION
### TL;DR
Added test coverage for SearchStopViewModel and enhanced FakeAnalytics tracking capabilities

### What changed?
- Enhanced `FakeAnalytics` to store and retrieve complete `AnalyticsEvent` objects instead of just event names
- Created `FakeStopFinderResponseBuilder` to generate test data for stop finder responses
- Updated `FakeTripPlanningService` to use the new response builder
- Added comprehensive test suite for `SearchStopViewModel` covering:
  - Initial state and screen view analytics
  - Search functionality with success and failure scenarios
  - Stop selection analytics tracking

### How to test?
1. Run the test suite in `SearchStopViewModelTest`
2. Verify all tests pass, including:
   - Initial UI state validation
   - Search functionality with success/failure cases
   - Analytics tracking for screen views and stop selections
   - Error state handling

### Why make this change?
To ensure reliable behavior of the SearchStopViewModel through comprehensive test coverage, particularly focusing on user interactions, API responses, and analytics tracking. This change improves the overall reliability and maintainability of the search stop feature.