### PR TITLE
Test: Add analytics event tracking helper and tests

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/helpers/AnalyticsTestHelper.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/helpers/AnalyticsTestHelper.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.core.test.helpers
+
+import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+object AnalyticsTestHelper {
+
+    fun assertAnalyticsEventTracked(
+        fakeAnalytics: Analytics,
+        expectedEventName: String,
+        expectedScreenName: String,
+    ) {
+        assertIs<FakeAnalytics>(fakeAnalytics)
+        assertTrue(fakeAnalytics.isEventTracked(expectedEventName))
+        val event = fakeAnalytics.getTrackedEvent(expectedEventName)
+        assertIs<AnalyticsEvent.ScreenViewEvent>(event)
+        assertEquals(expectedScreenName, event.screen.name)
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.sandook.Sandook
@@ -55,7 +56,7 @@ class SavedTripsViewModelTest {
                 assertEquals(item, SavedTripsState())
 
                 advanceUntilIdle()
-                assertTrue(analytics.isEventTracked("view_screen"))
+                assertAnalyticsEventTracked(analytics, "view_screen", "SavedTrips")
 
                 cancelAndConsumeRemainingEvents()
             }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeTripPlanningService
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
@@ -60,11 +61,7 @@ class SearchStopViewModelTest {
                 }
 
                 advanceUntilIdle()
-                assertTrue(fakeAnalytics is FakeAnalytics)
-                assertTrue(fakeAnalytics.isEventTracked("view_screen"))
-                val event = fakeAnalytics.getTrackedEvent("view_screen")
-                assertIs<AnalyticsEvent.ScreenViewEvent>(event)
-                assertEquals("SearchStop", event.screen.name)
+                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "SearchStop")
             }
         }
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
@@ -4,18 +4,25 @@ import app.cash.turbine.test
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionEvent
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -52,13 +59,82 @@ class ThemeSelectionViewModelTest {
                     assertFalse(themeSelected)
                 }
 
+                advanceUntilIdle()
+                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "ThemeSelection")
+
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
+    @Test
+    fun `GIVEN product class is null in Sandook WHEN uiState is collected THEN selectedTransportMode is Train`() =
+        runTest {
+            viewModel.uiState.test {
+                awaitItem().run {
+                    assertNull(selectedTransportMode)
+                    assertFalse(themeSelected)
+                }
 
-    // TODO - Write UT - `GIVEN ThemeSelectionViewModel WHEN isLoading is collected THEN analytics event is tracked`()
-    // TODO - write Sandook tests
+                // WHEN
+                assertNull(fakeSandook.getProductClass())
+
+                // THEN
+                awaitItem().run {
+                    assertFalse(themeSelected)
+                    assertEquals(TransportMode.Train(), selectedTransportMode)
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN product class is not null in Sandook WHEN uiState is collected THEN selectedTransportMode is product class value`() =
+        runTest {
+            // Set up the product class in FakeSandook
+            val productClass = 2L
+            fakeSandook.insertOrReplaceTheme(productClass)
+
+            viewModel.uiState.test {
+                skipItems(1) // initial state
+
+                // WHEN
+                assertEquals(productClass, fakeSandook.getProductClass())
+
+                // THEN
+                awaitItem().run {
+                    assertFalse(themeSelected)
+                    assertEquals(TransportMode.Metro(), selectedTransportMode)
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN transport mode WHEN TransportModeSelected is triggered THEN uiState is updated and analytics event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1) // initial state
+
+                // WHEN
+                viewModel.onEvent(ThemeSelectionEvent.TransportModeSelected(9))
+                advanceUntilIdle()
+
+                // THEN
+                assertEquals(9, fakeSandook.getProductClass())
+                awaitItem().run {
+                    assertTrue(themeSelected)
+                }
+                assertIs<FakeAnalytics>(fakeAnalytics)
+                assertTrue(fakeAnalytics.isEventTracked("theme_selected"))
+                val event = fakeAnalytics.getTrackedEvent("theme_selected")
+                assertIs<AnalyticsEvent.ThemeSelectedEvent>(event)
+                assertEquals("Ferry", event.transportMode)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `GIVEN transport mode WHEN TransportModeSelected is triggered THEN uiState is updated with themeSelected as true`() =
@@ -67,15 +143,12 @@ class ThemeSelectionViewModelTest {
                 awaitItem().run {
                     assertNull(selectedTransportMode)
                     assertFalse(themeSelected)
-                    println(this)
-
                 }
 
                 viewModel.onEvent(ThemeSelectionEvent.TransportModeSelected(1))
 
                 awaitItem().run {
-                    println(this)
-                   assertTrue(themeSelected)
+                    assertTrue(themeSelected)
                 }
 
                 cancelAndIgnoreRemainingEvents()

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -17,6 +17,7 @@ import xyz.ksharma.core.test.fakes.FakeRateLimiter
 import xyz.ksharma.core.test.fakes.FakeSandook
 import xyz.ksharma.core.test.fakes.FakeTripPlanningService
 import xyz.ksharma.core.test.fakes.FakeTripResponseBuilder.buildTripResponse
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.sandook.Sandook
@@ -80,7 +81,7 @@ class TimeTableViewModelTest {
                 assertEquals(isLoadingState, true)
 
                 advanceUntilIdle()
-                assertTrue(fakeAnalytics.isEventTracked("view_screen"))
+                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "TimeTable")
 
                 cancelAndConsumeRemainingEvents()
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
@@ -27,7 +27,6 @@ import xyz.ksharma.krail.core.log.log
 internal fun NavGraphBuilder.themeSelectionDestination(navController: NavHostController) {
     composable<ThemeSelectionRoute> {
         val viewModel: ThemeSelectionViewModel = koinViewModel<ThemeSelectionViewModel>()
-        val isUiStateLoading by viewModel.isLoading.collectAsStateWithLifecycle()
         val state by viewModel.uiState.collectAsStateWithLifecycle()
         var themeColor by LocalThemeColor.current
         var themeContentColor by LocalThemeContentColor.current

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -28,14 +28,10 @@ class ThemeSelectionViewModel(
     private val _uiState: MutableStateFlow<ThemeSelectionState> =
         MutableStateFlow(ThemeSelectionState())
     val uiState: StateFlow<ThemeSelectionState> = _uiState
-
-    private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading
         .onStart {
             getThemeTransportMode()
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.ThemeSelection)
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANR_TIMEOUT), true)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANR_TIMEOUT), ThemeSelectionState())
 
     private var transportSelectionJob: Job? = null
 
@@ -61,7 +57,8 @@ class ThemeSelectionViewModel(
         viewModelScope.launch(ioDispatcher) {
             // First app launch there will be no product class, so use default transport mode theme.
             val productClass = sandook.getProductClass()?.toInt()
-            val mode = productClass?.let { TransportMode.toTransportModeType(it) }
+            val mode =
+                productClass?.let { TransportMode.toTransportModeType(it) } ?: TransportMode.Train()
             updateUiState {
                 copy(selectedTransportMode = mode)
             }


### PR DESCRIPTION
### TL;DR
Added analytics test helper and improved theme selection tests with proper analytics tracking.

### What changed?
- Created new `AnalyticsTestHelper` to standardize analytics event testing
- Refactored analytics assertions in view model tests to use the new helper
- Enhanced `ThemeSelectionViewModel` tests with additional coverage for product class scenarios
- Removed unused `isLoading` state from `ThemeSelectionViewModel`
- Added default `Train` transport mode when no product class exists

### Why make this change?
To improve test consistency and maintainability by centralizing analytics testing logic while ensuring proper analytics tracking across the application. This change also provides better test coverage for theme selection scenarios and removes unused state management code.