### PR TITLE
Test: Add ServiceAlertsViewModel tests and make toServiceAlert public

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ServiceAlertsViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ServiceAlertsViewModelTest.kt
@@ -1,0 +1,83 @@
+package xyz.ksharma.core.test.viewmodels
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
+import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
+import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
+import xyz.ksharma.krail.trip.planner.ui.alerts.toServiceAlert
+import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlertState
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServiceAlertsViewModelTest {
+
+    private val fakeAnalytics = FakeAnalytics()
+    private val fakeSandook = FakeSandook()
+    private lateinit var viewModel: ServiceAlertsViewModel
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = ServiceAlertsViewModel(
+            analytics = fakeAnalytics,
+            sandook = fakeSandook
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `GIVEN ServiceAlertsViewModel initial state WHEN uiState is collected THEN assert Initial State`() =
+        runTest {
+            viewModel.uiState.test {
+                awaitItem().run {
+                    assertEquals(ServiceAlertState(), this)
+                }
+
+                advanceUntilIdle()
+                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "ServiceAlerts")
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN journeyId WHEN fetchAlerts is called THEN alerts are returned`() =
+        runTest {
+            val journeyId = "testJourneyId"
+            val expectedAlerts = listOf(
+                SelectServiceAlertsByJourneyId(
+                    heading = "Alert 1",
+                    message = "Message 1",
+                    journeyId = "1",
+                ),
+                SelectServiceAlertsByJourneyId(
+                    heading = "Alert 2",
+                    message = "Message 2",
+                    journeyId = "2",
+                )
+            )
+
+            fakeSandook.insertAlerts(journeyId, expectedAlerts)
+
+            val alerts = viewModel.fetchAlerts(journeyId)
+            assertEquals(expectedAlerts.map { it.toServiceAlert() }, alerts)
+        }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -123,14 +123,6 @@ class TimeTableViewModelTest {
 
                 // need to skip two items, because silentLoading will be toggled, as we manually call fetchTrip()
                 skipItems(2)
-                /*
-                                awaitItem().run {
-                                   assertTrue(silentLoading)
-                                }
-                                awaitItem().run {
-                                    assertFalse(silentLoading)
-                                }
-                */
 
                 awaitItem().run {
                     assertFalse(isLoading)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModel.kt
@@ -35,7 +35,7 @@ class ServiceAlertsViewModel(
     }
 }
 
-private fun SelectServiceAlertsByJourneyId.toServiceAlert() = ServiceAlert(
+fun SelectServiceAlertsByJourneyId.toServiceAlert() = ServiceAlert(
     heading = heading,
     message = message,
 )


### PR DESCRIPTION
### TL;DR
Added unit tests for ServiceAlertsViewModel and made toServiceAlert function public.

### What changed?
- Created new ServiceAlertsViewModelTest class with test coverage for initial state and alert fetching
- Made `toServiceAlert()` function public to support testing
- Removed commented code in TimeTableViewModelTest
- Added test cases to verify analytics tracking and proper state management

### How to test?
1. Run the unit tests in ServiceAlertsViewModelTest
2. Verify that both test cases pass:
   - Initial state test
   - Alert fetching test with mock data
3. Confirm analytics events are properly tracked

### Why make this change?
To ensure the ServiceAlertsViewModel behaves correctly and maintains proper state management. This change improves test coverage and helps catch potential regressions in the service alerts functionality.