### PR TITLE
Test: Refactor analytics screen view event tracking tests

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/helpers/AnalyticsTestHelper.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/helpers/AnalyticsTestHelper.kt
@@ -9,14 +9,13 @@ import kotlin.test.assertTrue
 
 object AnalyticsTestHelper {
 
-    fun assertAnalyticsEventTracked(
+    fun assertScreenViewEventTracked(
         fakeAnalytics: Analytics,
-        expectedEventName: String,
         expectedScreenName: String,
     ) {
         assertIs<FakeAnalytics>(fakeAnalytics)
-        assertTrue(fakeAnalytics.isEventTracked(expectedEventName))
-        val event = fakeAnalytics.getTrackedEvent(expectedEventName)
+        assertTrue(fakeAnalytics.isEventTracked("view_screen"))
+        val event = fakeAnalytics.getTrackedEvent("view_screen")
         assertIs<AnalyticsEvent.ScreenViewEvent>(event)
         assertEquals(expectedScreenName, event.screen.name)
     }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -11,8 +11,9 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeTripPlanningService
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -24,7 +25,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -61,7 +61,10 @@ class SearchStopViewModelTest {
                 }
 
                 advanceUntilIdle()
-                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "SearchStop")
+                assertScreenViewEventTracked(
+                    fakeAnalytics,
+                    expectedScreenName = AnalyticsScreen.SearchStop.name,
+                )
             }
         }
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ServiceAlertsViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ServiceAlertsViewModelTest.kt
@@ -10,7 +10,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.alerts.toServiceAlert
@@ -52,7 +53,10 @@ class ServiceAlertsViewModelTest {
                 }
 
                 advanceUntilIdle()
-                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "ServiceAlerts")
+                assertScreenViewEventTracked(
+                    fakeAnalytics,
+                    expectedScreenName = AnalyticsScreen.ServiceAlerts.name,
+                )
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
@@ -60,7 +60,10 @@ class ThemeSelectionViewModelTest {
                 }
 
                 advanceUntilIdle()
-                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "ThemeSelection")
+                assertScreenViewEventTracked(
+                    fakeAnalytics,
+                    expectedScreenName = AnalyticsScreen.ThemeSelection.name,
+                )
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -17,8 +17,9 @@ import xyz.ksharma.core.test.fakes.FakeRateLimiter
 import xyz.ksharma.core.test.fakes.FakeSandook
 import xyz.ksharma.core.test.fakes.FakeTripPlanningService
 import xyz.ksharma.core.test.fakes.FakeTripResponseBuilder.buildTripResponse
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertAnalyticsEventTracked
+import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
@@ -81,7 +82,10 @@ class TimeTableViewModelTest {
                 assertEquals(isLoadingState, true)
 
                 advanceUntilIdle()
-                assertAnalyticsEventTracked(fakeAnalytics, "view_screen", "TimeTable")
+                assertScreenViewEventTracked(
+                    fakeAnalytics,
+                    expectedScreenName = AnalyticsScreen.TimeTable.name,
+                )
 
                 cancelAndConsumeRemainingEvents()
             }


### PR DESCRIPTION
### TL;DR
Refactored analytics screen view tracking to use a consistent approach across view models.

### What changed?
- Renamed `assertAnalyticsEventTracked` to `assertScreenViewEventTracked` to better reflect its specific purpose
- Removed redundant `expectedEventName` parameter since it's always "view_screen"
- Updated all view model tests to use `AnalyticsScreen` enum values for screen names
- Standardized analytics variable naming to `fakeAnalytics` across test files

### Why make this change?
To improve code consistency and maintainability by:
- Using a more specific and accurate helper method name
- Eliminating redundant parameters
- Standardizing how screen names are referenced using the `AnalyticsScreen` enum
- Making analytics testing more uniform across the codebase