### PR TITLE
Bump version to 1.0.5

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 34
-        versionName = "1.0.4"
+        versionCode = 35
+        versionName = "1.0.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Bump version numbers for Android and iOS apps to 1.0.5

### What changed?
- Android: Increased `versionCode` to 35 and `versionName` to "1.0.5"
- iOS: Updated `CFBundleShortVersionString` to "1.0.5"

### Why make this change?
Prepare for the next app release by incrementing version numbers across platforms to maintain version consistency between Android and iOS builds.