### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 36
-        versionName = "1.0.5"
+        versionCode = 37
+        versionName = "1.0.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.5</string>
+	<string>1.0.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Version bump from 1.0.5 to 1.0.6

### What changed?
- Android version code increased from 36 to 37
- Android version name updated to 1.0.6
- iOS bundle version string updated to 1.0.6

### How to test?
1. Build and install the app on Android and iOS devices
2. Verify the version number in app settings/info
3. Confirm version appears correctly in respective app stores

### Why make this change?
Preparing for a new release by incrementing version numbers across platforms to maintain version parity between Android and iOS applications.