### PR TITLE
UI: Fix "Timetable" text casing

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -106,7 +106,7 @@ fun TimeTableScreen(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = "TimeTable",
+                            text = "Timetable",
                             color = KrailTheme.colors.onSurface,
                         )
 


### PR DESCRIPTION
### TL;DR
Fixed capitalization of "Timetable" text in TimeTableScreen

### What changed?
Changed the text display from "TimeTable" to "Timetable" to use proper capitalization

### Why make this change?
Improves consistency in UI text presentation by using proper capitalization conventions for the word "Timetable"