### PR TITLE
UI: Replace SecondaryButton with Text in DateTimeSelector

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -41,7 +41,6 @@ import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.trip.planner.ui.components.SecondaryButton
 import xyz.ksharma.krail.trip.planner.ui.components.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.themeContentColor
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
@@ -118,17 +117,28 @@ fun DateTimeSelectorScreen(
         TitleBar(title = { Text(text = "Plan your trip") },
             onNavActionClick = onBackClick,
             actions = {
-                SecondaryButton(text = "Reset",
-                    onClick = {
-                        val now: LocalDateTime =
-                            Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-                        selectedDateStr = now.date.toString()
-                        timePickerState.hour = now.time.hour
-                        timePickerState.minute = now.time.minute
-                        journeyTimeOption = JourneyTimeOptions.LEAVE
-                        reset = true
-                        onResetClick()
-                    })
+                Text(
+                    text = "Reset",
+                    style = KrailTheme.typography.bodyLarge,
+                    modifier = modifier
+                        .clickable(
+                            role = Role.Button,
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = {
+                                val now: LocalDateTime =
+                                    Clock.System.now()
+                                        .toLocalDateTime(TimeZone.currentSystemDefault())
+                                selectedDateStr = now.date.toString()
+                                timePickerState.hour = now.time.hour
+                                timePickerState.minute = now.time.minute
+                                journeyTimeOption = JourneyTimeOptions.LEAVE
+                                reset = true
+                                onResetClick()
+                            },
+                        )
+                        .padding(horizontal = 16.dp, vertical = 10.dp)
+                )
             })
 
         LazyColumn(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -95,8 +95,9 @@ fun Button(
 /** TODO
  * Button
  *      Kind
- *      - Cta button - text only
+ *      - CtaButton - text only
  *      - Button - text with background color
+ *      - SubtleButton - text with light background color
  *
  *      Sizing
  *      - Compact - a small button with minimal padding horizontally


### PR DESCRIPTION
### TL;DR
Replaced SecondaryButton with Text component in DateTimeSelectorScreen's reset button

### What changed?
- Removed SecondaryButton usage in DateTimeSelectorScreen
- Implemented reset functionality using a clickable Text component with proper styling and padding
- Added TODO comments for future button component implementations (CtaButton, Button, SubtleButton)

### How to test?
1. Navigate to the DateTimeSelectorScreen
2. Verify the "Reset" button appears in the TitleBar
3. Click the reset button and confirm it:
   - Updates the date to current date
   - Updates time to current time
   - Sets journey time option to "LEAVE"
   - Triggers reset functionality

### Why make this change?
To simplify the reset button implementation and lay groundwork for a more consistent button component system across the application. This change removes dependency on SecondaryButton while maintaining the same functionality with a more basic Text component.