### PR TITLE
UI: Add SubtleButton component to TAJ

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
@@ -71,7 +71,7 @@ internal fun transportModeBackgroundColor(transportMode: TransportMode): Color {
     }
 }
 
-@Composable
+@Composable // TODO - remove and move to taj
 internal fun themeBackgroundColor(): Color {
     val themeColor by LocalThemeColor.current
     return if (isSystemInDarkTheme()) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -46,6 +46,7 @@ import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
+import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -160,8 +161,8 @@ fun TimeTableScreen(
             }
 
             item {
-                SecondaryButton(
-                    text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
+                SubtleButton(
+                    label = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
                     onClick = dateTimeSelectorClicked,
                 )
             }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -1,5 +1,8 @@
 package xyz.ksharma.krail.taj
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 
 fun String.hexToComposeColor(): Color {
@@ -44,4 +47,14 @@ private fun String.isValidHexColorCode(): Boolean {
     // Regular expression to match #RRGGBB or #RRGGBBAA hex color codes
     val hexColorRegex = Regex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})\$")
     return hexColorRegex.matches(this)
+}
+
+@Composable
+internal fun themeBackgroundColor(): Color {
+    val themeColor by LocalThemeColor.current
+    return if (isSystemInDarkTheme()) {
+        themeColor.hexToComposeColor().copy(alpha = 0.45f)
+    } else {
+        themeColor.hexToComposeColor().copy(alpha = 0.15f)
+    }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContentAlpha
@@ -29,6 +30,7 @@ import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.EnabledContentAlpha
 
@@ -75,19 +77,57 @@ fun Button(
             textAlign = TextAlign.Center,
             color = LocalOnContentColor.current.copy(alpha = contentAlpha),
             style = LocalTextStyle.current,
-            modifier = modifier
-                .fillMaxWidth()
+            modifier = modifier.fillMaxWidth()
                 .padding(horizontal = 24.dp) // TODO - tokens for padding
                 .clip(RoundedCornerShape(50))
-                .background(color = LocalContentColor.current.copy(alpha = contentAlpha))
-                .clickable(
+                .background(color = LocalContentColor.current.copy(alpha = contentAlpha)).clickable(
                     role = Role.Button,
                     interactionSource = remember { MutableInteractionSource() },
                     enabled = enabled,
                     indication = null,
                     onClick = onClick,
+                ).padding(10.dp), // TODO - tokens for padding
+        )
+    }
+}
+
+@Composable
+fun SubtleButton(
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    onClick: () -> Unit = {},
+) {
+    val contentAlphaProvider =
+        rememberSaveable(enabled) { if (enabled) EnabledContentAlpha else DisabledContentAlpha }
+
+    val themeColor by LocalThemeColor.current
+    val contentColor by rememberSaveable(themeColor) { mutableStateOf(themeColor) }
+
+    CompositionLocalProvider(
+        LocalContentAlpha provides contentAlphaProvider,
+        LocalTextStyle provides KrailTheme.typography.titleMedium,
+        LocalContentColor provides contentColor.hexToComposeColor(),
+        LocalOnContentColor provides getForegroundColor(contentColor.hexToComposeColor()),
+    ) {
+        val contentAlpha = LocalContentAlpha.current
+
+        Text(
+            text = label,
+            style = KrailTheme.typography.titleSmall.copy(fontWeight = FontWeight.Normal),
+            color = LocalOnContentColor.current.copy(alpha = contentAlpha),
+            modifier = modifier.padding(10.dp)
+                .clickable(
+                    role = Role.Button,
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onClick,
                 )
-                .padding(10.dp), // TODO - tokens for padding
+                .background(
+                    color = themeBackgroundColor(),
+                    shape = RoundedCornerShape(50),
+                )
+                .padding(horizontal = 12.dp, vertical = 6.dp)
         )
     }
 }


### PR DESCRIPTION
### TL;DR
Introduced a new `SubtleButton` component and relocated theme background color functionality to the taj design system.

### What changed?
- Added a new `SubtleButton` component with a subtle background and rounded corners
- Moved `themeBackgroundColor()` function from trip planner to the taj design system
- Updated TimeTableScreen to use the new `SubtleButton` instead of `SecondaryButton`
- Added TODO comment to remove duplicate theme background color function

### How to test?
1. Navigate to the TimeTableScreen
2. Verify the date/time selector button displays with subtle styling
3. Confirm the button responds to clicks correctly
4. Check that the button's appearance is consistent in both light and dark themes

### Why make this change?
To enhance the design system's button offerings with a more subtle variant and consolidate theme-related functionality in the taj design system, promoting better code organization and reusability.