### PR TITLE
UI: Replace clickable with klickable modifier

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/IconButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/IconButton.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -13,7 +12,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.modifier.klickable
 
+//TODO - Should be RoundIconButton
 @Composable
 fun IconButton(
     painter: Painter,
@@ -25,7 +26,8 @@ fun IconButton(
         modifier = modifier
             .size(56.dp)
             .clip(CircleShape)
-            .clickable { onClick() }, contentAlignment = Alignment.Center
+            .klickable { onClick() },
+        contentAlignment = Alignment.Center,
     ) {
         Image(
             painter = painter,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OutlineRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OutlineRadioButton.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeContentColor
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
@@ -63,15 +64,13 @@ fun OutlineRadioButton(
                 .border(
                     width = 2.dp,
                     color = borderColor,
-                    shape = RoundedCornerShape(8.dp)
+                    shape = RoundedCornerShape(8.dp),
                 )
-                .padding(vertical = 4.dp, horizontal = 12.dp)
-                .clickable(
+                .klickable(
                     onClick = onClick,
                     enabled = enabled,
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                ),
+                )
+                .padding(vertical = 4.dp, horizontal = 12.dp),
             contentAlignment = Alignment.Center,
         ) {
             Text(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -33,6 +31,7 @@ import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -55,11 +54,7 @@ fun SavedTripCard(
                 color = primaryTransportMode?.let { transportModeBackgroundColor(it) }
                     ?: themeBackgroundColor(),
             )
-            .clickable(
-                role = Role.Button,
-                onClickLabel = "Open Trip Details",
-                onClick = onCardClick,
-            )
+            .klickable(onClick = onCardClick)
             .padding(vertical = 16.dp, horizontal = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -112,12 +112,10 @@ fun DateTimeSelectorScreen(
         TitleBar(title = { Text(text = "Plan your trip") },
             onNavActionClick = onBackClick,
             actions = {
-
                 TextButton(
                     onClick = {
-                        val now: LocalDateTime =
-                            Clock.System.now()
-                                .toLocalDateTime(TimeZone.currentSystemDefault())
+                        val now: LocalDateTime = Clock.System.now()
+                            .toLocalDateTime(TimeZone.currentSystemDefault())
                         selectedDateStr = now.date.toString()
                         timePickerState.hour = now.time.hour
                         timePickerState.minute = now.time.minute
@@ -125,7 +123,7 @@ fun DateTimeSelectorScreen(
                         reset = true
                         onResetClick()
                     },
-                    dimensions = ButtonDefaults.mediumButtonSize(),
+                    dimensions = ButtonDefaults.largeButtonSize(),
                 ) {
                     Text("Reset")
                 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -68,6 +68,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.backgroundColorOf
+import xyz.ksharma.krail.taj.modifier.klickable
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @Composable
@@ -229,10 +230,7 @@ fun SearchStopScreen(
                     modifier = Modifier
                         .size(48.dp)
                         .clip(CircleShape)
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() },
-                        ) {
+                        .klickable {
                             keyboard?.hide()
                             focusRequester.freeFocus()
                             backClicked = true

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.modifier.klickable
 
 @Composable
 fun SettingsScreen(
@@ -66,12 +67,7 @@ fun SettingsScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
-                        .clickable(
-                            role = Role.Button,
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() },
-                            onClick = { onChangeThemeClick() },
-                        )
+                        .klickable(onClick = { onChangeThemeClick() })
                         .padding(vertical = 24.dp)
                         .semantics(mergeDescendants = true) {},
                     horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -4,8 +4,6 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -24,14 +22,12 @@ import androidx.compose.material3.ButtonColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
@@ -40,10 +36,11 @@ import kotlinx.collections.immutable.toImmutableSet
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.transportModeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
@@ -170,12 +167,8 @@ private fun TransportModeRadioButton(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
+            .klickable { onClick(mode) }
             .background(color = backgroundColor, shape = RoundedCornerShape(12.dp))
-            .clickable(
-                role = Role.Button,
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() },
-            ) { onClick(mode) }
             .padding(vertical = 24.dp, horizontal = 24.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -43,19 +41,19 @@ import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.ActionData
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
 import xyz.ksharma.krail.trip.planner.ui.components.OriginDestination
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
 import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiAnim
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -308,8 +306,11 @@ fun ActionButton(
     content: @Composable () -> Unit,
 ) {
     Box(
-        modifier = modifier.size(40.dp).clip(CircleShape)
-            .clickable(role = Role.Button) { onClick() }.semantics(mergeDescendants = true) {
+        modifier = modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .klickable { onClick() }
+            .semantics(mergeDescendants = true) {
                 this.contentDescription = contentDescription
             },
         contentAlignment = Alignment.Center,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -54,6 +54,12 @@ private fun String.isValidHexColorCode(): Boolean {
 }
 
 @Composable
+fun themeColor(): Color {
+    val themeColor by LocalThemeColor.current
+    return themeColor.hexToComposeColor()
+}
+
+@Composable
 fun themeBackgroundColor(): Color {
     val themeColor by LocalThemeColor.current
     return if (isSystemInDarkTheme()) {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -298,7 +298,7 @@ object ButtonDefaults {
 
     fun mediumButtonSize(): ButtonDimensions {
         return ButtonDimensions(
-            height = 28.dp,
+            height = 32.dp,
             padding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
         )
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/RoundIconButton.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/RoundIconButton.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.taj.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -11,9 +10,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.Role
 import xyz.ksharma.krail.taj.LocalContainerColor
 import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.tokens.ButtonTokens.RoundButtonSize
 
@@ -43,10 +42,7 @@ fun RoundIconButton(
                 .size(RoundButtonSize) // TODO - token "SearchButtonHeight"
                 .clip(CircleShape)
                 .background(color = color ?: LocalContainerColor.current)
-                .clickable(
-                    role = Role.Button,
-                    onClickLabel = onClickLabel,
-                ) { onClick() },
+                .klickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {
             content()

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextFieldButton.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextFieldButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.tokens.TextFieldTokens
 import xyz.ksharma.krail.taj.tokens.TextFieldTokens.TextFieldHeight
@@ -48,9 +49,9 @@ fun TextFieldButton(
             modifier = modifier
                 .fillMaxWidth()
                 .height(TextFieldHeight)
-                .clip(RoundedCornerShape(TextFieldHeight.div(2)))
+                .clip(RoundedCornerShape(50))
                 .background(color = KrailTheme.colors.surface)
-                .clickable(role = Role.Button, onClick = onClick)
+                .klickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 4.dp),
             contentAlignment = Alignment.CenterStart,
         ) {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TitleBar.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TitleBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContainerColor
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
@@ -78,19 +79,17 @@ fun TitleBar(
     }
 }
 
+// TODO should be same as IconButton / RoundIconButton
 @Composable
 private fun NavActionButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier.size(40.dp).clip(CircleShape)
-            .clickable(
-                role = Role.Button,
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onClick,
-            )
+        modifier = modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .klickable(onClick = onClick)
             .semantics(mergeDescendants = true) {
                 this.contentDescription = "Back"
             },

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
@@ -3,15 +3,11 @@ package xyz.ksharma.krail.taj.modifier
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
-import xyz.ksharma.krail.taj.LocalThemeColor
-import xyz.ksharma.krail.taj.brighten
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.krailRipple
+import xyz.ksharma.krail.taj.themeBackgroundColor
 
 /**
  * Adds a click listener to the Modifier with a custom ripple effect.
@@ -30,14 +26,11 @@ fun Modifier.klickable(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     onClick: () -> Unit,
 ): Modifier {
-    val themeColorHex by LocalThemeColor.current
-    val themeColor by remember { mutableStateOf(themeColorHex.hexToComposeColor()) }
-
     return this.clickable(
         role = role,
         interactionSource = interactionSource,
         enabled = enabled,
-        indication = krailRipple(color = themeColor.brighten()),
+        indication = krailRipple(color = themeBackgroundColor()),
         onClick = onClick,
     )
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import xyz.ksharma.krail.taj.theme.krailRipple
-import xyz.ksharma.krail.taj.themeBackgroundColor
+import xyz.ksharma.krail.taj.themeColor
 
 /**
  * Adds a click listener to the Modifier with a custom ripple effect.
@@ -30,7 +30,7 @@ fun Modifier.klickable(
         role = role,
         interactionSource = interactionSource,
         enabled = enabled,
-        indication = krailRipple(color = themeBackgroundColor()),
+        indication = krailRipple(color = themeColor()),
         onClick = onClick,
     )
 }


### PR DESCRIPTION
### TL;DR
Standardized click interactions across the app by implementing a consistent `klickable` modifier and unified button sizes.

### What changed?
- Replaced all `clickable` modifiers with the custom `klickable` modifier
- Updated button dimensions for consistency (medium button height increased to 32dp)
- Standardized circular button sizes to 48dp
- Modified ripple effect color to use theme background color
- Adjusted TextFieldButton corner radius to 50%
- Removed unused imports and cleaned up formatting

### How to test?
1. Navigate through the app and verify click interactions work as expected
2. Check that all buttons maintain consistent sizing
3. Verify ripple effects are visible and uniform across:
   - Icon buttons
   - Text field buttons
   - Navigation buttons
   - Radio buttons
   - Saved trip cards

### Why make this change?
To improve UI consistency and user experience by:
- Ensuring predictable touch targets across the app
- Maintaining uniform visual feedback for interactions
- Reducing code duplication through standardized click handling
- Following Material Design guidelines for touch target sizes