### PR TITLE
UI: Refactor transport mode badge and icon styles

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -29,7 +30,7 @@ fun TransportModeBadge(
 
     Box(
         modifier = modifier
-            .requiredHeight(height = with(density) { 18.sp.toDp() })
+            .requiredHeightIn(with(density) { 22.sp.toDp() })
             .clip(shape = RoundedCornerShape(percent = 20))
             .background(color = backgroundColor),
         contentAlignment = Alignment.Center,
@@ -38,7 +39,7 @@ fun TransportModeBadge(
             text = badgeText,
             color = Color.White,
             // todo - need concrete token for style, meanwhile keep same as TransportModeIcon.
-            style = KrailTheme.typography.labelMedium.copy(fontWeight = FontWeight.Medium),
+            style = KrailTheme.typography.labelLarge,
             modifier = Modifier
                 .padding(2.dp)
                 .wrapContentWidth(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -28,11 +28,11 @@ fun TransportModeIcon(
     backgroundColor: Color,
     modifier: Modifier = Modifier,
     borderEnabled: Boolean = false,
-    iconSize: TextUnit = 18.sp,
+    iconSize: TextUnit = 22.sp,
     fontSize: TextUnit? = null,
 ) {
     val density = LocalDensity.current
-    val textStyle = KrailTheme.typography.labelLarge.copy(fontWeight = FontWeight.Medium)
+    val textStyle = KrailTheme.typography.labelLarge
 
     // Content alphas should always be 100% for Transport related icons
     CompositionLocalProvider(LocalContentAlpha provides 1f) {
@@ -41,18 +41,15 @@ fun TransportModeIcon(
                 .clip(shape = CircleShape)
                 .requiredSize(with(density) { iconSize.toDp() })
                 .aspectRatio(1f)
-                .background(color = backgroundColor)
-                .borderIfEnabled(enabled = borderEnabled),
+                .borderIfEnabled(enabled = borderEnabled)
+                .background(color = backgroundColor),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = "$letter",
                 color = Color.White,
                 // todo - need concrete token for style, meanwhile keep same as TransportModeBadge,
-                style = textStyle.copy(
-                    fontWeight = FontWeight.Medium,
-                    fontSize = fontSize ?: textStyle.fontSize,
-                ),
+                style = textStyle.copy(fontSize = fontSize ?: textStyle.fontSize),
             )
         }
     }
@@ -60,7 +57,7 @@ fun TransportModeIcon(
 
 private fun Modifier.borderIfEnabled(enabled: Boolean): Modifier =
     if (enabled) {
-        this.then(Modifier.border(width = 1.dp, color = Color.White, shape = CircleShape))
+        this.then(border(width = 1.dp, color = Color.White, shape = CircleShape))
     } else {
         this
     }


### PR DESCRIPTION
### TL;DR
Updated the visual styling of transport mode indicators to improve consistency and readability

### What changed?
- Increased transport mode icon size from 18sp to 22sp
- Adjusted badge height to match new icon size
- Simplified typography by removing redundant font weight modifications
- Standardized on `labelLarge` typography style
- Reordered border and background modifiers for consistent rendering

### Why make this change?
To establish visual consistency across transport mode indicators while improving readability through larger text size and cleaner typography implementation. This change aligns with design system best practices by reducing redundant style modifications.