### PR TITLE
UI: Add scaling click animation to Button component

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -32,6 +32,7 @@ import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.modifier.scalingKlickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.theme.krailRipple
@@ -65,11 +66,8 @@ fun Button(
                         else -> Modifier
                     }
                 )
-                .clickable(
-                    role = Role.Button,
-                    interactionSource = remember { MutableInteractionSource() },
+                .scalingKlickable(
                     enabled = enabled,
-                    indication = null,
                     onClick = onClick,
                 )
                 .heightIn(dimensions.height)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Indication.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Indication.kt
@@ -1,0 +1,53 @@
+package xyz.ksharma.krail.taj.modifier
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.node.DrawModifierNode
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple
+ */
+ class ScaleIndicationNode(
+    private val interactionSource: InteractionSource
+) : Modifier.Node(), DrawModifierNode {
+    private var currentPressPosition: Offset = Offset.Zero
+    private val animatedScalePercent = Animatable(1f)
+
+    private suspend fun animateToPressed(pressPosition: Offset) {
+        currentPressPosition = pressPosition
+        animatedScalePercent.animateTo(0.9f, spring())
+    }
+
+    private suspend fun animateToResting() {
+        animatedScalePercent.animateTo(1f, spring())
+    }
+
+    override fun onAttach() {
+        coroutineScope.launch {
+            interactionSource.interactions.collectLatest { interaction ->
+                when (interaction) {
+                    is PressInteraction.Press -> animateToPressed(interaction.pressPosition)
+                    is PressInteraction.Release -> animateToResting()
+                    is PressInteraction.Cancel -> animateToResting()
+                }
+            }
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        scale(
+            scale = animatedScalePercent.value,
+            pivot = currentPressPosition
+        ) {
+            this@draw.drawContent()
+        }
+    }
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
@@ -1,10 +1,13 @@
 package xyz.ksharma.krail.taj.modifier
 
+import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.semantics.Role
 import xyz.ksharma.krail.taj.theme.krailRipple
 import xyz.ksharma.krail.taj.themeColor
@@ -33,4 +36,30 @@ fun Modifier.klickable(
         indication = krailRipple(color = themeColor()),
         onClick = onClick,
     )
+}
+
+@Composable
+fun Modifier.scalingKlickable(
+    role: Role = Role.Button,
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    onClick: () -> Unit,
+): Modifier {
+    return this.clickable(
+        role = role,
+        interactionSource = interactionSource,
+        enabled = enabled,
+        indication = ScalingIndication,
+        onClick = onClick,
+    )
+}
+
+object ScalingIndication : IndicationNodeFactory {
+    override fun create(interactionSource: InteractionSource): DelegatableNode {
+        return ScaleIndicationNode(interactionSource)
+    }
+
+    override fun equals(other: Any?): Boolean = other === this
+
+    override fun hashCode(): Int = -1
 }


### PR DESCRIPTION
### TL;DR
Added a new scaling click animation for buttons that shrinks the component when pressed.

### What changed?
- Created a new `ScaleIndicationNode` that handles press animations
- Added `scalingKlickable` modifier that implements the scaling animation
- Updated the Button component to use the new scaling animation instead of the default click behavior
- The scaling animation shrinks components to 90% of their size when pressed

### How to test?
1. Run the app and navigate to any screen with buttons
2. Press and hold a button to see it scale down
3. Release the button to see it animate back to full size
4. Verify the animation feels smooth and responsive

### Why make this change?
To provide better visual feedback during button interactions, making the UI feel more dynamic and responsive. The scaling animation gives users clear indication that their touch input was registered, improving the overall user experience.