### PR TITLE
UI: Replace klickable with scalingKlickable in radio buttons

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OutlineRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OutlineRadioButton.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.modifier.scalingKlickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeContentColor
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
@@ -66,7 +67,7 @@ fun OutlineRadioButton(
                     color = borderColor,
                     shape = RoundedCornerShape(8.dp),
                 )
-                .klickable(
+                .scalingKlickable(
                     onClick = onClick,
                     enabled = enabled,
                 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -38,6 +38,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.modifier.scalingKlickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
@@ -167,7 +168,7 @@ private fun TransportModeRadioButton(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
-            .klickable { onClick(mode) }
+            .scalingKlickable { onClick(mode) }
             .background(color = backgroundColor, shape = RoundedCornerShape(12.dp))
             .padding(vertical = 24.dp, horizontal = 24.dp),
         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
### TL;DR
Updated click interactions in the Trip Planner UI to include scaling animations

### What changed?
- Replaced standard `klickable` modifier with `scalingKlickable` in OutlineRadioButton
- Updated TransportModeRadioButton to use `scalingKlickable` for enhanced touch feedback

### How to test?
1. Navigate to the Theme Selection screen
2. Tap on different transport mode options
3. Verify that buttons now scale slightly when pressed
4. Confirm that the outline radio buttons have the same scaling behavior

### Why make this change?
To improve touch feedback and create a more engaging user experience by adding subtle scaling animations to interactive elements in the Trip Planner interface