### PR TITLE
UI: Add 2025 festival dates for TimeTable loading screen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -85,8 +85,17 @@ object LoadingEmojiManager {
 
         // Can change dates
 
-        // Chinese New Year
+        // Chinese New Year 2025
         FestivalType.CHINESE_NEW_YEAR to MonthDay.of(1, 29),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(1, 30),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(1, 31),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(2, 1),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(2, 2),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(2, 3),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(2, 4),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(2, 5),
+        FestivalType.CHINESE_NEW_YEAR to MonthDay.of(2, 6),
+
         FestivalType.HOLI to MonthDay.of(3, 14),
         FestivalType.EID to MonthDay.of(3, 30),
         FestivalType.EID to MonthDay.of(3, 31),
@@ -112,6 +121,7 @@ object LoadingEmojiManager {
         // Easter 2025
         FestivalType.EASTER to MonthDay.of(4, 20),
 
+        // Vivid Sydney 2025
         FestivalType.VIVID_SYDNEY to MonthDay.of(5, 23),
         FestivalType.VIVID_SYDNEY to MonthDay.of(5, 24),
         FestivalType.VIVID_SYDNEY to MonthDay.of(5, 25),


### PR DESCRIPTION
### TL;DR
Added 2025 festival dates for Chinese New Year and labeled existing festival dates.

### What changed?
- Extended Chinese New Year celebration period from January 29 to February 6, 2025
- Added year labels to existing festival dates (Easter 2025, Vivid Sydney 2025)

### How to test?
1. Launch the app during Chinese New Year period (Jan 29 - Feb 6, 2025)
2. Verify that appropriate festival emojis appear during loading screens
3. Confirm loading emojis appear correctly for other labeled festivals (Easter, Vivid Sydney)

### Why make this change?
To ensure the app displays culturally appropriate loading animations during the extended Chinese New Year celebration period in 2025 and to improve code clarity by explicitly labeling festival years.