### PR TITLE
UI: Move ScalingIndication to dedicated file

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/Klickable.kt
@@ -1,13 +1,10 @@
 package xyz.ksharma.krail.taj.modifier
 
-import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.semantics.Role
 import xyz.ksharma.krail.taj.theme.krailRipple
 import xyz.ksharma.krail.taj.themeColor
@@ -52,14 +49,4 @@ fun Modifier.scalingKlickable(
         indication = ScalingIndication,
         onClick = onClick,
     )
-}
-
-object ScalingIndication : IndicationNodeFactory {
-    override fun create(interactionSource: InteractionSource): DelegatableNode {
-        return ScaleIndicationNode(interactionSource)
-    }
-
-    override fun equals(other: Any?): Boolean = other === this
-
-    override fun hashCode(): Int = -1
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/ScalingIndication.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/ScalingIndication.kt
@@ -2,15 +2,27 @@ package xyz.ksharma.krail.taj.modifier
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+
+object ScalingIndication : IndicationNodeFactory {
+    override fun create(interactionSource: InteractionSource): DelegatableNode {
+        return ScaleIndicationNode(interactionSource)
+    }
+
+    override fun equals(other: Any?): Boolean = other === this
+
+    override fun hashCode(): Int = -1
+}
 
 /**
  * https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple


### PR DESCRIPTION
### TL;DR
Moved scaling indication logic into its own file and cleaned up unused imports

### What changed?
- Relocated `ScalingIndication` object from `Klickable.kt` to a dedicated `ScalingIndication.kt` file
- Removed unused imports from `Klickable.kt`
- Renamed `Indication.kt` to `ScalingIndication.kt` to better reflect its contents

