### PR TITLE
Version: Bump to 1.0.7

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 37
-        versionName = "1.0.6"
+        versionCode = 39
+        versionName = "1.0.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.6</string>
+	<string>1.0.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Bumped version numbers for both Android and iOS apps to 1.0.7

### What changed?
- Android version code increased from 37 to 39
- Android version name updated from 1.0.6 to 1.0.7
- iOS bundle version string updated from 1.0.6 to 1.0.7

### How to test?
1. Build and install the app on both Android and iOS devices
2. Verify the version number shows as 1.0.7 in app settings/info
3. Verify the app installs and updates correctly from previous versions

### Why make this change?
Preparing for a new release by incrementing version numbers to maintain proper versioning across platforms and ensure consistent app store deployment.