### PR TITLE
Analytics: Add theme and timestamp to app_start event

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
@@ -71,6 +71,7 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
                 val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
                 val themeColor by viewModel.uiState.collectAsStateWithLifecycle()
 
+                // Set theme in CompositionLocal
                 themeId = themeColor.id
                 themeColorHexCode.value = themeColor.hexColorCode
 

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -46,6 +46,7 @@ class SplashViewModel(
                 fontSize = fontSize,
                 isDarkTheme = isDarkTheme,
                 deviceModel = deviceModel,
+                krailTheme = _uiState.value.id,
             )
         )
     }

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.core.analytics.event
 
+import kotlinx.datetime.Clock
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
@@ -137,6 +138,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val deviceModel: String,
         val fontSize: String,
         val isDarkTheme: Boolean,
+        val krailTheme: Int,
     ) : AnalyticsEvent(
         name = "app_start",
         properties = mapOf(
@@ -146,8 +148,9 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             "deviceModel" to deviceModel,
             "fontSize" to fontSize,
             "isDarkTheme" to isDarkTheme,
+            "krailTheme" to krailTheme,
+            "timeStamp" to Clock.System.now().toString(),
         )
     )
-
     // endregion
 }


### PR DESCRIPTION
### TL;DR
Added theme ID tracking to app start analytics and included event timestamps.

### What changed?
- Added `krailTheme` property to track theme ID in app start analytics
- Added `timeStamp` to app start analytics using `Clock.System.now()`
- Added clarifying comment for theme setting in CompositionLocal
- Updated `SplashViewModel` to pass theme ID to analytics event

### How to test?
1. Launch the app
2. Verify the app start analytics event includes:
   - Theme ID
   - Current timestamp
   - Device model
   - Font size
   - Dark theme setting
3. Confirm theme colors are still applied correctly

### Why make this change?
To enhance analytics data by tracking theme preferences and precise event timing. This data will help understand user customization patterns and provide accurate usage timestamps for better analysis.