### PR TITLE
AppInfo: Hide build version in release builds for iOS

### DIFF
--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -22,7 +22,7 @@ class IOSAppInfo : AppInfo {
                     ?: "Unknown"
             val buildVersion =
                 NSBundle.mainBundle.infoDictionary?.get("CFBundleVersion") as? String ?: "Unknown"
-            return "$shortVersion ($buildVersion)"
+            return "$shortVersion ${if (isDebug) "($buildVersion)" else ""}"
         }
 
     override val osVersion: String


### PR DESCRIPTION
### TL;DR
Modified iOS version string format to only show build version in debug builds

### What changed?
Updated the version string formatting in `IOSAppInfo` to conditionally display the build version number in parentheses only when running in debug mode. Release builds will now only show the short version.

### How to test?
1. Run the app in debug mode and verify version shows as "1.0.0 (123)"
2. Run the app in release mode and verify version shows as "1.0.0"

### Why make this change?
Build version numbers are primarily useful during development and debugging but add unnecessary complexity to the version string shown to end users in production builds. This change simplifies the version display for regular users while maintaining detailed version information for debugging purposes.