### PR TITLE
GTFS: Add file storage and service implementation

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -107,6 +107,7 @@ kotlin {
             implementation(projects.feature.tripPlanner.ui)
             implementation(projects.sandook)
             implementation(projects.taj)
+            implementation(projects.gtfsStatic)
 
             implementation(libs.navigation.compose)
 

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/AppModule.kt
@@ -11,6 +11,8 @@ import xyz.ksharma.krail.core.appinfo.di.appInfoModule
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.core.di.coroutineDispatchersModule
 import xyz.ksharma.krail.core.remote_config.di.remoteConfigModule
+import xyz.ksharma.krail.gtfs_static.di.fileStorageModule
+import xyz.ksharma.krail.gtfs_static.di.gtfsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.networkModule
@@ -27,6 +29,8 @@ val koinConfig = koinConfiguration {
         analyticsModule,
         remoteConfigModule,
         coroutineDispatchersModule,
+        gtfsModule,
+        fileStorageModule,
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -34,6 +34,8 @@ class SplashViewModel(
         .onStart {
             loadKrailThemeStyle()
             trackAppStartEvent()
+
+            // TODO - handle app stat events separately
             remoteConfig.setup() // App Start Event
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 

--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
                 implementation(projects.feature.tripPlanner.ui)
                 implementation(projects.feature.tripPlanner.state)
                 implementation(projects.feature.tripPlanner.network)
+                implementation(projects.gtfsStatic)
                 implementation(projects.taj)
 
                 implementation(libs.test.kotlin)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeGtfsService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeGtfsService.kt
@@ -1,0 +1,26 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.gtfs_static.NswGtfsService
+
+class FakeGtfsService : NswGtfsService {
+
+    override suspend fun getSydneyTrains() {
+        // Do nothing
+    }
+
+    override suspend fun getSydneyMetro() {
+        // Do nothing
+    }
+
+    override suspend fun getLightRail() {
+        // Do nothing
+    }
+
+    override suspend fun getNswTrains() {
+        // Do nothing
+    }
+
+    override suspend fun getSydneyFerries() {
+        // Do nothing
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -9,11 +9,13 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeGtfsService
 import xyz.ksharma.core.test.fakes.FakeSandook
 import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.gtfs_static.NswGtfsService
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -31,6 +33,7 @@ class SavedTripsViewModelTest {
 
     private val sandook: Sandook = FakeSandook()
     private val fakeAnalytics: Analytics = FakeAnalytics()
+    private val gtfsService: NswGtfsService = FakeGtfsService()
     private lateinit var viewModel: SavedTripsViewModel
 
     private val testDispatcher = StandardTestDispatcher()
@@ -38,7 +41,7 @@ class SavedTripsViewModelTest {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = SavedTripsViewModel(sandook, fakeAnalytics, testDispatcher)
+        viewModel = SavedTripsViewModel(sandook, fakeAnalytics, testDispatcher, gtfsService)
     }
 
     @AfterTest

--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -28,7 +28,7 @@ actual fun httpClient(appInfoProvider: AppInfoProvider): HttpClient {
                 level = LogLevel.BODY
                 logger = object : Logger {
                     override fun log(message: String) {
-                        println(message)
+//                        println(message)
                     }
                 }
                 sanitizeHeader { header -> header == HttpHeaders.Authorization }

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
                 implementation(projects.core.remoteConfig)
                 implementation(projects.feature.tripPlanner.network)
                 implementation(projects.feature.tripPlanner.state)
+                implementation(projects.gtfsStatic)
                 implementation(projects.sandook)
                 implementation(projects.taj)
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -24,6 +24,7 @@ val viewModelsModule = module {
             sandook = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
+            gtfsService = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -18,6 +18,7 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.gtfs_static.NswGtfsService
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -28,12 +29,14 @@ class SavedTripsViewModel(
     private val sandook: Sandook,
     private val analytics: Analytics,
     private val ioDispatcher: CoroutineDispatcher,
+    private val gtfsService: NswGtfsService,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
+            gtfsService.getSydneyTrains() // App Start Event
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
 
     fun onEvent(event: SavedTripUiEvent) {

--- a/gtfs-static/build.gradle.kts
+++ b/gtfs-static/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
                 implementation(projects.core.di)
 
                 api(libs.di.koinComposeViewmodel)
+                implementation(libs.firebase.gitLiveCrashlytics)
             }
         }
 

--- a/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.android.kt
+++ b/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.android.kt
@@ -1,11 +1,21 @@
 package xyz.ksharma.krail.gtfs_static
 
 import android.content.Context
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.crashlytics.crashlytics
+import xyz.ksharma.krail.core.log.log
 import java.io.File
 
 class AndroidFileStorage(private val context: Context) : FileStorage {
     override suspend fun saveFile(fileName: String, data: ByteArray) {
-        val file = File(context.filesDir, fileName)
-        file.writeBytes(data)
+        runCatching {
+            val file = File(context.filesDir, fileName)
+            file.writeBytes(data)
+        }.onFailure {
+            log("Failed to save file: $it")
+            Firebase.crashlytics.recordException(it)
+        }.onSuccess {
+            log("File saved at: ${context.filesDir.absolutePath}")
+        }
     }
 }

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.withContext
 import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
 
-class RealNswGtfsService(
+internal class RealNswGtfsService(
     private val httpClient: HttpClient,
     private val fileStorage: FileStorage,
     private val ioDispatcher: CoroutineDispatcher = DispatchersComponent().ioDispatcher,

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/di/GtfsModule.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/di/GtfsModule.kt
@@ -1,14 +1,14 @@
 package xyz.ksharma.krail.gtfs_static.di
 
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.bind
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import xyz.ksharma.krail.gtfs_static.NswGtfsService
 import xyz.ksharma.krail.gtfs_static.RealNswGtfsService
 
 val gtfsModule = module {
-    singleOf(::RealNswGtfsService) { bind<NswGtfsService>() }
+    single<NswGtfsService> {
+        RealNswGtfsService(get(), get())
+    }
 }
 
 expect val fileStorageModule: Module

--- a/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
+++ b/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.gtfs_static
 
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.crashlytics.crashlytics
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
@@ -14,21 +16,28 @@ import xyz.ksharma.krail.core.log.log
 class IosFileStorage : FileStorage {
     @OptIn(ExperimentalForeignApi::class)
     override suspend fun saveFile(fileName: String, data: ByteArray) {
-        log("Saving file: $fileName")
-        val fileManager = NSFileManager.defaultManager
-        val directory = fileManager.URLForDirectory(
-            directory = NSDocumentDirectory,
-            inDomain = NSUserDomainMask,
-            appropriateForURL = null,
-            create = true,
-            error = null,
-        )?.path
+        log("Trying to Save file: $fileName")
+        runCatching {
+            val fileManager = NSFileManager.defaultManager
+            val directory = fileManager.URLForDirectory(
+                directory = NSDocumentDirectory,
+                inDomain = NSUserDomainMask,
+                appropriateForURL = null,
+                create = true,
+                error = null,
+            )?.path
 
-        val filePath = "$directory/$fileName"
-        data.usePinned { pinned ->
-            NSData.dataWithBytes(pinned.addressOf(0), data.size.toULong())
-                .writeToFile(filePath, true)
+            val filePath = "$directory/$fileName"
+            data.usePinned { pinned ->
+                NSData.dataWithBytes(pinned.addressOf(0), data.size.toULong())
+                    .writeToFile(filePath, true)
+            }
+            log("File saved: $filePath")
+        }.onFailure {
+            log("Failed to save file: $it")
+            Firebase.crashlytics.recordException(it) // todo - move to another module
+        }.onSuccess {
+            log("File saved successfully")
         }
-        log("File saved: $filePath")
     }
 }


### PR DESCRIPTION
### TL;DR
Added GTFS static file download and storage functionality for NSW train data.

### What changed?
- Integrated GTFS static module into the app and trip planner feature
- Added file storage implementations for both Android and iOS platforms
- Implemented crash reporting for file storage failures
- Added NSW GTFS service to download train data
- Disabled HTTP client logging in trip planner network module

### How to test?
1. Launch the app
2. Navigate to the Saved Trips screen
3. Verify that GTFS data is downloaded and stored locally
4. Check device's file storage for saved GTFS files
5. Verify crash reporting works by simulating a file storage failure

### Why make this change?
To enable offline access to NSW train schedule data by downloading and storing GTFS static files locally on the device. This will improve app reliability and reduce dependency on network connectivity for basic schedule information.