### PR TITLE
Analytics: Add locale, battery and timezone to app_start event

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.RemoteConfig
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
@@ -38,15 +39,19 @@ class SplashViewModel(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     private fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {
+        log("AppInfo: $this")
         analytics.track(
             AnalyticsEvent.AppStart(
-                deviceType = devicePlatformType.name,
+                platformType = devicePlatformType.name,
                 osVersion = osVersion,
                 appVersion = appVersion,
                 fontSize = fontSize,
                 isDarkTheme = isDarkTheme,
                 deviceModel = deviceModel,
                 krailTheme = _uiState.value.id,
+                locale = locale,
+                batteryLevel = batteryLevel,
+                timeZone = timeZone
             )
         )
     }

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -132,17 +132,20 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         )
 
     data class AppStart(
-        val deviceType: String,
+        val platformType: String,
         val appVersion: String,
         val osVersion: String,
         val deviceModel: String,
         val fontSize: String,
         val isDarkTheme: Boolean,
         val krailTheme: Int,
+        val locale: String,
+        val batteryLevel: Int,
+        val timeZone: String,
     ) : AnalyticsEvent(
         name = "app_start",
         properties = mapOf(
-            "deviceType" to deviceType,
+            "platformType" to platformType,
             "appVersion" to appVersion,
             "osVersion" to osVersion,
             "deviceModel" to deviceModel,
@@ -150,6 +153,9 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             "isDarkTheme" to isDarkTheme,
             "krailTheme" to krailTheme,
             "timeStamp" to Clock.System.now().toString(),
+            "locale" to locale,
+            "batteryLevel" to batteryLevel,
+            "timeZone" to timeZone,
         )
     )
     // endregion

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -1,8 +1,10 @@
 package xyz.ksharma.krail.core.appinfo
 
 import android.content.Context
-import android.os.Build
+import android.content.Context.BATTERY_SERVICE
 import android.content.res.Configuration
+import android.os.BatteryManager
+import android.os.Build
 
 class AndroidAppInfo(private val context: Context) : AppInfo {
 
@@ -32,16 +34,41 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
             return (uiMode and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
         }
 
+    /**
+     * Device model. E.g. "Pixel 4"
+     */
     override val deviceModel: String
         get() = Build.MODEL
 
+    /**
+     * Device manufacturer. E.g. "Google"
+     */
     override val deviceManufacturer: String
         get() = Build.BRAND
 
+    /**
+     * Locale. E.g. "en_US"
+     */
+    override val locale: String
+        get() {
+            val localeList = context.resources.configuration.locales
+            return localeList.toLanguageTags()
+        }
+
+    override val batteryLevel: Int
+        get() {
+            val bm = context.getSystemService(BATTERY_SERVICE) as BatteryManager
+            return bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY)
+        }
+
+    override val timeZone: String
+        get() = java.util.TimeZone.getDefault().id
+
     override fun toString() =
-        "AndroidAppInfo(type=$devicePlatformType, isDebug=${isDebug}, version=$appVersion, osVersion=$osVersion, " +
+        "AndroidAppInfo(type=$devicePlatformType, isDebug=${isDebug}, appVersion=$appVersion, osVersion=$osVersion, " +
                 "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
-                "deviceManufacturer=$deviceManufacturer)"
+                "deviceManufacturer=$deviceManufacturer, locale=$locale, batteryLevel=$batteryLevel, " +
+                "timeZone=$timeZone)"
 }
 
 class AndroidAppInfoProvider(private val context: Context) : AppInfoProvider {

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -4,8 +4,14 @@ package xyz.ksharma.krail.core.appinfo
  * Inject [AppInfoProvider] to get instance of [AppInfo].
  */
 interface AppInfo {
+    /**
+     * Platform type. E.g. Android, iOS.
+     */
     val devicePlatformType: DevicePlatformType
 
+    /**
+     * Debug status. E.g. true if debug build.
+     */
     val isDebug: Boolean
 
     /**
@@ -13,15 +19,59 @@ interface AppInfo {
      */
     val appVersion: String
 
+    /**
+     * OS version.
+     * E.g.
+     *  - "30" for Android 11.
+     *  - "14.5" for iOS 14.5
+     */
     val osVersion: String
 
+    /**
+     * Font size.
+     * E.g. "L" for iOS
+     * E.g. "1.0" for Android
+     */
     val fontSize: String
 
+    /**
+     * Dark theme status.
+     * E.g. true if dark theme is enabled.
+     */
     val isDarkTheme: Boolean
 
+    /**
+     * Device model.
+     * E.g. "Pixel 4" for Android
+     * E.g. "iPhone" for iOS - Apple does not share this info.
+     */
     val deviceModel: String
 
+    /**
+     * Device manufacturer.
+     * E.g. "Google", "Samsung" for Android
+     * E.g. "Apple" for iOS
+     */
     val deviceManufacturer: String
+
+    /**
+     * Locale.
+     * Android - Provides list of all language tags
+     * iOS - Provides locale identifier, such as "en_US"
+     */
+    val locale: String
+
+    /**
+     * Battery level.
+     * E.g. 50 for 50% battery level.
+     */
+    val batteryLevel: Int
+
+    /**
+     * Timezone.
+     * E.g. "Australia/Sydney"
+     */
+    val timeZone: String
 }
 
 enum class DevicePlatformType {

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -1,11 +1,17 @@
 package xyz.ksharma.krail.core.appinfo
 
 import platform.Foundation.NSBundle
+import platform.Foundation.NSLocale
+import platform.Foundation.NSTimeZone
+import platform.Foundation.currentLocale
+import platform.Foundation.localTimeZone
+import platform.Foundation.localeIdentifier
 import platform.UIKit.UIApplication
 import platform.UIKit.UIDevice
 import platform.UIKit.UIScreen
 import platform.UIKit.UIUserInterfaceStyle
 import kotlin.experimental.ExperimentalNativeApi
+import kotlin.math.absoluteValue
 
 class IOSAppInfo : AppInfo {
 
@@ -41,20 +47,30 @@ class IOSAppInfo : AppInfo {
             return userInterfaceStyle == UIUserInterfaceStyle.UIUserInterfaceStyleDark
         }
 
-    /**
-     * TODO - what a hack! This is not the device model.
-     *    There needs to be a better way to do it without using 3rd party libraries.
-     */
+    // Note: this is not real device model, Apple does not share this info.
     override val deviceModel: String
         get() = UIDevice.currentDevice.model
 
     override val deviceManufacturer: String
         get() = "Apple"
 
+    override val locale: String
+        get() = NSLocale.currentLocale.localeIdentifier
+
+    override val batteryLevel: Int
+        get() {
+            val level = UIDevice.currentDevice.batteryLevel
+            return (level * 100).toInt().absoluteValue
+        }
+
+    override val timeZone: String
+        get() = NSTimeZone.localTimeZone.name
+
     override fun toString() =
-        "AndroidAppInfo(type=$devicePlatformType, isDebug=${isDebug}, version=$appVersion, osVersion=$osVersion, " +
+        "iOSAppInfo(type=$devicePlatformType, isDebug=${isDebug}, appVersion=$appVersion, osVersion=$osVersion, " +
                 "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
-                "deviceManufacturer=$deviceManufacturer)"
+                "deviceManufacturer=$deviceManufacturer, locale=$locale, batteryLevel=$batteryLevel, " +
+                "timeZone=$timeZone)"
 }
 
 class IosAppInfoProvider : AppInfoProvider {


### PR DESCRIPTION
### TL;DR
Added device locale, battery level, and timezone tracking to app analytics

### What changed?
- Enhanced the `AppStart` analytics event to include locale, battery level, and timezone information
- Added new properties to `AppInfo` interface for both Android and iOS implementations
- Renamed `deviceType` parameter to `platformType` in analytics for better clarity
- Added logging of AppInfo during app start
- Updated toString() implementations to include new properties

### How to test?
1. Launch the app on both Android and iOS devices
2. Check analytics events to verify new properties are being tracked:
   - Locale (e.g., "en_US")
   - Battery level (0-100)
   - Timezone (e.g., "Australia/Sydney")
3. Verify values are correct for your device settings
4. Test with different locales and timezone settings

### Why make this change?
To gather more detailed analytics about user devices and environments, enabling better understanding of the user base and potential optimization opportunities based on locale and device states.