### PR TITLE
DB: Add Sydney train stops table and queries

### DIFF
--- a/gtfs-static/build.gradle.kts
+++ b/gtfs-static/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.core.di)
-                implementation(projects.core.io)
+                implementation(projects.core.io) // TODO - ideally :core:io apis should not be in gtfs module.
                 implementation(projects.core.log)
 
                 implementation(libs.kotlinx.serialization.json)

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
@@ -16,7 +16,7 @@ import xyz.ksharma.krail.core.log.log
 
 internal class RealNswGtfsService(
     private val httpClient: HttpClient,
-    private val fileStorage: FileStorage,
+    private val fileStorage: FileStorage, // TODO - ideally :core:io apis should not be in gtfs module.
     private val zipManager: ZipFileManager,
     private val ioDispatcher: CoroutineDispatcher = DispatchersComponent().ioDispatcher,
     private val coroutineScope: CoroutineScope,
@@ -35,6 +35,10 @@ internal class RealNswGtfsService(
 
                 // Unzip the file
                 zipManager.unzip(path)
+
+                // Store to DB - should happen in another module.
+
+
             } else {
                 throw Exception("Failed to download file: ${response.status}")
             }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/GtfsSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/GtfsSandook.kt
@@ -1,0 +1,14 @@
+package xyz.ksharma.krail.sandook
+
+interface GtfsSandook {
+
+}
+
+internal class RealGtfsSandook(factory: SandookDriverFactory) : GtfsSandook {
+
+    private val query = SydneyStopsQueries(factory.createDriver())
+
+    fun test () {
+        query.selectStopsByPartialName("Central").executeAsList()
+    }
+}

--- a/sandook/src/commonMain/sqldelight/migrations/2.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/2.sqm
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS SydneyStops (
+    stopId TEXT PRIMARY KEY,
+    stopName TEXT NOT NULL,
+    stopLat REAL NOT NULL,
+    stopLon REAL NOT NULL,
+    productClass INTEGER NOT NULL
+);

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/SydneyStops.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/SydneyStops.sq
@@ -1,0 +1,24 @@
+-- Create Sydney Train Stops Table --
+CREATE TABLE SydneyStops (
+    stopId TEXT PRIMARY KEY,
+    stopName TEXT NOT NULL,
+    stopLat REAL NOT NULL,
+    stopLon REAL NOT NULL,
+    productClass INTEGER NOT NULL
+);
+
+-- Insert data into Stops Table --
+insertStop:
+INSERT OR IGNORE INTO SydneyStops(stopId, stopName, stopLat, stopLon, productClass)
+VALUES (?, ?, ?, ?, ?);
+
+-- Select stops with partial match on stop_name --
+selectStopsByPartialName:
+SELECT * FROM SydneyStops
+WHERE stopName LIKE '%' || ? || '%';
+
+-- Select stops with partial match on stop_name and specific productClass values --
+selectStopsByNameAndProductClass:
+SELECT * FROM SydneyStops
+WHERE stopName LIKE '%' || ? || '%'
+AND productClass IN ?;


### PR DESCRIPTION
Add SydneyStops table and queries

Creates a new SQLite table to store Sydney train stop information with fields for ID, name, location coordinates, and product class. Adds queries for inserting stops and searching by name or product class.

Migration still required:
- Store GTFS data into SQLite database after unzipping
- Move storage logic out of GTFS module

Add migration:
- Add migration file for SydneyStops table creation
- Create GtfsSandook interface and implementation