### PR TITLE
Version: Bump to 1.0.8

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 39
-        versionName = "1.0.7"
+        versionCode = 40
+        versionName = "1.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.7</string>
+	<string>1.0.8</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Bump version numbers for new release 1.0.8

### What changed?
- Android version code increased from 39 to 40
- Android version name updated from 1.0.7 to 1.0.8
- iOS bundle version string updated from 1.0.7 to 1.0.8

### How to test?
1. Build and install the app on Android and iOS devices
2. Verify the correct version number appears in app settings
3. Verify the version number in app stores (when published)

### Why make this change?
Prepare for new app release by incrementing version numbers across platforms to maintain version consistency between Android and iOS builds.