### PR TITLE
DI: Bump Koin to 4.0.2

### DIFF
--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/KrailApplication.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/KrailApplication.kt
@@ -3,18 +3,18 @@ package xyz.ksharma.krail
 import android.app.Application
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.initialize
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import xyz.ksharma.krail.di.initKoin
 
 class KrailApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-//        instance = this
+        initKoin {
+            androidContext(this@KrailApplication)
+            androidLogger()
+        }
         Firebase.initialize(context = this)
     }
-
-/*
-    companion object {
-        var instance: Application? = null
-    }
-*/
 }

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -4,9 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import org.koin.android.ext.koin.androidContext
-import org.koin.android.ext.koin.androidLogger
-import org.koin.core.logger.Level
 
 class MainActivity : ComponentActivity() {
 
@@ -14,10 +11,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
-            KrailApp {
-                androidContext(this@MainActivity)
-                androidLogger(Level.DEBUG)
-            }
+            KrailApp()
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/di/AppModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/di/AppModule.android.kt
@@ -1,8 +1,0 @@
-package xyz.ksharma.krail.di
-
-import org.koin.android.ext.koin.androidLogger
-import org.koin.dsl.koinConfiguration
-
-actual fun nativeConfig() = koinConfiguration {
-    androidLogger()
-}

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -1,17 +1,12 @@
 package xyz.ksharma.krail
 
 import androidx.compose.runtime.Composable
-import org.koin.compose.KoinApplication
-import org.koin.dsl.KoinAppDeclaration
-import xyz.ksharma.krail.di.koinConfig
+import org.koin.compose.KoinContext
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
-fun KrailApp(koinDeclaration: KoinAppDeclaration? = null) {
-    KoinApplication(application = {
-        koinDeclaration?.invoke(this)
-        koinConfig()
-    }) {
+fun KrailApp() {
+    KoinContext {
         KrailTheme {
             KrailNavHost()
         }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -1,10 +1,10 @@
 package xyz.ksharma.krail.di
 
+import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.includes
-import org.koin.dsl.koinConfiguration
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.analytics.di.analyticsModule
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
@@ -16,18 +16,21 @@ import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.networkModule
 import xyz.ksharma.krail.trip.planner.ui.di.viewModelsModule
 
-val koinConfig = koinConfiguration {
-    includes(nativeConfig())
-    modules(
-        networkModule,
-        viewModelsModule,
-        sandookModule,
-        splashModule,
-        appInfoModule,
-        analyticsModule,
-        remoteConfigModule,
-        coroutineDispatchersModule,
-    )
+fun initKoin(config: KoinAppDeclaration? = null) {
+    startKoin {
+        printLogger()
+        includes(config)
+        modules(
+            networkModule,
+            viewModelsModule,
+            sandookModule,
+            splashModule,
+            appInfoModule,
+            analyticsModule,
+            remoteConfigModule,
+            coroutineDispatchersModule,
+        )
+    }
 }
 
 val splashModule = module {
@@ -41,5 +44,3 @@ val splashModule = module {
         )
     }
 }
-
-expect fun nativeConfig(): KoinAppDeclaration

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/di/AppModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/di/AppModule.ios.kt
@@ -1,7 +1,0 @@
-package xyz.ksharma.krail.di
-
-import org.koin.dsl.koinConfiguration
-
-actual fun nativeConfig() = koinConfiguration {
-    printLogger()
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ kotlinxCoroutines = "1.10.1"
 buildkonfigGradlePlugin = "0.15.2"
 kermit = "2.0.5"
 sqlDelight = "2.0.2"
-koin = "4.0.1-Beta1"
+koin = "4.0.2"
 firebaseGitLive = "2.1.0"
 
 [libraries]

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import FirebaseCore
 import FirebaseFirestore
 import FirebaseAuth
+import KrailApp
 
 class AppDelegate: NSObject, UIApplicationDelegate {
   func application(_ application: UIApplication,
@@ -14,8 +15,10 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
 @main
 struct iOSApp: App {
-    init() {
-    }
+
+  init() {
+      KoinAppKt.doInitKoin()
+  }
 
   // register app delegate for Firebase setup
   @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate


### PR DESCRIPTION
Migrate to Koin 4.0.2 and improve DI initialization

- Move Koin initialization to Application class for Android
- Initialize Koin in iOS app delegate
- Replace `KoinApplication` with `KoinContext` in composables
- Remove platform-specific DI configuration files
- Consolidate Koin setup into single `KoinApp.kt` file
- Update Koin version to 4.0.2

Reference: https://github.com/InsertKoinIO/koin-getting-started/commit/b967900458376dddadba15c9e2a780f74afeba24