### PR TITLE
UI: Remove Barbie theme and update pink color code

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -29,8 +29,7 @@ val metro_theme = Color(0xFF009B77)
 val ferry_theme = Color(0xFF5AB031)
 val coach_theme = Color(0xFF742282)
 val light_rail_theme = Color(0xFFEE343F)
-
-val barbiePink = Color(0xFFDA1884)
+val barbie_pink_theme = Color(0xFFAA0999)
 
 val seed = Color(0xFFFFBA27)
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailThemeStyle.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailThemeStyle.kt
@@ -28,9 +28,4 @@ enum class KrailThemeStyle(val hexColorCode: String, val id: Int, val tagLine: S
         id = 9,
         tagLine = "Just floatin!"
     ),
-    BarbiePink(
-        hexColorCode = "#F836E5",
-        id = 100,
-        tagLine = "Mah city, mah rules!"
-    ),
 }


### PR DESCRIPTION
### TL;DR
Updated theme color values and removed Barbie theme option

### What changed?
- Renamed `barbiePink` to `barbie_pink_theme` and updated its color value from `0xFFDA1884` to `0xFFAA0999`
- Removed the `BarbiePink` enum option from `KrailThemeStyle`

### How to test?
1. Build and run the app
2. Verify the new pink color (`0xFFAA0999`) is displayed correctly where used
3. Confirm the Barbie theme option is no longer available in theme selection

### Why make this change?
To maintain consistency in theme naming conventions and remove an unused theme option while updating the pink color to better match the application's color palette.