### PR TITLE
UI: Update saved trips empty state message

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -100,7 +100,7 @@ fun SavedTripsScreen(
                         ErrorMessage(
                             emoji = "🌟",
                             title = "Ready to roll, mate?",
-                            message = "Star your fave trips and they'll be right here!",
+                            message = "Star your trips to see them here!",
                             modifier = Modifier
                                 .padding(horizontal = 16.dp)
                                 .animateItem(),


### PR DESCRIPTION
### TL;DR
Updated empty state message for saved trips screen to be more concise

### What changed?
Modified the empty state message from "Star your fave trips and they'll be right here!" to "Star your trips to see them here!"

### Why make this change?
The new message is more direct and clearer, removing colloquial language ("fave") while maintaining the same meaning. This creates a more professional and straightforward user experience.