### PR TITLE
UI: Refactor Text component and typography handling

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
@@ -26,7 +26,6 @@ fun Text(
     textAlign: TextAlign = TextAlign.Start,
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = if (maxLines == Int.MAX_VALUE) TextOverflow.Clip else TextOverflow.Ellipsis,
-    fontFamily: FontFamily? = null,
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
     Text(
@@ -37,7 +36,6 @@ fun Text(
         textAlign = textAlign,
         maxLines = maxLines,
         overflow = overflow,
-        fontFamily = fontFamily,
         onTextLayout = onTextLayout,
     )
 }
@@ -55,9 +53,11 @@ fun Text(
     onTextLayout: ((TextLayoutResult) -> Unit)? = null,
 ) {
     val contentAlpha = LocalContentAlpha.current
+    val textStyle = style.merge(LocalTextStyle.current)
+
     BasicText(
         text = text,
-        style = style.merge(
+        style = textStyle.copy(
             color = color?.copy(alpha = contentAlpha)
                 ?: LocalTextColor.current.copy(alpha = contentAlpha),
             textAlign = textAlign,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
@@ -54,12 +54,13 @@ fun Text(
 ) {
     val contentAlpha = LocalContentAlpha.current
     val textStyle = style.merge(LocalTextStyle.current)
+    val textColor: Color = LocalTextColor.current
+        .takeIf { it != Color.Unspecified } ?: color ?: KrailTheme.colors.onSurface
 
     BasicText(
         text = text,
         style = textStyle.copy(
-            color = color?.copy(alpha = contentAlpha)
-                ?: LocalTextColor.current.copy(alpha = contentAlpha),
+            color = textColor.copy(alpha = contentAlpha),
             textAlign = textAlign,
             fontFamily = fontFamily,
         ),

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailTypography.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailTypography.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.taj.theme
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight


### PR DESCRIPTION
### TL;DR
Improved text style handling and simplified Text component parameters.

### What changed?
- Removed redundant `fontFamily` parameter from Text component overload
- Added explicit handling of `LocalTextColor` with fallback to theme's `onSurface` color
- Introduced separate `textStyle` and `textColor` variables for clearer style composition
- Modified style merging to use `copy()` for more explicit property updates

### Why make this change?

When the Text API is used inside a Button, it will provide a composition local style for text and color, which should be respected by the Text component. However, Text can also be used independently, requiring a style parameter. If we provide a style parameter, users might misuse it within a Button. To address this, we are merging and giving higher priority to the composition local text and color styles, then falling back to the provided parameters. This ensures consistency and prevents misuse.
