### PR TITLE
UI: Set White color to TransportModeBadge and TransportModeIcon

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -16,6 +17,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -28,22 +30,26 @@ fun TransportModeBadge(
 ) {
     val density = LocalDensity.current
 
-    Box(
-        modifier = modifier
-            .requiredHeightIn(with(density) { 22.sp.toDp() })
-            .clip(shape = RoundedCornerShape(percent = 20))
-            .background(color = backgroundColor),
-        contentAlignment = Alignment.Center,
+    CompositionLocalProvider(
+        LocalTextColor provides Color.White,
     ) {
-        Text(
-            text = badgeText,
-            color = Color.White,
-            // todo - need concrete token for style, meanwhile keep same as TransportModeIcon.
-            style = KrailTheme.typography.labelLarge,
-            modifier = Modifier
-                .padding(2.dp)
-                .wrapContentWidth(),
-        )
+        Box(
+            modifier = modifier
+                .requiredHeightIn(with(density) { 22.sp.toDp() })
+                .clip(shape = RoundedCornerShape(percent = 20))
+                .background(color = backgroundColor),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = badgeText,
+                color = Color.White,
+                // todo - need concrete token for style, meanwhile keep same as TransportModeIcon.
+                style = KrailTheme.typography.labelLarge,
+                modifier = Modifier
+                    .padding(2.dp)
+                    .wrapContentWidth(),
+            )
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import xyz.ksharma.krail.taj.LocalContentAlpha
+import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -35,7 +36,10 @@ fun TransportModeIcon(
     val textStyle = KrailTheme.typography.labelLarge
 
     // Content alphas should always be 100% for Transport related icons
-    CompositionLocalProvider(LocalContentAlpha provides 1f) {
+    CompositionLocalProvider(
+        LocalContentAlpha provides 1f,
+        LocalTextColor provides Color.White,
+    ) {
         Box(
             modifier = modifier
                 .clip(shape = CircleShape)


### PR DESCRIPTION
### TL;DR
Added `LocalTextColor` provider to transport mode components to ensure consistent text coloring.

### What changed?
- Added `CompositionLocalProvider` for `LocalTextColor` in `TransportModeBadge` and `TransportModeIcon`
- Set text color to white for both components through the composition local
- Maintained existing content alpha settings

### How to test?
1. Navigate to any screen displaying transport mode badges or icons
2. Verify that text appears in white color
3. Confirm that the text remains visible against the component backgrounds
4. Check that the styling is consistent across different transport modes

### Why make this change?
To establish a consistent text color implementation across transport-related components using Compose's composition locals, rather than setting the color directly on individual Text components. This approach provides better maintainability and ensures color consistency throughout the application.