### PR TITLE
UI: Add start padding to LegView stop info

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -104,7 +104,11 @@ fun LegView(
             )
 
             Spacer(modifier = Modifier.height(12.dp))
-            Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 4.dp),
+            ) {
                 StopInfo(
                     time = stops.first().time,
                     name = stops.first().name,


### PR DESCRIPTION
### TL;DR
Added start padding to the stop information column in the leg view component.

### What changed?
Added a 4dp start padding to the Column containing stop information in the LegView component to improve visual alignment with other UI elements.

### Why make this change?
The stop information was previously flush with the start edge, making it visually inconsistent with other UI elements. This padding addition improves the visual hierarchy and readability of the trip information.