### PR TITLE
Analytics: Rename transportMode to themeId in theme selection event

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -51,9 +51,9 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // region Theme
 
-    data class ThemeSelectedEvent(val transportMode: String) : AnalyticsEvent(
+    data class ThemeSelectedEvent(val themeId: String) : AnalyticsEvent(
         name = "theme_selected",
-        properties = mapOf("transportMode" to transportMode),
+        properties = mapOf("themeId" to themeId),
     )
 
     // endregion

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
@@ -133,7 +133,7 @@ class ThemeSelectionViewModelTest {
                 assertTrue(fakeAnalytics.isEventTracked("theme_selected"))
                 val event = fakeAnalytics.getTrackedEvent("theme_selected")
                 assertIs<AnalyticsEvent.ThemeSelectedEvent>(event)
-                assertEquals("Ferry", event.transportMode)
+                assertEquals("9", event.themeId)
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -3,7 +3,6 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredHeightIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -14,9 +13,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -55,6 +54,7 @@ fun TransportModeBadge(
 
 // region Previews
 
+@Preview
 @Composable
 private fun TransportModeBadgeBusPreview() {
     KrailTheme {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionAnalytics.kt
@@ -2,12 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.themeselection
 
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
-import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
-internal fun Analytics.trackThemeSelectionEvent(productClass: Int) {
-    productClass.let { TransportMode.toTransportModeType(it) }?.let {
-        track(AnalyticsEvent.ThemeSelectedEvent(transportMode = it.name))
-    } ?: run {
-        track(AnalyticsEvent.ThemeSelectedEvent(transportMode = productClass.toString()))
-    }
+internal fun Analytics.trackThemeSelectionEvent(themeId: Int) {
+    track(AnalyticsEvent.ThemeSelectedEvent(themeId = themeId.toString()))
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -51,7 +51,7 @@ class ThemeSelectionViewModel(
             updateUiState {
                 copy(themeSelected = true)
             }
-            analytics.trackThemeSelectionEvent(productClass)
+            analytics.trackThemeSelectionEvent(themeId = productClass)
         }
     }
 


### PR DESCRIPTION
### TL;DR
Updated theme selection analytics to track theme IDs instead of transport modes

### What changed?
- Renamed `transportMode` parameter to `themeId` in `ThemeSelectedEvent`
- Simplified theme selection tracking by removing transport mode conversion
- Updated corresponding test cases to reflect the new parameter name

### How to test?
1. Navigate to theme selection screen
2. Select different themes
3. Verify analytics events are logged with theme IDs
4. Run unit tests to confirm analytics tracking behavior

### Why make this change?
Tracking raw theme IDs provides more accurate analytics data compared to converting them to transport modes, which may not always have a direct mapping. This change simplifies the analytics implementation and makes it more maintainable.