### PR TITLE
UI: Improve timeline spacing and typography in trip planner

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -123,13 +123,22 @@ fun LegView(
                         .padding(start = 16.dp),
                 )
 
+                Spacer(
+                    modifier = Modifier
+                        .height(12.dp)
+                        .timeLineCenter(
+                            color = timelineColor,
+                            strokeWidth = strokeWidth,
+                        )
+                )
+
                 Column(
                     modifier = Modifier
                         .timeLineCenter(
                             color = timelineColor,
                             strokeWidth = strokeWidth,
                         )
-                        .padding(start = 16.dp, top = 12.dp),
+                        .padding(start = 16.dp),
                 ) {
                     val stopsCount by rememberSaveable(stops) { mutableIntStateOf(stops.size - 1) }
                     if (stopsCount > 1) {
@@ -151,8 +160,19 @@ fun LegView(
                     }
                 }
 
+
                 if (showIntermediateStops) {
                     stops.drop(1).dropLast(1).forEach { stop ->
+
+                        Spacer(
+                            modifier = Modifier
+                                .height(12.dp)
+                                .timeLineCenter(
+                                    color = timelineColor,
+                                    strokeWidth = strokeWidth,
+                                )
+                        )
+
                         StopInfo(
                             time = stop.time,
                             name = stop.name,
@@ -169,10 +189,19 @@ fun LegView(
                                     strokeWidth = strokeWidth,
                                     circleRadius = circleRadius,
                                 )
-                                .padding(start = 16.dp, top = 12.dp),
+                                .padding(start = 16.dp),
                         )
                     }
                 }
+
+                Spacer(
+                    modifier = Modifier
+                        .height(12.dp)
+                        .timeLineCenter(
+                            color = timelineColor,
+                            strokeWidth = strokeWidth,
+                        )
+                )
 
                 StopInfo(
                     time = stops.last().time,
@@ -185,7 +214,7 @@ fun LegView(
                             strokeWidth = strokeWidth,
                             circleRadius = circleRadius,
                         )
-                        .padding(start = 16.dp, top = 12.dp),
+                        .padding(start = 16.dp),
                 )
             }
         }
@@ -210,7 +239,7 @@ private fun RouteSummary(
         ) {
             Text(
                 text = routeText,
-                style = KrailTheme.typography.bodySmall,
+                style = KrailTheme.typography.titleSmall,
                 modifier = Modifier
                     .padding(end = 12.dp)
                     .align(Alignment.CenterVertically),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -64,7 +63,7 @@ internal fun OriginDestination(
                 Text(
                     text = targetText,
                     color = timeLineColor,
-                    style = KrailTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
+                    style = KrailTheme.typography.titleLarge,
                     modifier = Modifier.fillMaxWidth().padding(start = 16.dp),
                 )
             }
@@ -105,7 +104,7 @@ internal fun OriginDestination(
                 Text(
                     text = targetText,
                     color = timeLineColor,
-                    style = KrailTheme.typography.titleMedium.copy(fontWeight = FontWeight.Normal),
+                    style = KrailTheme.typography.titleLarge,
                     modifier = Modifier.padding(start = 16.dp),
                 )
             }


### PR DESCRIPTION
### TL;DR
Updated the visual styling and spacing of the trip planner's journey view components

### What changed?
- Added consistent 12dp spacers between stop information
- Updated typography styles:
  - Route text now uses `titleSmall` instead of `bodySmall`
  - Origin/Destination text now uses `titleLarge` instead of `titleMedium`
- Removed redundant top padding from stop information components
- Removed font weight override from Origin/Destination text

### How to test?
1. Navigate to the trip planner
2. Search for and view any journey
3. Verify:
   - Consistent spacing between stops
   - Larger, more readable text for origin/destination
   - Clear route information text
   - Timeline alignment remains intact

### Why make this change?
To improve readability and visual consistency in the journey view by implementing proper spacing and typography hierarchy, making it easier for users to scan and understand their travel information.