### PR TITLE
UI: Add TransportModeChip component

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -1,0 +1,112 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.LocalTextColor
+import xyz.ksharma.krail.taj.LocalTextStyle
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.toAdaptiveDecorativeIconSize
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+
+@Composable
+fun TransportModeChip(
+    transportMode: TransportMode,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val backgroundColor by animateColorAsState(
+        targetValue = if (selected) transportMode.colorCode.hexToComposeColor()
+        else KrailTheme.colors.surface,
+        animationSpec = tween(200),
+    )
+
+    val textColor by animateColorAsState(
+        targetValue = if (selected) Color.White else Color.Gray, // gray needs to come from token
+        animationSpec = tween(200),
+    )
+
+    val borderColor by animateColorAsState(
+        targetValue = if (selected) Color.Transparent else transportMode.colorCode.hexToComposeColor(),
+        animationSpec = tween(200),
+    )
+
+    val modeIconBorderColor by animateColorAsState(
+        targetValue = if (selected) Color.White else KrailTheme.colors.surface,
+        animationSpec = tween(200),
+    )
+
+    CompositionLocalProvider(
+        LocalTextColor provides textColor,
+        LocalTextStyle provides KrailTheme.typography.titleMedium,
+    ) {
+        Row(
+            modifier = modifier
+                .background(
+                    color = backgroundColor,
+                    shape = RoundedCornerShape(50),
+                )
+                .border(
+                    width = 3.dp, // 3.dp is token , should be 1.dp less than the horizontal padding.
+                    color = borderColor,
+                    shape = RoundedCornerShape(50),
+                )
+                .clickable(
+                    indication = null,
+                    interactionSource = null,
+                ) { onClick() }
+                .padding(horizontal = 4.dp, vertical = 4.dp) // 4.dp is token
+                .padding(end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            // Make this a separate component - TransportModeIcon
+            Box(
+                modifier = Modifier
+                    .size(32.dp.toAdaptiveDecorativeIconSize())
+                    .clip(CircleShape)
+                    .background(
+                        color = transportMode.colorCode.hexToComposeColor(),
+                        shape = CircleShape,
+                    )
+                    .border(
+                        3.dp.toAdaptiveDecorativeIconSize(), // 3.dp is token value
+                        modeIconBorderColor,
+                        CircleShape,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                CompositionLocalProvider(
+                    LocalTextColor provides Color.White,
+                ) {
+                    Text(
+                        text = transportMode.name.first().toString(),
+                        color = Color.White,
+                    )
+                }
+            }
+
+            Text(text = transportMode.name)
+        }
+    }
+}


### PR DESCRIPTION
### TL;DR
Added a new TransportModeChip component for displaying transport mode selections with animated state changes.

### What changed?
- Created a new `TransportModeChip` component that displays transport modes in a selectable chip format
- Updated the border width in `TransportModeIcon` from 1.dp to 3.dp to maintain consistency
- Added color animations for background, text, and borders when selection state changes
- Implemented circular icon with the first letter of transport mode name

### How to test?
1. Navigate to the trip planner screen
2. Verify that transport mode chips display correctly with proper spacing and typography
3. Click on different transport modes to ensure:
   - Color transitions animate smoothly
   - Selected state shows filled background with white text
   - Unselected state shows outlined style with gray text
   - Icon border and background colors update appropriately

### Why make this change?
To provide users with a more intuitive and visually appealing way to select transport modes while maintaining consistent styling across the app. The animated transitions enhance the interactive experience and provide clear visual feedback for selection states.