### PR TITLE
UI: Refactor TransportModeIcon sizing and styling

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -369,7 +369,10 @@ fun DefaultJourneyCardContent(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
                         transportModeList.forEachIndexed { index, mode ->
-                            TransportModeIcon(transportMode = mode)
+                            TransportModeIcon(
+                                transportMode = mode,
+                                size = TransportModeIconSize.Small,
+                            )
                             if (index != transportModeList.lastIndex) {
                                 SeparatorIcon(modifier = Modifier.align(Alignment.CenterVertically))
                             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopSearchListItem.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopSearchListItem.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -53,7 +52,7 @@ fun StopSearchListItem(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             transportModeSet.forEach { mode ->
-                TransportModeIcon(transportMode = mode)
+                TransportModeIcon(transportMode = mode, size = TransportModeIconSize.Small)
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalTextColor
+import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -31,6 +32,7 @@ fun TransportModeBadge(
 
     CompositionLocalProvider(
         LocalTextColor provides Color.White,
+        LocalTextStyle provides KrailTheme.typography.titleSmall,
     ) {
         Box(
             modifier = modifier
@@ -42,8 +44,6 @@ fun TransportModeBadge(
             Text(
                 text = badgeText,
                 color = Color.White,
-                // todo - need concrete token for style, meanwhile keep same as TransportModeIcon.
-                style = KrailTheme.typography.labelLarge,
                 modifier = Modifier
                     .padding(2.dp)
                     .wrapContentWidth(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -6,18 +6,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalTextColor
@@ -25,7 +21,6 @@ import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.toAdaptiveDecorativeIconSize
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 @Composable
@@ -84,7 +79,6 @@ fun TransportModeChip(
             TransportModeIcon(
                 transportMode = transportMode,
                 borderColor = modeIconBorderColor,
-                textColor = textColor,
                 displayBorder = true,
             )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -19,6 +20,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.toAdaptiveDecorativeIconSize
+import xyz.ksharma.krail.taj.toAdaptiveSize
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 @Composable
@@ -26,17 +28,17 @@ fun TransportModeIcon(
     transportMode: TransportMode,
     modifier: Modifier = Modifier,
     borderColor: Color = Color.White,
-    textColor: Color = Color.White,
     displayBorder: Boolean = false,
-    size: TransportModeIconSize = TransportModeIconSize.Small,
+    size: TransportModeIconSize = TransportModeIconSize.Medium,
 ) {
     CompositionLocalProvider(
-        LocalTextColor provides textColor,
-        LocalTextStyle provides KrailTheme.typography.titleMedium,
+        LocalTextColor provides Color.White,
+        // should be same as StopsRow and TransportModeInfo
+        LocalTextStyle provides KrailTheme.typography.titleSmall,
     ) {
         Box(
             modifier = modifier
-                .size(size.dpSize.toAdaptiveDecorativeIconSize())
+                .size(size.dpSize.toAdaptiveSize())
                 .clip(CircleShape)
                 .background(
                     color = transportMode.colorCode.hexToComposeColor(),
@@ -48,14 +50,11 @@ fun TransportModeIcon(
                 ),
             contentAlignment = Alignment.Center,
         ) {
-            CompositionLocalProvider(
-                LocalTextColor provides Color.White,
-            ) {
-                Text(
-                    text = transportMode.name.first().toString().uppercase(),
-                    color = Color.White,
-                )
-            }
+            Text(
+                text = transportMode.name.first().toString().uppercase(),
+                color = Color.White,
+                modifier = Modifier.padding(2.dp),
+            )
         }
     }
 }
@@ -73,7 +72,7 @@ private fun Modifier.borderIfEnabled(enabled: Boolean, color: Color): Modifier =
     } else this
 
 enum class TransportModeIconSize(val dpSize: Dp) {
-    Small(24.dp), Medium(28.dp), Large(32.dp)
+    XSmall(20.dp), Small(22.dp), Medium(28.dp), Large(32.dp)
 }
 
 // region Previews
@@ -83,8 +82,6 @@ private fun TrainPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Train(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = false
         )
     }
@@ -95,8 +92,6 @@ private fun BusPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Bus(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = false
         )
     }
@@ -107,8 +102,6 @@ private fun MetroPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Metro(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = false
         )
     }
@@ -119,8 +112,6 @@ private fun LightRailPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.LightRail(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = false
         )
     }
@@ -131,8 +122,6 @@ private fun FerryPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Ferry(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = false
         )
     }
@@ -143,8 +132,6 @@ private fun TrainWithBackgroundPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Train(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = true
         )
     }
@@ -155,8 +142,6 @@ private fun BusWithBackgroundPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Bus(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = true
         )
     }
@@ -167,8 +152,6 @@ private fun MetroWithBackgroundPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Metro(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = true
         )
     }
@@ -179,8 +162,6 @@ private fun LightRailWithBackgroundPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.LightRail(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = true
         )
     }
@@ -191,8 +172,6 @@ private fun FerryWithBackgroundPreview() {
     KrailTheme {
         TransportModeIcon(
             transportMode = TransportMode.Ferry(),
-            borderColor = Color.White,
-            textColor = Color.White,
             displayBorder = true,
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeInfo.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeInfo.kt
@@ -31,6 +31,7 @@ fun TransportModeInfo(
             TransportModeIcon(
                 transportMode = transportMode,
                 displayBorder = borderEnabled,
+                size = TransportModeIconSize.Small,
             )
 
             TransportModeBadge(


### PR DESCRIPTION
### TL;DR
Standardized transport mode icon sizes and styling across the app's UI components.

### What changed?
- Added new `XSmall` size (20dp) to `TransportModeIconSize` enum
- Updated default icon size to `Medium` (28dp)
- Standardized text styling to use `titleSmall` typography
- Removed redundant color and border parameters
- Added consistent padding (2dp) to icon text
- Switched from `toAdaptiveDecorativeIconSize` to `toAdaptiveSize`
- Applied `Small` size (22dp) to icons in journey cards, stop search list, and transport mode info

### How to test?
1. Navigate through different screens showing transport mode icons
2. Verify consistent sizing across:
   - Journey cards
   - Stop search results
   - Transport mode information panels
3. Check that text remains centered and properly padded in all icons
4. Confirm icons scale appropriately on different screen sizes

### Why make this change?
To establish visual consistency across the application by implementing a standardized sizing and styling system for transport mode icons. This improves the overall user experience by maintaining a cohesive design language throughout the app.