### PR TITLE
UI: Add filter button to TimeTableScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_filter.xml
+++ b/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_filter.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M400,720v-80h160v80L400,720ZM240,520v-80h480v80L240,520ZM120,320v-80h720v80L120,320Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -37,9 +37,11 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_alert
 import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
+import krail.feature.trip_planner.ui.generated.resources.ic_filter
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.ButtonDefaults
@@ -158,14 +160,38 @@ fun TimeTableScreen(
             }
 
             item {
-                SubtleButton(
-                    onClick = dateTimeSelectorClicked,
-                    dimensions = ButtonDefaults.mediumButtonSize(),
-                    modifier = Modifier.padding(horizontal = 12.dp),
+                Row(
+                    modifier = Modifier.fillParentMaxWidth().padding(horizontal = 10.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Text(
-                        text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
-                    )
+                    SubtleButton(
+                        onClick = dateTimeSelectorClicked,
+                        dimensions = ButtonDefaults.mediumButtonSize(),
+                    ) {
+                        Text(
+                            text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
+                        )
+                    }
+
+                    SubtleButton(
+                        onClick = {
+
+                        },
+                        dimensions = ButtonDefaults.mediumButtonSize(),
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Image(
+                                painter = painterResource(Res.drawable.ic_filter),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(ButtonDefaults.subtleButtonColors().contentColor),
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Text(text = "Mode")
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
### TL;DR
Added a new filter button with mode selection to the time table screen

### What changed?
- Added a new `ic_filter.xml` vector asset for the filter icon
- Added a new "Mode" filter button next to the date/time selector
- Restructured the button layout to accommodate both buttons in a horizontal row
- Applied consistent styling and spacing between the buttons

### How to test?
1. Navigate to the time table screen
2. Verify that both the date/time selector and mode filter buttons are visible
3. Confirm the filter button displays the filter icon and "Mode" text
4. Check that both buttons maintain proper spacing and alignment
5. Verify the filter icon color matches the button's content color

### Why make this change?
To provide users with an easy way to filter their trip planning results by transportation mode, enhancing the overall user experience and making it more efficient to find relevant travel options.