### PR TITLE
UI: Add transport mode selection row to TimeTableScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -36,23 +36,18 @@ fun TransportModeChip(
         animationSpec = tween(200),
     )
 
-    val textColor by animateColorAsState(
-        targetValue = if (selected) Color.White else Color.Gray, // gray needs to come from token
-        animationSpec = tween(200),
-    )
-
     val borderColor by animateColorAsState(
         targetValue = if (selected) Color.Transparent else transportMode.colorCode.hexToComposeColor(),
         animationSpec = tween(200),
     )
 
-    val modeIconBorderColor by animateColorAsState(
-        targetValue = if (selected) Color.White else KrailTheme.colors.surface,
+    val textColor by animateColorAsState(
+        targetValue = if (selected) Color.White else Color.Gray,
         animationSpec = tween(200),
     )
 
     CompositionLocalProvider(
-        LocalTextColor provides textColor,
+        LocalTextColor provides Color.White,
         LocalTextStyle provides KrailTheme.typography.titleMedium,
     ) {
         Row(
@@ -70,7 +65,9 @@ fun TransportModeChip(
                     indication = null,
                     interactionSource = null,
                 ) { onClick() }
-                .padding(horizontal = 4.dp, vertical = 4.dp) // 4.dp is token
+                // horizontal padding value should be same as border width of
+                // TransportModeIcon
+                .padding(horizontal = 3.dp, vertical = 4.dp) // 4.dp is token
                 .padding(end = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -78,11 +75,15 @@ fun TransportModeChip(
             // Make this a separate component - TransportModeIcon
             TransportModeIcon(
                 transportMode = transportMode,
-                borderColor = modeIconBorderColor,
                 displayBorder = true,
+                adaptiveSize = true,
             )
 
-            Text(text = transportMode.name)
+            CompositionLocalProvider(
+                LocalTextColor provides textColor,
+            ) {
+                Text(text = transportMode.name)
+            }
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -12,8 +13,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
@@ -28,6 +31,7 @@ fun TransportModeIcon(
     transportMode: TransportMode,
     modifier: Modifier = Modifier,
     borderColor: Color = Color.White,
+    adaptiveSize: Boolean = false,
     displayBorder: Boolean = false,
     size: TransportModeIconSize = TransportModeIconSize.Medium,
 ) {
@@ -38,7 +42,10 @@ fun TransportModeIcon(
     ) {
         Box(
             modifier = modifier
-                .size(size.dpSize.toAdaptiveSize())
+                .size(
+                    if (adaptiveSize) size.dpSize.toAdaptiveSize()
+                    else size.dpSize.toAdaptiveDecorativeIconSize()
+                )
                 .clip(CircleShape)
                 .background(
                     color = transportMode.colorCode.hexToComposeColor(),
@@ -64,7 +71,7 @@ private fun Modifier.borderIfEnabled(enabled: Boolean, color: Color): Modifier =
     if (enabled) {
         this.then(
             border(
-                width = 3.dp.toAdaptiveDecorativeIconSize(),
+                width = 3.dp,
                 color = color,
                 shape = CircleShape,
             )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -25,6 +26,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,6 +59,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
 import xyz.ksharma.krail.trip.planner.ui.components.OriginDestination
+import xyz.ksharma.krail.trip.planner.ui.components.TransportModeChip
 import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
 import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiAnim
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -79,6 +83,7 @@ fun TimeTableScreen(
 ) {
     val themeColorHex by LocalThemeColor.current
     val themeColor = themeColorHex.hexToComposeColor()
+    var displayModeSelectionRow by rememberSaveable { mutableStateOf(false) }
 
     Column(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
@@ -160,6 +165,7 @@ fun TimeTableScreen(
             }
 
             item {
+
                 Row(
                     modifier = Modifier.fillParentMaxWidth().padding(horizontal = 10.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -175,7 +181,7 @@ fun TimeTableScreen(
 
                     SubtleButton(
                         onClick = {
-
+                            displayModeSelectionRow = !displayModeSelectionRow
                         },
                         dimensions = ButtonDefaults.mediumButtonSize(),
                     ) {
@@ -190,6 +196,31 @@ fun TimeTableScreen(
                                 modifier = Modifier.size(18.dp),
                             )
                             Text(text = "Mode")
+                        }
+                    }
+                }
+            }
+
+            if (displayModeSelectionRow) {
+                item {
+                    var selected by remember { mutableStateOf(false) }
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = PaddingValues(horizontal = 12.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 12.dp, bottom = 4.dp),
+                    ) {
+                        TransportMode.values().forEach {
+                            item {
+                                TransportModeChip(
+                                    transportMode = it,
+                                    selected = selected,
+                                    onClick = {
+                                        selected = !selected
+                                    },
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### TL;DR
Added transport mode filtering UI to the TimeTable screen with selectable mode chips

### What changed?
- Added a LazyRow of TransportModeChips to the TimeTable screen that appears when the filter button is clicked
- Updated TransportModeChip styling to handle selected states and proper text coloring
- Modified TransportModeIcon to support adaptive sizing and consistent border widths
- Fixed padding and border width consistency across transport mode components

### How to test?
1. Navigate to the TimeTable screen
2. Click the filter button to show the transport mode selection row
3. Click on different transport mode chips to verify selection states
4. Verify that the chips maintain proper styling in both selected and unselected states
5. Confirm that the transport mode icons display correctly with consistent borders

### Why make this change?
To provide users with the ability to filter their journey results by transport mode, making it easier to find specific types of transportation options in the timetable view. The UI improvements ensure a consistent and polished look across the transport mode selection interface.