### PR TITLE
UI: Update TransportModeChip text color and border styling

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -21,6 +21,7 @@ import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 @Composable
@@ -42,7 +43,7 @@ fun TransportModeChip(
     )
 
     val textColor by animateColorAsState(
-        targetValue = if (selected) Color.White else Color.Gray,
+        targetValue = if (selected) getForegroundColor(transportMode.colorCode.hexToComposeColor()) else Color.Gray,
         animationSpec = tween(200),
     )
 
@@ -57,7 +58,7 @@ fun TransportModeChip(
                     shape = RoundedCornerShape(50),
                 )
                 .border(
-                    width = 3.dp, // 3.dp is token , should be 1.dp less than the horizontal padding.
+                    width = 2.dp, // is token , should be 1.dp less than the horizontal padding.
                     color = borderColor,
                     shape = RoundedCornerShape(50),
                 )
@@ -67,7 +68,7 @@ fun TransportModeChip(
                 ) { onClick() }
                 // horizontal padding value should be same as border width of
                 // TransportModeIcon
-                .padding(horizontal = 3.dp, vertical = 4.dp) // 4.dp is token
+                .padding(horizontal = 3.dp, vertical = 4.dp) // is token
                 .padding(end = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
@@ -24,6 +25,7 @@ import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.toAdaptiveDecorativeIconSize
 import xyz.ksharma.krail.taj.toAdaptiveSize
+import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 @Composable
@@ -39,6 +41,8 @@ fun TransportModeIcon(
         LocalTextColor provides Color.White,
         // should be same as StopsRow and TransportModeInfo
         LocalTextStyle provides KrailTheme.typography.titleSmall,
+        // Alpha should always be 100%
+        LocalContentAlpha provides ContentAlphaTokens.EnabledContentAlpha,
     ) {
         Box(
             modifier = modifier
@@ -59,7 +63,6 @@ fun TransportModeIcon(
         ) {
             Text(
                 text = transportMode.name.first().toString().uppercase(),
-                color = Color.White,
                 modifier = Modifier.padding(2.dp),
             )
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -40,11 +40,10 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import krail.feature.trip_planner.ui.generated.resources.Res
-import krail.feature.trip_planner.ui.generated.resources.ic_alert
+import krail.feature.trip_planner.ui.generated.resources.ic_filter
 import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
-import krail.feature.trip_planner.ui.generated.resources.ic_filter
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.ButtonDefaults


### PR DESCRIPTION
### TL;DR
Updated the TransportModeChip and TransportModeIcon components to improve text contrast and visual consistency

### What changed?
- Modified text color in TransportModeChip to use a contrast-aware foreground color
- Reduced border width from 3dp to 2dp in TransportModeChip
- Added ContentAlpha token to TransportModeIcon to ensure 100% opacity
- Removed redundant color property from TransportModeIcon text

### How to test?
1. Navigate to the trip planner screen
2. Verify that transport mode chips have proper text contrast when selected
3. Confirm that transport mode icons display with full opacity
4. Check that the border width appears visually balanced

### Why make this change?
To enhance readability and visual consistency across transport mode components while ensuring proper contrast ratios for accessibility. The changes also streamline the implementation by removing redundant styling properties.