### PR TITLE
UI: Update light rail color and chip text contrast

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
  * Line Codes - https://transportnsw.info/plan/help/key-to-icons-line-codes
  *
  * Icons - https://opendata.transport.nsw.gov.au/dataset/transport-mode-symbols-and-pictograms
+ * Symbols - https://opendata.transport.nsw.gov.au/data/dataset/transport-mode-symbols-and-pictograms/resource/ea95a4b5-7d7b-4196-b886-c834953d19b6?inner_span=True
  */
 @Serializable
 sealed class TransportMode {
@@ -56,7 +57,7 @@ sealed class TransportMode {
     @Serializable
     data class LightRail(
         override val name: String = "Light Rail",
-        override val colorCode: String = "#EE343F",
+        override val colorCode: String = "#E4022D",
         override val productClass: Int = 4,
         override val priority: Int = 4444,
     ) : TransportMode()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -43,7 +43,7 @@ fun TransportModeChip(
     )
 
     val textColor by animateColorAsState(
-        targetValue = if (selected) getForegroundColor(transportMode.colorCode.hexToComposeColor()) else Color.Gray,
+        targetValue = if (selected) Color.White else Color.Gray,
         animationSpec = tween(200),
     )
 


### PR DESCRIPTION
### TL;DR
Updated Light Rail color code and transport mode chip text color for better visibility

### What changed?
- Changed Light Rail color code from `#EE343F` to `#E4022D` to match official NSW Transport documentation
- Modified transport mode chip text color to always be white when selected, instead of dynamically calculating based on background color
- Added reference link to official NSW Transport symbols documentation

### How to test?
1. Navigate to the trip planner screen
2. Observe the Light Rail transport mode chip
3. Select and deselect the chip to verify:
   - Selected state shows white text
   - Unselected state shows gray text
4. Verify Light Rail color matches official NSW Transport branding

### Why make this change?
To ensure consistent branding with official NSW Transport guidelines and improve text readability in the transport mode selection UI. The white text on colored backgrounds provides better contrast than the previous dynamic color calculation.