### PR TITLE
UI: Add stable keys and fix loading emoji animation

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiAnim.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiAnim.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -24,6 +26,9 @@ import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiManager.
 @Composable
 fun LoadingEmojiAnim(modifier: Modifier = Modifier, emoji: String? = null) {
     val infiniteTransition = rememberInfiniteTransition(label = "333")
+    val randomEmoji by rememberSaveable {
+        mutableStateOf(getRandomEmoji(overrideEmoji = emoji))
+    }
 
     val rotation by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -57,7 +62,7 @@ fun LoadingEmojiAnim(modifier: Modifier = Modifier, emoji: String? = null) {
 
     Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
         Text(
-            text = getRandomEmoji(overrideEmoji = emoji),
+            text = randomEmoji,
             style = KrailTheme.typography.headlineLarge.copy(fontSize = 64.sp),
             modifier = Modifier
                 .graphicsLayer {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -151,7 +151,7 @@ fun TimeTableScreen(
         }
 
         LazyColumn(contentPadding = PaddingValues(bottom = 16.dp)) {
-            item {
+            item (key = "Origin-Destination"){
                 timeTableState.trip?.let { trip ->
                     OriginDestination(
                         trip = trip,
@@ -163,8 +163,7 @@ fun TimeTableScreen(
                 }
             }
 
-            item {
-
+            item (key = "trip-actions-row"){
                 Row(
                     modifier = Modifier.fillParentMaxWidth().padding(horizontal = 10.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -201,25 +200,24 @@ fun TimeTableScreen(
             }
 
             if (displayModeSelectionRow) {
-                item {
+                item(key = "transport-mode-selection-row") {
                     var selected by remember { mutableStateOf(false) }
                     LazyRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         contentPadding = PaddingValues(horizontal = 12.dp),
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 12.dp, bottom = 4.dp),
+                            .padding(top = 12.dp, bottom = 4.dp)
+                            .animateItem(),
                     ) {
-                        TransportMode.values().forEach {
-                            item {
-                                TransportModeChip(
-                                    transportMode = it,
-                                    selected = selected,
-                                    onClick = {
-                                        selected = !selected
-                                    },
-                                )
-                            }
+                        items(
+                            items = TransportMode.values().toList(),
+                            key = { item -> item.productClass }) {
+                            TransportModeChip(
+                                transportMode = it,
+                                selected = selected,
+                                onClick = { selected = !selected },
+                            )
                         }
                     }
                 }
@@ -242,7 +240,7 @@ fun TimeTableScreen(
                     )
                 }
             } else if (timeTableState.isLoading) {
-                item {
+                item(key = "loading") {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         LoadingEmojiAnim(
                             modifier = Modifier.padding(vertical = 60.dp).animateItem(),
@@ -295,7 +293,7 @@ fun TimeTableScreen(
                     )
                 }
             } else { // Journey list is empty or null
-                item {
+                item(key = "no-results") {
                     ErrorMessage(
                         title = "No route found!",
                         message = "Search for another stop or check back later.",


### PR DESCRIPTION
### TL;DR
Fixed loading emoji animation flicker and added stable keys to LazyColumn items in TimeTableScreen

### What changed?
- Made loading emoji persistent across recompositions using `rememberSaveable`
- Added stable keys to all `LazyColumn` items in TimeTableScreen
- Converted `TransportMode` items loop to use `items` with keyed elements
- Added animation modifier to transport mode selection row

### How to test?
1. Navigate to TimeTableScreen
2. Verify loading emoji remains consistent during loading states
3. Check that transport mode selection row animates smoothly
4. Verify list items maintain their state during recomposition

### Why make this change?
The loading emoji was previously regenerating on each recomposition, causing a flickering effect. Adding stable keys and making the emoji persistent improves the user experience by maintaining visual consistency and optimizing list performance through proper item keying.