### PR TITLE
UI: Add animation to LegView intermediate stops

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -1,6 +1,9 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -159,37 +162,42 @@ fun LegView(
                     }
                 }
 
+                AnimatedVisibility(
+                    visible = showIntermediateStops,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
+                    Column {
+                        stops.drop(1).dropLast(1).forEach { stop ->
 
-                if (showIntermediateStops) {
-                    stops.drop(1).dropLast(1).forEach { stop ->
+                            Spacer(
+                                modifier = Modifier
+                                    .height(12.dp)
+                                    .timeLineCenter(
+                                        color = timelineColor,
+                                        strokeWidth = strokeWidth,
+                                    )
+                            )
 
-                        Spacer(
-                            modifier = Modifier
-                                .height(12.dp)
-                                .timeLineCenter(
-                                    color = timelineColor,
-                                    strokeWidth = strokeWidth,
-                                )
-                        )
-
-                        StopInfo(
-                            time = stop.time,
-                            name = stop.name,
-                            isProminent = false,
-                            isWheelchairAccessible = stop.isWheelchairAccessible,
-                            modifier = Modifier
-                                .timeLineCenterWithStop(
-                                    color = timelineColor,
-                                    strokeWidth = strokeWidth,
-                                    circleRadius = circleRadius,
-                                )
-                                .timeLineTop(
-                                    color = timelineColor,
-                                    strokeWidth = strokeWidth,
-                                    circleRadius = circleRadius,
-                                )
-                                .padding(start = 16.dp),
-                        )
+                            StopInfo(
+                                time = stop.time,
+                                name = stop.name,
+                                isProminent = false,
+                                isWheelchairAccessible = stop.isWheelchairAccessible,
+                                modifier = Modifier
+                                    .timeLineCenterWithStop(
+                                        color = timelineColor,
+                                        strokeWidth = strokeWidth,
+                                        circleRadius = circleRadius,
+                                    )
+                                    .timeLineTop(
+                                        color = timelineColor,
+                                        strokeWidth = strokeWidth,
+                                        circleRadius = circleRadius,
+                                    )
+                                    .padding(start = 16.dp),
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
### TL;DR
Added animation to intermediate stops in the trip planner leg view

### What changed?
Wrapped intermediate stops display in an `AnimatedVisibility` component with vertical expand/shrink animations when toggling the visibility of intermediate stops

### How to test?
1. Navigate to the trip planner
2. Select a route with multiple stops
3. Toggle the intermediate stops visibility
4. Verify that stops appear/disappear with a smooth vertical animation

### Why make this change?
To improve the user experience by providing smooth visual feedback when showing/hiding intermediate stops, making the interface feel more polished and interactive