### PR TITLE
UI: Fix text color precedence in Text component

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
@@ -54,8 +54,8 @@ fun Text(
 ) {
     val contentAlpha = LocalContentAlpha.current
     val textStyle = style.merge(LocalTextStyle.current)
-    val textColor: Color = LocalTextColor.current
-        .takeIf { it != Color.Unspecified } ?: color ?: KrailTheme.colors.onSurface
+    val textColor: Color = color ?: LocalTextColor.current
+        .takeIf { it != Color.Unspecified } ?: KrailTheme.colors.onSurface
 
     BasicText(
         text = text,


### PR DESCRIPTION
### TL;DR
Fixed text color precedence in Text component to prioritize explicitly provided colors over local text color.

### What changed?
Reordered the color selection logic in the Text component to first check for explicitly provided colors before falling back to `LocalTextColor`. If neither is specified, it defaults to the theme's `onSurface` color.

### How to test?
1. Create a Text component with an explicit color parameter
2. Create a Text component within a CompositionLocalProvider setting LocalTextColor
3. Verify that the explicit color takes precedence over LocalTextColor
4. Verify that LocalTextColor is used when no explicit color is provided
5. Verify that theme's onSurface color is used when neither is specified

### Why make this change?
The previous implementation incorrectly prioritized `LocalTextColor` over explicitly provided colors, which could lead to unexpected text styling behavior. This change ensures that developer-specified colors take precedence, following standard composition principles.