### PR TITLE
UI: Update check icon color in TimeTableScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -57,6 +57,7 @@ import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.ActionData
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
@@ -257,6 +258,7 @@ fun TimeTableScreen(
                             Image(
                                 painter = painterResource(Res.drawable.ic_check),
                                 contentDescription = null,
+                                colorFilter = ColorFilter.tint(color = getForegroundColor(themeColor)),
                                 modifier = Modifier.size(20.dp),
                             )
                             Text("Done", modifier = Modifier.padding(start = 4.dp))


### PR DESCRIPTION
### TL;DR
Added color tinting to the check icon in the TimeTableScreen's Done button

### What changed?
Added a `ColorFilter.tint()` to the check icon image in the TimeTableScreen, using the foreground color derived from the current theme color

### How to test?
1. Navigate to the TimeTableScreen
2. Verify that the check icon in the Done button matches the theme's foreground color
3. Test with different theme colors to ensure proper contrast

### Why make this change?
To ensure the check icon maintains proper visibility and consistency with the app's theme, particularly when different theme colors are applied