### PR TITLE
UI: Add mode selection analytics tracking

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -84,6 +84,32 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
         )
 
+    data class ModeClickEvent(
+        val fromStopId: String,
+        val toStopId: String,
+        val displayModeSelectionRow: Boolean,
+    ) :
+        AnalyticsEvent(
+            name = "mode_click",
+            properties = mapOf(
+                "fromStopId" to fromStopId,
+                "toStopId" to toStopId,
+                "displayModeSelectionRow" to displayModeSelectionRow,
+            ),
+        )
+
+    data class ModeSelectionDoneEvent(
+        val fromStopId: String, val toStopId: String,
+        val unselectedProductClasses: Set<Int>,
+    ) : AnalyticsEvent(
+        name = "mode_selection_done",
+        properties = mapOf(
+            "fromStopId" to fromStopId,
+            "toStopId" to toStopId,
+            "unselected" to unselectedProductClasses.toString(),
+        ),
+    )
+
     data class DateTimeSelectEvent(
         val dayOfWeek: String,
         val time: String,

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -22,4 +22,9 @@ sealed interface TimeTableUiEvent {
     data class JourneyLegClicked(val expanded: Boolean) : TimeTableUiEvent
 
     data class ModeSelectionChanged(val unselectedModes: Set<Int>) : TimeTableUiEvent
+
+    /**
+     * when tru, the selection row is displayed else it is hidden.
+     */
+    data class ModeClicked(val displayModeSelectionRow: Boolean) : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -83,6 +83,9 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             onModeSelectionChanged = { unselectedModes ->
                 log("onModeSelectionChanged Exclude :$unselectedModes")
                 viewModel.onEvent(TimeTableUiEvent.ModeSelectionChanged(unselectedModes))
+            },
+            onModeClick = { displayModeSelectionRow ->
+                viewModel.onEvent(TimeTableUiEvent.ModeClicked(displayModeSelectionRow))
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -85,6 +85,7 @@ fun TimeTableScreen(
     modifier: Modifier = Modifier,
     dateTimeSelectorClicked: () -> Unit = {},
     onModeSelectionChanged: (Set<Int>) -> Unit = {},
+    onModeClick: (Boolean) -> Unit = {},
 ) {
     val themeColorHex by LocalThemeColor.current
     val themeColor = themeColorHex.hexToComposeColor()
@@ -189,6 +190,7 @@ fun TimeTableScreen(
                     SubtleButton(
                         onClick = {
                             displayModeSelectionRow = !displayModeSelectionRow
+                            onModeClick(displayModeSelectionRow)
                         },
                         dimensions = ButtonDefaults.mediumButtonSize(),
                     ) {


### PR DESCRIPTION
### TL;DR
Added analytics tracking for mode selection events in trip planner

### What changed?
- Added new analytics events: `ModeClickEvent` and `ModeSelectionDoneEvent`
- Integrated mode selection tracking in TimeTableViewModel
- Added new UI event `ModeClicked` to handle mode selection visibility
- Connected mode click analytics to the UI through TimeTableScreen and TimeTableDestination

### How to test?
1. Open trip planner
2. Click on mode selection button
3. Verify analytics event is fired with correct fromStopId, toStopId, and displayModeSelectionRow state
4. Select/deselect different transport modes
5. Verify mode selection analytics event fires with correct unselected modes

### Why make this change?
To track user interaction with transport mode selection, providing insights into how users filter their journey planning options and which transport modes are commonly excluded from searches.