### PR TITLE
UI: Update loading emojis and bump version to 1.2

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 41
-        versionName = "1.0.9"
+        versionCode = 42
+        versionName = "1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -46,14 +46,14 @@ object LoadingEmojiManager {
         FestivalType.TEDDY_DAY to listOf("🧸", "💖"),
         FestivalType.PROMISE_DAY to listOf("🤝", "💖"),
         FestivalType.HUG_DAY to listOf("🤗", "💖"),
-        FestivalType.KISS_DAY to listOf("💋", "💖", "❤️", "💞"),
-        FestivalType.VALENTINES_DAY to listOf("❤️", "🌹", "💖"),
+        FestivalType.KISS_DAY to listOf("💖", "❤️", "😘"),
+        FestivalType.VALENTINES_DAY to listOf("❤️", "🌹"),
 
-        FestivalType.HOLI to listOf("🎨", "🌈", "🎉", "🎈"),
+        FestivalType.HOLI to listOf("🎨", "🌈", "🎈"),
 
         FestivalType.AUSTRALIA_DAY to listOf("🇦🇺", "🎉", "🎆"),
-        FestivalType.EID to listOf("🌙", "🕌", "🎉", "🎁"),
-        FestivalType.MARDI_GRAS to listOf("🏳️‍🌈", "💃", "🎭", "🪩", "🎉"),
+        FestivalType.EID to listOf("🌙", "🕌", "🎁"),
+        FestivalType.MARDI_GRAS to listOf("🏳️‍🌈", "🪩"),
         FestivalType.VIVID_SYDNEY to listOf("🎆", "🌈", "🌟", "✨"),
     )
 
@@ -73,19 +73,6 @@ object LoadingEmojiManager {
         MonthDay.of(4, 25) to FestivalType.ANZAC_DAY,
         MonthDay.of(1, 26) to FestivalType.AUSTRALIA_DAY,
 
-        // Can change dates
-
-        // Chinese New Year 2025
-        MonthDay.of(1, 29) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(1, 30) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(1, 31) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(2, 1) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(2, 2) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(2, 3) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(2, 4) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(2, 5) to FestivalType.CHINESE_NEW_YEAR,
-        MonthDay.of(2, 6) to FestivalType.CHINESE_NEW_YEAR,
-
         // Valentines day
         MonthDay.of(2, 7) to FestivalType.ROSE_DAY,
         MonthDay.of(2, 8) to FestivalType.PROPOSE_DAY,
@@ -95,6 +82,9 @@ object LoadingEmojiManager {
         MonthDay.of(2, 12) to FestivalType.HUG_DAY,
         MonthDay.of(2, 13) to FestivalType.KISS_DAY,
         MonthDay.of(2, 14) to FestivalType.VALENTINES_DAY,
+
+        // Can change dates
+
 
         // Mardi Gras 2025
         MonthDay.of(2, 15) to FestivalType.MARDI_GRAS,

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.9</string>
+	<string>1.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Update loading screen emojis and bump version to 1.2 (42)

### What changed?
- Simplified emoji sets for various festivals:
  - Removed excess emojis from Valentine's Day, Holi, Eid, and Mardi Gras celebrations
  - Updated Kiss Day emojis to include 😘 instead of 💋
- Removed Chinese New Year 2025 date entries
- Bumped version from 1.0.9 to 1.2 in Android and iOS
- Increased Android version code from 41 to 42

### How to test?
1. Open the app and verify loading screen animations
2. Check emoji displays during different festival dates
3. Verify version numbers in app settings on both platforms
4. Confirm loading animations are smooth and appropriate for each festival

### Why make this change?
Streamlines the festival emoji animations for better user experience while preparing for the next release with updated version numbers for app store distribution.