### PR TITLE
UI: Persist transport mode filter selections

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -1,7 +1,9 @@
 package xyz.ksharma.krail.trip.planner.ui.state.timetable
 
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -14,6 +16,7 @@ data class TimeTableState(
     val journeyList: ImmutableList<JourneyCardInfo> = persistentListOf(),
     val trip: Trip? = null,
     val isError: Boolean = false,
+    val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
 ) {
     data class JourneyCardInfo(
         val timeText: String, // "in x mins"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -90,8 +91,9 @@ fun TimeTableScreen(
     val themeColorHex by LocalThemeColor.current
     val themeColor = themeColorHex.hexToComposeColor()
     var displayModeSelectionRow by rememberSaveable { mutableStateOf(false) }
-    val unselectedModesProductClass: MutableList<Int> = remember {
-        mutableStateListOf()
+    val unselectedModesProductClass: MutableList<Int> = remember(timeTableState.unselectedModes) {
+        log("Initial Exclude - : ${timeTableState.unselectedModes}")
+        mutableStateListOf(*timeTableState.unselectedModes.toTypedArray())
     }
 
     Column(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -4,6 +4,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -173,7 +174,12 @@ class TimeTableViewModel(
 
             // call api
             rateLimiter.triggerEvent()
-            updateUiState { copy(isLoading = true) }
+            updateUiState {
+                copy(
+                    isLoading = true,
+                    unselectedModes = this@TimeTableViewModel.unselectedModes.toImmutableSet()
+                )
+            }
 
             // analytics
             analytics.track(


### PR DESCRIPTION
### TL;DR
Added persistence for transport mode filters in the trip planner timetable view

### What changed?
- Added `unselectedModes` property to `TimeTableState` to track filtered transport modes
- Updated `TimeTableViewModel` to store unselected modes in the UI state
- Modified `TimeTableScreen` to initialize the mode selection from the persisted state

### Screenshots

https://github.com/user-attachments/assets/8a84d9b5-3427-4905-b5be-b5d658405bc5


### How to test?
1. Open the trip planner
2. Select/deselect transport modes using the filter
3. Navigate away from the screen and return
4. Verify that previously selected/deselected transport modes remain in the same state

### Why make this change?
Previously, transport mode filters would reset whenever users left and returned to the timetable screen. This change maintains the user's filter preferences across navigation events, providing a more consistent and user-friendly experience.