### PR TITLE
CI: Add Google Play release workflow

### DIFF
--- a/.github/workflows/google-play-release.yml
+++ b/.github/workflows/google-play-release.yml
@@ -1,0 +1,86 @@
+name: Google Play Release
+
+on:
+  pull_request:
+    branches: [ google/* ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    environment: Firebase
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup environment variables
+        run: |
+          echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+
+      - name: set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
+      - name: Setup firebase
+        run: |
+          curl -sL https://firebase.tools | bash
+
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Firebase Android (Release) - Google Services.json file
+        env:
+          DATA: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON_RELEASE }}
+        run: echo $DATA | base64 -di > composeApp/src/release/google-services.json
+
+      - name: Build Android Release
+        env:
+          ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
+        run: ./gradlew :composeApp:bundleRelease
+
+      - name: Sign Android Release AAB
+        id: signed_release_aab
+        uses: r0adkll/sign-android-release@v1.0.4
+        with:
+          releaseDirectory: composeApp/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+          alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      # Uploading Signed AAB to internal track of PlayConsole
+      - name: Deploy to Play Store (Internal)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: xyz.ksharma.krail
+          releaseFiles: ${{steps.signed_release_aab.outputs.signedReleaseFile}}
+          track: internal
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v10000
+          generate_release_notes: true
+          changesNotSentForReview: false
+          prerelease: true
+          files: |
+            ${{steps.signed_release_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/google-play-release.yml
+++ b/.github/workflows/google-play-release.yml
@@ -23,6 +23,11 @@ jobs:
           echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
           echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
 
+      - name: Extract Version Name
+        run: |
+          VERSION_NAME=$(grep -oP 'versionName\s*=\s*"\K[^"]+' composeApp/build.gradle.kts)
+          echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV          
+
       - name: set up JDK
         uses: actions/setup-java@v4
         with:
@@ -78,5 +83,6 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: v${{ env.VERSION_NAME }}
           files: |
             ${{steps.signed_release_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/google-play-release.yml
+++ b/.github/workflows/google-play-release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - 'prod/**'
-  pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -85,9 +82,9 @@ jobs:
 
       - name: Create Github Release
         uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_KRAIL_GITHUB }}
         with:
           tag_name: v${{ env.VERSION_NAME }}
           generate_release_notes: true
           draft: true
-          files: |
-            ${{steps.signed_release_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/google-play-release.yml
+++ b/.github/workflows/google-play-release.yml
@@ -78,9 +78,5 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v10000
-          generate_release_notes: true
-          changesNotSentForReview: false
-          prerelease: true
           files: |
             ${{steps.signed_release_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/google-play-release.yml
+++ b/.github/workflows/google-play-release.yml
@@ -1,9 +1,12 @@
 name: Google Play Release
 
 on:
+  push:
+    branches:
+      - 'prod/**'
   pull_request:
     branches: [ main ]
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -86,6 +89,5 @@ jobs:
           tag_name: v${{ env.VERSION_NAME }}
           generate_release_notes: true
           draft: true
-          make_latest: true
           files: |
             ${{steps.signed_release_aab.outputs.signedReleaseFile}}

--- a/.github/workflows/google-play-release.yml
+++ b/.github/workflows/google-play-release.yml
@@ -2,7 +2,7 @@ name: Google Play Release
 
 on:
   pull_request:
-    branches: [ google/* ]
+    branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -80,9 +80,12 @@ jobs:
           releaseFiles: ${{steps.signed_release_aab.outputs.signedReleaseFile}}
           track: internal
 
-      - name: Create Release
+      - name: Create Github Release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ env.VERSION_NAME }}
+          generate_release_notes: true
+          draft: true
+          make_latest: true
           files: |
             ${{steps.signed_release_aab.outputs.signedReleaseFile}}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 46
+        versionCode = 47
         versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 43
+        versionCode = 44
         versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 44
+        versionCode = 45
         versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 47
+        versionCode = 48
         versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 45
+        versionCode = 46
         versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
This pull request introduces a new CI workflow for releasing Android applications to the Google Play Store. The workflow includes the following steps:

- **Setup environment variables**: Configures necessary environment variables for the build process.
- **Extract Version Name**: Extracts the version name from the `build.gradle.kts` file.
- **Setup JDK**: Sets up the Java Development Kit (JDK) using the Zulu distribution.
- **Setup Firebase**: Installs Firebase CLI tools.
- **Cache Gradle and wrapper**: Caches Gradle dependencies and wrapper to speed up the build process.
- **Make Gradle executable**: Ensures the Gradle wrapper is executable.
- **Firebase Android (Release) - Google Services.json file**: Decodes and sets up the `google-services.json` file for the release build.
- **Build Android Release**: Builds the Android release AAB (Android App Bundle).
- **Sign Android Release AAB**: Signs the release AAB using the provided keystore.
- **Deploy to Play Store (Internal)**: Uploads the signed AAB to the internal track of the Google Play Console.
- **Create Release**: Creates a new GitHub release with the signed AAB file.

This workflow is triggered on pull requests to branches matching the pattern `google/*` and includes concurrency control to cancel in-progress runs for the same pull request.

The version code has been incremented from 43 to 46, maintaining version name at 1.2.1.