### PR TITLE
Version: Bump to 1.2.1

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 42
-        versionName = "1.2"
+        versionCode = 43
+        versionName = "1.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Bumped version numbers to 1.2.1 for both Android and iOS apps

### What changed?
- Android version code increased from 42 to 43
- Android version name updated from 1.2 to 1.2.1
- iOS bundle short version string updated from 1.2 to 1.2.1

### How to test?
1. Build and install the Android app to verify the new version appears in settings
2. Build and install the iOS app to verify the new version appears in settings
3. Verify both platforms display version 1.2.1

### Why make this change?
Version bump needed for next app store release to maintain consistent versioning across both platforms