### PR TITLE
Deps: Remove unused ktor-client-cio dependency

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -119,7 +119,6 @@ kotlin {
             implementation(libs.androidx.lifecycle.runtime.compose)
 
             implementation(libs.ktor.client.core)
-            implementation(libs.ktor.client.cio)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.client.logging)
             implementation(libs.ktor.serialization.kotlinx.json)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,6 @@ di-koinComposeViewmodelNav = {module = "io.insert-koin:koin-compose-viewmodel-na
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }


### PR DESCRIPTION
### TL;DR
Removed unused Ktor CIO client dependency from the project

### What changed?
- Removed `ktor-client-cio` dependency from `build.gradle.kts`
- Removed corresponding entry from `libs.versions.toml`

### How to test?
1. Build the project and verify it compiles successfully
2. Run the application and confirm network operations still function as expected
3. Verify no CIO-related compilation errors or warnings appear

### Why make this change?
The CIO client was not being utilized in the project as we're using platform-specific HTTP clients (OkHttp for Android and Darwin for iOS). Removing this unused dependency helps reduce the application's dependency footprint and prevents potential conflicts.