### PR TITLE
Android: Update compile and target SDK to 35

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
@@ -45,7 +45,7 @@ fun Project.configureAndroid(
 
 object AndroidVersion {
     // https://developer.android.com/build/releases/gradle-plugin#api-level-support
-    const val COMPILE_SDK = 34
+    const val COMPILE_SDK = 35
     const val MIN_SDK = 26 // Oreo 8.0
-    const val TARGET_SDK = 34
+    const val TARGET_SDK = 35
 }


### PR DESCRIPTION
### TL;DR
Updated Android SDK versions from 34 to 35

### What changed?
- Increased `COMPILE_SDK` from 34 to 35
- Increased `TARGET_SDK` from 34 to 35
- Maintained `MIN_SDK` at 26 (Android 8.0 Oreo)

### How to test?
1. Build the project and verify it compiles successfully
2. Run the app on devices with Android 8.0 and above
3. Verify app functionality on the latest Android version

### Why make this change?
To ensure compatibility with the latest Android SDK and take advantage of new platform features while maintaining support for devices running Android 8.0 and above.