### PR TITLE
Network: Add logging for excluded transport modes

### DIFF
--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             dependencies {
                 implementation(projects.core.appInfo)
                 implementation(projects.core.di)
+                implementation(projects.core.log)
 
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -6,12 +6,12 @@ import io.ktor.client.request.get
 import io.ktor.http.ParametersBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.StopType
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.service.stop_finder.StopFinderRequestParams
 import xyz.ksharma.krail.trip.planner.network.api.service.trip.TripRequestParams
-import kotlin.math.log
 
 class RealTripPlanningService(
     private val httpClient: HttpClient,
@@ -56,11 +56,11 @@ class RealTripPlanningService(
         }.body()
     }
 
-    private inline fun addExcludedTransportModes(
+    private fun addExcludedTransportModes(
         excludeProductClassSet: Set<Int>,
         parameters: ParametersBuilder,
     ) {
-        println("Exclude - $excludeProductClassSet")
+        log("Exclude transport mode - $excludeProductClassSet")
         parameters.append(TripRequestParams.excludedMeans, "checkbox")
 
         if (excludeProductClassSet.contains(1)) {


### PR DESCRIPTION
This pull request adds logging functionality to the trip planner network module. The changes replace print statements with proper logging utilities to improve debugging and monitoring capabilities.

### Improvements to logging:

* [`feature/trip-planner/network/build.gradle.kts`](diffhunk://#diff-73942b080f9db6e3edcb351bd9198c913603aadde644ccbf9093168cdd3c8d9cR47): Added `projects.core.log` to the dependencies to include the logging functionality.
* [`feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt`](diffhunk://#diff-4b5c495280ed43049b2f9d7bafd1445cd4b458592419576be47a62bd00cb9ad4R9-L14): Imported `xyz.ksharma.krail.core.log.log` to use the logging utility in the `RealTripPlanningService` class.
* [`feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt`](diffhunk://#diff-4b5c495280ed43049b2f9d7bafd1445cd4b458592419576be47a62bd00cb9ad4L59-R63): Replaced the `println` statement with a `log` statement in the `addExcludedTransportModes` method to improve logging.