### PR TITLE
UI: Add rotation animation to reverse button

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -16,8 +18,11 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
@@ -45,6 +50,7 @@ fun SearchStopRow(
     onSearchButtonClick: () -> Unit = {},
 ) {
     val themeColor by LocalThemeColor.current
+    var isReverseButtonRotated by rememberSaveable { mutableStateOf(false) }
 
     Row(
         modifier = modifier
@@ -89,6 +95,11 @@ fun SearchStopRow(
                 .padding(start = 16.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp), // TODO - token "SearchFieldSpacing"
         ) {
+            val rotation by animateFloatAsState(
+                targetValue = if (isReverseButtonRotated) 180f else 0f,
+                animationSpec = tween(durationMillis = 300)
+            )
+
             RoundIconButton(
                 content = {
                     Image(
@@ -98,7 +109,13 @@ fun SearchStopRow(
                         modifier = Modifier.size(24.dp),
                     )
                 },
-                onClick = onReverseButtonClick,
+                onClick = {
+                    isReverseButtonRotated = !isReverseButtonRotated
+                    onReverseButtonClick()
+                },
+                modifier = Modifier.graphicsLayer {
+                    rotationZ = rotation
+                }
             )
 
             RoundIconButton(


### PR DESCRIPTION
### TL;DR
Added rotation animation to the reverse button in the SearchStopRow component

### What changed?
- Added a rotation animation to the reverse button using `animateFloatAsState`
- Implemented state tracking for the button's rotation using `rememberSaveable`
- The button now rotates 180 degrees when clicked
- Animation duration is set to 300 milliseconds with a tween animation spec

### How to test?
1. Navigate to the trip planner screen
2. Locate the reverse button between the origin and destination fields
3. Click the reverse button
4. Verify that it smoothly rotates 180 degrees
5. Click again to confirm it rotates back to its original position

### Why make this change?
The rotation animation provides visual feedback to users when they interact with the reverse button, making the interface more engaging and helping users understand that their action has been registered. This follows material design principles for interactive elements.