### PR TITLE
UI: Add animations to search stop text fields

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -1,7 +1,14 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.EaseOutBounce
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -20,6 +27,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
@@ -75,18 +83,55 @@ fun SearchStopRow(
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             TextFieldButton(onClick = fromButtonClick) {
-                Text(
-                    text = fromStopItem?.stopName
-                        ?: "Starting from",
-                    maxLines = 1,
-                )
+                AnimatedContent(
+                    targetState = fromStopItem?.stopName ?: "Starting from",
+                    transitionSpec = {
+                        (fadeIn(
+                            animationSpec = tween(200),
+                        ) + slideInVertically(
+                            initialOffsetY = { it / 2 },
+                            animationSpec = tween(500, easing = EaseOutBounce),
+                        )) togetherWith (fadeOut(
+                            animationSpec = tween(200),
+                        ) + slideOutVertically(
+                            targetOffsetY = { -it / 2 },
+                            animationSpec = tween(500),
+                        ))
+                    },
+                    contentAlignment = Alignment.CenterStart,
+                    label = "startingFromText",
+                ) { targetText ->
+                    Text(
+                        text = targetText,
+                        maxLines = 1,
+                    )
+                }
             }
+
             TextFieldButton(onClick = toButtonClick) {
-                Text(
-                    text = toStopItem?.stopName
-                        ?: "Destination",
-                    maxLines = 1,
-                )
+                AnimatedContent(
+                    targetState = toStopItem?.stopName ?: "Destination",
+                    transitionSpec = {
+                        (fadeIn(
+                            animationSpec = tween(200),
+                        ) + slideInVertically(
+                            initialOffsetY = { -it / 2 },
+                            animationSpec = tween(500, easing = EaseOutBounce),
+                        )) togetherWith (fadeOut(
+                            animationSpec = tween(200),
+                        ) + slideOutVertically(
+                            targetOffsetY = { it / 2 },
+                            animationSpec = tween(500),
+                        ))
+                    },
+                    contentAlignment = Alignment.CenterStart,
+                    label = "destinationText",
+                ) { targetText ->
+                    Text(
+                        text = targetText,
+                        maxLines = 1,
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
### TL;DR
Added animated transitions when selecting origin and destination stops in the trip planner.

### What changed?
- Wrapped the origin and destination text fields with `AnimatedContent`
- Added slide and fade animations when the text changes
- Implemented bounce easing for a more polished feel
- Added distinct animation directions for origin (slides up) and destination (slides down)

### How to test?
1. Open the trip planner
2. Tap on either the "Starting from" or "Destination" fields
3. Select a stop
4. Verify that the text smoothly animates with a bounce effect
5. Confirm that:
   - Origin text slides up when changing
   - Destination text slides down when changing

### Why make this change?
To improve the user experience by providing visual feedback when selecting stops. The animations make the interface feel more dynamic and polished, while helping users understand that their selection has been registered.