### PR TITLE
Get AppInfo infomation off main thread

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -41,7 +41,7 @@ class SplashViewModel(
             remoteConfig.setup() // App Start Event
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
-    private fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {
+    private suspend fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {
         log("AppInfo: $this, krailTheme: ${_uiState.value.id}")
         analytics.track(
             AnalyticsEvent.AppStart(

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
@@ -1,6 +1,8 @@
 package xyz.ksharma.krail.core.analytics
 
 import dev.gitlive.firebase.analytics.FirebaseAnalytics
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.log.log
@@ -8,14 +10,17 @@ import xyz.ksharma.krail.core.log.log
 class RealAnalytics(
     private val firebaseAnalytics: FirebaseAnalytics,
     private val appInfoProvider: AppInfoProvider,
+    private val coroutineScope: CoroutineScope,
 ) : Analytics {
 
     override fun track(event: AnalyticsEvent) {
-        // Only track prod builds analytics events
-        if (appInfoProvider.getAppInfo().isDebug.not()) {
-            firebaseAnalytics.logEvent(event.name, event.properties)
-        } else {
-            log("ANALYTICS EVENT: $event")
+        coroutineScope.launch {
+            // Only track prod builds analytics events
+            if (appInfoProvider.getAppInfo().isDebug.not()) {
+                firebaseAnalytics.logEvent(event.name, event.properties)
+            } else {
+                log("ANALYTICS EVENT: $event")
+            }
         }
     }
 

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/di/AnalyticsModule.kt
@@ -2,6 +2,9 @@ package xyz.ksharma.krail.core.analytics.di
 
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.analytics.analytics
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.RealAnalytics
@@ -11,6 +14,7 @@ val analyticsModule = module {
         RealAnalytics(
             firebaseAnalytics = Firebase.analytics,
             appInfoProvider = get(),
+            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         )
     }
 }

--- a/core/app-info/build.gradle.kts
+++ b/core/app-info/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
+                implementation(projects.core.di)
 
                 implementation(compose.runtime)
                 api(libs.di.koinComposeViewmodel)

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -5,6 +5,8 @@ import android.content.Context.BATTERY_SERVICE
 import android.content.res.Configuration
 import android.os.BatteryManager
 import android.os.Build
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
 
 class AndroidAppInfo(private val context: Context) : AppInfo {
 
@@ -71,9 +73,12 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
                 "timeZone=$timeZone)"
 }
 
-class AndroidAppInfoProvider(private val context: Context) : AppInfoProvider {
-    override fun getAppInfo(): AppInfo {
-        return AndroidAppInfo(context)
+class AndroidAppInfoProvider(
+    private val context: Context,
+    private val defaultDispatcher: CoroutineDispatcher,
+) : AppInfoProvider {
+    override suspend fun getAppInfo(): AppInfo = withContext(defaultDispatcher) {
+        AndroidAppInfo(context)
     }
 }
 

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/di/AppInfoModule.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/di/AppInfoModule.android.kt
@@ -1,15 +1,16 @@
 package xyz.ksharma.krail.core.appinfo.di
 
 import org.koin.android.ext.koin.androidContext
-import org.koin.core.module.dsl.bind
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appinfo.AndroidAppInfoProvider
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.di.DispatchersComponent
 
 actual val appInfoModule = module {
-    singleOf(::AndroidAppInfoProvider) { bind<AppInfoProvider>() }
-    single<AndroidAppInfoProvider> {
-        AndroidAppInfoProvider(context = androidContext())
+    single<AppInfoProvider> {
+        AndroidAppInfoProvider(
+            context = androidContext(),
+            defaultDispatcher = DispatchersComponent().defaultDispatcher,
+        )
     }
 }

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -81,5 +81,5 @@ enum class DevicePlatformType {
 }
 
 interface AppInfoProvider {
-    fun getAppInfo(): AppInfo
+    suspend fun getAppInfo(): AppInfo
 }

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -74,7 +74,7 @@ class IOSAppInfo : AppInfo {
 }
 
 class IosAppInfoProvider : AppInfoProvider {
-    override fun getAppInfo(): AppInfo {
+    override suspend fun getAppInfo(): AppInfo {
         return IOSAppInfo()
     }
 }

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/di/AppInfoModule.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/di/AppInfoModule.ios.kt
@@ -1,14 +1,11 @@
 package xyz.ksharma.krail.core.appinfo.di
 
-import org.koin.core.module.dsl.bind
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.appinfo.IosAppInfoProvider
 
 actual val appInfoModule = module {
-    singleOf(::IosAppInfoProvider) { bind<AppInfoProvider>() }
-    single<IosAppInfoProvider> {
+    single<AppInfoProvider> {
         IosAppInfoProvider()
     }
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/NetworkModule.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/NetworkModule.kt
@@ -1,6 +1,9 @@
 package xyz.ksharma.krail.trip.planner.network.api.di
 
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
@@ -15,7 +18,12 @@ import xyz.ksharma.krail.trip.planner.network.api.service.httpClient
 
 val networkModule = module {
     singleOf(::NetworkRateLimiter) { bind<RateLimiter>() }
-    single<HttpClient> { httpClient(appInfoProvider = get()) }
+    single<HttpClient> {
+        httpClient(
+            appInfoProvider = get(),
+            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        )
+    }
 
     single {
         RealTripPlanningService(

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.trip.planner.network.api.service
 
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CoroutineScope
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 
-expect fun httpClient(appInfoProvider: AppInfoProvider): HttpClient
+expect fun httpClient(appInfoProvider: AppInfoProvider, coroutineScope: CoroutineScope): HttpClient

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -9,11 +9,16 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.trip.planner.network.BuildKonfig
 
-actual fun httpClient(appInfoProvider: AppInfoProvider): HttpClient {
+actual fun httpClient(
+    appInfoProvider: AppInfoProvider,
+    coroutineScope: CoroutineScope,
+): HttpClient {
     return HttpClient(Darwin) {
         expectSuccess = true
         install(ContentNegotiation) {
@@ -24,16 +29,18 @@ actual fun httpClient(appInfoProvider: AppInfoProvider): HttpClient {
             })
         }
         install(Logging) {
-            if (appInfoProvider.getAppInfo().isDebug) {
-                level = LogLevel.BODY
-                logger = object : Logger {
-                    override fun log(message: String) {
-                        println(message)
+            coroutineScope.launch {
+                if (appInfoProvider.getAppInfo().isDebug) {
+                    level = LogLevel.BODY
+                    logger = object : Logger {
+                        override fun log(message: String) {
+                            println(message)
+                        }
                     }
+                    sanitizeHeader { header -> header == HttpHeaders.Authorization }
+                } else {
+                    level = LogLevel.NONE
                 }
-                sanitizeHeader { header -> header == HttpHeaders.Authorization }
-            } else {
-                level = LogLevel.NONE
             }
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -25,7 +25,7 @@ class SettingsViewModel(
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.Settings)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SettingsState())
 
-    private fun fetchAppVersion() {
+    private suspend fun fetchAppVersion() {
         val appVersion = appInfoProvider.getAppInfo().appVersion
         _uiState.value = _uiState.value.copy(appVersion = appVersion)
     }


### PR DESCRIPTION
This pull request refactors the retrieval of AppInfo to be performed off the main thread, ensuring that the main thread is not blocked by potentially long-running operations. 

The following changes have been made:  
- SplashViewModel: Updated trackAppStartEvent to be a suspend function.
- RealAnalytics: Modified the track method to use a CoroutineScope for logging analytics events.
- AnalyticsModule: Injected a CoroutineScope into RealAnalytics.
- AppInfo: Updated AppInfoProvider interface and its implementations to make getAppInfo a suspend function.
- HttpClient: Modified the httpClient function to accept a CoroutineScope and use it for logging.
- SettingsViewModel: Updated fetchAppVersion to be a suspend function.

These changes ensure that AppInfo retrieval and related operations are performed asynchronously, improving the responsiveness of the application.