### PR TITLE
UI: Add stop filtering and prioritization for search results

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -72,7 +72,7 @@ class SearchStopViewModelTest {
             }
         }
 
-/*
+/* This test is not valid anymore, as we're not calling API.
     @Test
     fun `GIVEN search query WHEN SearchTextChanged is triggered and api is success THEN uiState is updated with results`() =
         runTest {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -93,7 +93,19 @@ class SearchStopViewModel(
             transportMode.productClass to index
         }.toMap()
 
-        val highPriorityStopIds = listOf("10101234", "10101235", "10101236", "10101237", "10101238")
+        // TODO - these should come from Firebase config and have only these hardcoded as fallback.
+        val highPriorityStopIds = listOf(
+            "200060",
+            "200070",
+            "200080",
+            "206010",
+            "2150106",
+            "200017",
+            "200039",
+            "201016",
+            "201039",
+            "201080"
+        )
 
         return stopResults.sortedWith(compareBy(
             { stopResult ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -75,7 +75,7 @@ class SearchStopViewModel(
                     .let {
                         filterProductClasses(
                             stopResults = it,
-                            excludedProductClasses = listOf(TransportMode.Ferry())
+                            excludedProductClasses = listOf(TransportMode.Ferry().productClass).toImmutableList()
                         )
                     }
                     .let(::prioritiseStops)
@@ -129,9 +129,12 @@ class SearchStopViewModel(
 
 fun filterProductClasses(
     stopResults: List<SearchStopState.StopResult>,
-    excludedProductClasses: Any,
+    excludedProductClasses: List<Int>,
 ): List<SearchStopState.StopResult> {
-
+    return stopResults.filter { stopResult ->
+        val productClasses = stopResult.transportModeType.map { it.productClass }
+        productClasses.any { it !in excludedProductClasses }
+    }
 }
 
 /// TODO - move to mapper:

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -68,13 +68,16 @@ class SearchStopViewModel(
                     sandook.selectStops(
                         stopName = query,
                         excludeProductClassList = emptyList(),
-                    ).take(50)
-                resultsDb.forEach {
-                    log("resultsDb [$query]: ${it.stopName}")
-                }
-                val stopResults = resultsDb.map {
-                    it.toStopResult()
-                }.let(::prioritiseStops)
+                    )
+                /*
+                                resultsDb.forEach {
+                                    log("resultsDb [$query]: ${it.stopName}")
+                                }
+                */
+                val stopResults = resultsDb
+                    .map { it.toStopResult() }
+                    .let(::prioritiseStops)
+                    .take(50)
 
                 updateUiState { displayData(stopResults) }
             }.getOrElse {
@@ -94,7 +97,9 @@ class SearchStopViewModel(
 
         return stopResults.sortedWith(compareBy(
             { stopResult ->
-                stopResult.transportModeType.minOfOrNull { transportModePriorityMap[it.productClass] ?: Int.MAX_VALUE } ?: Int.MAX_VALUE
+                stopResult.transportModeType.minOfOrNull {
+                    transportModePriorityMap[it.productClass] ?: Int.MAX_VALUE
+                } ?: Int.MAX_VALUE
             },
             { it.stopName }
         ))

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -17,7 +17,6 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
-import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SelectProductClassesForStop
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
@@ -65,10 +64,7 @@ class SearchStopViewModel(
                   log("results: $results")*/
 
                 val resultsDb: List<SelectProductClassesForStop> =
-                    sandook.selectStops(
-                        stopName = query,
-                        excludeProductClassList = emptyList(),
-                    )
+                    sandook.selectStops(stopName = query)
                 /*
                                 resultsDb.forEach {
                                     log("resultsDb [$query]: ${it.stopName}")
@@ -76,6 +72,12 @@ class SearchStopViewModel(
                 */
                 val stopResults = resultsDb
                     .map { it.toStopResult() }
+                    .let {
+                        filterProductClasses(
+                            stopResults = it,
+                            excludedProductClasses = listOf(TransportMode.Ferry())
+                        )
+                    }
                     .let(::prioritiseStops)
                     .take(50)
 
@@ -123,6 +125,13 @@ class SearchStopViewModel(
     private fun updateUiState(block: SearchStopState.() -> SearchStopState) {
         _uiState.update(block)
     }
+}
+
+fun filterProductClasses(
+    stopResults: List<SearchStopState.StopResult>,
+    excludedProductClasses: Any,
+): List<SearchStopState.StopResult> {
+
 }
 
 /// TODO - move to mapper:

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -65,11 +65,7 @@ class SearchStopViewModel(
 
                 val resultsDb: List<SelectProductClassesForStop> =
                     sandook.selectStops(stopName = query)
-                /*
-                                resultsDb.forEach {
-                                    log("resultsDb [$query]: ${it.stopName}")
-                                }
-                */
+
                 val stopResults = resultsDb
                     .map { it.toStopResult() }
                     .let {
@@ -97,7 +93,12 @@ class SearchStopViewModel(
             transportMode.productClass to index
         }.toMap()
 
+        val highPriorityStopIds = listOf("10101234", "10101235", "10101236", "10101237", "10101238")
+
         return stopResults.sortedWith(compareBy(
+            { stopResult ->
+                if (stopResult.stopId in highPriorityStopIds) 0 else 1
+            },
             { stopResult ->
                 stopResult.transportModeType.minOfOrNull {
                     transportModePriorityMap[it.productClass] ?: Int.MAX_VALUE

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -104,7 +104,12 @@ class SearchStopViewModel(
             "200039",
             "201016",
             "201039",
-            "201080"
+            "201080",
+            "200066",
+            "200030",
+            "200046",
+            "200050",
+
         )
 
         return stopResults.sortedWith(compareBy(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -64,7 +64,7 @@ class SearchStopViewModel(
                   log("results: $results")*/
 
                 val resultsDb: List<SelectProductClassesForStop> =
-                    sandook.selectStops(stopName = query)
+                    sandook.selectStops(stopName = query, excludeProductClassList = listOf())
 
                 val stopResults = resultsDb
                     .map { it.toStopResult() }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopFilterByProductClassTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopFilterByProductClassTest.kt
@@ -1,0 +1,89 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StopFilterByProductClassTest {
+
+    @Test
+    fun `should return stops excluding given product classes`() = runTest {
+        // Given
+        val testCases = listOf(
+            TestCase(
+                excludedClasses = listOf(1),
+                expectedStopIds = listOf("10101101", "10101105", "12349", "12356")
+            ),
+            TestCase(
+                excludedClasses = listOf(1, 2),
+                expectedStopIds = listOf("12349", "12356")
+            ),
+            TestCase(
+                excludedClasses = listOf(5),
+                expectedStopIds = listOf("10101101", "10101100", "10101105", "12349")
+            ),
+            // All product classes are excluded
+            TestCase(
+                excludedClasses = listOf(1, 2, 5),
+                expectedStopIds = listOf()
+            )
+        )
+
+        testCases.forEach { testCase ->
+            // When
+            val actualResults = filterProductClasses(
+                stopResults = stopResults,
+                excludedProductClasses = testCase.excludedClasses
+            )
+
+            val actualStopIds = actualResults.map { it.stopId }
+
+            // Then
+            assertEquals(testCase.expectedStopIds.sorted(), actualStopIds.sorted())
+        }
+    }
+
+    private data class TestCase(
+        val excludedClasses: List<Int>,
+        val expectedStopIds: List<String>,
+    )
+
+    companion object {
+        private val stopResults = listOf(
+            SearchStopState.StopResult(
+                stopName = "Town Hall Station",
+                stopId = "10101101",
+                transportModeType = listOf(
+                    TransportMode.Train(),
+                    TransportMode.Metro()
+                ).toImmutableList(),
+            ),
+            SearchStopState.StopResult(
+                stopName = "Wynyard Station",
+                stopId = "10101100",
+                transportModeType = listOf(TransportMode.Train()).toImmutableList(),
+            ),
+            SearchStopState.StopResult(
+                stopName = "Metro Only Station",
+                stopId = "10101105",
+                transportModeType = listOf(TransportMode.Metro()).toImmutableList(),
+            ),
+            SearchStopState.StopResult(
+                stopName = "Schofields Station",
+                stopId = "12349",
+                transportModeType = listOf(
+                    TransportMode.Bus(),
+                    TransportMode.Train()
+                ).toImmutableList(),
+            ),
+            SearchStopState.StopResult(
+                stopName = "103 ABC Rd, Hallway",
+                stopId = "12356",
+                transportModeType = listOf(TransportMode.Bus()).toImmutableList(),
+            ),
+        )
+    }
+}

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -123,9 +123,8 @@ internal class RealSandook(factory: SandookDriverFactory) : Sandook {
         excludeProductClassList: List<Int>,
     ): List<SelectProductClassesForStop> {
         return nswStopsQueries.selectProductClassesForStop(
-            stopName,
-            stopName,
-            productClass = excludeProductClassList.map { it.toLong() },
+            stopId = stopName,
+            stopName = stopName,
         ).executeAsList()
     }
 

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -55,8 +55,6 @@ interface Sandook {
      */
     fun selectStops(
         stopName: String,
-        excludeProductClassList: List<Int> = emptyList(),
+        excludeProductClassList: List<Int>,
     ): List<SelectProductClassesForStop>
-
-    // endregion
 }

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswStops.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswStops.sq
@@ -42,14 +42,10 @@ selectProductClassesForStop:
 SELECT s.*,
        COALESCE(GROUP_CONCAT(p.productClass), '') AS productClasses
 FROM NswStops AS s
-LEFT JOIN NswStopProductClass AS p ON s.stopId = p.stopId
+LEFT JOIN NswStopProductClass AS p
+    ON s.stopId = p.stopId
 WHERE (
-    s.stopId = ?  -- Exact match scenario
-    OR s.stopName LIKE '%' || ? || '%'  -- Partial match scenario
-)
-AND s.stopId NOT IN (
-    SELECT stopId
-    FROM NswStopProductClass
-    WHERE productClass IN ?
+    s.stopId = :stopId  -- Use named parameter :stopId
+    OR s.stopName LIKE '%' || :stopName || '%'  -- Use named parameter :stopName
 )
 GROUP BY s.stopId;


### PR DESCRIPTION
# Stop Search Prioritization and Filtering Improvements

- Introduced `prioritiseStops` function to sort stops based on transport mode priority order
- Moved stop filtering logic from SQL to ViewModel layer for better control
- Added unit tests for product class filtering functionality
- Implemented high priority stops sorting with predefined list:
  - Town Hall (200060)
  - Central (200070)
  - Wynyard (200080)
  - Circular Quay (206010)
  - Bondi Junction (2150106)
  - Chatswood (200017)
  - Parramatta (200039)
  - Blacktown (201016)
  - Liverpool (201039)
  - Penrith (201080)
  - St James (200066)
  - Museum (200030)
  - Martin Place (200046)
  - Kings Cross (200050)
- Results are now limited to 50 stops after sorting and filtering