### PR TITLE
Version: Bump to 1.2.2

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 48
-        versionName = "1.2.1"
+        versionCode = 49
+        versionName = "1.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR
Bump version numbers for Android and iOS apps to 1.2.2

### What changed?
- Android: Version code increased from 48 to 49, version name updated to 1.2.2
- iOS: Bundle version string updated to 1.2.2

### How to test?
1. Build and install the app on both Android and iOS devices
2. Verify the version number shows as 1.2.2 in app settings/info
3. Confirm the app functions normally after the version update

### Why make this change?
Preparing for a new release by incrementing version numbers across platforms to maintain version consistency between Android and iOS builds.