### PR TITLE
Core: Add app-start module for launch operations

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -99,6 +99,7 @@ kotlin {
         commonMain.dependencies {
             implementation(projects.core.analytics)
             implementation(projects.core.appInfo)
+            implementation(projects.core.appStart)
             implementation(projects.core.di)
             implementation(projects.core.log)
             implementation(projects.core.remoteConfig)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -44,6 +44,7 @@ val splashModule = module {
             analytics = get(),
             appInfoProvider = get(),
             ioDispatcher = get(named(IODispatcher)),
+            appStart = get(),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -43,9 +43,7 @@ val splashModule = module {
             sandook = get(),
             analytics = get(),
             appInfoProvider = get(),
-            remoteConfig = get(),
             ioDispatcher = get(named(IODispatcher)),
-            protoParser = get(),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -8,6 +8,7 @@ import org.koin.dsl.includes
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.analytics.di.analyticsModule
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
+import xyz.ksharma.krail.core.appstart.di.appStartModule
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.core.di.coroutineDispatchersModule
 import xyz.ksharma.krail.core.remote_config.di.remoteConfigModule
@@ -31,6 +32,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             remoteConfigModule,
             coroutineDispatchersModule,
             gtfsModule,
+            appStartModule,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
@@ -57,7 +57,7 @@ fun SplashScreen(
 
         val splashComplete by rememberUpdatedState(onSplashComplete)
         LaunchedEffect(key1 = Unit) {
-            delay(2000) // TODO - replace back
+            delay(1200)
             splashComplete()
         }
     }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.withContext
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appstart.AppStart
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
@@ -22,6 +23,7 @@ class SplashViewModel(
     private val analytics: Analytics,
     private val appInfoProvider: AppInfoProvider,
     private val ioDispatcher: CoroutineDispatcher,
+    private val appStart: AppStart,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<KrailThemeStyle> =
@@ -33,6 +35,7 @@ class SplashViewModel(
         .onStart {
             loadKrailThemeStyle()
             trackAppStartEvent()
+            appStart.start()
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     private suspend fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -3,22 +3,16 @@ package xyz.ksharma.krail.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.log.log
-import xyz.ksharma.krail.core.remote_config.RemoteConfig
-import xyz.ksharma.krail.io.gtfs.nswstops.ProtoParser
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
@@ -27,9 +21,7 @@ class SplashViewModel(
     private val sandook: Sandook,
     private val analytics: Analytics,
     private val appInfoProvider: AppInfoProvider,
-    private val remoteConfig: RemoteConfig,
     private val ioDispatcher: CoroutineDispatcher,
-    private val protoParser: ProtoParser,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<KrailThemeStyle> =
@@ -41,14 +33,6 @@ class SplashViewModel(
         .onStart {
             loadKrailThemeStyle()
             trackAppStartEvent()
-            remoteConfig.setup() // App Start Event
-
-            kotlin.runCatching {
-                log("Reading NSW_STOPS proto file - StopsParser:")
-                protoParser.parseAndInsertStops()
-            }.getOrElse {
-                log("Error reading proto file: $it")
-            }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     private suspend fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.splash
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -33,9 +34,13 @@ class SplashViewModel(
     private val _isLoading: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
         .onStart {
-            loadKrailThemeStyle()
-            trackAppStartEvent()
-            appStart.start()
+            coroutineScope {
+                appStart.start()
+            }
+            coroutineScope {
+                loadKrailThemeStyle()
+                trackAppStartEvent()
+            }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), true)
 
     private suspend fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {

--- a/core/app-start/README.md
+++ b/core/app-start/README.md
@@ -1,0 +1,3 @@
+## AppStart Module
+
+This module will have code which will be executed at the start of app.

--- a/core/app-start/build.gradle.kts
+++ b/core/app-start/build.gradle.kts
@@ -30,6 +30,9 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
                 implementation(projects.core.di)
+                implementation(projects.core.log)
+                implementation(projects.core.remoteConfig)
+                implementation(projects.io.gtfs)
 
                 implementation(compose.runtime)
                 api(libs.di.koinComposeViewmodel)

--- a/core/app-start/build.gradle.kts
+++ b/core/app-start/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
                 implementation(projects.core.log)
                 implementation(projects.core.remoteConfig)
                 implementation(projects.io.gtfs)
+                implementation(projects.sandook)
 
                 implementation(compose.runtime)
                 api(libs.di.koinComposeViewmodel)

--- a/core/app-start/build.gradle.kts
+++ b/core/app-start/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    alias(libs.plugins.krail.android.library)
+    alias(libs.plugins.krail.kotlin.multiplatform)
+    alias(libs.plugins.krail.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "xyz.ksharma.krail.core.appstart"
+}
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    androidTarget()
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(libs.kotlinx.serialization.json)
+                implementation(projects.core.di)
+
+                implementation(compose.runtime)
+                api(libs.di.koinComposeViewmodel)
+            }
+        }
+    }
+}

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/AppStart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/AppStart.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.core.appstart
+
+interface AppStart {
+    fun start()
+}

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/AppStart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/AppStart.kt
@@ -1,5 +1,12 @@
 package xyz.ksharma.krail.core.appstart
 
 interface AppStart {
+
+    /**
+     * Called when the app starts.
+     * Perform all events here that should happen at app launch here.
+     *
+     * Only those operations should be launched here that should be scoped to application level.
+     */
     fun start()
 }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -13,6 +13,11 @@ class RealAppStart(
     private val protoParser: ProtoParser,
     private val sandook: Sandook,
 ) : AppStart {
+
+    init {
+        log("RealAppStart created.")
+    }
+
     override fun start() {
         coroutineScope.launch {
             parseAndInsertNswStopsIfNeeded()
@@ -30,7 +35,7 @@ class RealAppStart(
      * Parses and inserts NSW_STOPS data in the database if they are not already inserted.
      */
     private suspend fun parseAndInsertNswStopsIfNeeded() = runCatching {
-        if (isStopsNotInserted()) {
+        if (shouldInsertStops()) {
             protoParser.parseAndInsertStops()
         } else {
             log("Stops already inserted in the database.")
@@ -40,7 +45,7 @@ class RealAppStart(
         // TODO - Firebase performance track.
     }
 
-    private fun isStopsNotInserted(): Boolean {
+    private fun shouldInsertStops(): Boolean {
         return sandook.stopsCount() == 0 || sandook.productClassCount() == 0
     }
 }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -1,0 +1,12 @@
+package xyz.ksharma.krail.core.appstart
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+class RealAppStart(private val coroutineScope: CoroutineScope) : AppStart {
+    override fun start() {
+        coroutineScope.launch {
+
+        }
+    }
+}

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -15,27 +15,29 @@ class RealAppStart(
 ) : AppStart {
     override fun start() {
         coroutineScope.launch {
-
-            remoteConfig.setup() // App Start Event
-
             parseAndInsertNswStopsIfNeeded()
+            setupRemoteConfig()
         }
+    }
+
+    private fun setupRemoteConfig() = runCatching {
+        remoteConfig.setup()
+    }.getOrElse {
+        log("Error setting up remote config: $it")
     }
 
     /**
      * Parses and inserts NSW_STOPS data in the database if they are not already inserted.
      */
-    private suspend fun parseAndInsertNswStopsIfNeeded() {
-        kotlin.runCatching {
-            if (isStopsNotInserted()) {
-                protoParser.parseAndInsertStops()
-            } else {
-                log("Stops already inserted in the database.")
-            }
-        }.getOrElse {
-            log("Error reading proto file: $it")
-            // TODO - Firebase performance track.
+    private suspend fun parseAndInsertNswStopsIfNeeded() = runCatching {
+        if (isStopsNotInserted()) {
+            protoParser.parseAndInsertStops()
+        } else {
+            log("Stops already inserted in the database.")
         }
+    }.getOrElse {
+        log("Error reading proto file: $it")
+        // TODO - Firebase performance track.
     }
 
     private fun isStopsNotInserted(): Boolean {

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -2,11 +2,28 @@ package xyz.ksharma.krail.core.appstart
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.remote_config.RemoteConfig
+import xyz.ksharma.krail.io.gtfs.nswstops.ProtoParser
 
-class RealAppStart(private val coroutineScope: CoroutineScope) : AppStart {
+class RealAppStart(
+    private val coroutineScope: CoroutineScope,
+    private val remoteConfig: RemoteConfig,
+    private val protoParser: ProtoParser,
+) : AppStart {
     override fun start() {
         coroutineScope.launch {
 
+            remoteConfig.setup() // App Start Event
+
+            kotlin.runCatching {
+                log("Reading NSW_STOPS proto file - StopsParser:")
+                // Call only if stops are not inserted in the database.
+                protoParser.parseAndInsertStops()
+            }.getOrElse {
+                log("Error reading proto file: $it")
+                // TODO - Firebase performance track.
+            }
         }
     }
 }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.core.appstart
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.RemoteConfig

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -5,25 +5,40 @@ import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.RemoteConfig
 import xyz.ksharma.krail.io.gtfs.nswstops.ProtoParser
+import xyz.ksharma.krail.sandook.Sandook
 
 class RealAppStart(
     private val coroutineScope: CoroutineScope,
     private val remoteConfig: RemoteConfig,
     private val protoParser: ProtoParser,
+    private val sandook: Sandook,
 ) : AppStart {
     override fun start() {
         coroutineScope.launch {
 
             remoteConfig.setup() // App Start Event
 
-            kotlin.runCatching {
-                log("Reading NSW_STOPS proto file - StopsParser:")
-                // Call only if stops are not inserted in the database.
-                protoParser.parseAndInsertStops()
-            }.getOrElse {
-                log("Error reading proto file: $it")
-                // TODO - Firebase performance track.
-            }
+            parseAndInsertNswStopsIfNeeded()
         }
+    }
+
+    /**
+     * Parses and inserts NSW_STOPS data in the database if they are not already inserted.
+     */
+    private suspend fun parseAndInsertNswStopsIfNeeded() {
+        kotlin.runCatching {
+            if (isStopsNotInserted()) {
+                protoParser.parseAndInsertStops()
+            } else {
+                log("Stops already inserted in the database.")
+            }
+        }.getOrElse {
+            log("Error reading proto file: $it")
+            // TODO - Firebase performance track.
+        }
+    }
+
+    private fun isStopsNotInserted(): Boolean {
+        return sandook.stopsCount() == 0 || sandook.productClassCount() == 0
     }
 }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
@@ -1,0 +1,16 @@
+package xyz.ksharma.krail.core.appstart.di
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.koin.dsl.module
+import xyz.ksharma.krail.core.appstart.AppStart
+import xyz.ksharma.krail.core.appstart.RealAppStart
+
+val appStartModule = module {
+    single<AppStart> {
+        RealAppStart(
+            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        )
+    }
+}

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
@@ -10,7 +10,10 @@ import xyz.ksharma.krail.core.appstart.RealAppStart
 val appStartModule = module {
     single<AppStart> {
         RealAppStart(
-            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+            remoteConfig = get(),
+            protoParser = get(),
+            sandook = get(),
         )
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ include(":composeApp")
 include(":taj") // Design System
 include(":core:analytics")
 include(":core:app-info")
+include(":core:app-start")
 include(":core:coroutines-ext")
 include(":core:date-time")
 include(":core:di")


### PR DESCRIPTION
Create AppStart module

- Move RemoteConfig setup and ProtoParser from SplashViewModel to AppStart module
- Create AppStart interface to handle application-level startup operations
- Implement RealAppStart with coroutine scope for async operations
- Add Koin module for dependency injection
- Reduce splash screen delay from 2000ms to 1200ms