### PR TITLE
DB: Add product class count query

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeSandook.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeSandook.kt
@@ -85,6 +85,10 @@ class FakeSandook : Sandook {
         return stops.size
     }
 
+    override fun productClassCount(): Int {
+        return stopProductClasses.size
+    }
+
     override fun insertNswStopProductClass(stopId: String, productClass: Int) {
         val productClasses = stopProductClasses.getOrPut(stopId) { mutableListOf() }
         productClasses.add(productClass)

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -102,6 +102,10 @@ internal class RealSandook(factory: SandookDriverFactory) : Sandook {
         return nswStopsQueries.selectStopsCount().executeAsOne().toInt()
     }
 
+    override fun productClassCount(): Int {
+        return nswStopsQueries.selectStopProductClassCount().executeAsOne().toInt()
+    }
+
     override fun insertNswStopProductClass(stopId: String, productClass: Int) {
         nswStopsQueries.insertStopProductClass(stopId, productClass.toLong())
     }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -38,6 +38,8 @@ interface Sandook {
 
     fun stopsCount(): Int
 
+    fun productClassCount(): Int
+
     fun insertNswStopProductClass(stopId: String, productClass: Int)
 
     /**

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswStops.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswStops.sq
@@ -31,6 +31,11 @@ insertStopProductClass:
 INSERT INTO NswStopProductClass(stopId, productClass)
 VALUES (?, ?);
 
+-- Select count of items in NswStopProductClass
+selectStopProductClassCount:
+SELECT COUNT(*) AS totalItems
+FROM NswStopProductClass;
+
 clearNswStopsTable:
 DELETE FROM NswStops;
 


### PR DESCRIPTION
### TL;DR
Added a new method to count product classes in the NSW stops database.

### What changed?
- Added `productClassCount()` method to the `Sandook` interface
- Implemented the method in `RealSandook` class
- Created new SQL query `selectStopProductClassCount` to count entries in the NswStopProductClass table

### How to test?
1. Call `productClassCount()` on a Sandook instance
2. Verify the returned count matches the number of entries in the NswStopProductClass table
3. Add/remove product classes and confirm the count updates accordingly

### Why make this change?
To provide a way to monitor and verify the number of product classes stored in the database, which is useful for data validation and debugging purposes.