### PR TITLE
Version: Bump to 1.3.2

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 71
-        versionName = "1.3.1"
+        versionCode = 73
+        versionName = "1.3.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR
Bump version numbers for Android and iOS apps to 1.3.2

### What changed?
- Android: Updated version code to 73 and version name to 1.3.2
- iOS: Updated bundle version to 2 and bundle short version string to 1.3.2

### How to test?
1. Build and install the app on both Android and iOS devices
2. Verify the version number in app settings/info shows 1.3.2
3. For Android, verify the version code is 73 in Play Store console
4. For iOS, verify the build number is 2 in App Store Connect

### Why make this change?
Prepare for new app release by incrementing version numbers across platforms to maintain version parity between Android and iOS applications.