### PR TITLE
Festival: Add human-centric celebration days

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/FestivalType.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/FestivalType.kt
@@ -21,5 +21,12 @@ enum class FestivalType {
     HOLI,
     EID,
     MARDI_GRAS,
-    VIVID_SYDNEY
+    VIVID_SYDNEY,
+    WOMENS_DAY,
+    MENS_DAY,
+    NURSES_DAY,
+    A11Y_DAY,
+    PEACE_DAY,
+    ENGINEERS_DAY,
+    FRIENDSHIP_DAY,
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -53,8 +53,17 @@ object LoadingEmojiManager {
 
         FestivalType.AUSTRALIA_DAY to listOf("🇦🇺", "🎉", "🎆"),
         FestivalType.EID to listOf("🌙", "🕌", "🎁"),
-        FestivalType.MARDI_GRAS to listOf("🏳️‍🌈", "🪩"),
+        FestivalType.MARDI_GRAS to listOf("🏳️‍🌈", "🪩", "🌈"),
         FestivalType.VIVID_SYDNEY to listOf("🎆", "🌈", "🌟", "✨"),
+
+        // Human centric days
+        FestivalType.WOMENS_DAY to listOf("💜", "♀️", "👩", "👩‍🚀", "👩‍🚒", "👩‍✈️"),
+        FestivalType.MENS_DAY to listOf("💙", "♂️", "🚹", "👨‍🚒", "👨‍🌾", "👨‍🚀"),
+        FestivalType.ENGINEERS_DAY to listOf("⚙️", "🔧", "📐", "🏗️"),
+        FestivalType.NURSES_DAY to listOf("💉", "🏥", "🩺"),
+        FestivalType.FRIENDSHIP_DAY to listOf("🤝", "💛", "👫", "👭", "👬", "❤️"),
+        FestivalType.PEACE_DAY to listOf("☮️", "✌️"),
+        FestivalType.A11Y_DAY to listOf("♿️"),
     )
 
     // TODO - test logic add UT
@@ -83,27 +92,15 @@ object LoadingEmojiManager {
         MonthDay.of(2, 13) to FestivalType.KISS_DAY,
         MonthDay.of(2, 14) to FestivalType.VALENTINES_DAY,
 
+        MonthDay.of(3, 4) to FestivalType.ENGINEERS_DAY,
+        MonthDay.of(3, 8) to FestivalType.WOMENS_DAY,
+        MonthDay.of(5, 12) to FestivalType.NURSES_DAY,
+        MonthDay.of(7, 30) to FestivalType.FRIENDSHIP_DAY,
+        MonthDay.of(9, 21) to FestivalType.PEACE_DAY,
+        MonthDay.of(11, 19) to FestivalType.MENS_DAY,
+        MonthDay.of(12, 3) to FestivalType.A11Y_DAY,
+
         // Can change dates
-
-
-        // Mardi Gras 2025
-        MonthDay.of(2, 15) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 16) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 17) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 18) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 19) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 20) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 21) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 22) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 23) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 24) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 25) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 26) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 27) to FestivalType.MARDI_GRAS,
-        MonthDay.of(2, 28) to FestivalType.MARDI_GRAS,
-        MonthDay.of(3, 1) to FestivalType.MARDI_GRAS,
-        MonthDay.of(3, 2) to FestivalType.MARDI_GRAS,
-
         MonthDay.of(3, 14) to FestivalType.HOLI,
         MonthDay.of(3, 30) to FestivalType.EID,
         MonthDay.of(3, 31) to FestivalType.EID,


### PR DESCRIPTION
### TL;DR
Added new international observance days to the festival loading screen with corresponding emoji sets.

### What changed?
- Added new festival types including Women's Day, Men's Day, Nurses Day, Accessibility Day, Peace Day, Engineers Day, and Friendship Day
- Added emoji sets for each new festival type with relevant themed emojis
- Added corresponding calendar dates for the new observances
- Removed redundant Mardi Gras date entries
- Enhanced Mardi Gras emoji set with an additional rainbow emoji

### How to test?
1. Change your device date to match any of the new observances:
   - March 8 (Women's Day)
   - May 12 (Nurses Day)
   - July 30 (Friendship Day)
   - September 21 (Peace Day)
   - November 19 (Men's Day)
   - December 3 (Accessibility Day)
2. Open the app and verify the loading screen displays the corresponding themed emojis

### Why make this change?
To make the loading screen more inclusive and celebratory of various international observances throughout the year, providing users with a more diverse and engaging experience that acknowledges important global celebrations and awareness days.