### PR TITLE
Trip: Update display text logic for non-train transport

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -154,7 +154,12 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
             ?.let { TransportMode.toTransportModeType(productClass = it) }
     val lineName = transportation?.disassembledName
 
-    val displayText = transportation?.destination?.name
+    val displayText =
+        if (transportation?.product?.productClass?.toInt() == TransportMode.Train().productClass) {
+            transportation?.destination?.name
+        } else {
+            transportation?.description
+        }
     val numberOfStops = stopSequence?.size
     val displayDuration = duration?.seconds?.toFormattedDurationTimeString()
     val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()


### PR DESCRIPTION
### TL;DR
Updated train journey display text to show description for non-train transport modes

### What changed?
Modified the logic for displaying transport information in the trip planner. Now, for train journeys, it shows the destination name, while for other transport modes (bus, tram, etc.), it displays the transportation description instead.

### How to test?
1. Plan a journey that includes both train and non-train segments
2. Verify that train segments show the destination name
3. Verify that other transport modes (bus, tram) show their description
4. Check that the display text updates correctly when switching between different transport modes

### Why make this change?
For non-train transport modes, the description often provides more relevant information than the destination name. This change improves clarity and helps users better understand their journey details, especially for mixed-mode trips.