### PR TITLE
UI: Refactor SettingsScreen with reusable SettingsItem component

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -2,8 +2,6 @@ package xyz.ksharma.krail.trip.planner.ui.settings
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,11 +14,10 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
@@ -31,9 +28,9 @@ import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
-import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
 fun SettingsScreen(
@@ -42,8 +39,6 @@ fun SettingsScreen(
     onBackClick: () -> Unit = {},
     onChangeThemeClick: () -> Unit = {},
 ) {
-    val themeColor by LocalThemeColor.current
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -63,54 +58,56 @@ fun SettingsScreen(
             contentPadding = PaddingValues(top = 20.dp, bottom = 104.dp),
         ) {
             item {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .klickable(onClick = { onChangeThemeClick() })
-                        .padding(vertical = 24.dp)
-                        .semantics(mergeDescendants = true) {},
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Image(
-                        contentDescription = null,
-                        painter = painterResource(Res.drawable.ic_paint),
-                        colorFilter = ColorFilter.tint(color = themeColor.hexToComposeColor()),
-                        modifier = Modifier.size(20.dp),
-                    )
-                    Text(
-                        text = "Change Theme",
-                        style = KrailTheme.typography.bodyLarge,
-                    )
-                }
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                SettingsItem(
+                    icon = painterResource(Res.drawable.ic_paint),
+                    text = "Change Theme",
+                    onClick = {
+                        onChangeThemeClick()
+                    }
+                )
             }
 
             item {
-                // todo - common component
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .semantics(mergeDescendants = true) {}
-                        .padding(vertical = 24.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Image(
-                        contentDescription = null,
-                        painter = painterResource(Res.drawable.ic_dev),
-                        colorFilter = ColorFilter.tint(color = themeColor.hexToComposeColor()),
-                        modifier = Modifier.size(24.dp),
-                    )
-                    Text(
-                        text = "KRAIL App Version: $appVersion",
-                        style = KrailTheme.typography.bodyLarge,
-                    )
-                }
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                SettingsItem(
+                    icon = painterResource(Res.drawable.ic_dev),
+                    text = "KRAIL App Version: $appVersion",
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun SettingsItem(
+    icon: Painter,
+    text: String,
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
+    onClick: (() -> Unit)? = null,
+) {
+    val themeColor by LocalThemeColor.current
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .klickable(enabled = onClick != null, onClick = onClick ?: {})
+            .padding(horizontal = 16.dp, vertical = 24.dp)
+            .semantics(mergeDescendants = true) {},
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Image(
+            contentDescription = null,
+            painter = icon,
+            colorFilter = ColorFilter.tint(color = themeColor.hexToComposeColor()),
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = text,
+            style = KrailTheme.typography.bodyLarge,
+        )
+    }
+    if (showDivider) {
+        Divider(modifier = Modifier.padding(horizontal = 16.dp))
     }
 }


### PR DESCRIPTION
### TL;DR

Created a reusable `SettingsItem` component to improve code reusability in the settings screen.

### What changed?

- Extracted the settings item UI into a new reusable `SettingsItem` composable function
- Removed unused imports (clickable, MutableInteractionSource, remember, Role)
- Added parameters to the new component for customization:
  - `icon`: Painter for the item's icon
  - `text`: String for the item's text content
  - `modifier`: Optional Modifier for customizing the component
  - `showDivider`: Boolean to control divider visibility (defaults to true)
  - `onClick`: Optional callback function (nullable) to handle click events
- Refactored the existing settings item to use the new component

### How to test?

1. Navigate to the Settings screen
2. Verify that the app version item appears correctly with its icon and text
3. Confirm that the UI looks identical to the previous implementation
4. Test that the "Change Theme" item still responds to clicks properly

### Why make this change?

This refactoring improves code maintainability by creating a reusable component for settings items. As the "todo - common component" comment suggested, this was planned work to extract this UI pattern into a reusable component that can be used consistently throughout the settings screen as more items are added.