### PR TITLE
BUG: popBackStack() crash fix for Android 14

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -151,11 +151,16 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     // endregion
 
     // region Generic Events
-    data class BackClickEvent(val fromScreen: String) :
-        AnalyticsEvent(
-            name = "back_click",
-            properties = mapOf("fromScreen" to fromScreen),
-        )
+    data class BackClickEvent(
+        val fromScreen: AnalyticsScreen,
+        val isPreviousBackStackEntryNull: Boolean,
+    ) : AnalyticsEvent(
+        name = "back_click",
+        properties = mapOf(
+            "fromScreen" to fromScreen.name,
+            "isPreviousBackStackEntryNull" to isPreviousBackStackEntryNull,
+        ),
+    )
 
     data class AppStart(
         val platformType: String,

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -19,6 +19,8 @@ sealed interface TimeTableUiEvent {
 
     data object AnalyticsDateTimeSelectorClicked : TimeTableUiEvent
 
+    data class BackClick(val isPreviousBackStackEntryNull: Boolean) : TimeTableUiEvent
+
     data class JourneyLegClicked(val expanded: Boolean) : TimeTableUiEvent
 
     data class ModeSelectionChanged(val unselectedModes: Set<Int>) : TimeTableUiEvent

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -60,7 +60,10 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
             fromButtonClick = {
                 viewModel.onEvent(SavedTripUiEvent.AnalyticsFromButtonClick)
                 //              Timber.d("fromButtonClick - nav: ${SearchStopRoute(fieldType = SearchStopFieldType.FROM)}")
-                navController.navigate(SearchStopRoute(fieldTypeKey = SearchStopFieldType.FROM.key))
+                navController.navigate(
+                    route = SearchStopRoute(fieldTypeKey = SearchStopFieldType.FROM.key),
+                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                )
             },
             toButtonClick = {
                 viewModel.onEvent(SavedTripUiEvent.AnalyticsToButtonClick)
@@ -98,9 +101,6 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                         ),
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
-                } else {
-                    // TODO - show message - to select both stops
-                    // logError(("Select both stops")
                 }
             },
             onSearchButtonClick = {
@@ -123,9 +123,6 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                         ),
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
-                } else {
-                    // TODO - show message - to select both stops
-                    // logError(("Select both stops")
                 }
             },
             onSettingsButtonClick = {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -14,6 +14,7 @@ import xyz.ksharma.krail.core.log.log
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
@@ -56,7 +57,18 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             timeTableState = timeTableState,
             expandedJourneyId = expandedJourneyId,
             onEvent = { viewModel.onEvent(it) },
-            onBackClick = { navController.popBackStack() },
+            onBackClick = {
+                viewModel.onEvent(
+                    TimeTableUiEvent.BackClick(
+                        isPreviousBackStackEntryNull = navController.previousBackStackEntry != null
+                    )
+                )
+
+                navController.navigate(
+                    route = SavedTripsRoute,
+                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                )
+            },
             onAlertClick = { journeyId ->
                 log("AlertClicked for journeyId: $journeyId")
                 viewModel.fetchAlertsForJourney(journeyId) { alerts ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -60,7 +60,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
             onBackClick = {
                 viewModel.onEvent(
                     TimeTableUiEvent.BackClick(
-                        isPreviousBackStackEntryNull = navController.previousBackStackEntry != null
+                        isPreviousBackStackEntryNull = navController.previousBackStackEntry == null
                     )
                 )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -46,10 +45,10 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_check
 import krail.feature.trip_planner.ui.generated.resources.ic_filter
 import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
-import krail.feature.trip_planner.ui.generated.resources.ic_check
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.core.log.log

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -154,6 +154,8 @@ class TimeTableViewModel(
             is TimeTableUiEvent.ModeSelectionChanged -> onModeSelectionChanged(event.unselectedModes)
 
             is TimeTableUiEvent.ModeClicked -> trackOnModeClickEvent(event.displayModeSelectionRow)
+
+            is TimeTableUiEvent.BackClick -> trackBackClickEvent(event.isPreviousBackStackEntryNull)
         }
     }
 
@@ -489,6 +491,15 @@ class TimeTableViewModel(
             alerts = alerts.map { it.toSelectServiceAlertsByJourneyId(journey.journeyId) },
         )
         return alerts
+    }
+
+    private fun trackBackClickEvent(isPreviousBackStackEntryNull: Boolean) {
+        analytics.track(
+            AnalyticsEvent.BackClickEvent(
+                fromScreen = AnalyticsScreen.TimeTable,
+                isPreviousBackStackEntryNull = isPreviousBackStackEntryNull
+            )
+        )
     }
 
     override fun onCleared() {


### PR DESCRIPTION
# Enhanced Back Button Analytics for Crash Debugging

This PR adds analytics tracking to the back button functionality to help debug crashes. Key changes:

- Updated `BackClickEvent` to include `isPreviousBackStackEntryNull` flag and use `AnalyticsScreen` enum
- Added `BackClick` event to `TimeTableUiEvent` interface
- Modified navigation in `TimeTableDestination` to navigate to `SavedTripsRoute` instead of using `popBackStack()`
- Implemented tracking for back button clicks in `TimeTableViewModel`
- Removed unnecessary TODO comments in `SavedTripsDestination`
- Added `setLaunchSingleTop(true)` to navigation options for consistent navigation behavior

These changes will provide better breadcrumb data to help identify the root cause of back button crashes.