### PR TITLE
UI: Change title from "Saved Trips" to "KRAIL"

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -72,7 +72,7 @@ fun SavedTripsScreen(
         Column {
             TitleBar(
                 title = {
-                    Text(text = "Saved Trips")
+                    Text(text = "KRAIL")
                 },
                 actions = {
                     RoundIconButton(


### PR DESCRIPTION
### TL;DR

Changed the title text in the SavedTripsScreen from "Saved Trips" to "KRAIL".

### What changed?

Modified the title text displayed in the TitleBar component of the SavedTripsScreen from "Saved Trips" to "KRAIL".

### How to test?

1. Navigate to the SavedTripsScreen in the app
2. Verify that the title bar now displays "KRAIL" instead of "Saved Trips"
3. Ensure the title is properly centered and styled

### Why make this change?

This change aligns the screen title with our app branding. Using "KRAIL" as the title provides better brand consistency across the application and improves user recognition of our product.