### PR TITLE
Festival: Replace Holi with Pi Day and clean up emoji lists

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/FestivalType.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/FestivalType.kt
@@ -18,7 +18,6 @@ enum class FestivalType {
     VALENTINES_DAY,
     HALLOWEEN,
     CHINESE_NEW_YEAR,
-    HOLI,
     EID,
     MARDI_GRAS,
     VIVID_SYDNEY,
@@ -29,4 +28,5 @@ enum class FestivalType {
     PEACE_DAY,
     ENGINEERS_DAY,
     FRIENDSHIP_DAY,
+    PI_DAY,
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -43,13 +43,11 @@ object LoadingEmojiManager {
         FestivalType.ROSE_DAY to listOf("🌹"),
         FestivalType.PROPOSE_DAY to listOf("💍", "💞", "💌"),
         FestivalType.CHOCOLATE_DAY to listOf("🍫", "💞"),
-        FestivalType.TEDDY_DAY to listOf("🧸", "💖"),
-        FestivalType.PROMISE_DAY to listOf("🤝", "💖"),
-        FestivalType.HUG_DAY to listOf("🤗", "💖"),
-        FestivalType.KISS_DAY to listOf("💖", "❤️", "😘"),
+        FestivalType.TEDDY_DAY to listOf("🧸"),
+        FestivalType.PROMISE_DAY to listOf("🤝"),
+        FestivalType.HUG_DAY to listOf("🤗"),
+        FestivalType.KISS_DAY to listOf("😘"),
         FestivalType.VALENTINES_DAY to listOf("❤️", "🌹"),
-
-        FestivalType.HOLI to listOf("🎨", "🌈", "🎈"),
 
         FestivalType.AUSTRALIA_DAY to listOf("🇦🇺", "🎉", "🎆"),
         FestivalType.EID to listOf("🌙", "🕌", "🎁"),
@@ -59,11 +57,12 @@ object LoadingEmojiManager {
         // Human centric days
         FestivalType.WOMENS_DAY to listOf("💜", "♀️", "👩", "👩‍🚀", "👩‍🚒", "👩‍✈️"),
         FestivalType.MENS_DAY to listOf("💙", "♂️", "🚹", "👨‍🚒", "👨‍🌾", "👨‍🚀"),
-        FestivalType.ENGINEERS_DAY to listOf("⚙️", "🔧", "📐", "🏗️"),
-        FestivalType.NURSES_DAY to listOf("💉", "🏥", "🩺"),
-        FestivalType.FRIENDSHIP_DAY to listOf("🤝", "💛", "👫", "👭", "👬", "❤️"),
+        FestivalType.ENGINEERS_DAY to listOf("⚙️", "🔧"),
+        FestivalType.NURSES_DAY to listOf("🏥", "🩺"),
+        FestivalType.FRIENDSHIP_DAY to listOf("🤝", "💛"),
         FestivalType.PEACE_DAY to listOf("☮️", "✌️"),
         FestivalType.A11Y_DAY to listOf("♿️"),
+        FestivalType.PI_DAY to listOf("🥧", "π"),
     )
 
     // TODO - test logic add UT
@@ -92,8 +91,10 @@ object LoadingEmojiManager {
         MonthDay.of(2, 13) to FestivalType.KISS_DAY,
         MonthDay.of(2, 14) to FestivalType.VALENTINES_DAY,
 
+        // Special Days
         MonthDay.of(3, 4) to FestivalType.ENGINEERS_DAY,
         MonthDay.of(3, 8) to FestivalType.WOMENS_DAY,
+        MonthDay.of(3, 14) to FestivalType.PI_DAY,
         MonthDay.of(5, 12) to FestivalType.NURSES_DAY,
         MonthDay.of(7, 30) to FestivalType.FRIENDSHIP_DAY,
         MonthDay.of(9, 21) to FestivalType.PEACE_DAY,
@@ -101,7 +102,6 @@ object LoadingEmojiManager {
         MonthDay.of(12, 3) to FestivalType.A11Y_DAY,
 
         // Can change dates
-        MonthDay.of(3, 14) to FestivalType.HOLI,
         MonthDay.of(3, 30) to FestivalType.EID,
         MonthDay.of(3, 31) to FestivalType.EID,
 


### PR DESCRIPTION
### TL;DR

Added Pi Day (March 14) as a new festival type with appropriate emojis for the loading screen.

### What changed?

- Added `PI_DAY` to the `FestivalType` enum
- Added Pi Day emojis (🥧, π) to the loading emoji map
- Set March 14 (3/14) to display Pi Day emojis instead of Holi emojis
- Removed `HOLI` from the `FestivalType` enum
- Simplified emoji lists for several festival types by removing duplicate heart emojis

### How to test?

1. Change your device date to March 14
2. Open the trip planner and navigate to a screen with loading indicators
3. Verify that Pi Day themed emojis (🥧, π) appear in the loading animation

### Why make this change?

Pi Day (March 14 or 3/14) is a celebration of the mathematical constant π (pi), which is approximately 3.14. Adding this festival enhances our seasonal loading animations with a fun, educational reference that many users will recognize and appreciate.