### PR TITLE
UI: Increase horizontal padding in TransportModeBadge text

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -45,7 +45,7 @@ fun TransportModeBadge(
                 text = badgeText,
                 color = Color.White,
                 modifier = Modifier
-                    .padding(2.dp)
+                    .padding(horizontal = 4.dp, vertical = 2.dp)
                     .wrapContentWidth(),
             )
         }


### PR DESCRIPTION
### TL;DR

Increased horizontal padding in TransportModeBadge component text.

### What changed?

Modified the padding in the TransportModeBadge component's text from a uniform 2.dp to 4.dp horizontal and 2.dp vertical padding. This provides more space on the left and right sides of the text within the badge.

### How to test?

1. Navigate to any screen that displays the TransportModeBadge component
2. Verify that the text inside the badge has more horizontal spacing than before
3. Confirm that the vertical spacing remains unchanged at 2.dp

### Why make this change?

The increased horizontal padding improves the visual appearance and readability of the badge text by providing more breathing room on the sides while maintaining the same vertical spacing.