### PR TITLE
UI: Remove "Select a color" subtitle from theme selection screen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -79,17 +79,7 @@ fun ThemeSelectionScreen(
                         style = KrailTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Normal),
                         modifier = Modifier
                             .padding(horizontal = 24.dp)
-                            .padding(bottom = 8.dp),
-                    )
-                }
-
-                item {
-                    Text(
-                        text = "Select a color",
-                        style = KrailTheme.typography.titleSmall.copy(fontWeight = FontWeight.Normal),
-                        modifier = Modifier
-                            .padding(horizontal = 24.dp)
-                            .padding(bottom = 16.dp),
+                            .padding(bottom = 32.dp),
                     )
                 }
 


### PR DESCRIPTION
### TL;DR

Removed the "Select a color" text label from the Theme Selection screen.

### What changed?

Removed the redundant "Select a color" text label that was previously displayed above the theme selection radio buttons in the ThemeSelectionScreen. This simplifies the UI by removing unnecessary instructional text. The bottom padding of the headline was increased from 8dp to 32dp to maintain proper spacing.

### How to test?

1. Navigate to the Theme Selection screen
2. Verify that the "Select a color" text no longer appears above the theme selection options
3. Confirm that the theme selection radio buttons still display and function correctly

### Why make this change?

The removed text was redundant as the purpose of the screen is already clear from the context and the radio button options themselves. This change creates a cleaner, more streamlined user interface with less visual clutter.