### PR TITLE
Sandook: Add preferences storage with SQLite implementation

### DIFF
--- a/core/app-info/build.gradle.kts
+++ b/core/app-info/build.gradle.kts
@@ -45,8 +45,5 @@ kotlin {
                 api(libs.di.koinComposeViewmodel)
             }
         }
-
-        iosMain.dependencies {
-        }
     }
 }

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
@@ -1,7 +1,3 @@
 package xyz.ksharma.krail.core.appinfo
 
-import androidx.compose.runtime.staticCompositionLocalOf
-
-val LocalAppPlatformProvider = staticCompositionLocalOf { getAppPlatformType() }
-
 expect fun getAppPlatformType(): DevicePlatformType

--- a/core/app-start/build.gradle.kts
+++ b/core/app-start/build.gradle.kts
@@ -28,7 +28,6 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinx.serialization.json)
                 implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.remoteConfig)
@@ -37,6 +36,7 @@ kotlin {
 
                 implementation(compose.runtime)
                 api(libs.di.koinComposeViewmodel)
+                implementation(libs.kotlinx.serialization.json)
             }
         }
     }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.core.appstart
 
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.RemoteConfig

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandookPreferences.kt
@@ -1,0 +1,50 @@
+package xyz.ksharma.krail.sandook
+
+internal class RealSandookPreferences(
+    factory: SandookDriverFactory
+) : SandookPreferences {
+
+    private val queries = AppPreferencesQueries(factory.createDriver())
+
+    override fun getLong(key: String): Long? {
+        return queries.getLongPreference(key).executeAsOneOrNull()?.int_value
+    }
+
+    override fun setLong(key: String, value: Long) {
+        queries.setLongPreference(key, value)
+    }
+
+    override fun getString(key: String): String? {
+        return queries.getStringPreference(key).executeAsOneOrNull()?.string_value
+    }
+
+    override fun setString(key: String, value: String) {
+        queries
+            .setStringPreference(key, value)
+    }
+
+    override fun getBoolean(key: String): Boolean? {
+        return queries
+            .getBooleanPreference(key)
+            .executeAsOneOrNull()?.let { it.bool_value == 1L }
+    }
+
+    override fun setBoolean(key: String, value: Boolean) {
+        queries.setBooleanPreference(key, if (value) 1L else 0L)
+    }
+
+    override fun getDouble(key: String): Double? {
+        return queries
+            .getDoublePreference(key)
+            .executeAsOneOrNull()?.float_value
+    }
+
+    override fun setDouble(key: String, value: Double) {
+        queries.setDoublePreference(key, value)
+    }
+
+    override fun deletePreference(key: String) {
+        queries
+            .deletePreference(key)
+    }
+}

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.krail.sandook
+
+interface SandookPreferences {
+
+    // Integer preferences
+    fun getLong(key: String): Long?
+    fun setLong(key: String, value: Long)
+
+    // String preferences
+    fun getString(key: String): String?
+    fun setString(key: String, value: String)
+
+    // Boolean preferences
+    fun getBoolean(key: String): Boolean?
+    fun setBoolean(key: String, value: Boolean)
+
+    // Double preferences
+    fun getDouble(key: String): Double?
+    fun setDouble(key: String, value: Double)
+
+    // Delete preference
+    fun deletePreference(key: String)
+}

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
@@ -6,10 +6,13 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 import xyz.ksharma.krail.sandook.RealSandook
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.SandookPreferences
+import xyz.ksharma.krail.sandook.RealSandookPreferences
 
 val sandookModule = module {
     singleOf(::RealSandook) { bind<Sandook>() }
     includes(sqlDriverModule)
+    singleOf(::RealSandookPreferences) { bind<SandookPreferences>() }
 }
 
 expect val sqlDriverModule: Module

--- a/sandook/src/commonMain/sqldelight/migrations/3.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/3.sqm
@@ -1,0 +1,7 @@
+CREATE TABLE app_preferences (
+    key TEXT PRIMARY KEY NOT NULL,
+    int_value INTEGER,
+    string_value TEXT,
+    bool_value INTEGER,
+    float_value REAL
+);

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/AppPreferences.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/AppPreferences.sq
@@ -1,0 +1,50 @@
+-- core/app-info/src/commonMain/sqldelight/xyz/ksharma/krail/core/appinfo/AppPreferences.sq
+
+CREATE TABLE app_preferences (
+    key TEXT PRIMARY KEY NOT NULL,
+    int_value INTEGER,
+    string_value TEXT,
+    bool_value INTEGER,
+    float_value REAL
+);
+
+-- Runs when db is created, sets default value as 0 for nsw_stops_version for version tracking.
+-- will execute only once on fresh install and not when app updates.
+INSERT OR IGNORE INTO app_preferences(key, int_value)
+VALUES ('nsw_stops_version', 0);
+
+-- Integer operations
+getLongPreference:
+SELECT int_value FROM app_preferences WHERE key = ?;
+
+setLongPreference:
+INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+VALUES (?, ?, NULL, NULL, NULL);
+
+-- String operations
+getStringPreference:
+SELECT string_value FROM app_preferences WHERE key = ?;
+
+setStringPreference:
+INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+VALUES (?, NULL, ?, NULL, NULL);
+
+-- Boolean operations (stored as INTEGER 0/1)
+getBooleanPreference:
+SELECT bool_value FROM app_preferences WHERE key = ?;
+
+setBooleanPreference:
+INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+VALUES (?, NULL, NULL, ?, NULL);
+
+-- Float operations
+getDoublePreference:
+SELECT float_value FROM app_preferences WHERE key = ?;
+
+setDoublePreference:
+INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+VALUES (?, NULL, NULL, NULL, ?);
+
+-- Delete operation
+deletePreference:
+DELETE FROM app_preferences WHERE key = ?;

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
@@ -5,6 +5,7 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter1
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter2
+import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter3
 
 class IosSandookDriverFactory : SandookDriverFactory {
     override fun createDriver(): SqlDriver {
@@ -18,5 +19,6 @@ class IosSandookDriverFactory : SandookDriverFactory {
     private fun getMigrationCallbacks(): Array<AfterVersion> = arrayOf(
         AfterVersion(1) { SandookMigrationAfter1.migrate(it) },
         AfterVersion(2) { SandookMigrationAfter2.migrate(it) },
+        AfterVersion(3) { SandookMigrationAfter3.migrate(it) },
     )
 }

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter3.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter3.kt
@@ -1,0 +1,24 @@
+package xyz.ksharma.krail.sandook.migrations
+
+import app.cash.sqldelight.db.SqlDriver
+import xyz.ksharma.krail.core.log.log
+
+internal object SandookMigrationAfter3 : SandookMigration {
+
+    override fun migrate(sqlDriver: SqlDriver) {
+        log("Upgrading database from version 3 to 4")
+        sqlDriver.execute(
+            identifier = null,
+            sql = """
+                   CREATE TABLE app_preferences (
+                       key TEXT PRIMARY KEY NOT NULL,
+                       int_value INTEGER,
+                       string_value TEXT,
+                       bool_value INTEGER,
+                       float_value REAL
+                   );
+                """.trimIndent(),
+            parameters = 0,
+        )
+    }
+}


### PR DESCRIPTION
### TL;DR

Added a new `SandookPreferences` interface for key-value storage with SQLite implementation.

### What changed?

- Created a new `SandookPreferences` interface for storing key-value preferences
- Implemented `RealSandookPreferences` class that uses SQLDelight for storage
- Added SQLite table schema for app preferences with support for different data types (long, string, boolean, double)
- Added SQLDelight queries for CRUD operations on preferences
- Updated database migration scripts to include the new preferences table
- Registered the preferences implementation in the DI module
- Removed unused iOS dependencies and composition locals
- Added app-info dependency to app-start module

### How to test?

1. Inject `SandookPreferences` into a component that needs to store preferences
2. Test storing and retrieving different data types:
   ```kotlin
   // Store values
   preferences.setString("user_name", "John")
   preferences.setLong("user_id", 12345)
   preferences.setBoolean("is_logged_in", true)
   preferences.setDouble("account_balance", 100.50)
   
   // Retrieve values
   val userName = preferences.getString("user_name")
   val userId = preferences.getLong("user_id")
   val isLoggedIn = preferences.getBoolean("is_logged_in")
   val balance = preferences.getDouble("account_balance")
   
   // Delete a preference
   preferences.deletePreference("user_name")
   ```
3. Verify that values persist across app restarts

### Why make this change?

This change provides a standardized way to store application preferences using SQLite, which offers better reliability and type safety compared to other storage options. The implementation supports various data types and provides a clean API for storing and retrieving preferences throughout the application.