### PR TITLE
Data: Improve NSW stops versioning and update mechanism

### DIFF
--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
@@ -13,7 +13,7 @@ val appStartModule = module {
             coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
             remoteConfig = get(),
             protoParser = get(),
-            sandook = get(),
+            preferences = get(),
         )
     }
 }

--- a/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/ProtoParser.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/ProtoParser.kt
@@ -1,11 +1,8 @@
 package xyz.ksharma.krail.io.gtfs.nswstops
 
-import app.krail.kgtfs.proto.NswStopList
-
 interface ProtoParser {
     /**
      * Reads and decodes the NSW stops from a protobuf file, then inserts the stops into the database.
-     * @return The decoded `NswStopList` containing the NSW stops.
      */
-    suspend fun parseAndInsertStops(): NswStopList?
+    suspend fun parseAndInsertStops()
 }

--- a/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/StopsProtoParser.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/StopsProtoParser.kt
@@ -19,11 +19,9 @@ class StopsProtoParser(
 
     /**
      * Reads and decodes the NSW stops from a protobuf file, then inserts the stops into the database.
-     *
-     * @return The decoded `NswStopList` containing the NSW stops.
      */
     @OptIn(ExperimentalResourceApi::class)
-    override suspend fun parseAndInsertStops(): NswStopList = withContext(ioDispatcher) {
+    override suspend fun parseAndInsertStops() = withContext(ioDispatcher) {
         var start = Clock.System.now()
 
         sandook.clearNswStopsTable()
@@ -45,8 +43,6 @@ class StopsProtoParser(
             Clock.System.now(), DateTimeUnit.MILLISECOND, TimeZone.currentSystemDefault()
         )
         log("Inserted #Stops: ${decodedStops.nswStops.size} in duration: $duration ms")
-
-        decodedStops
     }
 
     private suspend fun insertStopsInTransaction(decoded: NswStopList) = withContext(ioDispatcher) {
@@ -72,7 +68,7 @@ class StopsProtoParser(
             Clock.System.now(), DateTimeUnit.MILLISECOND, TimeZone.currentSystemDefault(),
         )
         // Log less frequently, for example once after the transaction completes
-        println("Inserted ${decoded.nswStops.size} stops in a single transaction in $duration ms")
+        log("Inserted ${decoded.nswStops.size} stops in a single transaction in $duration ms")
         // TODO - analytics track how much time it took to insert stops.
         // Also track based on Firebase for performance.
     }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandookPreferences.kt
@@ -19,8 +19,7 @@ internal class RealSandookPreferences(
     }
 
     override fun setString(key: String, value: String) {
-        queries
-            .setStringPreference(key, value)
+        queries.setStringPreference(key, value)
     }
 
     override fun getBoolean(key: String): Boolean? {

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -20,4 +20,11 @@ interface SandookPreferences {
 
     // Delete preference
     fun deletePreference(key: String)
+
+    companion object {
+        // Increment this when bundling new stops data
+        const val NSW_STOPS_VERSION = 1L
+
+        const val KEY_NSW_STOPS_VERSION = "KEY_NSW_STOPS_VERSION"
+    }
 }


### PR DESCRIPTION
### TL;DR

Improved NSW stops data versioning to enable proper updates when new data is available.

### What changed?

- Replaced the stop count check with a version-based approach for determining when to update NSW stops data
- Added a version constant `NSW_STOPS_VERSION` in `SandookPreferences` that can be incremented when bundling new stops data
- Modified `RealAppStart` to store and check the version number instead of counting stops
- Updated `ProtoParser` interface to remove the return value since it's no longer needed
- Added version tracking to store the current NSW stops version in preferences

### How to test?

1. Run the app on a fresh install to verify NSW stops are properly loaded
2. Increment the `NSW_STOPS_VERSION` constant and verify that stops are reloaded on next app start
3. Check that the version is properly stored in preferences after loading

### Why make this change?

The previous approach of checking if stops existed in the database wasn't sufficient for handling updates to the stops data. By implementing version tracking, the app can now detect when newer stops data is available and reload it accordingly, ensuring users always have the most up-to-date transit information.