### PR TITLE
Version: Bump to 1.3.3

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 73
-        versionName = "1.3.2"
+        versionCode = 74
+        versionName = "1.3.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.3.2 to 1.3.3 for both Android and iOS apps.

### What changed?

- Updated Android `versionCode` from 73 to 74
- Updated Android `versionName` from 1.3.2 to 1.3.3
- Updated iOS `CFBundleShortVersionString` from 1.3.2 to 1.3.3

### How to test?

- Build the Android app and verify the version in the app info
- Build the iOS app and verify the version in the app info
- Ensure both platforms display version 1.3.3

### Why make this change?

Preparing for the next release by incrementing the version numbers across platforms to maintain version consistency between Android and iOS.