### PR TITLE
DB: Rename app_preferences table to KrailPref

### DIFF
--- a/sandook/src/commonMain/sqldelight/migrations/3.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/3.sqm
@@ -1,4 +1,4 @@
-CREATE TABLE app_preferences (
+CREATE TABLE IF NOT EXISTS KrailPref (
     key TEXT PRIMARY KEY NOT NULL,
     int_value INTEGER,
     string_value TEXT,

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/AppPreferences.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/AppPreferences.sq
@@ -1,6 +1,4 @@
--- core/app-info/src/commonMain/sqldelight/xyz/ksharma/krail/core/appinfo/AppPreferences.sq
-
-CREATE TABLE app_preferences (
+CREATE TABLE IF NOT EXISTS KrailPref (
     key TEXT PRIMARY KEY NOT NULL,
     int_value INTEGER,
     string_value TEXT,
@@ -10,41 +8,41 @@ CREATE TABLE app_preferences (
 
 -- Runs when db is created, sets default value as 0 for nsw_stops_version for version tracking.
 -- will execute only once on fresh install and not when app updates.
-INSERT OR IGNORE INTO app_preferences(key, int_value)
+INSERT OR IGNORE INTO KrailPref(key, int_value)
 VALUES ('nsw_stops_version', 0);
 
 -- Integer operations
 getLongPreference:
-SELECT int_value FROM app_preferences WHERE key = ?;
+SELECT int_value FROM KrailPref WHERE key = ?;
 
 setLongPreference:
-INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+INSERT OR REPLACE INTO KrailPref(key, int_value, string_value, bool_value, float_value)
 VALUES (?, ?, NULL, NULL, NULL);
 
 -- String operations
 getStringPreference:
-SELECT string_value FROM app_preferences WHERE key = ?;
+SELECT string_value FROM KrailPref WHERE key = ?;
 
 setStringPreference:
-INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+INSERT OR REPLACE INTO KrailPref(key, int_value, string_value, bool_value, float_value)
 VALUES (?, NULL, ?, NULL, NULL);
 
 -- Boolean operations (stored as INTEGER 0/1)
 getBooleanPreference:
-SELECT bool_value FROM app_preferences WHERE key = ?;
+SELECT bool_value FROM KrailPref WHERE key = ?;
 
 setBooleanPreference:
-INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+INSERT OR REPLACE INTO KrailPref(key, int_value, string_value, bool_value, float_value)
 VALUES (?, NULL, NULL, ?, NULL);
 
 -- Float operations
 getDoublePreference:
-SELECT float_value FROM app_preferences WHERE key = ?;
+SELECT float_value FROM KrailPref WHERE key = ?;
 
 setDoublePreference:
-INSERT OR REPLACE INTO app_preferences(key, int_value, string_value, bool_value, float_value)
+INSERT OR REPLACE INTO KrailPref(key, int_value, string_value, bool_value, float_value)
 VALUES (?, NULL, NULL, NULL, ?);
 
 -- Delete operation
 deletePreference:
-DELETE FROM app_preferences WHERE key = ?;
+DELETE FROM KrailPref WHERE key = ?;

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter3.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter3.kt
@@ -10,7 +10,7 @@ internal object SandookMigrationAfter3 : SandookMigration {
         sqlDriver.execute(
             identifier = null,
             sql = """
-                   CREATE TABLE app_preferences (
+                   CREATE TABLE IF NOT EXISTS KrailPref (
                        key TEXT PRIMARY KEY NOT NULL,
                        int_value INTEGER,
                        string_value TEXT,


### PR DESCRIPTION
### TL;DR

Renamed the preferences table from `app_preferences` to `KrailPref` and added `IF NOT EXISTS` clause to table creation.

### What changed?

- Renamed the SQLite table from `app_preferences` to `KrailPref` across all SQL files
- Added `IF NOT EXISTS` clause to the table creation statement to prevent errors if the table already exists
- Updated all SQL queries to reference the new table name
- Modified the iOS migration script to use the new table name

### How to test?

1. Run the app on a fresh install to verify the new table is created correctly
2. Upgrade from a previous version to verify the migration works properly
3. Test all preference operations (get/set/delete) to ensure they function with the new table name

### Why make this change?

This change standardizes the naming convention for database tables and adds protection against potential table creation errors during app initialization or migration. The `KrailPref` name better aligns with the project's naming conventions, and the `IF NOT EXISTS` clause improves robustness during database setup.