### PR TITLE
Cleanup: Remove empty buildTypes and iosMain blocks from GTFS module

### DIFF
--- a/io/gtfs/build.gradle.kts
+++ b/io/gtfs/build.gradle.kts
@@ -1,10 +1,5 @@
 android {
     namespace = "xyz.ksharma.krail.io.gtfs"
-
-    buildTypes {
-        debug {}
-        release {}
-    }
 }
 
 plugins {
@@ -46,11 +41,6 @@ kotlin {
                 implementation(compose.components.resources)
 
                 api(libs.di.koinComposeViewmodel)
-            }
-        }
-
-        iosMain {
-            dependencies {
             }
         }
 


### PR DESCRIPTION
### TL;DR

Removed unnecessary build configuration blocks from GTFS module's Gradle file.

### What changed?

- Removed empty `buildTypes` block with unused `debug` and `release` configurations
- Removed empty `iosMain` dependencies block that wasn't being used

### How to test?

1. Build the project to ensure the GTFS module compiles correctly
2. Run any existing tests that use the GTFS module to verify functionality is maintained

### Why make this change?

This change cleans up the build configuration by removing empty, unused blocks that don't contribute to the build process. This improves maintainability by reducing unnecessary code in the Gradle files and makes the build configuration more concise.