### PR TITLE
Perf: Add Firebase performance tracing to NSW stops parsing

### DIFF
--- a/io/gtfs/build.gradle.kts
+++ b/io/gtfs/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
                 implementation(libs.kotlinx.datetime)
                 implementation(compose.runtime)
                 implementation(compose.components.resources)
+                implementation(libs.firebase.gitLivePerformance)
 
                 api(libs.di.koinComposeViewmodel)
             }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -23,7 +23,7 @@ interface SandookPreferences {
 
     companion object {
         // Increment this when bundling new stops data
-        const val NSW_STOPS_VERSION = 2L
+        const val NSW_STOPS_VERSION = 3L
 
         const val KEY_NSW_STOPS_VERSION = "KEY_NSW_STOPS_VERSION"
     }


### PR DESCRIPTION
### TL;DR

Added Firebase Performance Monitoring to track GTFS stops parsing and insertion times.

### What changed?

- Added Firebase GitLive Performance dependency to the GTFS module
- Implemented performance traces for NSW stops parsing and insertion operations
- Incremented NSW_STOPS_VERSION from 2 to 3 to trigger a refresh of stops data

### How to test?

1. Run the app and observe the Firebase Performance dashboard for new traces:
   - "parseNswStops" - measures time to parse the NSW stops protobuf file
   - "insertNSWStops" - measures time to insert all stops into the database
2. Verify that stops data is properly loaded after the version increment

### Why make this change?

This change helps us monitor and optimize the performance of GTFS data processing. By tracking how long it takes to parse and insert stops data, we can identify bottlenecks and measure improvements over time. The version increment ensures all users will get the latest stops data with the performance monitoring in place.