### PR TITLE
Data: Verify NSW stops count before updating version

### DIFF
--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.RemoteConfig
 import xyz.ksharma.krail.io.gtfs.nswstops.ProtoParser
+import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SandookPreferences.Companion.NSW_STOPS_VERSION
 
@@ -13,6 +14,7 @@ class RealAppStart(
     private val remoteConfig: RemoteConfig,
     private val protoParser: ProtoParser,
     private val preferences: SandookPreferences,
+    private val sandook: Sandook,
 ) : AppStart {
 
     init {
@@ -38,23 +40,32 @@ class RealAppStart(
     private suspend fun parseAndInsertNswStopsIfNeeded() = runCatching {
         if (shouldInsertNswStops()) {
             protoParser.parseAndInsertStops()
-            preferences.setLong(
-                key = SandookPreferences.KEY_NSW_STOPS_VERSION,
-                value = NSW_STOPS_VERSION,
-            )
+
+            // Verify success before updating version
+            val insertedCount = sandook.stopsCount()
+            if (insertedCount >= MINIMUM_REQUIRED_STOPS) {
+                preferences.setLong(
+                    key = SandookPreferences.KEY_NSW_STOPS_VERSION,
+                    value = NSW_STOPS_VERSION,
+                )
+            }
             log("NswStops inserted in the database, new version: $NSW_STOPS_VERSION.")
         } else {
             log("Stops already inserted in the database.")
         }
     }.getOrElse {
         log("Error reading proto file: $it")
-        // TODO - Firebase performance track.
     }
 
     private fun shouldInsertNswStops(): Boolean {
         val storedVersion = preferences.getLong(SandookPreferences.KEY_NSW_STOPS_VERSION) ?: 0
         log("Current NSW Stops data version: $NSW_STOPS_VERSION, Stored version: $storedVersion")
+        val insertedStopsCount = sandook.stopsCount()
+        return storedVersion < NSW_STOPS_VERSION || insertedStopsCount < MINIMUM_REQUIRED_STOPS
+    }
 
-        return storedVersion < NSW_STOPS_VERSION
+    companion object {
+        // Define this as a constant for better maintainability
+        private const val MINIMUM_REQUIRED_STOPS = 36_000
     }
 }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
@@ -14,6 +14,7 @@ val appStartModule = module {
             remoteConfig = get(),
             protoParser = get(),
             preferences = get(),
+            sandook = get(),
         )
     }
 }


### PR DESCRIPTION
### TL;DR

Added validation to ensure NSW stops data is properly loaded during app startup.

### What changed?

- Added `sandook` parameter to `RealAppStart` constructor
- Implemented validation to check the actual number of stops inserted in the database
- Added a minimum threshold constant (`MINIMUM_REQUIRED_STOPS = 36_000`) to verify successful data loading
- Modified the logic to only update the version number after confirming stops were successfully inserted
- Enhanced the `shouldInsertNswStops()` method to also check if the current number of stops is below the minimum threshold

### How to test?

1. Clear app data to force a fresh stops data insertion
2. Launch the app and verify logs show successful stops insertion
3. Check that the app correctly reloads stops data if the count is below the minimum threshold
4. Verify the app works correctly with transit data after initialization

### Why make this change?

This change adds robustness to the app initialization process by ensuring the NSW stops data is properly loaded before proceeding. Previously, the app would mark the data as loaded even if the insertion process failed, potentially leading to missing transit data. The new validation ensures a minimum number of stops are present, preventing scenarios where the app might operate with incomplete data.