### PR TITLE
Cleanup: Remove performance tracing and error logging

### DIFF
--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -28,10 +28,8 @@ class RealAppStart(
         }
     }
 
-    private fun setupRemoteConfig() = runCatching {
+    private fun setupRemoteConfig() {
         remoteConfig.setup()
-    }.getOrElse {
-        log("Error setting up remote config: $it")
     }
 
     /**

--- a/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/StopsProtoParser.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/StopsProtoParser.kt
@@ -1,14 +1,8 @@
 package xyz.ksharma.krail.io.gtfs.nswstops
 
 import app.krail.kgtfs.proto.NswStopList
-import dev.gitlive.firebase.Firebase
-import dev.gitlive.firebase.perf.performance
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.until
 import krail.io.gtfs.generated.resources.Res
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import xyz.ksharma.krail.core.log.log
@@ -24,36 +18,17 @@ class StopsProtoParser(
      */
     @OptIn(ExperimentalResourceApi::class)
     override suspend fun parseAndInsertStops() = withContext(ioDispatcher) {
-        val trace = Firebase.performance.newTrace("parseNswStops")
-        trace.start()
-        var start = Clock.System.now()
-
         sandook.clearNswStopsTable()
         sandook.clearNswProductClassTable()
 
         val byteArray = Res.readBytes("files/NSW_STOPS.pb")
         val decodedStops = NswStopList.ADAPTER.decode(byteArray)
-        trace.stop()
-
-        var duration = start.until(
-            Clock.System.now(), DateTimeUnit.MILLISECOND,
-            TimeZone.currentSystemDefault(),
-        )
-        log("Decoded #Stops: ${decodedStops.nswStops.size} - duration: $duration ms")
 
         log("Start inserting stops. Currently ${sandook.stopsCount()} stops in the database")
-        start = Clock.System.now()
         insertStopsInTransaction(decodedStops)
-        duration = start.until(
-            Clock.System.now(), DateTimeUnit.MILLISECOND, TimeZone.currentSystemDefault()
-        )
-        log("Inserted #Stops: ${decodedStops.nswStops.size} in duration: $duration ms")
     }
 
     private suspend fun insertStopsInTransaction(decoded: NswStopList) = withContext(ioDispatcher) {
-        val trace = Firebase.performance.newTrace("insertNSWStops")
-        trace.start()
-        val start = Clock.System.now()
         sandook.insertTransaction {
             decoded.nswStops.forEach { nswStop ->
                 sandook.insertNswStop(
@@ -70,11 +45,5 @@ class StopsProtoParser(
                 }
             }
         }
-
-        val duration = start.until(
-            Clock.System.now(), DateTimeUnit.MILLISECOND, TimeZone.currentSystemDefault(),
-        )
-        log("Inserted ${decoded.nswStops.size} stops in a single transaction in $duration ms")
-        trace.stop()
     }
 }


### PR DESCRIPTION
### TL;DR

Removed performance tracing and error handling in remote config setup.

### What changed?

- Removed error handling in `setupRemoteConfig()` method, making it a simple function call without try-catch
- Removed Firebase performance tracing in the `StopsProtoParser` class
- Removed time measurement and logging of performance metrics during stop parsing and insertion
- Simplified the code by removing unused imports related to time measurement and Firebase performance

### How to test?

- Verify that remote config setup still works correctly without the error handling
- Ensure that NSW stops are still properly parsed and inserted into the database
- Check that the application functions normally without the performance tracing

### Why make this change?

This change streamlines the code by removing performance measurement that was likely used for development/debugging purposes. The removal of error handling in the remote config setup suggests that errors are now expected to be handled elsewhere or that the setup process is now more robust. This change makes the code cleaner and more focused on its core functionality.