### PR TITLE
Version: Bump to 1.3.4

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 74
-        versionName = "1.3.3"
+        versionCode = 75
+        versionName = "1.3.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.3</string>
+	<string>1.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version to 1.3.4 for both Android and iOS apps.

### What changed?

- Android: Incremented `versionCode` from 74 to 75 and `versionName` from "1.3.3" to "1.3.4"
- iOS: Updated `CFBundleShortVersionString` from "1.3.3" to "1.3.4" and reset `CFBundleVersion` from "2" to "1"

### How to test?

- Build the Android app and verify the version in the app info settings
- Build the iOS app and verify the version in the app info settings
- Ensure both platforms display version 1.3.4

### Why make this change?

Preparing for the next release (1.3.4) by updating version numbers in both Android and iOS applications to maintain version consistency across platforms.