### PR TITLE
UI: Update KRAIL title color to use theme color

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -33,7 +33,10 @@ import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_settings
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.RoundIconButton
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.getForegroundColor
 
 @Composable
 fun SavedTripsScreen(
@@ -50,6 +53,7 @@ fun SavedTripsScreen(
     onEvent: (SavedTripUiEvent) -> Unit = {},
 ) {
     val themeContentColor by LocalThemeContentColor.current
+    val themeColor by LocalThemeColor.current
     // TODO -  handle colors of status bar
     /*    DisposableEffect(themeContentColor) {
             context.getActivityOrNull()?.let { activity ->
@@ -72,7 +76,7 @@ fun SavedTripsScreen(
         Column {
             TitleBar(
                 title = {
-                    Text(text = "KRAIL")
+                    Text(text = "KRAIL", color = themeColor.hexToComposeColor())
                 },
                 actions = {
                     RoundIconButton(


### PR DESCRIPTION
### TL;DR

Updated the KRAIL title text color in the SavedTripsScreen to use the theme color.

### What changed?

- Added imports for `LocalThemeColor`, `hexToComposeColor`, and `getForegroundColor` from the taj package
- Retrieved the current theme color using `LocalThemeColor.current`
- Modified the title text in the TitleBar to use the theme color by applying `color = themeColor.hexToComposeColor()`

### How to test?

1. Navigate to the SavedTripsScreen
2. Verify that the "KRAIL" title text now appears in the current theme color instead of the default color
3. Test with different theme settings to ensure the color changes appropriately

### Why make this change?

This change ensures the title text color is consistent with the app's theming system, improving visual coherence and following the design guidelines for the application.