### PR TITLE
Refactor: Use FlagKeys enum for remote config keys

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.core.remote_config
 
+import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
+
 /**
  * Holds the default values for remote configuration.
  * Add new default values here. These will be used as fallbacks when the remote config is not available
@@ -13,9 +15,9 @@ object RemoteConfigDefaults {
      */
     fun getDefaults(): Array<Pair<String, Any?>> {
         return arrayOf(
-            Pair("local_stops_enabled", true),
+            Pair(FlagKeys.LOCAL_STOPS_ENABLED.key, true),
             Pair(
-                "high_priority_stop_ids",
+                FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
                 """["200060", "200070", "200080", "206010", "2150106", "200017", "200039", "201016", "201039", "201080", "200066", "200030", "200046", "200050"]""".trimMargin()
             )
         )


### PR DESCRIPTION
### TL;DR

Refactored remote config keys to use the FlagKeys enum instead of hardcoded strings.

### What changed?

- Imported the `FlagKeys` enum in `RemoteConfigDefaults.kt`
- Replaced hardcoded string keys with their corresponding enum values:
  - `"local_stops_enabled"` → `FlagKeys.LOCAL_STOPS_ENABLED.key`
  - `"high_priority_stop_ids"` → `FlagKeys.HIGH_PRIORITY_STOP_IDS.key`

### How to test?

1. Verify that remote config functionality works as expected
2. Check that the default values are correctly applied when remote config is unavailable
3. Ensure that features dependent on these flags (local stops and high priority stops) continue to function properly

### Why make this change?

Using enum constants instead of string literals improves code maintainability and reduces the risk of typos. This change centralizes flag key definitions, making it easier to track and update them across the codebase. It also provides better IDE support with auto-completion and refactoring capabilities.