### PR TITLE
Deps: Update Gradle dependencies and disable Kotlin Native caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 android.useAndroidX=true
 org.gradle.caching=true
 kotlin.native.ignoreDisabledTargets=true
+# https://kotlinlang.org/docs/native-improving-compilation-time.html
+kotlin.native.cacheKind=none

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ desugar_jdk_libs = "2.1.5"
 java = "17"
 # AGP - Android API level mapping https://developer.android.com/build/releases/gradle-plugin#api-level-support
 # AGP compatability https://developer.android.com/build/releases/gradle-plugin
-agp = "8.9.1" # Android Gradle Plugin
+agp = "8.9.0" # Android Gradle Plugin
 kotlin = "2.1.20"
 core-ktx = "1.15.0"
 junit = "4.13.2"
@@ -16,7 +16,7 @@ lifecycleViewmodelCompose = "2.8.4"
 navigationCompose = "2.8.0-alpha13"
 kotlinxSerializationJson = "1.8.1"
 ksp = "2.1.20-1.0.32" # ksp to kotlin version mapping https://github.com/google/ksp/releases
-compose-multiplatform = "1.7.3"
+compose-multiplatform = "1.8.0-beta01"
 ktor = "3.1.2"
 androidx-lifecycle = "2.8.4"
 kotlinxCoroutines = "1.10.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### TL;DR

Updated Gradle and dependency versions to improve build stability.

### What changed?

- Disabled Kotlin Native caching by setting `kotlin.native.cacheKind=none` in gradle.properties
- Downgraded Android Gradle Plugin from 8.9.1 to 8.9.0
- Upgraded Compose Multiplatform from 1.7.3 to 1.8.0-beta01
- Downgraded Gradle wrapper from 8.13 to 8.12.1

### How to test?

1. Clean and rebuild the project
2. Verify that the application builds successfully
3. Run the app on both Android and iOS targets to ensure functionality is maintained
4. Check that Compose UI components render correctly with the new Compose Multiplatform version

### Why make this change?

The Kotlin Native cache was disabled to improve compilation time as recommended in the Kotlin documentation. The AGP version was downgraded to 8.9.0 for better stability, while Compose Multiplatform was upgraded to the latest beta to take advantage of new features and improvements. Gradle was downgraded to 8.12.1 to ensure compatibility with the updated dependency versions.