### PR TITLE
Version: Bump to 1.3.5

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 75
-        versionName = "1.3.4"
+        versionCode = 76
+        versionName = "1.3.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.4</string>
+	<string>1.3.5</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.3.4 to 1.3.5 for both Android and iOS apps.

### What changed?

- Android: 
  - Increased `versionCode` from 75 to 76
  - Updated `versionName` from "1.3.4" to "1.3.5"
- iOS:
  - Updated `CFBundleShortVersionString` from "1.3.4" to "1.3.5"
  - Increased `CFBundleVersion` from "1" to "2"

### How to test?

1. Build the app for both Android and iOS platforms
2. Verify the version information in the app settings or about page
3. Confirm the version numbers match the expected values (1.3.5)

### Why make this change?

Version bump for the next release to ensure proper versioning across platforms and to maintain consistent version tracking in app stores.