### PR TITLE
Refactor: Replace DisplayWithDensityCheck with isFontScaleLessThanThreshold function

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/A11yExt.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/A11yExt.kt
@@ -3,13 +3,8 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
 
-/**
- * Display the content only if the font scale is less than the threshold.
- */
 @Composable
-fun DisplayWithDensityCheck(fontScaleThreshold: Float = 1.8f, content: @Composable () -> Unit) {
+fun isFontScaleLessThanThreshold(fontScaleThreshold: Float = 1.8f): Boolean {
     val density = LocalDensity.current
-    if (density.fontScale < fontScaleThreshold) {
-        content()
-    }
+    return density.fontScale < fontScaleThreshold
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
-import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
@@ -330,7 +329,6 @@ fun getPaddingValue(lastLeg: TimeTableState.JourneyCardInfo.Leg): Dp {
     ) 16.dp else 0.dp
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalSharedTransitionApi::class)
 @Composable
 fun DefaultJourneyCardContent(
     timeToDeparture: String,
@@ -362,7 +360,7 @@ fun DefaultJourneyCardContent(
                         .padding(end = 8.dp)
                         .align(Alignment.CenterVertically),
                 )
-                DisplayWithDensityCheck {
+                if (transportModeList.size < 4 || isFontScaleLessThanThreshold()) {
                     Row(
                         modifier = Modifier
                             .align(Alignment.CenterVertically),


### PR DESCRIPTION
### TL;DR

Refactored accessibility handling for font scaling in the trip planner UI.

### What changed?

- Replaced `DisplayWithDensityCheck` composable with a new `isFontScaleLessThanThreshold` function that returns a boolean instead of conditionally displaying content
- Updated the `DefaultJourneyCardContent` to use the new function with additional logic to only show transport mode list when there are fewer than 4 items or the font scale is below the threshold
- Removed unnecessary `@OptIn` annotations from `DefaultJourneyCardContent`

### How to test?

1. Test the UI with different font scale settings (both below and above 1.8x)
2. Verify that transport mode lists with fewer than 4 items always display regardless of font scale
3. Verify that transport mode lists with 4+ items only display when font scale is below 1.8x
4. Ensure no regressions in journey card display

### Why make this change?

This change improves accessibility by providing more granular control over what UI elements are displayed based on font scale. The new approach allows for more flexible conditional rendering based on both content size and font scale, rather than just hiding content based on font scale alone.