### PR TITLE
Feature: Add share functionality for referring friends

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -16,6 +16,7 @@ import xyz.ksharma.krail.io.gtfs.di.gtfsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.networkModule
+import xyz.ksharma.krail.trip.planner.ui.di.shareModule
 import xyz.ksharma.krail.trip.planner.ui.di.viewModelsModule
 
 fun initKoin(config: KoinAppDeclaration? = null) {
@@ -33,6 +34,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             coroutineDispatchersModule,
             gtfsModule,
             appStartModule,
+            shareModule,
         )
     }
 }

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
             dependencies {
                 implementation(projects.core.appInfo)
                 implementation(projects.core.analytics)
+                implementation(projects.core.coroutinesExt)
                 implementation(projects.core.dateTime)
                 implementation(projects.core.di)
                 implementation(projects.core.log)

--- a/feature/trip-planner/ui/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/AndroidShareModule.kt
+++ b/feature/trip-planner/ui/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/AndroidShareModule.kt
@@ -1,0 +1,9 @@
+package xyz.ksharma.krail.trip.planner.ui.di
+
+import org.koin.dsl.module
+import xyz.ksharma.krail.trip.planner.ui.settings.AndroidSharer
+import xyz.ksharma.krail.trip.planner.ui.settings.Sharer
+
+actual val shareModule = module {
+    single<Sharer> { AndroidSharer(context = get()) }
+}

--- a/feature/trip-planner/ui/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/AndroidSharer.kt
+++ b/feature/trip-planner/ui/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/AndroidSharer.kt
@@ -1,0 +1,33 @@
+package xyz.ksharma.krail.trip.planner.ui.settings
+
+// androidMain
+import android.content.Context
+import android.content.Intent
+import xyz.ksharma.krail.core.log.log
+
+class AndroidSharer(private val context: Context) : Sharer {
+
+    override fun shareText() {
+        handleShareClick(context, Sharer.options.random())
+    }
+}
+
+// In your androidMain implementation
+fun handleShareClick(context: Context, text: String) {
+    log("handleShareClick: $text")
+
+//    startActivity(shareIntent)
+
+    // Create and start the share intent
+    val intent = Intent().apply {
+        action = Intent.ACTION_SEND
+        putExtra(Intent.EXTRA_TEXT, text)
+        type = "text/plain"
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    val shareIntent = Intent.createChooser(intent, "Share via")
+    shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    context.startActivity(shareIntent)
+
+//    context.startActivity(Intent.createChooser(intent, "Share via"))
+}

--- a/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_heart.xml
+++ b/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_heart.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M41.676,9.22C40.655,8.198 39.442,7.387 38.107,6.834C36.772,6.281 35.341,5.996 33.896,5.996C32.451,5.996 31.021,6.281 29.686,6.834C28.351,7.387 27.138,8.198 26.116,9.22L23.996,11.34L21.876,9.22C19.813,7.157 17.014,5.997 14.096,5.997C11.178,5.997 8.38,7.157 6.316,9.22C4.253,11.283 3.094,14.082 3.094,17C3.094,19.918 4.253,22.717 6.316,24.78L23.996,42.46L41.676,24.78C42.698,23.758 43.509,22.546 44.062,21.211C44.615,19.876 44.9,18.445 44.9,17C44.9,15.555 44.615,14.124 44.062,12.789C43.509,11.454 42.698,10.241 41.676,9.22Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ShareModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ShareModule.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.trip.planner.ui.di
+
+import org.koin.core.module.Module
+
+expect val shareModule: Module

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -5,15 +5,15 @@ import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
-import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
-import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
-import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
-import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewModel
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
+import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
+import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 
 val viewModelsModule = module {
     viewModelOf(::SearchStopViewModel)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
@@ -27,6 +27,9 @@ internal fun NavGraphBuilder.settingsDestination(navController: NavHostControlle
             onBackClick = {
                 navController.popBackStack()
             },
+            onReferFriendClick = {
+                viewModel.onReferFriendClick()
+            }
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_dev
+import krail.feature.trip_planner.ui.generated.resources.ic_heart
 import krail.feature.trip_planner.ui.generated.resources.ic_paint
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
@@ -38,6 +39,7 @@ fun SettingsScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
     onChangeThemeClick: () -> Unit = {},
+    onReferFriendClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -63,6 +65,16 @@ fun SettingsScreen(
                     text = "Change Theme",
                     onClick = {
                         onChangeThemeClick()
+                    }
+                )
+            }
+
+            item {
+                SettingsItem(
+                    icon = painterResource(Res.drawable.ic_heart),
+                    text = "Spread some love \uD83D\uDC95",
+                    onClick = {
+                        onReferFriendClick()
                     }
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -11,11 +11,13 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
 
 class SettingsViewModel(
     private val appInfoProvider: AppInfoProvider,
     private val analytics: Analytics,
+    private val share: Sharer,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SettingsState> = MutableStateFlow(SettingsState())
@@ -28,5 +30,10 @@ class SettingsViewModel(
     private suspend fun fetchAppVersion() {
         val appVersion = appInfoProvider.getAppInfo().appVersion
         _uiState.value = _uiState.value.copy(appVersion = appVersion)
+    }
+
+    fun onReferFriendClick() {
+        log("onReferFriendClick")
+        share.shareText()
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/Sharer.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/Sharer.kt
@@ -1,0 +1,55 @@
+package xyz.ksharma.krail.trip.planner.ui.settings
+
+interface Sharer {
+
+    fun shareText()
+
+    companion object {
+        const val REFER_FRIEND_TEXT = "KRAIL - Ride the rail without fail\n" +
+                "Hey mate!\n" +
+                "Try the best Sydney public transport app.\n" +
+                "Download now - https://krail.app"
+
+        val options: List<String> = listOf(
+            "Yo! legend,\n" +
+                    "Sydney’s best public transport app is here.\n" +
+                    "Download it now 👉 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+
+            "KRAIL — Sydney trains, minus the drama \uD83E\uDEE0\n" +
+                    "No more guessing. No more stressin’.\n" +
+                    "Get the app ya should’ve had yesterday.\n" +
+                    "\uD83D\uDC49 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+
+            "Oi where’s my train?\n" +
+                    "KRAIL: knows before ya even ask \uD83D\uDC40\n" +
+                    "The app that actually gets it.\n" +
+                    "\uD83D\uDE89 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+
+            "Not all heroes wear capes.\n" +
+                    "Some just show you when your bus is actually coming.\n" +
+                    "\uD83D\uDC85 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+
+            "Oi mate, tryna catch a bull, are ya?\n" +
+                    "Don’t get stitched up by late trains.\n" +
+                    "Use KRAIL — it’s like Google Maps but actually good.\n" +
+                    "\uD83D\uDE89 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+
+            "Bus ghosted ya again? Rude.\n" +
+                    "KRAIL tells you when and where — no cap.\n" +
+                    "Real-time vibes mate!" +
+                    "\uD83D\uDE89 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+
+            "Late again? Haha, your train’s playing hide and seek.\n" +
+                    "Catch it before it ghosts ya.\n" +
+                    "KRAIL’s got your back.\n" +
+                    "\uD83D\uDE89 https://krail.app\n" +
+                    "Let's KRAIL - Ride the rail without fail",
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/IosShareModule.kt
+++ b/feature/trip-planner/ui/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/IosShareModule.kt
@@ -1,0 +1,9 @@
+package xyz.ksharma.krail.trip.planner.ui.di
+
+import org.koin.dsl.module
+import xyz.ksharma.krail.trip.planner.ui.settings.IosSharer
+import xyz.ksharma.krail.trip.planner.ui.settings.Sharer
+
+actual val shareModule = module {
+    single<Sharer> { IosSharer() }
+}

--- a/feature/trip-planner/ui/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/IosSharer.kt
+++ b/feature/trip-planner/ui/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/IosSharer.kt
@@ -1,0 +1,25 @@
+package xyz.ksharma.krail.trip.planner.ui.settings
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIApplication
+
+class IosSharer : Sharer {
+    override fun shareText() {
+        handleShareClick(Sharer.REFER_FRIEND_TEXT)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+fun handleShareClick(text: String) {
+    val activityItems = listOf(text)
+    val activityViewController = UIActivityViewController(activityItems, null)
+
+    val application = UIApplication.sharedApplication
+    application.keyWindow?.rootViewController?.presentViewController(
+        activityViewController,
+        animated = true,
+        completion = null
+    )
+}


### PR DESCRIPTION
### TL;DR

Added a sharing feature that allows users to refer friends to the app with fun, pre-written messages.

### What changed?

- Created a `Sharer` interface with platform-specific implementations for Android and iOS
- Added a new "Spread some love" option in the Settings screen
- Implemented sharing functionality that randomly selects from a collection of pre-written referral messages
- Added a heart icon for the new settings option
- Set up platform-specific sharing modules for dependency injection

### How to test?

1. Navigate to the Settings screen
2. Tap on the new "Spread some love ❤️" option
3. Verify that the system share dialog appears with a randomly selected referral message
4. Test on both Android and iOS platforms to ensure platform-specific sharing works correctly

### Why make this change?

This change enables users to easily share the app with friends through a fun, engaging referral system. The pre-written messages are casual and playful, making it more likely that users will share the app. This feature helps with organic user acquisition and growth by leveraging existing users as advocates for the app.