### PR TITLE
Version: Bump to 1.3.6

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 76
-        versionName = "1.3.5"
+        versionCode = 77
+        versionName = "1.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.5</string>
+	<string>1.3.6</string>
 	<key>CFBundleVersion</key>
 	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.3.5 to 1.3.6 for both Android and iOS apps.

### What changed?

- Updated Android `versionCode` from 76 to 77
- Updated Android `versionName` from "1.3.5" to "1.3.6"
- Updated iOS `CFBundleShortVersionString` from "1.3.5" to "1.3.6"

### How to test?

- Build the Android app and verify the version in the app info
- Build the iOS app and verify the version in the app info
- Ensure both platforms display version 1.3.6

### Why make this change?

Version bump needed for the next release to properly track the new version in app stores and for users.