### PR TITLE
Refactor: Inject main dispatcher into SettingsViewModel

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -4,6 +4,7 @@ import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewModel
@@ -17,9 +18,17 @@ import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 
 val viewModelsModule = module {
     viewModelOf(::SearchStopViewModel)
-    viewModelOf(::SettingsViewModel)
     viewModelOf(::ServiceAlertsViewModel)
     viewModelOf(::DateTimeSelectorViewModel)
+
+    viewModel {
+        SettingsViewModel(
+            appInfoProvider = get(),
+            analytics = get(),
+            share = get(),
+            mainDispatcher = get(named(DispatchersComponent.MainDispatcher)),
+        )
+    }
 
     viewModel {
         SavedTripsViewModel(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -22,6 +23,7 @@ class SettingsViewModel(
     private val appInfoProvider: AppInfoProvider,
     private val analytics: Analytics,
     private val share: ContentSharing,
+    private val mainDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SettingsState> = MutableStateFlow(SettingsState())
@@ -37,7 +39,7 @@ class SettingsViewModel(
     }
 
     fun onReferFriendClick() {
-        viewModelScope.launchWithExceptionHandler<SettingsViewModel>(Dispatchers.Default) {
+        viewModelScope.launchWithExceptionHandler<SettingsViewModel>(mainDispatcher) {
             share.sharePlainText(getReferText())
             analytics.track(AnalyticsEvent.ReferAFriend)
         }


### PR DESCRIPTION
### TL;DR

Added `mainDispatcher` parameter to `SettingsViewModel` to improve testability and consistency.

### What changed?

- Added a `mainDispatcher` parameter to the `SettingsViewModel` constructor
- Updated the Koin module to provide the main dispatcher to the `SettingsViewModel`
- Changed the dispatcher used in `onReferFriendClick()` from `Dispatchers.Default` to the injected `mainDispatcher`

### How to test?

1. Navigate to the Settings screen
2. Click on "Refer a Friend" option
3. Verify that the share dialog appears correctly
4. Verify that analytics tracking for the "Refer a Friend" event works as expected

### Why make this change?

This change improves testability by making the dispatcher injectable, allowing for easier unit testing with test dispatchers. It also ensures consistent dispatcher usage across the application by leveraging the centrally defined dispatchers from `DispatchersComponent`.