### PR TITLE
Version: Bump to 1.3.6 (79) and update referral messages

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 77
+        versionCode = 79
         versionName = "1.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
@@ -12,52 +12,32 @@ object ReferFriendManager {
 
     // TODO - fetch these from Firebase.
     private val referTextOptions: List<String> = listOf(
-        "Hey mate!\n" +
-                "Try the best Sydney public transport app.\n" +
-                "Download now \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
-                "KRAIL - Ride the rail without fail",
-
-        "Yo! legend,\n" +
-                "Sydney’s best public transport app is here.\n" +
-                "Download now \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
-                "KRAIL - Ride the rail without fail",
-
-        "KRAIL - Sydney trains, minus the drama \uD83E\uDEE0\n" +
-                "Download now \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
-                "KRAIL - Ride the rail without fail",
-
-        "Oi where’s my train?\n" +
-                "Use KRAIL - it’s like TripView but actually good.\n" +
-                "Download now \uD83D\uDC47 \n" +
+        "Hey mate,\n" +
+                "Sydney’s best public transport app is here. Like TripView but ad-free\n\n" +
+                "Download KRAIL here \uD83D\uDC47 \n" +
                 "Apple - $KRAIL_APP_STORE\n" +
                 "Android - $KRAIL_GOOGLE_PLAY\n" +
                 "KRAIL - Ride the rail without fail",
 
         "Not all heroes wear capes.\n" +
-                "Some just show you when your bus is actually coming.\n" +
-                "Download now \uD83D\uDC47 \n" +
+                "Some just show you when your bus is actually coming.\n\n" +
+                "Download KRAIL here \uD83D\uDC47 \n" +
                 "Apple - $KRAIL_APP_STORE\n" +
                 "Android - $KRAIL_GOOGLE_PLAY\n" +
                 "KRAIL - Ride the rail without fail",
 
         "Bus ghosted ya again? Rude.\n" +
-                "KRAIL tells you when and where - no cap.\n" +
-                "Download now \uD83D\uDC47 \n" +
+                "KRAIL tells you when and where - no cap.\n\n" +
+                "Download KRAIL here \uD83D\uDC47 \n" +
                 "Apple - $KRAIL_APP_STORE\n" +
                 "Android - $KRAIL_GOOGLE_PLAY\n" +
                 "KRAIL - Ride the rail without fail",
 
-        "Late again? Haha, your train’s playing hide and seek.\n" +
-                "KRAIL’s got your back.\n" +
-                "Download now \uD83D\uDC47 \n" +
+        "Your train was late again?.\n" +
+                "KRAIL App’s got your back.\n\n" +
+                "Download KRAIL here \uD83D\uDC47 \n" +
                 "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
+                "Android - $KRAIL_GOOGLE_PLAY\n\n" +
                 "KRAIL - Ride the rail without fail",
     )
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -72,7 +72,7 @@ fun SettingsScreen(
             item {
                 SettingsItem(
                     icon = painterResource(Res.drawable.ic_heart),
-                    text = "Spread some love \uD83D\uDC95",
+                    text = "Invite your fiends \uD83D\uDC95",
                     onClick = {
                         onReferFriendClick()
                     }


### PR DESCRIPTION
### TL;DR

Updated version code and refined the refer-a-friend messaging.

### What changed?

- Incremented the app version code from 77 to 79
- Refined the refer-a-friend text options with clearer formatting and improved messaging
- Changed the settings menu item text from "Spread some love 💕" to "Invite your fiends 💕"

### How to test?

1. Navigate to the Settings screen and verify the "Invite your fiends" option appears correctly
2. Tap on the option and confirm the refer-a-friend functionality works as expected
3. Verify the shared text contains the updated messaging format

### Why make this change?

The refer-a-friend messaging needed refinement to be more effective and professional. The updated text options are better formatted with clearer spacing and more concise messaging to encourage app adoption. The version code bump prepares for a new release with these improvements.