### PR TITLE
Version: Bump to 1.3.6 (80)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 79
+        versionCode = 80
         versionName = "1.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
### TL;DR

Bumped version code from 79 to 80 for the next release.

### What changed?

Updated the `versionCode` in the Android configuration from 79 to 80 while maintaining the version name at "1.3.6".

### How to test?

Build the app and verify that the version code is correctly set to 80 in the generated APK/AAB metadata.

### Why make this change?

Version code incrementation is required for publishing a new build to the Google Play Store, even when the user-facing version name remains the same. This ensures the Play Store recognizes this as a newer build than the previous release.