### PR TITLE
Feature: Add About Us screen to Settings

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_smile.xml
+++ b/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_smile.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M16,28C16,28 19,32 24,32C29,32 32,28 32,28M18,18H18.02M30,18H30.02M44,24C44,35.046 35.046,44 24,44C12.954,44 4,35.046 4,24C4,12.954 12.954,4 24,4C35.046,4 44,12.954 44,24Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -8,6 +8,7 @@ import xyz.ksharma.krail.trip.planner.ui.alerts.alertsDestination
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.dateTimeSelectorDestination
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.savedTripsDestination
 import xyz.ksharma.krail.trip.planner.ui.searchstop.searchStopDestination
+import xyz.ksharma.krail.trip.planner.ui.settings.about.aboutUsDestination
 import xyz.ksharma.krail.trip.planner.ui.settings.settingsDestination
 import xyz.ksharma.krail.trip.planner.ui.timetable.timeTableDestination
 import xyz.ksharma.krail.trip.planner.ui.themeselection.themeSelectionDestination
@@ -34,6 +35,8 @@ fun NavGraphBuilder.tripPlannerDestinations(
         settingsDestination(navController)
 
         dateTimeSelectorDestination(navController)
+
+        aboutUsDestination(navController)
     }
 }
 
@@ -83,6 +86,9 @@ internal data class ServiceAlertRoute(
 
 @Serializable
 data object SettingsRoute
+
+@Serializable
+data object AboutUsRoute
 
 @Serializable
 data class DateTimeSelectorRoute(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import org.koin.compose.viewmodel.koinViewModel
+import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SettingsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
 
@@ -29,7 +30,13 @@ internal fun NavGraphBuilder.settingsDestination(navController: NavHostControlle
             },
             onReferFriendClick = {
                 viewModel.onReferFriendClick()
-            }
+            },
+            onAboutUsClick = {
+                navController.navigate(
+                    route = AboutUsRoute,
+                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                )
+            },
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_dev
+import krail.feature.trip_planner.ui.generated.resources.ic_smile
 import krail.feature.trip_planner.ui.generated.resources.ic_heart
 import krail.feature.trip_planner.ui.generated.resources.ic_paint
 import org.jetbrains.compose.resources.painterResource
@@ -40,6 +41,7 @@ fun SettingsScreen(
     onBackClick: () -> Unit = {},
     onChangeThemeClick: () -> Unit = {},
     onReferFriendClick: () -> Unit = {},
+    onAboutUsClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -85,6 +87,17 @@ fun SettingsScreen(
                     text = "KRAIL App Version: $appVersion",
                 )
             }
+
+            item {
+                SettingsItem(
+                    icon = painterResource(Res.drawable.ic_smile),
+                    text = "About Us",
+                    onClick = {
+                        onAboutUsClick()
+                    }
+                )
+            }
+
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsDestination.kt
@@ -1,0 +1,16 @@
+package xyz.ksharma.krail.trip.planner.ui.settings.about
+
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
+
+internal fun NavGraphBuilder.aboutUsDestination(navController: NavHostController) {
+    composable<AboutUsRoute> {
+
+        AboutUsScreen(
+            onBackClick = { navController.popBackStack() }
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
@@ -1,0 +1,71 @@
+package xyz.ksharma.krail.trip.planner.ui.settings.about
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_dev
+import krail.feature.trip_planner.ui.generated.resources.ic_heart
+import krail.feature.trip_planner.ui.generated.resources.ic_paint
+import krail.feature.trip_planner.ui.generated.resources.ic_smile
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.components.TitleBar
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+@Composable
+fun AboutUsScreen(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = KrailTheme.colors.surface)
+            .statusBarsPadding(),
+    ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            TitleBar(
+                modifier = Modifier.fillMaxWidth(),
+                onNavActionClick = onBackClick,
+                title = { Text(text = "About Us") },
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier,
+            contentPadding = PaddingValues(top = 20.dp, bottom = 104.dp),
+        ) {
+            item {
+                Text(
+                    "KRAIL - Ride the rail without fail.",
+                    style = KrailTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
+                )
+            }
+
+            item {
+                Text(
+                    "Thank you for downloading the KRAIL App. If the app has helped you, " +
+                            "please review on App Store and share with friends. You can save trips " +
+                            "and see real-time public transport information across Sydney, NSW. " +
+                            "The real time trip data is provided by Transport for NSW. " +
+                            "Best efforts are taken to ensure the " +
+                            "accuracy of the data. However, no guarantees are made. " +
+                            "Please refer to the Transport for NSW website (www.transportnsw.info) for more " +
+                            "information.",
+                    style = KrailTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
### TL;DR

Added an "About Us" screen accessible from the Settings menu.

### What changed?

- Created a new "About Us" screen with app information and disclaimers
- Added navigation to the About Us screen from Settings
- Added a new smile icon for the About Us menu item
- Implemented the AboutUsRoute and destination in the navigation graph
- Updated the Settings screen to include an About Us option

### How to test?

1. Navigate to the Settings screen
2. Tap on the "About Us" option with the smile icon
3. Verify the About Us screen appears with the correct content
4. Test that the back button returns to the Settings screen

### Why make this change?

To provide users with important information about the app, including its purpose, data sources, and disclaimers about data accuracy. This helps set appropriate expectations for users and provides attribution to Transport for NSW as the data provider.