### PR TITLE
Feature: Add animated intro screen with horizontal pager

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -10,14 +10,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
@@ -26,6 +30,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
@@ -39,58 +44,82 @@ fun IntroScreen(
     modifier: Modifier = Modifier,
     onEvent: (IntroUiEvent) -> Unit = {},
 ) {
-    Column(modifier = modifier.fillMaxSize().systemBarsPadding()) {
-        Text(
-            text = "Intro Screen",
-            style = KrailTheme.typography.title,
-            modifier = Modifier.padding(16.dp),
-        )
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = KrailTheme.colors.surface)
+            .statusBarsPadding(),
+    ) {
+        Column(modifier = Modifier.align(Alignment.TopCenter)) {
+            Text(
+                text = "Intro Screen",
+                style = KrailTheme.typography.title,
+                modifier = Modifier.padding(16.dp),
+            )
 
-        Spacer(modifier = Modifier.height(48.dp))
+            Spacer(modifier = Modifier.height(32.dp))
 
-        val pagerState = rememberPagerState(pageCount = { 5 })
-        val colors = listOf(Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Magenta)
+            val pagerState = rememberPagerState(pageCount = { 5 })
+            val colors = listOf(Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Magenta)
 
-        BoxWithConstraints(Modifier.fillMaxWidth()) {
-            val screenHeight = maxHeight
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                val screenHeight = maxHeight
 
-            val selectedHeight = screenHeight * 0.80f
-            val unselectedHeight = screenHeight * 0.6f
+                val selectedHeight = screenHeight * 0.80f
+                val unselectedHeight = screenHeight * 0.6f
 
-            HorizontalPager(
-                state = pagerState,
-                contentPadding = PaddingValues(horizontal = 64.dp),
-                pageSpacing = 20.dp,
-                modifier = Modifier.fillMaxWidth()
-            ) { pageNumber ->
+                HorizontalPager(
+                    state = pagerState,
+                    contentPadding = PaddingValues(horizontal = 64.dp),
+                    pageSpacing = 20.dp,
+                    modifier = Modifier.fillMaxWidth()
+                ) { pageNumber ->
 
-                val pageOffset = pagerState.calculateCurrentOffsetForPage(pageNumber).absoluteValue
-                val animatedHeight by animateDpAsState(
-                    targetValue = lerp(selectedHeight, unselectedHeight, min(1f, pageOffset)),
-                    label = "cardHeight"
-                )
+                    val pageOffset =
+                        pagerState.calculateCurrentOffsetForPage(pageNumber).absoluteValue
+                    val animatedHeight by animateDpAsState(
+                        targetValue = lerp(selectedHeight, unselectedHeight, min(1f, pageOffset)),
+                        label = "cardHeight"
+                    )
 
-                val scale = lerp(1f, 0.9f, min(1f, pageOffset))
+                    val scale = lerp(1f, 0.9f, min(1f, pageOffset))
 
-                val greyOverlayAlpha = min(1f, pageOffset * 1.2f) // Gradual tinting
-                val greyOverlay = Color(0xFF888888).copy(alpha = greyOverlayAlpha)
+                    val greyOverlayAlpha = min(0.6f, pageOffset * 1.2f) // Gradual tinting
+                    val greyOverlay = Color(0xFF888888).copy(alpha = greyOverlayAlpha)
 
-                Box(
-                    modifier = Modifier
-                        .zIndex(1f - pageOffset)
-                        .height(animatedHeight)
-                        .graphicsLayer {
-                            scaleX = scale
-                            scaleY = scale
-                        }
-                        .fillMaxWidth()
-                        .clip(RoundedCornerShape(24.dp))
-                        .background(colors[pageNumber % colors.size])
-                        .drawWithContent {
-                            drawContent()
-                            drawRect(greyOverlay) // overlays a semi-transparent grey
-                        }
-                )
+                    Column(
+                        modifier = Modifier
+                            .zIndex(1f - pageOffset)
+                            .height(animatedHeight)
+                            .graphicsLayer {
+                                scaleX = scale
+                                scaleY = scale
+                            }
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(24.dp))
+                            .background(colors[pageNumber % colors.size])
+                            .drawWithContent {
+                                drawContent()
+                                drawRect(greyOverlay) // overlays a semi-transparent grey
+                            }
+                            .verticalScroll(rememberScrollState())
+                    ) {
+                        Text("Page $pageNumber", modifier = Modifier.padding(16.dp))
+                    }
+                }
+            }
+        }
+
+        Column(
+            modifier = Modifier.align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(bottom = 10.dp)
+        ) {
+            Button(
+                onClick = { },
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+            ) {
+                Text(text = "Let's #KRAIL")
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -1,11 +1,37 @@
 package xyz.ksharma.krail.trip.planner.ui.intro
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
+import kotlin.math.absoluteValue
+
+val colors = listOf(
+    Color.Red,
+    Color.Blue,
+    Color.Green,
+    Color.Yellow,
+    Color.Magenta,
+)
+
 
 @Composable
 fun IntroScreen(
@@ -13,7 +39,54 @@ fun IntroScreen(
     modifier: Modifier = Modifier,
     onEvent: (IntroUiEvent) -> Unit = {},
 ) {
-    Column {
-        Text(text = "Intro Screen")
+    Column(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
+
+        Text(
+            text = "Intro Screen",
+            style = KrailTheme.typography.title,
+            modifier = Modifier.padding(16.dp),
+        )
+
+        val pagerState = rememberPagerState(pageCount = { 5 })
+        HorizontalPager(
+            modifier = modifier.padding(vertical = 24.dp),
+            state = pagerState
+        ) { pageNumber ->
+            Box(
+                Modifier
+                    .graphicsLayer {
+                        val pageOffset = pagerState.calculateCurrentOffsetForPage(pageNumber)
+                        // translate the contents by the size of the page, to prevent the pages
+                        // from sliding in from left or right and stays in the center
+                        translationX = pageOffset * size.width
+                        // apply an alpha to fade the current page in and the old page out
+                        alpha = 1 - pageOffset.absoluteValue
+                    }) {
+
+                Column(
+                    modifier = Modifier.height(300.dp).fillMaxWidth().padding(horizontal = 56.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(
+                            color = colors[pageNumber % colors.size]
+                        )
+                ) {
+
+                }
+
+            }
+        }
     }
+}
+
+
+fun Modifier.pagerFadeTransition(page: Int, pagerState: PagerState) =
+    graphicsLayer {
+        val pageOffset = pagerState.calculateCurrentOffsetForPage(page)
+        translationX = pageOffset * size.width
+        alpha = 1 - pageOffset.absoluteValue
+    }
+
+
+private fun PagerState.calculateCurrentOffsetForPage(page: Int): Float {
+    return (currentPage - page) + currentPageOffsetFraction
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -1,8 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.intro
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -13,16 +15,20 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
 import kotlin.math.absoluteValue
+import kotlin.math.min
 
 val colors = listOf(
     Color.Red,
@@ -32,7 +38,6 @@ val colors = listOf(
     Color.Magenta,
 )
 
-
 @Composable
 fun IntroScreen(
     state: IntroState,
@@ -40,7 +45,6 @@ fun IntroScreen(
     onEvent: (IntroUiEvent) -> Unit = {},
 ) {
     Column(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
-
         Text(
             text = "Intro Screen",
             style = KrailTheme.typography.title,
@@ -48,45 +52,55 @@ fun IntroScreen(
         )
 
         val pagerState = rememberPagerState(pageCount = { 5 })
+
         HorizontalPager(
-            modifier = modifier.padding(vertical = 24.dp),
-            state = pagerState
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 32.dp),
+            state = pagerState,
+            contentPadding = PaddingValues(horizontal = 64.dp),
+            pageSpacing = 24.dp
         ) { pageNumber ->
+
+            val pageOffset = pagerState.calculateCurrentOffsetForPage(pageNumber).absoluteValue
+
+            // Animate height
+            val maxHeight = 600.dp
+            val minHeight = 450.dp
+            val animatedHeight: Dp by animateDpAsState(
+                targetValue = lerp(maxHeight, minHeight, min(1f, pageOffset)),
+                label = "cardHeight"
+            )
+
+            // Animate scale
+            val scale = lerp(1f, 0.9f, min(1f, pageOffset))
+
             Box(
-                Modifier
+                modifier = Modifier
                     .graphicsLayer {
-                        val pageOffset = pagerState.calculateCurrentOffsetForPage(pageNumber)
-                        // translate the contents by the size of the page, to prevent the pages
-                        // from sliding in from left or right and stays in the center
-                        translationX = pageOffset * size.width
-                        // apply an alpha to fade the current page in and the old page out
-                        alpha = 1 - pageOffset.absoluteValue
-                    }) {
-
-                Column(
-                    modifier = Modifier.height(300.dp).fillMaxWidth().padding(horizontal = 56.dp)
-                        .clip(RoundedCornerShape(16.dp))
-                        .background(
-                            color = colors[pageNumber % colors.size]
-                        )
-                ) {
-
-                }
-
-            }
+                        scaleX = scale
+                        scaleY = scale
+                    }
+                    .zIndex(1f - pageOffset) // ensure selected page is on top
+                    .height(animatedHeight)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(colors[pageNumber % colors.size])
+            )
         }
     }
 }
 
-
-fun Modifier.pagerFadeTransition(page: Int, pagerState: PagerState) =
-    graphicsLayer {
-        val pageOffset = pagerState.calculateCurrentOffsetForPage(page)
-        translationX = pageOffset * size.width
-        alpha = 1 - pageOffset.absoluteValue
-    }
-
-
+// Offset calculation helper
 private fun PagerState.calculateCurrentOffsetForPage(page: Int): Float {
     return (currentPage - page) + currentPageOffsetFraction
+}
+
+// Linear interpolation between two Dp values
+private fun lerp(start: Dp, end: Dp, fraction: Float): Dp {
+    return start + (end - start) * fraction
+}
+
+private fun lerp(start: Float, end: Float, fraction: Float): Float {
+    return start + (end - start) * fraction
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SettingsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
 
@@ -30,6 +31,12 @@ internal fun NavGraphBuilder.settingsDestination(navController: NavHostControlle
             },
             onReferFriendClick = {
                 viewModel.onReferFriendClick()
+            },
+            onIntroClick = {
+                navController.navigate(
+                    route = IntroRoute,
+                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                )
             },
             onAboutUsClick = {
                 navController.navigate(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -42,6 +42,7 @@ fun SettingsScreen(
     onChangeThemeClick: () -> Unit = {},
     onReferFriendClick: () -> Unit = {},
     onAboutUsClick: () -> Unit = {},
+    onIntroClick: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -83,6 +84,14 @@ fun SettingsScreen(
 
             item {
                 SettingsItem(
+                    icon = painterResource(Res.drawable.ic_heart),
+                    text = "Intro to KRAIL",
+                    onClick = onIntroClick,
+                )
+            }
+
+            item {
+                SettingsItem(
                     icon = painterResource(Res.drawable.ic_dev),
                     text = "KRAIL App Version: $appVersion",
                 )
@@ -91,7 +100,7 @@ fun SettingsScreen(
             item {
                 SettingsItem(
                     icon = painterResource(Res.drawable.ic_smile),
-                    text = "About Us",
+                    text = "About KRAIL",
                     onClick = {
                         onAboutUsClick()
                     }


### PR DESCRIPTION
# Add horizontal pager to IntroScreen with animated card transitions

Implemented a horizontal pager in the IntroScreen with animated card transitions featuring:

- Dynamic card height animation based on page selection
- Scale transformations for unselected pages
- Z-index manipulation to control card stacking order
- Gray overlay effect that increases opacity for unselected pages
- Smooth transitions between pages with custom lerp functions

Also added an "Intro to KRAIL" option in the Settings screen that navigates to the IntroScreen.