### PR TITLE
Fix: Correct typo in friend referral text

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -74,7 +74,7 @@ fun SettingsScreen(
             item {
                 SettingsItem(
                     icon = painterResource(Res.drawable.ic_heart),
-                    text = "Invite your fiends \uD83D\uDC95",
+                    text = "Invite your friends \uD83D\uDC95",
                     onClick = {
                         onReferFriendClick()
                     }


### PR DESCRIPTION
### TL;DR

Fixed a typo in the settings screen where "friends" was misspelled as "fiends".
