### PR TITLE
Update: Redesign intro screens with ferry theme and reorder pages

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
@@ -51,16 +51,15 @@ data class IntroState(
                 IntroPage(
                     id = 1,
                     colorsList = persistentListOf(
-                        TransportMode.LightRail().colorCode,
-                        KrailThemeStyle.Bus.hexColorCode,
+                        TransportMode.Ferry().colorCode,
                         "#FFC800", // Yellow
-                        TransportMode.LightRail().colorCode,
+                        TransportMode.Ferry().colorCode,
                     ),
                     title = "Real-time information",
                     tagline = "FASTEST\nROUTES\nEVERYTIME",
                     emoji = "\uD83D\uDE80",
                     ctaText = "LET'S KRAIL",
-                    primaryStyle = TransportMode.LightRail().colorCode,
+                    primaryStyle = TransportMode.Ferry().colorCode,
                     type = IntroPageType.REAL_TIME_DATA,
                     ),
                 IntroPage(
@@ -80,32 +79,32 @@ data class IntroState(
                 IntroPage(
                     id = 3,
                     colorsList = persistentListOf(
-                        KrailThemeStyle.Coach.hexColorCode,
-                        KrailThemeStyle.Bus.hexColorCode,
-                        "#FFC800", // Yellow
-                        KrailThemeStyle.Coach.hexColorCode,
-                    ),
-                    title = "Plan your trip",
-                    tagline = "WE\nCAN TELL\nTHE FUTURE",
-                    emoji = "\uD83D\uDD2E",
-                    ctaText = "LET'S KRAIL",
-                    primaryStyle =  KrailThemeStyle.Coach.hexColorCode,
-                    type = IntroPageType.PLAN_TRIP,
-                    ),
-                IntroPage(
-                    id = 4,
-                    colorsList = persistentListOf(
                         KrailThemeStyle.Train.hexColorCode,
                         KrailThemeStyle.Bus.hexColorCode,
                         KrailThemeStyle.Train.hexColorCode,
                     ),
-                    title = "Select transport mode",
+                    title = "Choose your mode",
                     tagline = "TRAIN, BUS\nOR ALL\nYOUR CHOICE",
                     emoji = "\uD83D\uDE0E",
                     ctaText = "LET'S KRAIL",
                     primaryStyle =  KrailThemeStyle.Train.hexColorCode,
                     type = IntroPageType.SELECT_MODE,
                 ),
+                IntroPage(
+                    id = 4,
+                    colorsList = persistentListOf(
+                        KrailThemeStyle.PurpleDrip.hexColorCode,
+                        KrailThemeStyle.Bus.hexColorCode,
+                        "#FFC800", // Yellow
+                        KrailThemeStyle.PurpleDrip.hexColorCode,
+                    ),
+                    title = "Plan your trip",
+                    tagline = "WE\nCAN TELL\nTHE FUTURE",
+                    emoji = "\uD83D\uDD2E",
+                    ctaText = "LET'S KRAIL",
+                    primaryStyle =  KrailThemeStyle.PurpleDrip.hexColorCode,
+                    type = IntroPageType.PLAN_TRIP,
+                    ),
                 IntroPage(
                     id = 5,
                     colorsList = persistentListOf(

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
@@ -83,7 +83,7 @@ data class IntroState(
                         KrailThemeStyle.Bus.hexColorCode,
                         KrailThemeStyle.Train.hexColorCode,
                     ),
-                    title = "Choose your mode",
+                    title = "Pick your mode",
                     tagline = "TRAIN, BUS\nOR ALL\nYOUR CHOICE",
                     emoji = "\uD83D\uDE0E",
                     ctaText = "LET'S KRAIL",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContent.kt
@@ -78,7 +78,7 @@ fun IntroContentSaveTrips(
     style: String, // hexCode - // todo - see if it can be color instead.
 ) {
     Column(
-        modifier = modifier.padding(vertical = 20.dp, horizontal = 10.dp)
+        modifier = modifier
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -135,7 +135,6 @@ fun IntroContentRealTime(
 ) {
     Column(
         modifier = modifier
-            .padding(vertical = 16.dp, horizontal = 16.dp)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -165,11 +164,12 @@ fun IntroContentAlerts(
 ) {
     Column(
         modifier = modifier
-            .padding(vertical = 16.dp, horizontal = 16.dp)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
 
             var displayAlert by rememberSaveable { mutableStateOf(false) }
 
@@ -234,7 +234,6 @@ fun IntroContentPlanTrip(
 ) {
     Column(
         modifier = modifier
-            .padding(vertical = 16.dp, horizontal = 16.dp)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -285,7 +284,6 @@ fun IntroContentInviteFriends(
 ) {
     Column(
         modifier = modifier
-            .padding(vertical = 16.dp, horizontal = 16.dp)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -333,7 +331,6 @@ fun IntroContentSelectTransportMode(
 ) {
     Column(
         modifier = modifier
-            .padding(vertical = 16.dp, horizontal = 16.dp)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -349,6 +346,7 @@ fun IntroContentSelectTransportMode(
                             selectedModes - mode
                         } else selectedModes + mode
                     },
+                    //modifier = Modifier.padding(horizontal = 10.dp),
                 )
             }
         }
@@ -371,7 +369,7 @@ private fun TagLineWithEmoji(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier.padding(top = 20.dp, start = 10.dp, end = 10.dp),
+        modifier = modifier.padding(top = 20.dp, end = 10.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Text(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContent.kt
@@ -141,10 +141,10 @@ fun IntroContentRealTime(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             LegView(
-                routeText = "Central to Dulwich Hill",
+                routeText = "Manly to Circular Quay",
                 transportModeLine = TransportModeLine(
-                    transportMode = TransportMode.LightRail(),
-                    lineName = "L1",
+                    transportMode = TransportMode.Ferry(),
+                    lineName = "MFF",
                 ),
                 stops = stopsList(),
             )
@@ -290,7 +290,11 @@ fun IntroContentInviteFriends(
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text("RIDING SOLO\nNAH THANKS", style = KrailTheme.typography.headlineMedium)
+            Text(
+                text = "RIDING SOLO\nNAH THANKS",
+                style = KrailTheme.typography.headlineMedium,
+                color = style.hexToComposeColor(),
+            )
         }
 
         Column(
@@ -386,58 +390,13 @@ private fun TagLineWithEmoji(
 
 private fun stopsList() = persistentListOf(
     TimeTableState.JourneyCardInfo.Stop(
-        name = "Central Light Rail",
+        name = "Manly, Wharf 2",
         time = "10:10 AM",
         isWheelchairAccessible = true,
     ),
     TimeTableState.JourneyCardInfo.Stop(
-        "Capitol Square Light Rail",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Paddy's Market Light Rail",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Central Station",
-        time = "12:00",
-        isWheelchairAccessible = true,
-    ),
-    TimeTableState.JourneyCardInfo.Stop(
-        "Glebe Light Rail",
-        time = "10:15 AM",
+        name = "Circular Quay, Wharf 2",
+        time = "10:30 AM",
         isWheelchairAccessible = true,
     ),
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -197,7 +197,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
             IntroContentSaveTrips(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier,
+                modifier = modifier.padding(20.dp),
             )
         }
 
@@ -205,7 +205,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
             IntroContentRealTime(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier,
+                modifier = modifier.padding(20.dp),
             )
         }
 
@@ -213,32 +213,36 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
             IntroContentAlerts(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier,
-            )
+                modifier = modifier.padding(20.dp),
+
+                )
         }
 
         IntroState.IntroPageType.PLAN_TRIP -> {
             IntroContentPlanTrip(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier,
-            )
+                modifier = modifier.padding(20.dp),
+
+                )
         }
 
         IntroState.IntroPageType.SELECT_MODE -> {
             IntroContentSelectTransportMode(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier,
-            )
+                modifier = modifier.padding(20.dp),
+
+                )
         }
 
         IntroState.IntroPageType.INVITE_FRIENDS -> {
             IntroContentInviteFriends(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier,
-            )
+                modifier = modifier.padding(20.dp),
+
+                )
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -85,7 +85,7 @@ fun SettingsScreen(
             item {
                 SettingsItem(
                     icon = painterResource(Res.drawable.ic_heart),
-                    text = "Intro to KRAIL",
+                    text = "How to KRAIL?",
                     onClick = onIntroClick,
                 )
             }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -28,6 +28,7 @@ val train_theme = Color(0xFFF6891F)
 val metro_theme = Color(0xFF009B77)
 val ferry_theme = Color(0xFF5AB031)
 val coach_theme = Color(0xFF742282)
+val purple_drip_theme = Color(0xFFAC00C9)
 val light_rail_theme = Color(0xFFE4022D)
 val barbie_pink_theme = Color(0xFFE0218A)
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailThemeStyle.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailThemeStyle.kt
@@ -20,8 +20,8 @@ enum class KrailThemeStyle(val hexColorCode: String, val id: Int, val tagLine: S
         id = 5,
         tagLine = "Hoppin' the concrete jungle!"
     ),
-    Coach(
-        hexColorCode = coach_theme.toHex(),
+    PurpleDrip(
+        hexColorCode = purple_drip_theme.toHex(),
         id = 7,
         tagLine = "Purple drip, endless trip!"
     ),


### PR DESCRIPTION
### TL;DR

Updated the intro screens with new transport modes, colors, and content to improve the onboarding experience.

### What changed?

- Changed the first intro page from Light Rail to Ferry theme, updating colors and route information
- Swapped the order of "Plan your trip" and "Choose your mode" intro pages
- Updated "Choose your mode" title (previously "Select transport mode")
- Changed the color scheme for the "Plan your trip" page to use PurpleDrip instead of Coach
- Simplified the stops list to show only Manly and Circular Quay ferry stops
- Added text color styling to the "Invite Friends" screen text
- Added a new purple_drip_theme color and renamed Coach to PurpleDrip in KrailThemeStyle

### How to test?

1. Launch the app and navigate through the intro screens
2. Verify the new Ferry theme on the first page shows "Manly to Circular Quay" route
3. Check that the intro pages appear in the correct order
4. Confirm the color schemes match the specified transport modes
5. Verify the text on the "Invite Friends" screen has the correct color

### Why make this change?

This update provides a more visually appealing and logical flow through the intro screens, highlighting ferry transport options and creating a better color hierarchy. The simplified stops list and reordered pages create a more intuitive onboarding experience for users.