### PR TITLE
Version: Bump to 1.5.1 (84) and add intro screen navigation

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 81
-        versionName = "1.4.0"
+        versionCode = 84
+        versionName = "1.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
@@ -4,19 +4,28 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 
 fun NavGraphBuilder.introDestination(navController: NavHostController) {
     composable<IntroRoute> { backStackEntry ->
         val viewModel = koinViewModel<IntroViewModel>()
         val introState by viewModel.uiState.collectAsStateWithLifecycle()
-        val route: IntroRoute = backStackEntry.toRoute()
 
         IntroScreen(
             state = introState,
+            onComplete = {
+                navController.navigate(
+                    route = SavedTripsRoute,
+                    navOptions = NavOptions.Builder()
+                        .setLaunchSingleTop(true)
+                        .setPopUpTo<SavedTripsRoute>(inclusive = false)
+                        .build(),
+                )
+            },
         ) { event -> viewModel.onEvent(event) }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -48,6 +48,7 @@ import kotlin.math.min
 fun IntroScreen(
     state: IntroState,
     modifier: Modifier = Modifier,
+    onComplete: () -> Unit = {},
     onEvent: (IntroUiEvent) -> Unit = {},
 ) {
     val pagerState = rememberPagerState(pageCount = { state.pages.size })
@@ -177,14 +178,14 @@ fun IntroScreen(
                 .padding(bottom = 10.dp)
         ) {
             Button(
-                onClick = { },
+                onClick = onComplete,
                 colors = ButtonDefaults.buttonColors(
                     customContainerColor = animatedButtonColor,
                     customContentColor = Color.White,
                 ),
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
             ) {
-                Text(text = "Let's #KRAIL")
+                Text(text = state.pages[startPage].ctaText)
             }
         }
     }
@@ -241,8 +242,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-
-                )
+            )
         }
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Added navigation from intro screen to saved trips and updated app version to 1.5.1.

### What changed?

- Added an `onComplete` callback to the `IntroScreen` component that navigates to the `SavedTripsRoute`
- Updated the CTA button to use the text from the current intro page
- Bumped version code from 81 to 84 and version name from 1.4.0 to 1.5.1 in Android
- Updated iOS version from 1.4.0 to 1.5.1 and reset build number to 1

### How to test?

1. Launch the app and go through the intro screens
2. Verify that tapping the CTA button ("Let's #KRAIL") navigates to the Saved Trips screen
3. Confirm the button text matches what's defined in the intro page data
4. Check that the app version shows as 1.5.1 in both Android and iOS settings

### Why make this change?

The intro screen previously had a non-functional CTA button. This change completes the user onboarding flow by allowing users to navigate to the main app experience after viewing the introduction. The version bump prepares the app for a new release with these improvements.