### PR TITLE
Feature: Add share functionality to Intro screen

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.state.intro
 
 sealed interface IntroUiEvent {
-    data object OnNextClick : IntroUiEvent
-    data object OnCompleteClick : IntroUiEvent
+    data object ReferFriendClick : IntroUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContent.kt
@@ -8,6 +8,8 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +35,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
@@ -280,7 +283,8 @@ fun IntroContentPlanTrip(
 fun IntroContentInviteFriends(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
-    modifier: Modifier = Modifier
+    onShareClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = modifier
@@ -304,7 +308,13 @@ fun IntroContentInviteFriends(
                 modifier = Modifier
                     .size(64.dp)
                     .clip(CircleShape)
-                    .background(color = style.hexToComposeColor()),
+                    .background(color = style.hexToComposeColor())
+                    .clickable(
+                        indication = null,
+                        role = Role.Button,
+                        interactionSource = remember { MutableInteractionSource() },
+                        onClick = onShareClick
+                    ),
                 contentAlignment = Alignment.Center,
             ) { // TODO - show diff. image for ios / android
                 Image(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -40,6 +40,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
+import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState.IntroPageType
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
 import kotlin.math.absoluteValue
 import kotlin.math.min
@@ -160,7 +161,11 @@ fun IntroScreen(
                                 )
                             }
                     ) {
-                        IntroPageContent(pageData, modifier = Modifier.fillMaxSize())
+                        IntroPageContent(
+                            pageData = pageData,
+                            onShareClick = { onEvent(IntroUiEvent.ReferFriendClick) },
+                            modifier = Modifier.fillMaxSize(),
+                        )
                     }
                 }
             }
@@ -178,7 +183,13 @@ fun IntroScreen(
                 .padding(bottom = 10.dp)
         ) {
             Button(
-                onClick = onComplete,
+                onClick = {
+                    if (IntroPageType.INVITE_FRIENDS == state.pages[startPage].type) {
+                        onEvent(IntroUiEvent.ReferFriendClick)
+                    } else {
+                        onComplete()
+                    }
+                },
                 colors = ButtonDefaults.buttonColors(
                     customContainerColor = animatedButtonColor,
                     customContentColor = Color.White,
@@ -192,9 +203,13 @@ fun IntroScreen(
 }
 
 @Composable
-private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier) {
+private fun IntroPageContent(
+    pageData: IntroState.IntroPage,
+    modifier: Modifier = Modifier,
+    onShareClick: () -> Unit = {}
+) {
     when (pageData.type) {
-        IntroState.IntroPageType.SAVE_TRIPS -> {
+        IntroPageType.SAVE_TRIPS -> {
             IntroContentSaveTrips(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
@@ -202,7 +217,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
             )
         }
 
-        IntroState.IntroPageType.REAL_TIME_DATA -> {
+        IntroPageType.REAL_TIME_DATA -> {
             IntroContentRealTime(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
@@ -210,7 +225,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
             )
         }
 
-        IntroState.IntroPageType.ALERTS -> {
+        IntroPageType.ALERTS -> {
             IntroContentAlerts(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
@@ -219,7 +234,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
                 )
         }
 
-        IntroState.IntroPageType.PLAN_TRIP -> {
+        IntroPageType.PLAN_TRIP -> {
             IntroContentPlanTrip(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
@@ -228,7 +243,7 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
                 )
         }
 
-        IntroState.IntroPageType.SELECT_MODE -> {
+        IntroPageType.SELECT_MODE -> {
             IntroContentSelectTransportMode(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
@@ -237,10 +252,11 @@ private fun IntroPageContent(pageData: IntroState.IntroPage, modifier: Modifier)
                 )
         }
 
-        IntroState.IntroPageType.INVITE_FRIENDS -> {
+        IntroPageType.INVITE_FRIENDS -> {
             IntroContentInviteFriends(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
+                onShareClick = onShareClick,
                 modifier = modifier.padding(20.dp),
             )
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -10,12 +10,16 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.platform.ops.ContentSharing
+import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
 
 class IntroViewModel(
     private val analytics: Analytics,
+    private val share: ContentSharing,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<IntroState> = MutableStateFlow(IntroState.default())
@@ -26,8 +30,10 @@ class IntroViewModel(
 
     fun onEvent(event: IntroUiEvent) {
         when (event) {
-            IntroUiEvent.OnCompleteClick -> TODO()
-            IntroUiEvent.OnNextClick -> TODO()
+            IntroUiEvent.ReferFriendClick -> {
+                share.sharePlainText(getReferText())
+                analytics.track(AnalyticsEvent.ReferAFriend)
+            }
         }
     }
 


### PR DESCRIPTION
### TL;DR

Added "Refer a Friend" functionality to the Trip Planner intro screen.

### What changed?

- Replaced `OnNextClick` and `OnCompleteClick` events with a single `ReferFriendClick` event
- Added click functionality to the share button in the "Invite Friends" intro page
- Updated the main button behavior to trigger the share action when on the "Invite Friends" page
- Implemented the share functionality in the ViewModel using the `ContentSharing` service
- Added analytics tracking for the refer-a-friend action

### How to test?

1. Navigate to the Trip Planner intro flow
2. Go to the "Invite Friends" page
3. Tap either the share icon or the main button at the bottom
4. Verify that the system share dialog appears with the correct referral text
5. Confirm that the analytics event is properly tracked

### Why make this change?

This change enhances the app's virality by making it easier for users to refer friends directly from the intro flow. The implementation simplifies the UI events while adding practical functionality to the previously static "Invite Friends" screen.