### PR TITLE
UI: Add platform-specific share icons for Android and iOS

### DIFF
--- a/feature/trip-planner/ui/src/androidMain/res/drawable/ic_android_share.xml
+++ b/feature/trip-planner/ui/src/androidMain/res/drawable/ic_android_share.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M17.18,27.02L30.84,34.98M30.82,13.02L17.18,20.98M42,10C42,13.314 39.314,16 36,16C32.686,16 30,13.314 30,10C30,6.686 32.686,4 36,4C39.314,4 42,6.686 42,10ZM18,24C18,27.314 15.314,30 12,30C8.686,30 6,27.314 6,24C6,20.686 8.686,18 12,18C15.314,18 18,20.686 18,24ZM42,38C42,41.314 39.314,44 36,44C32.686,44 30,41.314 30,38C30,34.686 32.686,32 36,32C39.314,32 42,34.686 42,38Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
@@ -22,8 +22,11 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_android_share
 import krail.feature.trip_planner.ui.generated.resources.ic_ios_share
 import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+import xyz.ksharma.krail.core.appinfo.getAppPlatformType
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -67,10 +70,14 @@ fun IntroContentInviteFriends(
                 contentAlignment = Alignment.Center,
             ) { // TODO - show diff. image for ios / android
                 Image(
-                    painter = painterResource(Res.drawable.ic_ios_share),
-                    contentDescription = null,
+                    painter = if (getAppPlatformType() == DevicePlatformType.IOS) {
+                        painterResource(Res.drawable.ic_ios_share)
+                    } else {
+                        painterResource(Res.drawable.ic_android_share)
+                    },
+                    contentDescription = "Invite Friends",
                     colorFilter = ColorFilter.tint(Color.White),
-                    modifier = Modifier.size(48.dp),
+                    modifier = Modifier.size(32.dp),
                 )
             }
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -94,7 +94,7 @@ fun IntroScreen(
                 if (offsetFraction < 0.5f) {
                     Text(
                         text = state.pages[startPage].title,
-                        style = KrailTheme.typography.title,
+                        style = KrailTheme.typography.headlineMedium,
                         textAlign = TextAlign.Center,
                         color = animatedButtonColor,
                         modifier = Modifier


### PR DESCRIPTION
### TL;DR

Added platform-specific share icons for the Trip Planner invite friends feature.

### What changed?

- Added a new Android-specific share icon (`ic_android_share.xml`)
- Updated the invite friends component to display different share icons based on platform (iOS or Android)
- Added a proper content description "Invite Friends" to the share icon for accessibility
- Adjusted the icon size from 48dp to 32dp for better visual balance
- Updated the typography style in the IntroScreen from `title` to `headlineMedium`

### How to test?

1. Open the Trip Planner feature on both Android and iOS devices
2. Navigate to the invite friends section
3. Verify that Android shows the new Android-style share icon while iOS shows the iOS-style share icon
4. Check that the icon size appears appropriate at 32dp
5. Confirm the text styling appears correct with the new `headlineMedium` style

### Why make this change?

To improve platform-specific UI consistency by showing the appropriate share icon that users are familiar with on their respective platforms. This enhances the native feel of the application while maintaining a cohesive cross-platform experience. The accessibility improvement with the content description ensures screen reader users understand the purpose of the icon.