### PR TITLE
Version: Bump to 1.5.2 (85)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 84
-        versionName = "1.5.1"
+        versionCode = 85
+        versionName = "1.5.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.1</string>
+	<string>1.5.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.5.1 to 1.5.2 for both Android and iOS apps.

### What changed?

- Incremented Android `versionCode` from 84 to 85
- Updated Android `versionName` from "1.5.1" to "1.5.2"
- Updated iOS `CFBundleShortVersionString` from "1.5.1" to "1.5.2"

### How to test?

- Build the Android app and verify the version in the app info
- Build the iOS app and verify the version in the app info
- Ensure both platforms display version 1.5.2

### Why make this change?

Preparing for the next release by incrementing version numbers across platforms to maintain version consistency between Android and iOS.