### PR TITLE
UI: Update splash screen typography and padding

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
@@ -115,14 +115,14 @@ private fun AnimatedKrailLogo(
 
         Text(
             text = "Ride the rail, without fail.",
-            style = KrailTheme.typography.titleMedium.copy(
-                fontWeight = FontWeight.Normal,
+            style = KrailTheme.typography.titleLarge.copy(
+                fontWeight = FontWeight.Medium,
             ),
             textAlign = TextAlign.Center,
             color = logoColor,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 0.dp),
+                .padding(horizontal = 16.dp,),
         )
     }
 }
@@ -169,14 +169,14 @@ private fun AnimatedLetter(
             style = KrailTheme.typography.displayLarge.copy(
                 fontSize = fontSize,
                 letterSpacing = 4.sp,
-                fontWeight = FontWeight.ExtraBold,
+                fontWeight = FontWeight.Black,
             ),
             modifier = modifier
                 .graphicsLayer {
                     scaleX = letterScale
                     scaleY = letterScale
                 }
-                .padding(4.dp),
+                .padding(horizontal = 4.dp, vertical = 2.dp),
         )
     }
 }


### PR DESCRIPTION
### TL;DR

Updated typography and spacing in the splash screen for improved visual appearance.

### What changed?

- Changed the tagline text style from `titleMedium` to `titleLarge`
- Updated the tagline font weight from `Normal` to `Medium`
- Simplified padding syntax by removing unnecessary vertical padding parameter
- Changed the animated letter font weight from `ExtraBold` to `Black` for stronger visual impact
- Improved the animated letter padding by specifying different horizontal and vertical values

### How to test?

1. Launch the app and observe the splash screen
2. Verify the tagline "Ride the rail, without fail" appears with the new larger text style and medium font weight
3. Check that the animated letters of the logo have the darker font weight and proper padding

### Why make this change?

These typography and spacing adjustments enhance the visual hierarchy and readability of the splash screen. The larger text style for the tagline and the darker font weight for the animated letters create a more polished and impactful first impression for users.