### PR TITLE
UI: Increase TransportModeChip border width and horizontal padding

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -59,7 +59,7 @@ fun TransportModeChip(
                     shape = RoundedCornerShape(50),
                 )
                 .border(
-                    width = 2.dp, // is token , should be 1.dp less than the horizontal padding.
+                    width = 3.dp, // is token , should be 1.dp less than the horizontal padding.
                     color = borderColor,
                     shape = RoundedCornerShape(50),
                 )
@@ -69,7 +69,7 @@ fun TransportModeChip(
                 ) { onClick() }
                 // horizontal padding value should be same as border width of
                 // TransportModeIcon
-                .padding(horizontal = 3.dp, vertical = 4.dp) // is token
+                .padding(horizontal = 4.dp, vertical = 4.dp) // is token
                 .padding(end = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),


### PR DESCRIPTION
### TL;DR

Adjusted the border width and horizontal padding of the TransportModeChip component.

### What changed?

- Increased the border width from 2.dp to 3.dp
- Increased the horizontal padding from 3.dp to 4.dp to maintain the design rule that horizontal padding should be 1.dp more than the border width

### How to test?

1. Navigate to any screen that displays TransportModeChip components
2. Verify that the chips have a slightly thicker border
3. Confirm that the spacing looks correct with the updated horizontal padding

### Why make this change?

This change improves the visual appearance of the TransportModeChip component by ensuring proper proportions between the border width and padding. The adjustment follows the design token rule that horizontal padding should be 1.dp more than the border width.