### PR TITLE
Refactor: Extract gradient border modifier and rename ReferAFriend to ReferFriend

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -188,7 +188,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // region Settings
 
-    data object ReferAFriend : AnalyticsEvent(name = "refer_friend",)
+    data object ReferFriend : AnalyticsEvent(name = "refer_friend",)
 
     // endregion
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
@@ -1,5 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.state.intro
 
 sealed interface IntroUiEvent {
-    data object ReferFriendClick : IntroUiEvent
+    data object ReferFriend : IntroUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/modifier/GradientBorder.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/modifier/GradientBorder.kt
@@ -1,0 +1,43 @@
+package xyz.ksharma.krail.trip.planner.ui.components.modifier
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.hexToComposeColor
+import kotlin.math.min
+
+fun Modifier.gradientBorder(
+    pageOffset: Float,
+    colorsList: List<String>,
+    borderThickness: Dp = 8.dp,
+    cornerRadius: Dp = 24.dp,
+): Modifier = this.drawWithContent {
+    val fraction = min(1f, pageOffset)
+    val grey = Color(0xFF888888)
+    val gradientColors = colorsList
+        .map { it.hexToComposeColor() }
+        .map { originalColor -> androidx.compose.ui.graphics.lerp(originalColor, grey, fraction) }
+    val gradientBrush = Brush.linearGradient(
+        colors = gradientColors,
+        start = Offset(0f, 0f),
+        end = Offset(size.width, size.height)
+    )
+    drawContent()
+    drawRoundRect(
+        brush = gradientBrush,
+        size = size,
+        cornerRadius = CornerRadius(cornerRadius.toPx(), cornerRadius.toPx()),
+        style = Stroke(width = borderThickness.toPx())
+    )
+}
+
+internal fun lerp(start: Dp, end: Dp, fraction: Float): Dp = start + (end - start) * fraction
+
+internal fun lerp(start: Float, end: Float, fraction: Float): Float =
+    start + (end - start) * fraction

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
@@ -17,7 +17,7 @@ fun NavGraphBuilder.introDestination(navController: NavHostController) {
 
         IntroScreen(
             state = introState,
-            onComplete = {
+            onIntroComplete = {
                 navController.navigate(
                     route = SavedTripsRoute,
                     navOptions = NavOptions.Builder()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
@@ -11,7 +11,7 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 
 fun NavGraphBuilder.introDestination(navController: NavHostController) {
-    composable<IntroRoute> { backStackEntry ->
+    composable<IntroRoute> {
         val viewModel = koinViewModel<IntroViewModel>()
         val introState by viewModel.uiState.collectAsStateWithLifecycle()
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -22,16 +22,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import xyz.ksharma.krail.taj.components.Button
@@ -39,6 +33,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.modifier.gradientBorder
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState.IntroPageType
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
@@ -132,10 +127,18 @@ fun IntroScreen(
                     val pageOffset =
                         pagerState.calculateCurrentOffsetForPage(pageNumber).absoluteValue
                     val animatedHeight by animateDpAsState(
-                        targetValue = lerp(selectedHeight, unselectedHeight, min(1f, pageOffset)),
+                        targetValue = xyz.ksharma.krail.trip.planner.ui.components.modifier.lerp(
+                            start = selectedHeight,
+                            end = unselectedHeight,
+                            fraction = min(1f, pageOffset)
+                        ),
                         label = "cardHeight"
                     )
-                    val scale = lerp(1f, 0.9f, min(1f, pageOffset))
+                    val scale = xyz.ksharma.krail.trip.planner.ui.components.modifier.lerp(
+                        start = 1f,
+                        end = 0.9f,
+                        fraction = min(1f, pageOffset)
+                    )
                     val pageData = state.pages[pageNumber]
 
                     Column(
@@ -147,27 +150,10 @@ fun IntroScreen(
                                 scaleY = scale
                             }
                             .fillMaxWidth()
-                            .drawWithContent { // todo make a modifier
-                                val borderThicknessPx = 8.dp.toPx()
-                                val cornerRadiusPx = 24.dp.toPx()
-                                val fraction = min(1f, pageOffset)
-                                val grey = Color(0xFF888888)
-                                val gradientColors = pageData.colorsList
-                                    .map { it.hexToComposeColor() }
-                                    .map { originalColor -> lerp(originalColor, grey, fraction) }
-                                val gradientBrush = Brush.linearGradient(
-                                    colors = gradientColors,
-                                    start = Offset(0f, 0f),
-                                    end = Offset(size.width, size.height)
-                                )
-                                drawContent()
-                                drawRoundRect(
-                                    brush = gradientBrush,
-                                    size = size,
-                                    cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
-                                    style = Stroke(width = borderThicknessPx)
-                                )
-                            }
+                            .gradientBorder(
+                                pageOffset = pageOffset,
+                                colorsList = pageData.colorsList,
+                            ),
                     ) {
                         IntroPageContent(
                             pageData = pageData,
@@ -233,8 +219,7 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-
-                )
+            )
         }
 
         IntroPageType.PLAN_TRIP -> {
@@ -242,8 +227,7 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-
-                )
+            )
         }
 
         IntroPageType.SELECT_MODE -> {
@@ -251,8 +235,7 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-
-                )
+            )
         }
 
         IntroPageType.INVITE_FRIENDS -> {
@@ -269,8 +252,3 @@ private fun IntroPageContent(
 private fun PagerState.calculateCurrentOffsetForPage(page: Int): Float {
     return (currentPage - page) + currentPageOffsetFraction
 }
-
-private fun lerp(start: Dp, end: Dp, fraction: Float): Dp = start + (end - start) * fraction
-
-private fun lerp(start: Float, end: Float, fraction: Float): Float =
-    start + (end - start) * fraction

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -171,7 +171,7 @@ fun IntroScreen(
                     ) {
                         IntroPageContent(
                             pageData = pageData,
-                            onShareClick = { onEvent(IntroUiEvent.ReferFriendClick) },
+                            onShareClick = { onEvent(IntroUiEvent.ReferFriend) },
                             modifier = Modifier.fillMaxSize(),
                         )
                     }
@@ -188,7 +188,7 @@ fun IntroScreen(
             Button(
                 onClick = {
                     if (IntroPageType.INVITE_FRIENDS == state.pages[startPage].type) {
-                        onEvent(IntroUiEvent.ReferFriendClick)
+                        onEvent(IntroUiEvent.ReferFriend)
                     } else {
                         onComplete()
                     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -44,7 +44,7 @@ import kotlin.math.min
 fun IntroScreen(
     state: IntroState,
     modifier: Modifier = Modifier,
-    onComplete: () -> Unit = {},
+    onIntroComplete: () -> Unit = {},
     onEvent: (IntroUiEvent) -> Unit = {},
 ) {
     val pagerState = rememberPagerState(pageCount = { state.pages.size })
@@ -86,27 +86,14 @@ fun IntroScreen(
                     .fillMaxWidth()
                     .padding(vertical = 32.dp, horizontal = 24.dp)
             ) {
-                if (offsetFraction < 0.5f) {
-                    Text(
-                        text = state.pages[startPage].title,
-                        style = KrailTheme.typography.headlineMedium,
-                        textAlign = TextAlign.Center,
-                        color = animatedButtonColor,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .alpha(animatedAlpha)
-                    )
-                } else if (offsetFraction > 0.5f) {
-                    Text(
-                        text = state.pages[targetPage].title,
-                        style = KrailTheme.typography.headlineMedium,
-                        textAlign = TextAlign.Center,
-                        color = animatedButtonColor,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .alpha(animatedAlpha)
-                    )
-                }
+                IntroTitle(
+                    offsetFraction,
+                    state,
+                    startPage,
+                    animatedButtonColor,
+                    animatedAlpha,
+                    targetPage
+                )
             }
 
             BoxWithConstraints(
@@ -176,7 +163,7 @@ fun IntroScreen(
                     if (IntroPageType.INVITE_FRIENDS == state.pages[startPage].type) {
                         onEvent(IntroUiEvent.ReferFriend)
                     } else {
-                        onComplete()
+                        onIntroComplete()
                     }
                 },
                 colors = ButtonDefaults.buttonColors(
@@ -188,6 +175,38 @@ fun IntroScreen(
                 Text(text = state.pages[startPage].ctaText)
             }
         }
+    }
+}
+
+@Composable
+private fun IntroTitle(
+    offsetFraction: Float,
+    state: IntroState,
+    startPage: Int,
+    animatedButtonColor: Color,
+    animatedAlpha: Float,
+    targetPage: Int
+) {
+    if (offsetFraction < 0.5f) {
+        Text(
+            text = state.pages[startPage].title,
+            style = KrailTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center,
+            color = animatedButtonColor,
+            modifier = Modifier
+                .fillMaxWidth()
+                .alpha(animatedAlpha)
+        )
+    } else {
+        Text(
+            text = state.pages[targetPage].title,
+            style = KrailTheme.typography.headlineMedium,
+            textAlign = TextAlign.Center,
+            color = animatedButtonColor,
+            modifier = Modifier
+                .fillMaxWidth()
+                .alpha(animatedAlpha)
+        )
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -30,9 +30,9 @@ class IntroViewModel(
 
     fun onEvent(event: IntroUiEvent) {
         when (event) {
-            IntroUiEvent.ReferFriendClick -> {
+            IntroUiEvent.ReferFriend -> {
                 share.sharePlainText(getReferText())
-                analytics.track(AnalyticsEvent.ReferAFriend)
+                analytics.track(AnalyticsEvent.ReferFriend)
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -36,6 +36,6 @@ class SettingsViewModel(
 
     fun onReferFriendClick() {
         share.sharePlainText(getReferText())
-        analytics.track(AnalyticsEvent.ReferAFriend)
+        analytics.track(AnalyticsEvent.ReferFriend)
     }
 }


### PR DESCRIPTION
# Refactor Intro Screen and Add Gradient Border Modifier

- Renamed `ReferAFriend` to `ReferFriend` in `AnalyticsEvent` for consistency
- Renamed `ReferFriendClick` to `ReferFriend` in `IntroUiEvent` for consistency
- Created a reusable `gradientBorder` modifier to replace inline border drawing code
- Extracted `IntroTitle` as a separate composable function for better readability
- Moved `lerp` utility functions to the modifier file
- Renamed callback from `onComplete` to `onIntroComplete` for clarity
- Updated event handling to use the renamed events