### PR TITLE
UI: Extract AppLogo component and update AboutUsScreen content

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AppLogo.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AppLogo.kt
@@ -1,0 +1,40 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import xyz.ksharma.krail.taj.LocalThemeColor
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+@Composable
+fun AppLogo(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+        val themeColor by LocalThemeColor.current
+
+        Text(
+            text = "KRAIL",
+            style = KrailTheme.typography.displayLarge.copy(
+                fontWeight = FontWeight.Black,
+            ),
+            color = themeColor.hexToComposeColor(),
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = "Ride the rail without fail",
+            style = KrailTheme.typography.displaySmall.copy(
+                fontWeight = FontWeight.Normal,
+            ),
+            color = themeColor.hexToComposeColor(),
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.ButtonColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -26,21 +25,19 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
-import krail.feature.trip_planner.ui.generated.resources.ic_pen
 import krail.feature.trip_planner.ui.generated.resources.ic_heart
 import krail.feature.trip_planner.ui.generated.resources.ic_info
 import krail.feature.trip_planner.ui.generated.resources.ic_paint
+import krail.feature.trip_planner.ui.generated.resources.ic_pen
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
-import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.theme.getForegroundColor
-import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
+import xyz.ksharma.krail.trip.planner.ui.components.AppLogo
 
 @Composable
 fun SettingsScreen(
@@ -129,24 +126,7 @@ fun SettingsScreen(
                 .navigationBarsPadding()
                 .padding(bottom = 10.dp),
         ) {
-            Text(
-                text = "KRAIL",
-                style = KrailTheme.typography.displayLarge.copy(
-                    fontWeight = FontWeight.Black,
-                ),
-                color = themeColor.hexToComposeColor(),
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-            )
-            Text(
-                text = "Ride the rail without fail",
-                style = KrailTheme.typography.displaySmall.copy(
-                    fontWeight = FontWeight.Normal,
-                ),
-                color = themeColor.hexToComposeColor(),
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center,
-            )
+            AppLogo()
             Text(
                 text = "v$appVersion",
                 style = KrailTheme.typography.bodyLarge,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.AppLogo
 
 @Composable
 fun AboutUsScreen(
@@ -30,7 +31,7 @@ fun AboutUsScreen(
             TitleBar(
                 modifier = Modifier.fillMaxWidth(),
                 onNavActionClick = onBackClick,
-                title = { Text(text = "Our Story") },
+                title = { Text(text = "Our story") },
             )
         }
 
@@ -40,25 +41,55 @@ fun AboutUsScreen(
         ) {
             item {
                 Text(
-                    "KRAIL - Ride the rail without fail.",
-                    style = KrailTheme.typography.titleMedium,
+                    "Welcome to KRAIL, and thank you so much for using the app 🫶. " +
+                            "I truly hope it’s made getting around Sydney just a little easier 🛤️.\n\n" +
+                            "Every detail in this app, from the colors and buttons to the animations, " +
+                            "was crafted with care, passion ❤️, and many late nights and weekends 🌙 " +
+                            "envisioning the digital experience for you. KRAIL isn’t built by a " +
+                            "company or a team. It is built by one person, simply trying to create " +
+                            "something calm, helpful, and free from distraction 🧘.\n\n" +
+                            "I’m Karan. I live in Sydney 🏙️, and I originally built KRAIL for myself — " +
+                            "just to check the next train without scrolling past ads. I also needed " +
+                            "the text to be larger than usual to read comfortably, something most " +
+                            "popular apps don’t handle well 😿. So, I set out to build " +
+                            "something more accessible and fun 🎨, an app that could support different " +
+                            "needs while staying simple, clear, and easy to use ✅.\n\n" +
+                            "At first, it was just mine. Then I shared it with friends and family 👨‍👩‍👧‍👦, " +
+                            "and they shared it with others. Slowly, it started to grow, not " +
+                            "through ads or big launches, but through people who found it helpful " +
+                            "and passed it along 🤝. Maybe that’s how it reached you, too \uD83D\uDC9E.\n\n" +
+                            "If KRAIL has helped you in any way, I’d really love to hear from you 💬. " +
+                            "Many features were added thanks to someone taking a moment to share an idea 💡. " +
+                            "Whether it’s a suggestion, a bug 🐛, or just a hello 👋, feel free to " +
+                            "email me anytime at hey@krail.app. I read every single message ✉️, " +
+                            "and your feedback means the world to me 🌏.\n\n" +
+                            "And if you’ve found KRAIL helpful, I hope you’ll share it with someone " +
+                            "else, just like someone once shared it with you 💞.\n\n" +
+                            "Thanks again for being part of this journey 🚆.",
+                    style = KrailTheme.typography.bodyLarge,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
                 )
             }
 
             item {
                 Text(
-                    "Thank you for downloading the KRAIL App. If the app has helped you, " +
-                            "please review on App Store and share with friends. You can save trips " +
-                            "and see real-time public transport information across Sydney, NSW. " +
-                            "The real time trip data is provided by Transport for NSW. " +
-                            "Best efforts are taken to ensure the " +
-                            "accuracy of the data. However, no guarantees are made. " +
-                            "Please refer to the Transport for NSW website (www.transportnsw.info) for more " +
-                            "information.",
-                    style = KrailTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
+                    text = "Disclaimer:",
+                    style = KrailTheme.typography.titleMedium,
+                    modifier = Modifier.padding(horizontal = 16.dp).padding(top = 32.dp)
                 )
+            }
+            item {
+                Text(
+                    "Real-time data in KRAIL is provided by Transport for NSW. " +
+                            "I do my best to keep everything accurate, but I can’t guarantee it " +
+                            "will always be correct. For the latest updates, visit www.transportnsw.info.\n",
+                    style = KrailTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 24.dp)
+                )
+            }
+
+            item {
+                AppLogo(modifier = Modifier.padding(top = 32.dp))
             }
         }
     }


### PR DESCRIPTION
### TL;DR

Created a reusable AppLogo component and updated the About Us screen with a personal story.

### What changed?

- Created a new `AppLogo` composable that encapsulates the KRAIL logo and tagline
- Refactored the Settings screen to use the new AppLogo component
- Updated the About Us screen with a personal story from the developer
- Added a disclaimer section to the About Us screen
- Improved the About Us screen layout with the AppLogo at the bottom
- Changed the title bar text from "Our Story" to "Our story"

### How to test?

1. Navigate to the Settings screen to verify the logo appears correctly
2. Open the About Us screen to see the updated content and layout
3. Verify the AppLogo appears at the bottom of the About Us screen
4. Check that the personal story and disclaimer text are properly formatted

### Why make this change?

This change improves code reusability by extracting the app logo into a dedicated component that can be used across multiple screens. It also enhances the About Us screen with a personal touch from the developer, sharing the story behind KRAIL and creating a more meaningful connection with users. The updated content provides context about the app's purpose and development journey.