### PR TITLE
Version: Bump to 1.5.3 (86)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 85
-        versionName = "1.5.2"
+        versionCode = 87
+        versionName = "1.5.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.2</string>
+	<string>1.5.3</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Version bump for app release

### What changed?

- Incremented Android version code from 85 to 86
- Incremented Android version name from 1.5.2 to 1.5.3
- Incremented iOS version string from 1.5.2 to 1.5.3
- Incremented iOS build number from 1 to 4

### How to test?

- Build the app for Android and verify the version code is 86 and version name is 1.5.3
- Build the app for iOS and verify the version string is 1.5.3 and build number is 4
- Verify the version displays correctly in both platforms' app info screens

### Why make this change?

Preparing for a new app store release with minor updates. This version bump ensures proper tracking in the app stores and allows users to receive the latest improvements.