### PR TITLE
Feature: Add intro screen for first-time users

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
@@ -27,6 +27,7 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.toHex
 import xyz.ksharma.krail.taj.unspecifiedColor
+import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.tripPlannerDestinations
 
@@ -69,11 +70,11 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
             composable<SplashScreen> {
                 val viewModel: SplashViewModel = koinViewModel<SplashViewModel>()
                 val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
-                val themeColor by viewModel.uiState.collectAsStateWithLifecycle()
+                val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
                 // Set theme in CompositionLocal
-                themeId = themeColor.id
-                themeColorHexCode.value = themeColor.hexColorCode
+                themeId = uiState.themeStyle.id
+                themeColorHexCode.value = uiState.themeStyle.hexColorCode
 
                 SplashScreen(
                     logoColor = if (themeId != null && themeColorHexCode.value != unspecifiedColor) {
@@ -84,7 +85,7 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
                     backgroundColor = KrailTheme.colors.surface,
                     onSplashComplete = {
                         navController.navigate(
-                            route = SavedTripsRoute,
+                            route = if(uiState.hasSeenIntro) SavedTripsRoute else IntroRoute,
                             navOptions = NavOptions.Builder()
                                 .setLaunchSingleTop(true)
                                 .setPopUpTo<SplashScreen>(inclusive = true)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -47,6 +47,7 @@ val splashModule = module {
             appInfoProvider = get(),
             ioDispatcher = get(named(IODispatcher)),
             appStart = get(),
+            preferences = get(),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashState.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashState.kt
@@ -1,0 +1,9 @@
+package xyz.ksharma.krail.splash
+
+import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+
+data class SplashState(
+    val hasSeenIntro: Boolean = true,
+    val themeStyle: KrailThemeStyle = DEFAULT_THEME_STYLE,
+)

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
@@ -2,4 +2,5 @@ package xyz.ksharma.krail.trip.planner.ui.state.intro
 
 sealed interface IntroUiEvent {
     data object ReferFriend : IntroUiEvent
+    data object Complete : IntroUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
@@ -1,30 +1,35 @@
 package xyz.ksharma.krail.trip.planner.ui.intro
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
+import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
 
 fun NavGraphBuilder.introDestination(navController: NavHostController) {
     composable<IntroRoute> {
         val viewModel = koinViewModel<IntroViewModel>()
         val introState by viewModel.uiState.collectAsStateWithLifecycle()
+        val scope = rememberCoroutineScope()
 
         IntroScreen(
             state = introState,
             onIntroComplete = {
-                navController.navigate(
-                    route = SavedTripsRoute,
-                    navOptions = NavOptions.Builder()
-                        .setLaunchSingleTop(true)
-                        .setPopUpTo<SavedTripsRoute>(inclusive = false)
-                        .build(),
-                )
+                scope.launch {
+                    viewModel.onEvent(IntroUiEvent.Complete)
+                    // Nav to SavedTripsRoute and keep clean back stack, so pressing back will exit
+                    // app and not navigate to Intro Screen.
+                    navController.navigate(SavedTripsRoute) {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
             },
         ) { event -> viewModel.onEvent(event) }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -13,6 +13,7 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.platform.ops.ContentSharing
+import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
@@ -20,6 +21,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroUiEvent
 class IntroViewModel(
     private val analytics: Analytics,
     private val share: ContentSharing,
+    private val preferences: SandookPreferences,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<IntroState> = MutableStateFlow(IntroState.default())
@@ -33,6 +35,10 @@ class IntroViewModel(
             IntroUiEvent.ReferFriend -> {
                 share.sharePlainText(getReferText())
                 analytics.track(AnalyticsEvent.ReferFriend)
+            }
+
+            IntroUiEvent.Complete -> {
+                preferences.setBoolean(SandookPreferences.KEY_HAS_SEEN_INTRO, true)
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
@@ -42,30 +42,31 @@ fun AboutUsScreen(
             item {
                 Text(
                     "Welcome to KRAIL, and thank you so much for using the app 🫶. " +
-                            "I truly hope it’s made getting around Sydney just a little easier 🛤️.\n\n" +
+                            "I truly hope it’s made getting around Sydney just a little easier.\n\n" +
                             "Every detail in this app, from the colors and buttons to the animations, " +
-                            "was crafted with care, passion ❤️, and many late nights and weekends 🌙 " +
-                            "envisioning the digital experience for you. KRAIL isn’t built by a " +
-                            "company or a team. It is built by one person, simply trying to create " +
-                            "something calm, helpful, and free from distraction 🧘.\n\n" +
-                            "I’m Karan. I live in Sydney 🏙️, and I originally built KRAIL for myself — " +
-                            "just to check the next train without scrolling past ads. I also needed " +
+                            "was crafted with care, passion️, love over late nights and weekends. " +
+                            "KRAIL isn’t built by a company or a team, it is built by one person, simply trying to create " +
+                            "something calm, helpful, and free from distractions 🧘.\n\n" +
+                            "I’m Karan. I live in Sydney, and I originally built KRAIL for myself, " +
+                            "just to check the next train time without scrolling past ads. I also needed " +
                             "the text to be larger than usual to read comfortably, something most " +
-                            "popular apps don’t handle well 😿. So, I set out to build " +
-                            "something more accessible and fun 🎨, an app that could support different " +
-                            "needs while staying simple, clear, and easy to use ✅.\n\n" +
-                            "At first, it was just mine. Then I shared it with friends and family 👨‍👩‍👧‍👦, " +
+                            "popular apps don’t handle very well. 😿 So, I set out to build " +
+                            "something more accessible and fun, an app that could support different " +
+                            "needs while staying simple, clear, and easy to use.\n\n" +
+                            "At first, it was just mine. Then I shared it with friends and family, " +
                             "and they shared it with others. Slowly, it started to grow, not " +
                             "through ads or big launches, but through people who found it helpful " +
-                            "and passed it along 🤝. Maybe that’s how it reached you, too \uD83D\uDC9E.\n\n" +
-                            "If KRAIL has helped you in any way, I’d really love to hear from you 💬. " +
-                            "Many features were added thanks to someone taking a moment to share an idea 💡. " +
-                            "Whether it’s a suggestion, a bug 🐛, or just a hello 👋, feel free to " +
-                            "email me anytime at hey@krail.app. I read every single message ✉️, " +
-                            "and your feedback means the world to me 🌏.\n\n" +
-                            "And if you’ve found KRAIL helpful, I hope you’ll share it with someone " +
-                            "else, just like someone once shared it with you 💞.\n\n" +
-                            "Thanks again for being part of this journey 🚆.",
+                            "and passed it along. Maybe that’s how it reached you, too. 💕\n\n" +
+                            "If KRAIL has helped you in any way, I’d really love to hear from you. " +
+                            "Many features you enjoy in KRAIL, were only possible because someone " +
+                            "shared feedback and suggestions. " +
+                            "I truly want KRAIL to be your personal companion therefore, I'm always listening," +
+                            " whether it’s a suggestion, a bug, or just a hello 👋, feel free to " +
+                            "email me anytime at (hey@krail.app). I read every single message, " +
+                            "and your feedback means the world to me.\n\n" +
+                            "If you’ve found KRAIL helpful, I hope you’ll share it with someone " +
+                            "else, just like someone once shared it with you \uD83D\uDC95.\n\n" +
+                            "Thanks again for being a part of this journey 🚆.",
                     style = KrailTheme.typography.bodyLarge,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
                 )
@@ -74,7 +75,7 @@ fun AboutUsScreen(
             item {
                 Text(
                     text = "Disclaimer:",
-                    style = KrailTheme.typography.titleMedium,
+                    style = KrailTheme.typography.labelLarge,
                     modifier = Modifier.padding(horizontal = 16.dp).padding(top = 32.dp)
                 )
             }
@@ -82,8 +83,8 @@ fun AboutUsScreen(
                 Text(
                     "Real-time data in KRAIL is provided by Transport for NSW. " +
                             "I do my best to keep everything accurate, but I can’t guarantee it " +
-                            "will always be correct. For the latest updates, visit www.transportnsw.info.\n",
-                    style = KrailTheme.typography.bodyLarge,
+                            "will always be correct. For the latest updates, please visit www.transportnsw.info.\n",
+                    style = KrailTheme.typography.labelMedium,
                     modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 24.dp)
                 )
             }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -26,5 +26,6 @@ interface SandookPreferences {
         const val NSW_STOPS_VERSION = 6L
 
         const val KEY_NSW_STOPS_VERSION = "KEY_NSW_STOPS_VERSION"
+        const val KEY_HAS_SEEN_INTRO = "KEY_HAS_SEEN_INTRO"
     }
 }

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/AppPreferences.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/AppPreferences.sq
@@ -11,6 +11,11 @@ CREATE TABLE IF NOT EXISTS KrailPref (
 INSERT OR IGNORE INTO KrailPref(key, int_value)
 VALUES ('nsw_stops_version', 0);
 
+-- Runs when db is created, sets default value as 0 for has_seen_intro.
+-- will execute only once on fresh install and not when app updates.
+INSERT OR IGNORE INTO KrailPref(key, bool_value)
+VALUES ('has_seen_intro', 0);
+
 -- Integer operations
 getLongPreference:
 SELECT int_value FROM KrailPref WHERE key = ?;


### PR DESCRIPTION
### TL;DR

Added an intro screen flow that displays on first app launch, with navigation to saved trips after completion.

### What changed?

- Created a new `SplashState` data class to track both theme style and whether the user has seen the intro
- Modified `SplashViewModel` to check if the user has seen the intro screen before
- Updated navigation logic to direct users to the intro screen on first launch
- Added a new `Complete` event to `IntroUiEvent` to mark when the intro is finished
- Implemented persistence of intro screen completion status using `SandookPreferences`
- Added a default value for the intro screen flag in the SQLite database
- Refined the About Us screen text formatting and styling

### How to test?

1. Clear app data or install on a new device
2. Launch the app
3. Verify the intro screen appears on first launch
4. Complete the intro flow and confirm it navigates to the Saved Trips screen
5. Restart the app and verify it goes directly to Saved Trips (skipping intro)

### Why make this change?

This change improves the first-time user experience by providing an introduction to the app's features before showing the main content. The intro screen helps users understand the app's purpose and functionality, while the persistence mechanism ensures returning users aren't repeatedly shown the intro screen.