### PR TITLE
Version: Bump Android to 88 and iOS to 6

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 87
+        versionCode = 88
         versionName = "1.5.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.3</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version codes for Android and iOS apps

### What changed?

- Incremented Android version code from 87 to 88
- Incremented iOS build number from 4 to 6
- Version name/string remains at 1.5.3 for both platforms

### How to test?

- Build the Android app and verify the version code is 88
- Build the iOS app and verify the build number is 6
- Verify both apps still display version 1.5.3 to users

### Why make this change?

Preparing for a new release while maintaining the same user-facing version number. This allows for new builds to be submitted to the app stores without changing the version that users see.