### PR TITLE
UI: Improve intro screen layout and fix display logic

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -51,7 +51,7 @@ class SplashViewModel(
     private suspend fun displayIntroScreen() = safeResult(ioDispatcher) {
         val hasSeenIntro = preferences.getBoolean(KEY_HAS_SEEN_INTRO)
         log("Has seen intro: $hasSeenIntro")
-        if (hasSeenIntro == null) {
+        if (hasSeenIntro == null || hasSeenIntro == false) {
             updateUiState { copy(hasSeenIntro = false) }
         } else {
             updateUiState { copy(hasSeenIntro = true) }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
@@ -47,18 +47,23 @@ fun IntroContentPlanTrip(
                 is24Hour = false,
             )
 
-            JourneyTimeOptionsGroup(
-                selectedOption = journeyTimeOption,
-                themeColor = style.hexToComposeColor(),
-                onOptionSelected = { journeyTimeOption = it },
-            )
-            val themeColor = rememberSaveable { mutableStateOf(TransportMode.Coach().colorCode) }
             val density = LocalDensity.current
+            val themeColor = rememberSaveable { mutableStateOf(TransportMode.Coach().colorCode) }
+
+            if (density.fontScale < 1.5f) {
+                // Not required to display if font size is large.
+                JourneyTimeOptionsGroup(
+                    selectedOption = journeyTimeOption,
+                    themeColor = style.hexToComposeColor(),
+                    onOptionSelected = { journeyTimeOption = it },
+                )
+            }
+
             CompositionLocalProvider(
                 LocalThemeColor provides themeColor,
                 LocalDensity provides Density(
-                    (density.density - 0.6f).coerceIn(1.5f, 3f),
-                    fontScale = 1f
+                    (density.density - 0.6f).coerceIn(1.5f, 2.5f),
+                    fontScale = 1f,
                 ),
             ) {
                 TimeSelection(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
@@ -2,6 +2,8 @@ package xyz.ksharma.krail.trip.planner.ui.intro
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -29,18 +31,24 @@ fun IntroContentSelectTransportMode(
                 mutableStateSetOf(TransportMode.Train().productClass)
             }
 
-            TransportMode.values().forEach { mode ->
-                TransportModeChip(
-                    transportMode = mode,
-                    selected = selectedProductClasses.contains(mode.productClass),
-                    onClick = {
-                        if (selectedProductClasses.contains(mode.productClass)) {
-                            selectedProductClasses.removeAll(setOf(mode.productClass))
-                        } else {
-                            selectedProductClasses.add(mode.productClass)
-                        }
-                    },
-                )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                TransportMode.values().sortedBy { it.priority }.forEach { mode ->
+                    TransportModeChip(
+                        transportMode = mode,
+                        selected = selectedProductClasses.contains(mode.productClass),
+                        onClick = {
+                            if (selectedProductClasses.contains(mode.productClass)) {
+                                selectedProductClasses.removeAll(setOf(mode.productClass))
+                            } else {
+                                selectedProductClasses.add(mode.productClass)
+                            }
+                        },
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
# Intro Screen and UI Improvements

- Show intro screen when `hasSeenIntro` is either `null` or `false` (previously only checked for `null`)
- Hide journey time options (Leave/Arrive) when font scale is large (≥ 1.5f) to improve accessibility
- Adjust density coercion range to max of 2.5f (was 3f) for better display scaling
- Implement `FlowRow` for transport mode selection to properly handle wrapping on different screen sizes
- Sort transport modes by priority for more consistent display order