### PR TITLE
Feature: Add OurStory analytics screen and AboutUs state management

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -9,4 +9,5 @@ sealed class AnalyticsScreen(val name: String) {
     data object SearchStop : AnalyticsScreen(name = "SearchStop")
     data object ServiceAlerts : AnalyticsScreen(name = "ServiceAlerts")
     data object Intro : AnalyticsScreen(name = "Intro")
+    data object OurStory : AnalyticsScreen(name = "OurStory")
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/about/AboutUsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/about/AboutUsState.kt
@@ -1,0 +1,6 @@
+package xyz.ksharma.krail.trip.planner.ui.state.settings.about
+
+data class AboutUsState(
+    val story: String = "", // TODO. default value
+    val disclaimer: String = "",
+)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsDestination.kt
@@ -1,15 +1,21 @@
 package xyz.ksharma.krail.trip.planner.ui.settings.about
 
-
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
 
 internal fun NavGraphBuilder.aboutUsDestination(navController: NavHostController) {
     composable<AboutUsRoute> {
 
+        val viewModel: AboutUsViewModel = koinViewModel<AboutUsViewModel>()
+        val aboutUsState by viewModel.uiState.collectAsStateWithLifecycle()
+
         AboutUsScreen(
+            state = aboutUsState,
             onBackClick = { navController.popBackStack() }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
@@ -41,32 +41,21 @@ fun AboutUsScreen(
         ) {
             item {
                 Text(
-                    "Welcome to KRAIL, and thank you so much for using the app 🫶. " +
-                            "I truly hope it’s made getting around Sydney just a little easier.\n\n" +
-                            "Every detail in this app, from the colors and buttons to the animations, " +
-                            "was crafted with care, passion️, love over late nights and weekends. " +
-                            "KRAIL isn’t built by a company or a team, it is built by one person, simply trying to create " +
-                            "something calm, helpful, and free from distractions 🧘.\n\n" +
-                            "I’m Karan. I live in Sydney, and I originally built KRAIL for myself, " +
-                            "just to check the next train time without scrolling past ads. I also needed " +
-                            "the text to be larger than usual to read comfortably, something most " +
-                            "popular apps don’t handle very well. 😿 So, I set out to build " +
-                            "something more accessible and fun, an app that could support different " +
-                            "needs while staying simple, clear, and easy to use.\n\n" +
-                            "At first, it was just mine. Then I shared it with friends and family, " +
-                            "and they shared it with others. Slowly, it started to grow, not " +
-                            "through ads or big launches, but through people who found it helpful " +
-                            "and passed it along. Maybe that’s how it reached you, too. 💕\n\n" +
-                            "If KRAIL has helped you in any way, I’d really love to hear from you. " +
-                            "Many features you enjoy in KRAIL, were only possible because someone " +
-                            "shared feedback and suggestions. " +
-                            "I truly want KRAIL to be your personal companion therefore, I'm always listening," +
-                            " whether it’s a suggestion, a bug, or just a hello 👋, feel free to " +
-                            "email me anytime at (hey@krail.app). I read every single message, " +
-                            "and your feedback means the world to me.\n\n" +
-                            "If you’ve found KRAIL helpful, I hope you’ll share it with someone " +
-                            "else, just like someone once shared it with you \uD83D\uDC95.\n\n" +
-                            "Thanks again for being a part of this journey 🚆.",
+                    "Welcome to KRAIL, and thank you so much for using the app. \uD83D\uDC4B\n" +
+                            "\n" +
+                            "I hope navigating around Sydney has become slightly easier for you.\n" +
+                            "\n" +
+                            "Every detail in this app, from the colors and buttons to the animations, was crafted with care, passion\uFE0F, and love over late nights and weekends. KRAIL isn’t built by a company; it is built by one person, simply trying to create something calm, helpful, and free from distractions \uD83E\uDDD8.\n" +
+                            "\n" +
+                            "I’m Karan. I live in Sydney, and I originally built KRAIL for myself, just to check the next train time without scrolling past ads. I also needed the text to be larger than usual to read comfortably, something most popular apps don’t handle very well. \uD83D\uDE3F So, I set out to build something more accessible and fun, an app that could support different needs while staying simple, clear, and easy to use.\n" +
+                            "\n" +
+                            "At first, it was just mine. Then I shared it with friends and family, and they shared it with others. Slowly, it started to grow, not through ads or big launches, but through people who found it helpful and passed it along. Maybe that’s how it reached you, too. \uD83D\uDC95\n" +
+                            "\n" +
+                            "If KRAIL has helped you in any way, I’d really love to hear from you. Many features you enjoy in KRAIL were only possible because someone shared feedback and suggestions. I truly want KRAIL to be your personal companion; therefore, I'm always listening. Whether it’s a suggestion, a bug, or just a hello \uD83D\uDC4B, feel free to email me anytime at hey@krail.app. I read every single message, and your feedback means the world to me.\n" +
+                            "\n" +
+                            "If you’ve found KRAIL helpful, I hope you’ll share it with someone else, just like someone once shared it with you \uD83D\uDC96.\n" +
+                            "\n" +
+                            "Thanks again for being a part of this journey.",
                     style = KrailTheme.typography.bodyLarge,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
                 )
@@ -74,23 +63,14 @@ fun AboutUsScreen(
 
             item {
                 Text(
-                    text = "Disclaimer:",
+                    text = "Important to note: Real-time data in KRAIL is provided by Transport for NSW. While I strive to ensure accuracy, I cannot guarantee it will always be correct. For the latest and most up-to-date information, please visit www.transportnsw.info",
                     style = KrailTheme.typography.labelLarge,
-                    modifier = Modifier.padding(horizontal = 16.dp).padding(top = 32.dp)
-                )
-            }
-            item {
-                Text(
-                    "Real-time data in KRAIL is provided by Transport for NSW. " +
-                            "I do my best to keep everything accurate, but I can’t guarantee it " +
-                            "will always be correct. For the latest updates, please visit www.transportnsw.info.\n",
-                    style = KrailTheme.typography.labelMedium,
-                    modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 24.dp)
+                    modifier = Modifier.padding(horizontal = 16.dp).padding(top = 12.dp)
                 )
             }
 
             item {
-                AppLogo(modifier = Modifier.padding(top = 32.dp))
+                AppLogo(modifier = Modifier.padding(top = 48.dp))
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsScreen.kt
@@ -15,9 +15,11 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.AppLogo
+import xyz.ksharma.krail.trip.planner.ui.state.settings.about.AboutUsState
 
 @Composable
 fun AboutUsScreen(
+    state: AboutUsState,
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
 ) {
@@ -41,21 +43,7 @@ fun AboutUsScreen(
         ) {
             item {
                 Text(
-                    "Welcome to KRAIL, and thank you so much for using the app. \uD83D\uDC4B\n" +
-                            "\n" +
-                            "I hope navigating around Sydney has become slightly easier for you.\n" +
-                            "\n" +
-                            "Every detail in this app, from the colors and buttons to the animations, was crafted with care, passion\uFE0F, and love over late nights and weekends. KRAIL isn’t built by a company; it is built by one person, simply trying to create something calm, helpful, and free from distractions \uD83E\uDDD8.\n" +
-                            "\n" +
-                            "I’m Karan. I live in Sydney, and I originally built KRAIL for myself, just to check the next train time without scrolling past ads. I also needed the text to be larger than usual to read comfortably, something most popular apps don’t handle very well. \uD83D\uDE3F So, I set out to build something more accessible and fun, an app that could support different needs while staying simple, clear, and easy to use.\n" +
-                            "\n" +
-                            "At first, it was just mine. Then I shared it with friends and family, and they shared it with others. Slowly, it started to grow, not through ads or big launches, but through people who found it helpful and passed it along. Maybe that’s how it reached you, too. \uD83D\uDC95\n" +
-                            "\n" +
-                            "If KRAIL has helped you in any way, I’d really love to hear from you. Many features you enjoy in KRAIL were only possible because someone shared feedback and suggestions. I truly want KRAIL to be your personal companion; therefore, I'm always listening. Whether it’s a suggestion, a bug, or just a hello \uD83D\uDC4B, feel free to email me anytime at hey@krail.app. I read every single message, and your feedback means the world to me.\n" +
-                            "\n" +
-                            "If you’ve found KRAIL helpful, I hope you’ll share it with someone else, just like someone once shared it with you \uD83D\uDC96.\n" +
-                            "\n" +
-                            "Thanks again for being a part of this journey.",
+                    state.story,
                     style = KrailTheme.typography.bodyLarge,
                     modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
                 )
@@ -63,7 +51,7 @@ fun AboutUsScreen(
 
             item {
                 Text(
-                    text = "Important to note: Real-time data in KRAIL is provided by Transport for NSW. While I strive to ensure accuracy, I cannot guarantee it will always be correct. For the latest and most up-to-date information, please visit www.transportnsw.info",
+                    text = state.disclaimer,
                     style = KrailTheme.typography.labelLarge,
                     modifier = Modifier.padding(horizontal = 16.dp).padding(top = 12.dp)
                 )
@@ -75,3 +63,27 @@ fun AboutUsScreen(
         }
     }
 }
+
+/*
+story
+"Welcome to KRAIL, and thank you so much for using the app. \uD83D\uDC4B\n" +
+"\n" +
+"I hope navigating around Sydney has become slightly easier for you.\n" +
+"\n" +
+"Every detail in this app, from the colors and buttons to the animations, was crafted with care, passion\uFE0F, and love over late nights and weekends. KRAIL isn’t built by a company; it is built by one person, simply trying to create something calm, helpful, and free from distractions \uD83E\uDDD8.\n" +
+"\n" +
+"I’m Karan. I live in Sydney, and I originally built KRAIL for myself, just to check the next train time without scrolling past ads. I also needed the text to be larger than usual to read comfortably, something most popular apps don’t handle very well. \uD83D\uDE3F So, I set out to build something more accessible and fun, an app that could support different needs while staying simple, clear, and easy to use.\n" +
+"\n" +
+"At first, it was just mine. Then I shared it with friends and family, and they shared it with others. Slowly, it started to grow, not through ads or big launches, but through people who found it helpful and passed it along. Maybe that’s how it reached you, too. \uD83D\uDC95\n" +
+"\n" +
+"If KRAIL has helped you in any way, I’d really love to hear from you. Many features you enjoy in KRAIL were only possible because someone shared feedback and suggestions. I truly want KRAIL to be your personal companion; therefore, I'm always listening. Whether it’s a suggestion, a bug, or just a hello \uD83D\uDC4B, feel free to email me anytime at hey@krail.app. I read every single message, and your feedback means the world to me.\n" +
+"\n" +
+"If you’ve found KRAIL helpful, I hope you’ll share it with someone else, just like someone once shared it with you \uD83D\uDC96.\n" +
+"\n" +
+"Thanks again for being a part of this journey.",*/
+
+
+// Disclaimer
+/*
+text = "Important to note: Real-time data in KRAIL is provided by Transport for NSW. While I strive to ensure accuracy, I cannot guarantee it will always be correct. For the latest and most up-to-date information, please visit www.transportnsw.info",
+ */

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/about/AboutUsViewModel.kt
@@ -1,0 +1,26 @@
+package xyz.ksharma.krail.trip.planner.ui.settings.about
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.trip.planner.ui.state.settings.about.AboutUsState
+
+class AboutUsViewModel(
+    private val analytics: Analytics,
+) : ViewModel() {
+
+    private val _uiState: MutableStateFlow<AboutUsState> = MutableStateFlow(AboutUsState())
+    val uiState: StateFlow<AboutUsState> = _uiState
+        .onStart {
+
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AboutUsState())
+
+}


### PR DESCRIPTION
### TL;DR

Added a new "Our Story" screen with dynamic content for the About Us section.

### What changed?

- Added `OurStory` to the `AnalyticsScreen` enum for tracking
- Created a new `AboutUsState` data class to hold story and disclaimer content
- Refactored `AboutUsScreen` to use the state for displaying content instead of hardcoded text
- Implemented `AboutUsViewModel` to manage the UI state and track analytics events
- Updated `AboutUsDestination` to connect the view model with the screen

### How to test?

1. Navigate to the About Us section in the app
2. Verify that the story and disclaimer text are displayed correctly
3. Check that analytics events are properly tracked when viewing the screen

### Why make this change?

This change improves the maintainability of the About Us section by moving the content from hardcoded strings to a state-driven approach. This makes it easier to update the content in the future and allows for potential localization or dynamic content loading. The addition of analytics tracking also provides insights into how often users view this section.