### PR TITLE
Analytics: Add tracking for intro screen interactions and refer friend events

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -171,24 +171,70 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     ) : AnalyticsEvent(
         name = "app_start",
         properties = mapOf(
-            "platformType" to platformType,
-            "appVersion" to appVersion,
-            "osVersion" to osVersion,
-            "deviceModel" to deviceModel,
-            "fontSize" to fontSize,
+            "platformType" to platformType.trim(),
+            "appVersion" to appVersion.trim(),
+            "osVersion" to osVersion.trim(),
+            "deviceModel" to deviceModel.trim(),
+            "fontSize" to fontSize.trim(),
             "isDarkTheme" to isDarkTheme,
             "krailTheme" to krailTheme,
             "timeStamp" to Clock.System.now().toString(),
-            "locale" to locale,
+            "locale" to locale.trim(),
             "batteryLevel" to batteryLevel,
-            "timeZone" to timeZone,
+            "timeZone" to timeZone.trim(),
         )
     )
     // endregion
 
     // region Settings
 
-    data object ReferFriend : AnalyticsEvent(name = "refer_friend",)
+    /**
+     * Analytics event for the refer friend button click.
+     *
+     * @param entryPoint The entry point from which the user referred a friend. E.g. Setting / Intro
+     * screen etc.
+     */
+    data class ReferFriend(val entryPoint: EntryPoint) : AnalyticsEvent(
+        name = "refer_friend",
+        properties = mapOf(
+            "entryPoint" to entryPoint.from,
+        )
+    ) {
+        enum class EntryPoint(val from: String) {
+            SETTINGS("settings"),
+            INTRO_BUTTON("intro_button"),
+            INTRO_CONTENT_BUTTON("intro_content_button"),
+        }
+    }
+
+    /**
+     * Analytics event for the refer friend button click in the intro screen.
+     *
+     * @param pageType The page number of the intro screen from which the user clicked Let's KRAIL button.
+     * @param interactionPages Represents pages list where interaction was performed. with the
+     * content inside the intro pages.
+     */
+    data class IntroLetsKrailClickEvent(
+        val pageType: InteractionPage,
+        val pageNumber: Int,
+        val interactionPages: Set<InteractionPage>,
+    ) : AnalyticsEvent(
+        name = "intro_lets_krail",
+        properties = mapOf(
+            "completedOnPage" to pageType.name,
+            "completedOnPageNumber" to pageNumber,
+            "interaction" to interactionPages.joinToString { it.name },
+        )
+    ) {
+        enum class InteractionPage {
+            SAVE_TRIPS,
+            REAL_TIME_ROUTES,
+            ALERTS,
+            PLAN_TRIP,
+            SELECT_MODE,
+            INVITE_FRIENDS,
+        }
+    }
 
     // endregion
 }

--- a/feature/trip-planner/state/build.gradle.kts
+++ b/feature/trip-planner/state/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
             dependencies {
                 implementation(projects.core.dateTime)
                 implementation(projects.taj)
+                implementation(projects.core.analytics)
 
                 implementation(libs.kotlinx.collections.immutable)
                 implementation(libs.kotlinx.serialization.json)

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
@@ -1,6 +1,19 @@
 package xyz.ksharma.krail.trip.planner.ui.state.intro
 
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.ReferFriend.EntryPoint
+
 sealed interface IntroUiEvent {
-    data object ReferFriend : IntroUiEvent
-    data object Complete : IntroUiEvent
+    data class ReferFriend(val analyticsEntryPoint: EntryPoint) : IntroUiEvent
+
+    /**
+     * When the user completes the intro screen.
+     * @param pageType - The page type of the intro screen, where Complete action was performed.
+     */
+    data class Complete(
+        val pageType: IntroState.IntroPageType,
+        val pageNumber: Int,
+    ) : IntroUiEvent
+
+    // Represents the interaction with ui elements displayed for app usage / decoration in intro screen.
+    data class IntroElementsInteraction(val pageType: IntroState.IntroPageType) : IntroUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
@@ -30,7 +30,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 fun IntroContentAlerts(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -45,7 +46,10 @@ fun IntroContentAlerts(
 
             AlertButton(
                 dimensions = ButtonDefaults.smallButtonSize(),
-                onClick = { displayAlert = !displayAlert },
+                onClick = {
+                    displayAlert = !displayAlert
+                    onInteraction()
+                },
             ) { Text(text = "2 Alerts") }
 
             AnimatedAlertsOneByOne(displayAlert)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
@@ -37,6 +37,7 @@ fun IntroContentInviteFriends(
     style: String, // hexCode - // todo - see if it can be color instead.
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -65,10 +66,13 @@ fun IntroContentInviteFriends(
                         indication = null,
                         role = Role.Button,
                         interactionSource = remember { MutableInteractionSource() },
-                        onClick = onShareClick
+                        onClick = {
+                            onShareClick()
+                            onInteraction()
+                        }
                     ),
                 contentAlignment = Alignment.Center,
-            ) { // TODO - show diff. image for ios / android
+            ) {
                 Image(
                     painter = if (getAppPlatformType() == DevicePlatformType.IOS) {
                         painterResource(Res.drawable.ic_ios_share)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
@@ -31,7 +31,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptio
 fun IntroContentPlanTrip(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -55,7 +56,10 @@ fun IntroContentPlanTrip(
                 JourneyTimeOptionsGroup(
                     selectedOption = journeyTimeOption,
                     themeColor = style.hexToComposeColor(),
-                    onOptionSelected = { journeyTimeOption = it },
+                    onOptionSelected = {
+                        journeyTimeOption = it
+                        onInteraction()
+                    },
                 )
             }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
@@ -18,7 +18,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 fun IntroContentRealTime(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -33,6 +34,7 @@ fun IntroContentRealTime(
                     lineName = "MFF",
                 ),
                 stops = stopsList(),
+                onClick = { onInteraction() },
             )
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
@@ -41,8 +41,9 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 @Composable
 fun IntroContentSaveTrips(
     tagline: String,
-    modifier: Modifier = Modifier,
     style: String, // hexCode - // todo - see if it can be color instead.
+    modifier: Modifier = Modifier,
+    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -77,7 +78,10 @@ fun IntroContentSaveTrips(
                         indication = null,
                         role = Role.Button,
                         interactionSource = remember { MutableInteractionSource() },
-                        onClick = { isTripSaved = !isTripSaved }
+                        onClick = {
+                            isTripSaved = !isTripSaved
+                            onInteraction()
+                        }
                     ),
                 contentAlignment = Alignment.Center,
             ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
@@ -19,7 +19,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 fun IntroContentSelectTransportMode(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -41,6 +42,7 @@ fun IntroContentSelectTransportMode(
                         transportMode = mode,
                         selected = selectedProductClasses.contains(mode.productClass),
                         onClick = {
+                            onInteraction()
                             if (selectedProductClasses.contains(mode.productClass)) {
                                 selectedProductClasses.removeAll(setOf(mode.productClass))
                             } else {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroDestination.kt
@@ -20,9 +20,9 @@ fun NavGraphBuilder.introDestination(navController: NavHostController) {
 
         IntroScreen(
             state = introState,
-            onIntroComplete = {
+            onIntroComplete = { pageType, pageNumber ->
                 scope.launch {
-                    viewModel.onEvent(IntroUiEvent.Complete)
+                    viewModel.onEvent(IntroUiEvent.Complete(pageType, pageNumber))
                     // Nav to SavedTripsRoute and keep clean back stack, so pressing back will exit
                     // app and not navigate to Intro Screen.
                     navController.navigate(SavedTripsRoute) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
@@ -44,7 +45,7 @@ import kotlin.math.min
 fun IntroScreen(
     state: IntroState,
     modifier: Modifier = Modifier,
-    onIntroComplete: () -> Unit = {},
+    onIntroComplete: (pageType: IntroPageType, pageNumber: Int) -> Unit = { _, _ -> },
     onEvent: (IntroUiEvent) -> Unit = {},
 ) {
     val pagerState = rememberPagerState(pageCount = { state.pages.size })
@@ -126,7 +127,7 @@ fun IntroScreen(
                         end = 0.9f,
                         fraction = min(1f, pageOffset)
                     )
-                    val pageData = state.pages[pageNumber]
+                    val pageData: IntroState.IntroPage = state.pages[pageNumber]
 
                     Column(
                         modifier = Modifier
@@ -144,8 +145,11 @@ fun IntroScreen(
                     ) {
                         IntroPageContent(
                             pageData = pageData,
-                            onShareClick = { onEvent(IntroUiEvent.ReferFriend) },
+                            onShareClick = { onEvent(IntroUiEvent.ReferFriend(AnalyticsEvent.ReferFriend.EntryPoint.INTRO_CONTENT_BUTTON)) },
                             modifier = Modifier.fillMaxSize(),
+                            onInteraction = { pageType ->
+                                onEvent(IntroUiEvent.IntroElementsInteraction(pageType))
+                            }
                         )
                     }
                 }
@@ -161,9 +165,12 @@ fun IntroScreen(
             Button(
                 onClick = {
                     if (IntroPageType.INVITE_FRIENDS == state.pages[startPage].type) {
-                        onEvent(IntroUiEvent.ReferFriend)
+                        onEvent(IntroUiEvent.ReferFriend(AnalyticsEvent.ReferFriend.EntryPoint.INTRO_BUTTON))
                     } else {
-                        onIntroComplete()
+                        onIntroComplete(
+                            state.pages[pagerState.currentPage].type,
+                            pagerState.currentPage + 1,
+                        )
                     }
                 },
                 colors = ButtonDefaults.buttonColors(
@@ -214,7 +221,8 @@ private fun IntroTitle(
 private fun IntroPageContent(
     pageData: IntroState.IntroPage,
     modifier: Modifier = Modifier,
-    onShareClick: () -> Unit = {}
+    onShareClick: () -> Unit = {},
+    onInteraction: (IntroPageType) -> Unit,
 ) {
     when (pageData.type) {
         IntroPageType.SAVE_TRIPS -> {
@@ -222,6 +230,9 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
             )
         }
 
@@ -230,6 +241,9 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
             )
         }
 
@@ -238,6 +252,9 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
             )
         }
 
@@ -246,6 +263,9 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
             )
         }
 
@@ -254,6 +274,9 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
             )
         }
 
@@ -263,6 +286,9 @@ private fun IntroPageContent(
                 style = pageData.primaryStyle,
                 onShareClick = onShareClick,
                 modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -36,6 +36,8 @@ class SettingsViewModel(
 
     fun onReferFriendClick() {
         share.sharePlainText(getReferText())
-        analytics.track(AnalyticsEvent.ReferFriend)
+        analytics.track(AnalyticsEvent.ReferFriend(
+            entryPoint = AnalyticsEvent.ReferFriend.EntryPoint.SETTINGS,
+        ))
     }
 }


### PR DESCRIPTION
### TL;DR

Enhanced analytics tracking for the intro screen and refer friend functionality.

### What changed?

- Added detailed analytics tracking for the intro screen:
  - Created a new `IntroLetsKrailClickEvent` to track which page the user completed the intro on
  - Added tracking for user interactions with UI elements on each intro page
  - Implemented tracking of which pages the user interacted with

- Enhanced the `ReferFriend` analytics event:
  - Converted it from a data object to a data class with an `EntryPoint` parameter
  - Added enum values for different entry points (settings, intro button, intro content button)

- Updated the intro screen UI components to track user interactions:
  - Added `onInteraction` callbacks to all intro content components
  - Modified the intro screen to pass interaction data to the view model

- Improved data quality in `AppStart` analytics event by trimming string values

### How to test?

1. Navigate through the intro screens and verify interactions are tracked
2. Click the "Let's KRAIL" button and confirm the analytics event is fired with correct page information
3. Test the refer friend functionality from different entry points (settings, intro button, intro content)
4. Verify that the appropriate analytics events are logged with the correct parameters

### Why make this change?

This change provides more detailed analytics data about how users interact with the intro screens and the refer friend functionality. The enhanced tracking will help understand which intro pages users engage with most, where they complete the intro flow, and which entry points are most effective for referrals. This data can inform future UX improvements and feature prioritization.