### PR TITLE
Version: Bump Android to 89 and reset iOS build to 1

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 88
+        versionCode = 89
         versionName = "1.5.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.3</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Version bump for Android and iOS builds.

### What changed?

- Incremented Android `versionCode` from 88 to 89 in `composeApp/build.gradle.kts`
- Reset iOS `CFBundleVersion` from 6 to 1 in `iosApp/iosApp/Info.plist`
- Maintained version name/string at "1.5.3" for both platforms

### How to test?

- Build the Android app and verify the version code is 89
- Build the iOS app and verify the build number is 1
- Ensure both apps display version 1.5.3 in their respective UIs

### Why make this change?

Preparing for a new release cycle. The Android version code increment supports Play Store requirements for new uploads, while the iOS build number reset aligns with the start of a new version iteration.