### PR TITLE
Analytics: Add tracking for settings navigation and fix intro page state

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -236,5 +236,12 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         }
     }
 
+    data object SettingsHowToUseClickEvent : AnalyticsEvent(
+        name = "how_to_krail",
+    )
+
+    data object OurStoryClick : AnalyticsEvent(
+        name = "our_story",
+    )
     // endregion
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -58,6 +58,7 @@ class IntroViewModel(
                         interactionPages = interactionPages,
                     )
                 )
+                interactionPages.clear()
             }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
@@ -1,11 +1,13 @@
 package xyz.ksharma.krail.trip.planner.ui.settings
 
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
@@ -17,6 +19,7 @@ internal fun NavGraphBuilder.settingsDestination(navController: NavHostControlle
 
         val viewModel: SettingsViewModel = koinViewModel<SettingsViewModel>()
         val settingsState by viewModel.uiState.collectAsStateWithLifecycle()
+        val scope = rememberCoroutineScope()
 
         SettingsScreen(
             appVersion = settingsState.appVersion,
@@ -33,16 +36,22 @@ internal fun NavGraphBuilder.settingsDestination(navController: NavHostControlle
                 viewModel.onReferFriendClick()
             },
             onIntroClick = {
-                navController.navigate(
-                    route = IntroRoute,
-                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
-                )
+                scope.launch {
+                    viewModel.onIntroClick()
+                    navController.navigate(
+                        route = IntroRoute,
+                        navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                    )
+                }
             },
             onAboutUsClick = {
-                navController.navigate(
-                    route = AboutUsRoute,
-                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
-                )
+                scope.launch {
+                    viewModel.onOurStoryClick()
+                    navController.navigate(
+                        route = AboutUsRoute,
+                        navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
+                    )
+                }
             },
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -40,4 +40,12 @@ class SettingsViewModel(
             entryPoint = AnalyticsEvent.ReferFriend.EntryPoint.SETTINGS,
         ))
     }
+
+    fun onIntroClick() {
+        analytics.track(AnalyticsEvent.SettingsHowToUseClickEvent)
+    }
+
+    fun onOurStoryClick() {
+        analytics.track(AnalyticsEvent.OurStoryClick)
+    }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.5.3</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Added analytics tracking for "How to Use" and "Our Story" clicks in the Settings screen, and fixed a memory leak in the IntroViewModel.

### What changed?

- Added two new analytics events:
  - `SettingsHowToUseClickEvent` for tracking when users click on the "How to Use" option
  - `OurStoryClick` for tracking when users click on the "Our Story" option
- Implemented tracking for these events in the `SettingsViewModel`
- Updated the `SettingsDestination` to call the new tracking methods when users navigate to the Intro or About Us screens
- Fixed a memory leak in `IntroViewModel` by clearing the `interactionPages` list after use

### How to test?

1. Navigate to the Settings screen
2. Click on "How to Use" and verify that the `how_to_krail` analytics event is tracked
3. Click on "Our Story" and verify that the `our_story` analytics event is tracked
4. Verify that the Intro screen properly clears its interaction pages after use to prevent memory leaks

### Why make this change?

This change helps us better understand how users interact with the Settings screen, specifically tracking engagement with educational content like "How to Use" and "Our Story". The memory leak fix in the IntroViewModel prevents potential performance issues by ensuring resources are properly cleaned up after use.