### PR TITLE
A11y: Replace Row with FlowRow in trip actions for better wrapping

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -189,9 +190,10 @@ fun TimeTableScreen(
             }
 
             item(key = "trip-actions-row") {
-                Row(
+                FlowRow(
                     modifier = Modifier.fillParentMaxWidth().padding(horizontal = 10.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     SubtleButton(
                         onClick = dateTimeSelectorClicked,


### PR DESCRIPTION
### TL;DR

Replace Row with FlowRow in TimeTableScreen to improve layout flexibility.

### What changed?

- Imported `FlowRow` from Compose foundation layout
- Replaced `Row` with `FlowRow` in the trip-actions-row item
- Added `verticalArrangement = Arrangement.spacedBy(12.dp)` to properly space items when they wrap to a new line

### How to test?

1. Open the TimeTableScreen on various screen sizes
2. Verify that the action buttons now wrap to a new line when there's not enough horizontal space
3. Confirm that the buttons maintain proper spacing both horizontally and vertically when wrapped

### Why make this change?

The previous implementation using `Row` forced all action buttons to stay on a single line, which could cause layout issues on smaller screens or when many buttons are present. Using `FlowRow` allows the buttons to wrap naturally to additional lines when needed, improving the UI's responsiveness and preventing horizontal overflow or clipping.