### PR TITLE
Network: Fix HTTP client logging by using platform-specific loggers

### DIFF
--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -32,11 +33,7 @@ actual fun httpClient(
             coroutineScope.launch {
                 if (appInfoProvider.getAppInfo().isDebug) {
                     level = LogLevel.BODY
-                    logger = object : Logger {
-                        override fun log(message: String) {
-                            log(message)
-                        }
-                    }
+                    logger = Logger.ANDROID
                     sanitizeHeader { header -> header == HttpHeaders.Authorization }
                 } else {
                     level = LogLevel.NONE

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,4 +4,7 @@ import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 
-expect fun httpClient(appInfoProvider: AppInfoProvider, coroutineScope: CoroutineScope): HttpClient
+expect fun httpClient(
+    appInfoProvider: AppInfoProvider,
+    coroutineScope: CoroutineScope,
+): HttpClient

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -32,11 +33,7 @@ actual fun httpClient(
             coroutineScope.launch {
                 if (appInfoProvider.getAppInfo().isDebug) {
                     level = LogLevel.BODY
-                    logger = object : Logger {
-                        override fun log(message: String) {
-                            log(message)
-                        }
-                    }
+                    logger = Logger.DEFAULT
                     sanitizeHeader { header -> header == HttpHeaders.Authorization }
                 } else {
                     level = LogLevel.NONE


### PR DESCRIPTION
### TL;DR

Fixed HTTP client logging implementation by using platform-specific loggers instead of custom implementations.

### What changed?

- Replaced custom logger implementations with platform-specific loggers:
  - Used `Logger.ANDROID` for Android platform
  - Used `Logger.DEFAULT` for iOS platform
- Fixed a potential infinite recursion issue in the previous custom logger implementation where `log()` was calling itself
- Reformatted the `httpClient` function signature in the common module for better readability

### How to test?

1. Run the app in debug mode on both Android and iOS platforms
2. Perform network requests through the trip planner feature
3. Verify that network logs are properly displayed in the respective platform's logging system
4. Confirm that authorization headers are properly sanitized in the logs

### Why make this change?

The previous implementation had a critical issue where the custom logger was recursively calling itself, which could lead to a stack overflow. Using the platform-specific loggers not only fixes this issue but also ensures that logs are properly formatted and displayed according to each platform's conventions.