### PR TITLE
Refactor: Rename AboutUs to OurStory for consistency

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/story/OurStoryState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/story/OurStoryState.kt
@@ -1,6 +1,6 @@
-package xyz.ksharma.krail.trip.planner.ui.state.settings.about
+package xyz.ksharma.krail.trip.planner.ui.state.settings.story
 
-data class AboutUsState(
+data class OurStoryState(
     val isLoading: Boolean = true,
     val story: String = "",
     val disclaimer: String = "",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -13,7 +13,7 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
-import xyz.ksharma.krail.trip.planner.ui.settings.about.AboutUsViewModel
+import xyz.ksharma.krail.trip.planner.ui.settings.story.OurStoryViewModel
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 
@@ -22,7 +22,7 @@ val viewModelsModule = module {
     viewModelOf(::ServiceAlertsViewModel)
     viewModelOf(::DateTimeSelectorViewModel)
     viewModelOf(::IntroViewModel)
-    viewModelOf(::AboutUsViewModel)
+    viewModelOf(::OurStoryViewModel)
 
     viewModel {
         SettingsViewModel(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -9,7 +9,7 @@ import xyz.ksharma.krail.trip.planner.ui.datetimeselector.dateTimeSelectorDestin
 import xyz.ksharma.krail.trip.planner.ui.intro.introDestination
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.savedTripsDestination
 import xyz.ksharma.krail.trip.planner.ui.searchstop.searchStopDestination
-import xyz.ksharma.krail.trip.planner.ui.settings.about.aboutUsDestination
+import xyz.ksharma.krail.trip.planner.ui.settings.story.aboutUsDestination
 import xyz.ksharma.krail.trip.planner.ui.settings.settingsDestination
 import xyz.ksharma.krail.trip.planner.ui.timetable.timeTableDestination
 import xyz.ksharma.krail.trip.planner.ui.themeselection.themeSelectionDestination
@@ -91,7 +91,7 @@ internal data class ServiceAlertRoute(
 data object SettingsRoute
 
 @Serializable
-data object AboutUsRoute
+data object OurStoryRoute
 
 @Serializable
 data object IntroRoute

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
@@ -9,7 +9,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
-import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.OurStoryRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SettingsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
@@ -48,7 +48,7 @@ internal fun NavGraphBuilder.settingsDestination(navController: NavHostControlle
                 scope.launch {
                     viewModel.onOurStoryClick()
                     navController.navigate(
-                        route = AboutUsRoute,
+                        route = OurStoryRoute,
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
                     )
                 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryDestination.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.krail.trip.planner.ui.settings.about
+package xyz.ksharma.krail.trip.planner.ui.settings.story
 
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -6,16 +6,16 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import org.koin.compose.viewmodel.koinViewModel
-import xyz.ksharma.krail.trip.planner.ui.navigation.AboutUsRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.OurStoryRoute
 
 internal fun NavGraphBuilder.aboutUsDestination(navController: NavHostController) {
-    composable<AboutUsRoute> {
+    composable<OurStoryRoute> {
 
-        val viewModel: AboutUsViewModel = koinViewModel<AboutUsViewModel>()
-        val aboutUsState by viewModel.uiState.collectAsStateWithLifecycle()
+        val viewModel: OurStoryViewModel = koinViewModel<OurStoryViewModel>()
+        val ourStoryState by viewModel.uiState.collectAsStateWithLifecycle()
 
-        AboutUsScreen(
-            state = aboutUsState,
+        OurStoryScreen(
+            state = ourStoryState,
             onBackClick = { navController.popBackStack() }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.krail.trip.planner.ui.settings.about
+package xyz.ksharma.krail.trip.planner.ui.settings.story
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
@@ -16,11 +16,11 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.AppLogo
-import xyz.ksharma.krail.trip.planner.ui.state.settings.about.AboutUsState
+import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryState
 
 @Composable
-fun AboutUsScreen(
-    state: AboutUsState,
+fun OurStoryScreen(
+    state: OurStoryState,
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
 ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryViewModel.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.krail.trip.planner.ui.settings.about
+package xyz.ksharma.krail.trip.planner.ui.settings.story
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -14,9 +14,9 @@ import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.asString
-import xyz.ksharma.krail.trip.planner.ui.state.settings.about.AboutUsState
+import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryState
 
-class AboutUsViewModel(
+class OurStoryViewModel(
     private val analytics: Analytics,
     private val flag: Flag,
 ) : ViewModel() {
@@ -29,14 +29,14 @@ class AboutUsViewModel(
         flag.getFlagValue(FlagKeys.DISCLAIMER_TEXT.key).asString()
     }
 
-    private val _uiState: MutableStateFlow<AboutUsState> = MutableStateFlow(AboutUsState())
-    val uiState: StateFlow<AboutUsState> = _uiState
+    private val _uiState: MutableStateFlow<OurStoryState> = MutableStateFlow(OurStoryState())
+    val uiState: StateFlow<OurStoryState> = _uiState
         .onStart {
-            updateAboutUsState()
+            updateOurStoryState()
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), AboutUsState())
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), OurStoryState())
 
-    private fun updateAboutUsState() {
+    private fun updateOurStoryState() {
         if (storyText.isNotBlank() && disclaimerText.isNotBlank()) {
             updateUiState {
                 copy(
@@ -48,7 +48,7 @@ class AboutUsViewModel(
         }
     }
 
-    private fun updateUiState(block: AboutUsState.() -> AboutUsState) {
+    private fun updateUiState(block: OurStoryState.() -> OurStoryState) {
         _uiState.update(block)
     }
 }


### PR DESCRIPTION
### TL;DR

Renamed "About Us" to "Our Story" throughout the codebase to better reflect the content and purpose of the screen.

### What changed?

- Renamed `AboutUsState` to `OurStoryState` and moved it to a new package path
- Renamed `AboutUsViewModel` to `OurStoryViewModel` with corresponding method name updates
- Renamed `AboutUsScreen` to `OurStoryScreen` and updated its parameters
- Updated `AboutUsRoute` to `OurStoryRoute` in navigation components
- Updated all related imports and references throughout the codebase

### How to test?

1. Navigate to the Settings screen
2. Tap on the "Our Story" option
3. Verify the screen loads correctly and displays the story content and disclaimer
4. Verify the back button works properly to return to the Settings screen

### Why make this change?

This change aligns the naming in the codebase with the actual content being displayed. "Our Story" better represents the narrative content of this section rather than the more generic "About Us" label, providing a more accurate and engaging description for users.