### PR TITLE
iOS: Add iPad support for content sharing popover presentation

### DIFF
--- a/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/IosContentSharing.kt
+++ b/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/IosContentSharing.kt
@@ -1,21 +1,59 @@
 package xyz.ksharma.krail.platform.ops
 
-import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.cValue
+import kotlinx.cinterop.useContents
+import platform.CoreGraphics.CGRect
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
+import platform.UIKit.popoverPresentationController
+import xyz.ksharma.krail.core.log.log
 
 class IosContentSharing : ContentSharing {
-
     override fun sharePlainText(text: String) {
         handleShareClick(text)
     }
 }
 
-@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+@OptIn(ExperimentalForeignApi::class,)
 fun handleShareClick(text: String) {
     val activityItems = listOf(text)
     val activityViewController = UIActivityViewController(activityItems, null)
+
+    // Configure popover presentation for iPad
+    activityViewController.popoverPresentationController?.apply {
+        val application = UIApplication.sharedApplication
+        sourceView = application.keyWindow
+
+        // Use CGRectMake to create a rectangle directly
+        val window = application.keyWindow
+        if (window != null) {
+            log("keywindow is not null")
+
+            // CValue<CGRect> needs to be unwrapped using special getters
+            val frame: CValue<CGRect> = window.frame
+
+            sourceRect = cValue {
+                // Initialize using the getter methods for CValue<CGRect>
+                this.origin.x = frame.useContents { this.origin.x }
+                this.origin.y = frame.useContents { this.origin.y }
+                this.size.width = frame.useContents { this.size.width }
+                this.size.height = frame.useContents { this.size.height }
+            }
+        } else {
+            log("keywindow is null")
+            // Fallback to zero rectangle when window is null
+            sourceRect = cValue {
+                this.origin.x = 0.0
+                this.origin.y = 0.0
+                this.size.width = 0.0
+                this.size.height = 0.0
+            }
+        }
+
+        permittedArrowDirections = 0u
+    }
 
     val application = UIApplication.sharedApplication
 


### PR DESCRIPTION
### TL;DR

Fixed content sharing on iPad by properly configuring the popover presentation controller.

### What changed?

- Added proper iPad support for the content sharing functionality
- Configured the popover presentation controller with the correct source view and source rect
- Added fallback handling when the key window is null
- Implemented proper CGRect handling using Kotlin/Native interop functions
- Added logging to track window availability
- Set permitted arrow directions to zero to center the popover

### How to test?

1. Run the app on an iPad device or simulator
2. Try to share content using the share functionality
3. Verify that the share sheet appears correctly centered on the screen
4. Test on both iPad and iPhone to ensure sharing works on all device types

### Why make this change?

The previous implementation lacked proper iPad support for content sharing which crashed app when clicked in InviteFiends. On iPad, UIActivityViewController must be presented as a popover with a valid source view and source rect, otherwise it crashes or displays incorrectly. This change ensures the share functionality works consistently across all iOS devices.