### PR TITLE
Feature: Add new refer friend text options and refactor message format

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
@@ -2,7 +2,8 @@ package xyz.ksharma.krail.trip.planner.ui.settings
 
 object ReferFriendManager {
 
-    private const val KRAIL_GOOGLE_PLAY = "https://play.google.com/store/apps/details?id=xyz.ksharma.krail"
+    private const val KRAIL_GOOGLE_PLAY =
+        "https://play.google.com/store/apps/details?id=xyz.ksharma.krail"
     private const val KRAIL_APP_STORE = "https://apps.apple.com/us/app/krail-app/id6738934832"
 
     fun getReferText(): String {
@@ -10,34 +11,44 @@ object ReferFriendManager {
         return referTextOptions[randomIndex]
     }
 
+    private const val SUFFIX = "Download KRAIL here \uD83D\uDC47 \n" +
+            "Apple - $KRAIL_APP_STORE\n" +
+            "Android - $KRAIL_GOOGLE_PLAY\n\n" +
+            "KRAIL - Ride the rail without fail"
+
     // TODO - fetch these from Firebase.
     private val referTextOptions: List<String> = listOf(
         "Hey mate,\n" +
                 "Sydney’s best public transport app is here. Like TripView but ad-free\n\n" +
-                "Download KRAIL here \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
-                "KRAIL - Ride the rail without fail",
+                SUFFIX,
 
         "Not all heroes wear capes.\n" +
                 "Some just show you when your bus is actually coming.\n\n" +
-                "Download KRAIL here \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
-                "KRAIL - Ride the rail without fail",
+                SUFFIX,
 
-        "Bus ghosted ya again? Rude.\n" +
-                "KRAIL tells you when and where - no cap.\n\n" +
-                "Download KRAIL here \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n" +
-                "KRAIL - Ride the rail without fail",
+        "With great power, comes great public transport.\n" +
+                "Swing into KRAIL App, let’s get on the fastest route. \uD83D\uDD78\uFE0F \uD83D\uDD77\uFE0F" +
+                SUFFIX,
 
-        "Your train was late again?.\n" +
-                "KRAIL App’s got your back.\n\n" +
-                "Download KRAIL here \uD83D\uDC47 \n" +
-                "Apple - $KRAIL_APP_STORE\n" +
-                "Android - $KRAIL_GOOGLE_PLAY\n\n" +
-                "KRAIL - Ride the rail without fail",
+        "These are the tracks you’re looking for. \uD83C\uDF0C\n" +
+                "Use KRAIL App, mate and may the fastest routes be with us. \uD83D\uDE80\uD83D\uDE80" +
+                SUFFIX,
+
+        "I’m not the transport app Sydney deserves. \n" +
+                "I’m the one it needs - KRAIL App. \uD83D\uDE87" +
+                SUFFIX,
+
+        "\uD83D\uDCA3 Your mission, should you choose to accept it is to \n" +
+                "Invite two mates to KRAIL App and upgrade their Sydney experience.\n" +
+                "⏱\uFE0F This message will self-destruct in 2 minutes." +
+                SUFFIX,
+
+        "\uD83E\uDDF3 Still stuck at Platform 9¾?\n" +
+                "Cast the real spell, say “KRAILiosa Commuta!” \uD83E\uDE84 ✨" +
+                SUFFIX,
+
+        "\uD83E\uDDE0 “It’s a train app. Obviously, I love it.”\n" +
+                "Join me on KRAIL App. I’ve already saved some trips. \uD83D\uDE86 " +
+                SUFFIX,
     )
 }


### PR DESCRIPTION
### TL;DR

Added new referral text options and refactored the existing text structure in the ReferFriendManager.

### What changed?

- Extracted the common suffix text into a constant `SUFFIX` to avoid repetition
- Added 5 new creative referral text options with pop culture references
- Reformatted the Google Play URL for better readability
- Removed some existing referral text options that were less engaging

### How to test?

1. Navigate to the refer friend section in the app settings
2. Trigger the referral flow multiple times to see different messages
3. Verify that all new referral texts appear correctly with the proper suffix

### Why make this change?

The new referral texts add more personality and fun to the sharing experience, potentially increasing user engagement and app virality. The code refactoring also improves maintainability by eliminating duplicate text across multiple referral options.