### PR TITLE
BUG: Improve journey caching and add detailed logging for trip planner

### DIFF
--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,7 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -33,7 +32,12 @@ actual fun httpClient(
             coroutineScope.launch {
                 if (appInfoProvider.getAppInfo().isDebug) {
                     level = LogLevel.BODY
-                    logger = Logger.ANDROID
+                    logger = object : Logger {
+                        override fun log(message: String) {
+                            // Package name is used to avoid collision with the overriden Log method
+                            xyz.ksharma.krail.core.log.log(message)
+                        }
+                    }
                     sanitizeHeader { header -> header == HttpHeaders.Authorization }
                 } else {
                     level = LogLevel.NONE

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.timetable
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CoroutineDispatcher
@@ -250,45 +251,63 @@ class TimeTableViewModel(
     @VisibleForTesting
     suspend fun updateTripsCache(response: TripResponse) = withContext(ioDispatcher) {
         val newJourneyList = response.buildJourneyList()
-        val startedJourneyList = journeys.values
-            .filter {
-                // Find list of journeys that have started.
-                it.hasJourneyStarted
-            }
-            .filterNot {
-                // If a journey has ended then remove it from the cache.
-                // This is to avoid displaying ended journeys.
-                // The threshold time is set to 10 minutes.
-                val thresholdTime = Clock.System.now().minus(JOURNEY_ENDED_CACHE_THRESHOLD_TIME)
-                Instant.parse(it.destinationUtcDateTime).isBefore(thresholdTime)
-            }
-            .filterNot {
-                // Those trips that are started / saved in cache but still part of new api data.
-                newJourneyList?.any { newJourney -> newJourney.journeyId == it.journeyId } == true
-            }
-            .sortedBy {
-                // Sort by chronological order, from earliest to latest
-                Instant.parse(it.originUtcDateTime)
-            }
+        log("API Data - JourneyList Size: ${newJourneyList?.size}")
+        logJourneyList(newJourneyList)
+        log("")
+        val cacheJourneyList = journeys
+        log("Cache Data - JourneyList Size: ${cacheJourneyList?.size}")
+        logJourneyList(journeys.values.toImmutableList())
+        log("")
+        log("---Filter Data Now---")
+
+        val now = Clock.System.now()
+        val journeyExpiredThresholdTime = now.minus(JOURNEY_ENDED_CACHE_THRESHOLD_TIME)
+        val apiJourneyIds = newJourneyList?.map { it.journeyId }?.toSet() ?: emptySet()
+
+        // Filter cache journeys not expired and not in API
+        val cacheJourneysNotInApi = journeys.values
+            // Remove journeys that have ended (expired), so we don't keep/display them.
+            .filterNot { Instant.parse(it.destinationUtcDateTime).isBefore(journeyExpiredThresholdTime) }
+            // Remove journeys that are already present in the new API data, to avoid duplicates.
+            .filterNot { it.journeyId in apiJourneyIds }
+
+        // Up to 2 most recent started journeys (origin time <= now)
+        val startedJourneys = cacheJourneysNotInApi
+            .filter { Instant.parse(it.originUtcDateTime) <= now }
+            .sortedBy { Instant.parse(it.originUtcDateTime) }
             .takeLast(MAX_STARTED_JOURNEY_DISPLAY_THRESHOLD)
 
-        // Clear all journeys and re-create using started trips(cache) and new api data.
+        // Only the single earliest upcoming journey (origin time > now)
+        val upcomingJourney = cacheJourneysNotInApi
+            .filter { Instant.parse(it.originUtcDateTime) > now }
+            // minByOrNull is same as sortedBy then firstOrNull(), it unifies in 1 line.
+            .minByOrNull { Instant.parse(it.originUtcDateTime) }
+
+        val eligibleCacheJourneys = startedJourneys + listOfNotNull(upcomingJourney)
+
+        eligibleCacheJourneys.forEach {
+            log("Kept from cache: [${it.journeyId}] ${it.originUtcDateTime.utcToLocalDateTimeAEST().toHHMM()}")
+        }
+
+        // Merge: API journeys + eligible cache journeys
         journeys.clear()
         newJourneyList?.associateBy { it.journeyId }?.let { journeys.putAll(it) }
-        journeys.putAll(startedJourneyList.associateBy { it.journeyId })
+        eligibleCacheJourneys.associateBy { it.journeyId }.let { journeys.putAll(it) }
 
-        startedJourneyList.forEach {
+        log("==FINAL==")
+        log("\tKept from cache - JourneyList Size: ${eligibleCacheJourneys.size}")
+        logJourneyList(eligibleCacheJourneys.toImmutableList())
+        log("\tNEW API - JourneyList Size: ${newJourneyList?.size}")
+        logJourneyList(newJourneyList?.toImmutableList())
+        log("========")
+    }
+
+    private fun logJourneyList(newJourneyList: ImmutableList<TimeTableState.JourneyCardInfo>?) {
+        newJourneyList?.forEachIndexed { index, journeyCardInfo ->
             log(
-                "TripsCache - Started tripCode:[${it.journeyId}], Time: ${
-                    it.originUtcDateTime.utcToLocalDateTimeAEST().toHHMM()
-                }"
-            )
-        }
-        newJourneyList?.forEach {
-            log(
-                "TripsCache - New tripCode:[${it.journeyId}], Time: ${
-                    it.originUtcDateTime.utcToLocalDateTimeAEST().toHHMM()
-                }"
+                "\t#$index: ${journeyCardInfo.journeyId.takeLast(6)} - ${
+                    journeyCardInfo.originUtcDateTime.utcToLocalDateTimeAEST().toHHMM()
+                } - ${journeyCardInfo.platformText}"
             )
         }
     }


### PR DESCRIPTION
## Problem

Previously, the cache merge logic only preserved:  
- All journeys from the latest API response.
- Up to 2 "started" journeys from cache (not in API and not expired).

This meant that if a journey was not in the API and not considered "started" (e.g., a future journey), it was dropped from the cache and UI. As a result, journeys like the 2:59 PM trip disappeared from the UI when the API stopped returning them, even if they were still relevant (not expired).  

**Note,** API sometimes does not provide the latest upcoming journey as part of response.  e.g time now is 2:00 pm then API does not give us 2:04 train, it gives 2:08 and 2:10. however the train is not cancelled and still in future (upcoming), so to safeguard against this issue we need to cache and display it. Sometimes the train may actualaly be cancelled in which case this will be an issue though.  

## Solution

The cache filter logic is now updated to:  
- Split cached journeys not in the latest API response into two groups:
  - startedJourneys: Up to 2 most recent journeys that have already started (origin time <= now).
  - upcomingJourney: The single earliest journey that is scheduled to start in the future (origin time > now).
   **NOTE:** We need to keep only one upcoming Journey, because API sometimes does not provide the latest upcoming journey as part of response.  
  
- These are combined into eligibleCacheJourneys (startedJourneys + upcomingJourney), which are then merged with the latest API journeys for display.

### Purpose

This approach ensures that:
- Users always see up to 2 recently started journeys, even if the API omits them, so recent/past trips remain visible for a short period.
- Only the most relevant missing upcoming journey (the one closest to now) is kept, preventing the cache from growing with less relevant future trips.
- The UI remains consistent and focused on the most important journeys, improving user experience and cache efficiency.

## Summary of Changes
- Changed the cache filter to select up to 2 most recent, not-expired journeys from cache that are not in the latest API response, regardless of their "started" status.

- This prevents relevant journeys from disappearing from the UI when the API omits them.


This fix improves the user experience by ensuring that recent and upcoming journeys are reliably shown, even if temporarily missing from the API response.