### PR TITLE
UI: Replace platform number circle with complete platformText in JourneyCard

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -148,7 +148,7 @@ fun JourneyCard(
                     isWheelchairAccessible = isWheelchairAccessible,
                     themeColor = themeColor,
                     transportModeList = transportModeList,
-                    platformNumber = platformNumber,
+                    platformText = platformText,
                     totalWalkTime = totalWalkTime,
                     modifier = Modifier
                         .semantics(mergeDescendants = true) { }
@@ -329,7 +329,7 @@ fun DefaultJourneyCardContent(
     isWheelchairAccessible: Boolean,
     themeColor: Color,
     transportModeList: ImmutableList<TransportMode>,
-    platformNumber: String?,
+    platformText: String?,
     totalWalkTime: String?,
     modifier: Modifier = Modifier,
 ) {
@@ -370,26 +370,13 @@ fun DefaultJourneyCardContent(
                 }
             }
 
-            platformNumber?.let { platform ->
-                Box(
-                    modifier = Modifier
-                        .padding(start = 8.dp)
-                        .align(Alignment.CenterVertically)
-                        .size(28.dp.toAdaptiveDecorativeIconSize())
-                        .border(
-                            width = 3.dp,
-                            color = themeColor,
-                            shape = CircleShape,
-                        ),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = platform,
-                        textAlign = TextAlign.Center,
-                        style = KrailTheme.typography.labelLarge,
-                        modifier = Modifier,
-                    )
-                }
+            platformText?.let { text ->
+                Text(
+                    text = text,
+                    textAlign = TextAlign.Center,
+                    style = KrailTheme.typography.labelLarge,
+                    modifier = Modifier,
+                )
             }
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -4,12 +4,12 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifference
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toHHMM
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToAEST
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -17,8 +17,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
-import xyz.ksharma.krail.core.log.log
-import xyz.ksharma.krail.core.log.logError
 
 @Suppress("ComplexCondition")
 internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.JourneyCardInfo>? =


### PR DESCRIPTION
### TL;DR

Changed platform display from a circular number to a simple text label in the JourneyCard component.

### What changed?

- Renamed `platformNumber` parameter to `platformText` in `JourneyCard` and `DefaultJourneyCardContent` functions
- Removed the circular border styling for platform display
- Replaced the Box container with a simple Text component for displaying platform information
- This allows for more flexible platform information display beyond just numbers

### How to test?

1. Navigate to the trip planner screen
2. Search for a journey that includes platform information
3. Verify that platform information is displayed as plain text rather than in a circular border
4. Check that the text is properly aligned and styled according to the design

### Why make this change?

Platform information isn't always just a number - it can include additional text or identifiers. This change makes the UI more flexible to accommodate various platform display formats while maintaining a clean, readable interface.