### PR TITLE
Version: Bump to 1.6.0 (Android 90, iOS build 1)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 89
-        versionName = "1.5.3"
+        versionCode = 90
+        versionName = "1.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.3</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version to 1.6.0 for both Android and iOS apps

### What changed?

- Android:
  - Increased `versionCode` from 89 to 90
  - Updated `versionName` from "1.5.3" to "1.6.0"

- iOS:
  - Updated `CFBundleShortVersionString` from "1.5.3" to "1.6.0"
  - Reset `CFBundleVersion` from "8" to "1" for the new version

### How to test?

- Build both Android and iOS apps
- Verify the version information in app settings or about screens
- Ensure the apps can be properly submitted to respective app stores with the new version numbers

### Why make this change?

Preparing for the 1.6.0 release with new features and improvements. The version bump follows semantic versioning with a minor version increase, indicating new functionality while maintaining backward compatibility.