### PR TITLE
UI: Update error message typography and text content

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ErrorMessage.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ErrorMessage.kt
@@ -64,7 +64,7 @@ fun ErrorMessage(
             Text(
                 text = actionData.actionText,
                 color = themeColor.hexToComposeColor(),
-                style = KrailTheme.typography.titleSmall,
+                style = KrailTheme.typography.titleMedium,
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .padding(top = 24.dp)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -255,7 +255,7 @@ fun SearchStopScreen(
             if (searchStopState.isError && textFieldText.isNotBlank() && searchStopState.isLoading.not()) {
                 item(key = "Error") {
                     ErrorMessage(
-                        title = "Eh! That's not looking right mate.",
+                        title = "Eh! That's not looking right.",
                         message = "Let's try searching again.",
                         modifier = Modifier
                             .fillMaxWidth()


### PR DESCRIPTION
### TL;DR

Updated text styling and error message wording in the Trip Planner UI.

### What changed?

- Changed the action text style in `ErrorMessage.kt` from `titleSmall` to `titleMedium` to improve readability
- Updated the error message text in `SearchStopScreen.kt` from "Eh! That's not looking right mate." to "Eh! That's not looking right." for a more professional tone

### How to test?

1. Navigate to the Trip Planner feature
2. Enter an invalid search query in the stop search field
3. Verify the error message displays with the updated text and proper styling
4. Check that the action button text appears in the `titleMedium` style

### Why make this change?

The increased text size improves readability for action buttons, and the updated error message maintains a friendly tone while removing the casual "mate" reference for a more universal appeal.