### PR TITLE
UI: Replace clickable text with TextButton in ErrorMessage component

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ErrorMessage.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ErrorMessage.kt
@@ -16,7 +16,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import xyz.ksharma.krail.taj.LocalThemeColor
+import xyz.ksharma.krail.taj.components.Button
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.components.TextButton
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -61,17 +65,17 @@ fun ErrorMessage(
         )
 
         actionData?.let {
-            Text(
-                text = actionData.actionText,
-                color = themeColor.hexToComposeColor(),
-                style = KrailTheme.typography.titleMedium,
-                textAlign = TextAlign.Center,
+            TextButton(
+                dimensions = ButtonDefaults.largeButtonSize(),
+                onClick = actionData.onActionClick,
                 modifier = Modifier
-                    .padding(top = 24.dp)
-                    .clickable(
-                        onClick = actionData.onActionClick,
-                    ),
-            )
+                    .padding(vertical = 16.dp, horizontal = 16.dp),
+            ) {
+                Text(
+                    text = actionData.actionText,
+                    color = themeColor.hexToComposeColor(),
+                )
+            }
         }
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -214,7 +214,7 @@ private fun buttonTextStyle(dimensions: ButtonDimensions) =
     when (dimensions) {
         ButtonDefaults.extraSmallButtonSize() -> KrailTheme.typography.bodySmall
         ButtonDefaults.smallButtonSize() -> KrailTheme.typography.titleSmall
-        ButtonDefaults.mediumButtonSize() -> KrailTheme.typography.bodyMedium
+        ButtonDefaults.mediumButtonSize() -> KrailTheme.typography.titleMedium
         ButtonDefaults.largeButtonSize() -> KrailTheme.typography.titleLarge
         else -> KrailTheme.typography.titleSmall
     }


### PR DESCRIPTION
### TL;DR

Replaced text link with TextButton component in ErrorMessage and updated button text styling.

### What changed?

- In `ErrorMessage.kt`, replaced the clickable Text component with a proper TextButton component for action items
- Added proper padding and dimensions to the TextButton
- In `Button.kt`, updated the text style for medium-sized buttons from `bodyMedium` to `titleMedium` for better visual hierarchy

### How to test?

1. Navigate to a screen that displays an error message with an action button
2. Verify that the action button appears as a proper TextButton with the correct styling
3. Confirm that the button is clickable and performs the expected action
4. Check that medium-sized buttons throughout the app now use the `titleMedium` text style

### Why make this change?

This change improves UI consistency by using proper button components instead of clickable text. It also enhances the visual hierarchy by updating the text styling for medium-sized buttons, making the UI more polished and aligned with design standards.