### PR TITLE
Version: Bump to 1.6.0 (Android 91, iOS build 2)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 90
+        versionCode = 91
         versionName = "1.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version codes for Android and iOS apps for the 1.6.0 release.

### What changed?

- Incremented Android `versionCode` from 90 to 91
- Incremented iOS `CFBundleVersion` from 1 to 2
- Maintained version name/string as "1.6.0" for both platforms

### How to test?

- Build the Android app and verify the version code is 91
- Build the iOS app and verify the build number is 2
- Verify both apps still display version 1.6.0 to users

### Why make this change?

This version code bump is necessary for releasing the next build of version 1.6.0 to the app stores. The version codes need to be incremented for each new build submission while maintaining the same user-facing version number.