### PR TITLE
Version: Bump to 1.6.1 (Android 92, iOS build 1)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 91
-        versionName = "1.6.0"
+        versionCode = 92
+        versionName = "1.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.6.0 to 1.6.1 for both Android and iOS apps.

### What changed?

- Android:
  - Increased `versionCode` from 91 to 92
  - Updated `versionName` from "1.6.0" to "1.6.1"

- iOS:
  - Updated `CFBundleShortVersionString` from "1.6.0" to "1.6.1"
  - Reset `CFBundleVersion` (build number) from "2" to "1"

### How to test?

1. Build the app for both platforms
2. Verify the version information in app settings or about screen
3. Confirm the version numbers appear correctly in the respective app stores when uploading

### Why make this change?

Preparing for a new patch release (1.6.1) that includes bug fixes or minor improvements to the 1.6.0 version.