### PR TITLE
Revert "Fix: Improve journey caching and add detailed logging for trip planner (#759)"

### DIFF
--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.logging.ANDROID
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -32,12 +33,7 @@ actual fun httpClient(
             coroutineScope.launch {
                 if (appInfoProvider.getAppInfo().isDebug) {
                     level = LogLevel.BODY
-                    logger = object : Logger {
-                        override fun log(message: String) {
-                            // Package name is used to avoid collision with the overriden Log method
-                            xyz.ksharma.krail.core.log.log(message)
-                        }
-                    }
+                    logger = Logger.ANDROID
                     sanitizeHeader { header -> header == HttpHeaders.Authorization }
                 } else {
                     level = LogLevel.NONE


### PR DESCRIPTION
# Simplify HTTP logging and refactor trip cache management

No longer required after - https://github.com/ksharma-xyz/KRAIL-GTFS/pull/112

- Replace custom logger with built-in `Logger.ANDROID` in HttpClient
- Refactor `updateTripsCache` method with clearer filtering logic for journey management
- Improve logging to be more concise and informative
- Maintain the same functionality while making the code more maintainable