### PR TITLE
Test: Add ModeSelectionChanged test and use custom logger for HTTP client

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -636,4 +636,15 @@ class TimeTableViewModelTest {
         }
 
     // endregion
+
+    // region Test for ModeSelectionChanged
+    @Test
+    fun `GIVEN unselectedModes WHEN ModeSelectionChanged is called THEN UI state and analytics are updated`() = runTest {
+        val initialUnselectedModes = setOf(1, 2)
+        viewModel.onEvent(TimeTableUiEvent.ModeSelectionChanged(initialUnselectedModes))
+        advanceUntilIdle()
+        assertEquals(initialUnselectedModes, viewModel.uiState.value.unselectedModes)
+        assertTrue((fakeAnalytics as FakeAnalytics).isEventTracked("mode_selection_done"))
+    }
+    // endregion
 }

--- a/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/androidMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -33,7 +33,12 @@ actual fun httpClient(
             coroutineScope.launch {
                 if (appInfoProvider.getAppInfo().isDebug) {
                     level = LogLevel.BODY
-                    logger = Logger.ANDROID
+                    logger = object : Logger {
+                        override fun log(message: String) {
+                            // Package name is used to avoid collision with the overriden Log method
+                            xyz.ksharma.krail.core.log.log(message)
+                        }
+                    }
                     sanitizeHeader { header -> header == HttpHeaders.Authorization }
                 } else {
                     level = LogLevel.NONE

--- a/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
+++ b/feature/trip-planner/network/src/iosMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/HttpClient.kt
@@ -4,7 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
@@ -33,7 +32,12 @@ actual fun httpClient(
             coroutineScope.launch {
                 if (appInfoProvider.getAppInfo().isDebug) {
                     level = LogLevel.BODY
-                    logger = Logger.DEFAULT
+                    logger = object : Logger {
+                        override fun log(message: String) {
+                            // Package name is used to avoid collision with the overriden Log method
+                            xyz.ksharma.krail.core.log.log(message)
+                        }
+                    }
                     sanitizeHeader { header -> header == HttpHeaders.Authorization }
                 } else {
                     level = LogLevel.NONE


### PR DESCRIPTION
### TL;DR

Added a test for ModeSelectionChanged event and improved HTTP client logging across platforms.

### What changed?

- Added a unit test for the `TimeTableUiEvent.ModeSelectionChanged` event to verify that UI state and analytics are properly updated
- Replaced default loggers in both Android and iOS HTTP clients with custom loggers that use our application's logging system
- Ensured consistent logging behavior across platforms

### How to test?

1. Run the new test to verify the `ModeSelectionChanged` event works correctly
2. Test HTTP client logging in debug mode on both Android and iOS to confirm logs are properly captured
3. Verify that authorization headers are still sanitized in logs

### Why make this change?

The new test improves coverage for the TimeTable feature, ensuring that mode selection changes are properly reflected in the UI state and tracked in analytics.

The HTTP client logging changes provide better integration with our application's logging system, making it easier to collect and analyze network logs in a consistent way across platforms. This helps with debugging and troubleshooting network-related issues.