### PR TITLE
UI: Add bottom spacing and improve footer styling in SettingsScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -49,7 +51,6 @@ fun SettingsScreen(
     onAboutUsClick: () -> Unit = {},
     onIntroClick: () -> Unit = {},
 ) {
-    val themeColor by LocalThemeColor.current
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -118,13 +119,18 @@ fun SettingsScreen(
                         onClick = { onAboutUsClick() }
                     )
                 }
+
+                item {
+                    Spacer(modifier = Modifier.fillMaxWidth().height(108.dp))
+                }
             }
         }
 
         Column(
             modifier = Modifier.align(Alignment.BottomCenter)
+                .background(KrailTheme.colors.surface)
                 .navigationBarsPadding()
-                .padding(bottom = 10.dp),
+                .padding(bottom = 10.dp, top = 16.dp),
         ) {
             AppLogo()
             Text(


### PR DESCRIPTION
### TL;DR

Added a spacer at the bottom of the settings list and improved the app logo section styling.

### What changed?

- Added a `Spacer` with a height of 108.dp at the bottom of the settings list to provide better spacing
- Added a background color to the bottom app logo section using `KrailTheme.colors.surface`
- Added top padding (16.dp) to the app logo container
- Removed unused `themeColor` variable that was being collected but not used

### How to test?

1. Navigate to the Settings screen
2. Verify there's proper spacing at the bottom of the settings list
3. Check that the app logo section at the bottom has the correct background color and padding
4. Scroll through the settings to ensure the bottom section appears correctly

### Why make this change?

These UI improvements enhance the visual separation between the settings list and the app logo section, creating a more polished and professional appearance. The added spacer prevents content from being hidden behind the logo section, while the background color helps distinguish the logo area from the content above it.