### PR TITLE
Feature: Implement Molecule for OurStory screen state management

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/story/OurStoryEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/story/OurStoryEvent.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.trip.planner.ui.state.settings.story
+
+interface OurStoryEvent {
+    data object SampleEvent : OurStoryEvent
+}

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -50,6 +50,8 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.lifecycle.viewmodel.compose)
                 implementation(libs.navigation.compose)
+
+                implementation(libs.molecule.runtime)
             }
         }
         commonTest {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/MoleculeViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/MoleculeViewModel.kt
@@ -1,0 +1,36 @@
+package xyz.ksharma.krail.trip.planner.ui
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.cash.molecule.RecompositionMode.Immediate
+import app.cash.molecule.launchMolecule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+abstract class MoleculeViewModel<Event, Model> : ViewModel() {
+
+    private val scope = CoroutineScope(viewModelScope.coroutineContext + Dispatchers.Main)
+
+    // Events have a capacity large enough to handle simultaneous UI events, but
+    // small enough to surface issues if they get backed up for some reason.
+    private val events = MutableSharedFlow<Event>(extraBufferCapacity = 20)
+
+    val models: StateFlow<Model> by lazy(LazyThreadSafetyMode.NONE) {
+        scope.launchMolecule(mode = Immediate) {
+            models(events)
+        }
+    }
+
+    fun take(event: Event) {
+        if (!events.tryEmit(event)) {
+            error("Event buffer overflow.")
+        }
+    }
+
+    @Composable
+    protected abstract fun models(events: Flow<Event>): Model
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryDestination.kt
@@ -1,18 +1,19 @@
 package xyz.ksharma.krail.trip.planner.ui.settings.story
 
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.OurStoryRoute
+import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryState
 
 internal fun NavGraphBuilder.aboutUsDestination(navController: NavHostController) {
     composable<OurStoryRoute> {
 
         val viewModel: OurStoryViewModel = koinViewModel<OurStoryViewModel>()
-        val ourStoryState by viewModel.uiState.collectAsStateWithLifecycle()
+        val ourStoryState: OurStoryState by viewModel.models.collectAsState()
 
         OurStoryScreen(
             state = ourStoryState,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryViewModel.kt
@@ -1,54 +1,90 @@
 package xyz.ksharma.krail.trip.planner.ui.settings.story
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.Flow
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.asString
+import xyz.ksharma.krail.trip.planner.ui.MoleculeViewModel
+import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryEvent
 import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryState
 
 class OurStoryViewModel(
     private val analytics: Analytics,
     private val flag: Flag,
-) : ViewModel() {
+) : MoleculeViewModel<OurStoryEvent, OurStoryState>() {
 
-    private val storyText: String by lazy {
-        flag.getFlagValue(FlagKeys.OUR_STORY_TEXT.key).asString()
-    }
+    /*
+        private val _uiState: MutableStateFlow<OurStoryState> = MutableStateFlow(OurStoryState())
+        val uiState: StateFlow<OurStoryState> = _uiState
+            .onStart {
+                updateOurStoryState()
+                analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
+            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), OurStoryState())
+    */
 
-    private val disclaimerText: String by lazy {
-        flag.getFlagValue(FlagKeys.DISCLAIMER_TEXT.key).asString()
-    }
-
-    private val _uiState: MutableStateFlow<OurStoryState> = MutableStateFlow(OurStoryState())
-    val uiState: StateFlow<OurStoryState> = _uiState
-        .onStart {
-            updateOurStoryState()
-            analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), OurStoryState())
-
-    private fun updateOurStoryState() {
-        if (storyText.isNotBlank() && disclaimerText.isNotBlank()) {
-            updateUiState {
-                copy(
-                    story = storyText,
-                    disclaimer = disclaimerText,
-                    isLoading = false,
-                )
+    /*
+        private fun updateOurStoryState() {
+            if (storyText.isNotBlank() && disclaimerText.isNotBlank()) {
+                updateUiState {
+                    copy(
+                        story = storyText,
+                        disclaimer = disclaimerText,
+                        isLoading = false,
+                    )
+                }
             }
         }
+    */
+
+    /*
+        private fun updateUiState(block: OurStoryState.() -> OurStoryState) {
+            _uiState.update(block)
+        }
+    */
+
+    @Composable
+    override fun models(events: Flow<OurStoryEvent>): OurStoryState {
+        return ourStoryPresenter(events)
     }
 
-    private fun updateUiState(block: OurStoryState.() -> OurStoryState) {
-        _uiState.update(block)
+    @Composable
+    private fun ourStoryPresenter(events: Flow<OurStoryEvent>): OurStoryState {
+        val storyText: String by remember {
+            mutableStateOf(flag.getFlagValue(FlagKeys.OUR_STORY_TEXT.key).asString())
+        }
+
+        val disclaimerText: String by remember {
+            mutableStateOf(flag.getFlagValue(FlagKeys.DISCLAIMER_TEXT.key).asString())
+        }
+
+        LaunchedEffect(Unit) {
+            log("OurStoryViewModel-  Our Story Text: ${storyText.take(10)}")
+            analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
+        }
+
+        val ourStoryState = if (storyText.isNotBlank() && disclaimerText.isNotBlank()) {
+            OurStoryState(
+                story = storyText,
+                disclaimer = disclaimerText,
+                isLoading = false,
+            )
+        } else {
+            OurStoryState(
+                story = "",
+                disclaimer = "",
+                isLoading = true,
+            )
+        }
+
+        return ourStoryState
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ kotlinxDatetime = "0.6.2"
 kotlinxIoCore = "0.7.0"
 lifecycleViewmodelCompose = "2.8.4"
 materialIconsCore = "1.7.3"
+moleculeRuntime = "1.1.0"
 navigationCompose = "2.8.0-alpha13"
 kotlinxSerializationJson = "1.8.1"
 ksp = "2.1.21-2.0.1" # ksp to kotlin version mapping https://github.com/google/ksp/releases
@@ -91,6 +92,8 @@ firebase-gitLiveRemoteConfig = { module = "dev.gitlive:firebase-config", version
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar_jdk_libs" }
 androidx-ui-geometry-android = { group = "androidx.compose.ui", name = "ui-geometry-android", version.ref = "uiGeometryAndroid" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
+
+molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "moleculeRuntime" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### TL;DR

Integrated Molecule for state management in the OurStory feature, replacing traditional ViewModel state handling with a more reactive approach.

### What changed?

- Added a new `MoleculeViewModel` abstract class that provides a foundation for Molecule-based state management
- Created `OurStoryEvent` interface to define events for the OurStory feature
- Refactored `OurStoryViewModel` to use Molecule's reactive approach instead of traditional StateFlow
- Updated the OurStory screen to collect state from the new Molecule-based ViewModel
- Added Molecule runtime dependency to the trip-planner UI module

### How to test?

1. Navigate to the OurStory screen in the app
2. Verify that the story text and disclaimer are displayed correctly
3. Check logs to confirm "OurStoryViewModel- Our Story Text: [text]" appears
4. Ensure analytics events are still being tracked properly

### Why make this change?

Molecule provides a more reactive and composable approach to state management, allowing for cleaner separation of UI state logic from the view layer. This change improves code organization by:

1. Making state transformations more declarative and easier to reason about
2. Reducing boilerplate code needed for state management
3. Providing a consistent pattern for handling UI events and state updates
4. Better aligning with Compose's reactive programming model