### PR TITLE
Feature: Add Park & Ride network service and API models

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -105,6 +105,7 @@ kotlin {
             implementation(projects.core.log)
             implementation(projects.core.network)
             implementation(projects.core.remoteConfig)
+            implementation(projects.feature.parkRide.network)
             implementation(projects.feature.tripPlanner.network)
             implementation(projects.feature.tripPlanner.state)
             implementation(projects.feature.tripPlanner.ui)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -14,6 +14,7 @@ import xyz.ksharma.krail.core.di.coroutineDispatchersModule
 import xyz.ksharma.krail.core.network.coreNetworkModule
 import xyz.ksharma.krail.core.remote_config.di.remoteConfigModule
 import xyz.ksharma.krail.io.gtfs.di.gtfsModule
+import xyz.ksharma.krail.park.ride.network.parkRideNetworkModule
 import xyz.ksharma.krail.platform.ops.di.opsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel
@@ -37,6 +38,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             appStartModule,
             opsModule,
             tripPlannerNetworkModule,
+            parkRideNetworkModule,
         )
     }
 }

--- a/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/BaseUrl.kt
+++ b/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/BaseUrl.kt
@@ -1,0 +1,3 @@
+package xyz.ksharma.krail.core.network
+
+const val NSW_TRANSPORT_BASE_URL = "https://api.transport.nsw.gov.au"

--- a/feature/park-ride/network/build.gradle.kts
+++ b/feature/park-ride/network/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
                 implementation(projects.core.appInfo)
                 implementation(projects.core.di)
                 implementation(projects.core.log)
+                implementation(projects.core.network)
 
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)

--- a/feature/park-ride/network/src/androidMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideHttpClient.kt
+++ b/feature/park-ride/network/src/androidMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideHttpClient.kt
@@ -1,0 +1,17 @@
+package xyz.ksharma.krail.park.ride.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpHeaders
+import xyz.ksharma.krail.core.network.NetworkBuildKonfig.ANDROID_NSW_TRANSPORT_API_KEY
+
+actual fun parkRideHttpClient(baseClient: HttpClient): HttpClient {
+    return baseClient.config {
+        defaultRequest {
+            headers.append(
+                HttpHeaders.Authorization,
+                "apikey $ANDROID_NSW_TRANSPORT_API_KEY"
+            )
+        }
+    }
+}

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideHttpClient.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideHttpClient.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.park.ride.network
+
+import io.ktor.client.HttpClient
+
+expect fun parkRideHttpClient(baseClient: HttpClient): HttpClient

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideNetworkModule.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideNetworkModule.kt
@@ -1,0 +1,17 @@
+package xyz.ksharma.krail.park.ride.network
+
+import org.koin.core.qualifier.named
+import org.koin.dsl.bind
+import org.koin.dsl.module
+import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
+import xyz.ksharma.krail.park.ride.network.service.ParkRideService
+import xyz.ksharma.krail.park.ride.network.service.RealParkRideService
+
+val parkRideNetworkModule = module {
+    single {
+        RealParkRideService(
+            httpClient = parkRideHttpClient(get()),
+            ioDispatcher = get(named(IODispatcher)),
+        )
+    } bind ParkRideService::class
+}

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
@@ -4,13 +4,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CarParkFacilitiesResponse(
-
-    @SerialName("facilities")
-    val facilities: Map<String, String>
-)
-
-@Serializable
 data class CarParkFacilityDetailResponse(
 
     @SerialName("tsn")

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
@@ -1,0 +1,102 @@
+package xyz.ksharma.krail.park.ride.network.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CarParkFacilitiesResponse(
+
+    @SerialName("facilities")
+    val facilities: Map<String, String>
+)
+
+@Serializable
+data class CarParkFacilityDetailResponse(
+
+    @SerialName("tsn")
+    val tsn: String,
+
+    @SerialName("time")
+    val time: String,
+
+    @SerialName("spots")
+    val spots: String,
+
+    @SerialName("zones")
+    val zones: List<Zone>,
+
+    @SerialName("ParkID")
+    val parkID: Int,
+
+    @SerialName("location")
+    val location: Location,
+
+    @SerialName("occupancy")
+    val occupancy: Occupancy,
+
+    @SerialName("MessageDate")
+    val messageDate: String,
+
+    @SerialName("facility_id")
+    val facilityId: String,
+
+    @SerialName("facility_name")
+    val facilityName: String,
+
+    @SerialName("tfnsw_facility_id")
+    val tfnswFacilityId: String
+)
+
+@Serializable
+data class Zone(
+
+    @SerialName("spots")
+    val spots: String,
+
+    @SerialName("zone_id")
+    val zoneId: String,
+
+    @SerialName("occupancy")
+    val occupancy: Occupancy,
+
+    @SerialName("zone_name")
+    val zoneName: String,
+
+    @SerialName("parent_zone_id")
+    val parentZoneId: String
+)
+
+@Serializable
+data class Occupancy(
+
+    @SerialName("loop")
+    val loop: String?,
+
+    @SerialName("total")
+    val total: String?,
+
+    @SerialName("monthlies")
+    val monthlies: String?,
+
+    @SerialName("open_gate")
+    val openGate: String?,
+
+    @SerialName("transients")
+    val transients: String?
+)
+
+@Serializable
+data class Location(
+
+    @SerialName("suburb")
+    val suburb: String,
+
+    @SerialName("address")
+    val address: String,
+
+    @SerialName("latitude")
+    val latitude: String,
+
+    @SerialName("longitude")
+    val longitude: String
+)

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
@@ -4,6 +4,7 @@ import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
 
 /**
  * Swagger: https://opendata.transport.nsw.gov.au/data/dataset/car-park-api/resource/b880cae7-ed81-4d3e-9aba-b948d6626b20
+ * API documentation: https://opendata.transport.nsw.gov.au/data/dataset/car-park-api/resource/1cd0b16d-d9f8-4973-93cd-3c6f66a3e99c
  */
 interface ParkRideService {
 

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.park.ride.network.service
 
-import xyz.ksharma.krail.park.ride.network.model.CarParkFacilitiesResponse
 import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
 
 /**
@@ -8,7 +7,14 @@ import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
  */
 interface ParkRideService {
 
+    /**
+     * Returns the details of a car park facility by its ID.
+     */
     suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse
 
-    suspend fun getCarParkFacilities(): CarParkFacilitiesResponse
+    /**
+     * Returns a map of facility ID to facility name for all car parks.
+     * Since facility ID is not specified, a list of facility names with their ID will be returned.
+     */
+    suspend fun getCarParkFacilities(): Map<String, String>
 }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
@@ -1,0 +1,14 @@
+package xyz.ksharma.krail.park.ride.network.service
+
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilitiesResponse
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+
+/**
+ * Swagger: https://opendata.transport.nsw.gov.au/data/dataset/car-park-api/resource/b880cae7-ed81-4d3e-9aba-b948d6626b20
+ */
+interface ParkRideService {
+
+    suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse
+
+    suspend fun getCarParkFacilities(): CarParkFacilitiesResponse
+}

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/RealParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/RealParkRideService.kt
@@ -1,15 +1,14 @@
 package xyz.ksharma.krail.park.ride.network.service
 
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
 import io.ktor.client.request.get
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import io.ktor.client.call.body
 import xyz.ksharma.krail.core.network.NSW_TRANSPORT_BASE_URL
-import xyz.ksharma.krail.park.ride.network.model.CarParkFacilitiesResponse
 import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
 
-class RealParkRideService(
+internal class RealParkRideService(
     private val httpClient: HttpClient,
     private val ioDispatcher: CoroutineDispatcher
 ) : ParkRideService {
@@ -17,15 +16,15 @@ class RealParkRideService(
     override suspend fun getCarParkFacilities(
         facilityId: String
     ): CarParkFacilityDetailResponse = withContext(ioDispatcher) {
-        httpClient.get("$NSW_TRANSPORT_BASE_URL/carpark") {
+        httpClient.get("$NSW_TRANSPORT_BASE_URL/v1/carpark") {
             url {
                 parameters.append("facility", facilityId)
             }
         }.body()
     }
 
-    override suspend fun getCarParkFacilities(): CarParkFacilitiesResponse =
+    override suspend fun getCarParkFacilities(): Map<String, String> =
         withContext(ioDispatcher) {
-            httpClient.get("$NSW_TRANSPORT_BASE_URL/carpark") {}.body()
+            httpClient.get("$NSW_TRANSPORT_BASE_URL/v1/carpark") {}.body()
         }
 }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/RealParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/RealParkRideService.kt
@@ -1,0 +1,31 @@
+package xyz.ksharma.krail.park.ride.network.service
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import io.ktor.client.call.body
+import xyz.ksharma.krail.core.network.NSW_TRANSPORT_BASE_URL
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilitiesResponse
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+
+class RealParkRideService(
+    private val httpClient: HttpClient,
+    private val ioDispatcher: CoroutineDispatcher
+) : ParkRideService {
+
+    override suspend fun getCarParkFacilities(
+        facilityId: String
+    ): CarParkFacilityDetailResponse = withContext(ioDispatcher) {
+        httpClient.get("$NSW_TRANSPORT_BASE_URL/carpark") {
+            url {
+                parameters.append("facility", facilityId)
+            }
+        }.body()
+    }
+
+    override suspend fun getCarParkFacilities(): CarParkFacilitiesResponse =
+        withContext(ioDispatcher) {
+            httpClient.get("$NSW_TRANSPORT_BASE_URL/carpark") {}.body()
+        }
+}

--- a/feature/park-ride/network/src/iosMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideHttpClient.kt
+++ b/feature/park-ride/network/src/iosMain/kotlin/xyz/ksharma/krail/park/ride/network/ParkRideHttpClient.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.park.ride.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.HttpHeaders
+import xyz.ksharma.krail.core.network.NetworkBuildKonfig.ANDROID_NSW_TRANSPORT_API_KEY
+import xyz.ksharma.krail.core.network.NetworkBuildKonfig.IOS_NSW_TRANSPORT_API_KEY
+
+actual fun parkRideHttpClient(baseClient: HttpClient): HttpClient {
+    return baseClient.config {
+        defaultRequest {
+            headers.append(
+                HttpHeaders.Authorization,
+                "apikey $IOS_NSW_TRANSPORT_API_KEY"
+            )
+        }
+    }
+}

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -7,6 +7,7 @@ import io.ktor.http.ParametersBuilder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.network.NSW_TRANSPORT_BASE_URL
 import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.StopType
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
@@ -7,8 +7,6 @@ import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 /**
  * Swagger: https://opendata.transport.nsw.gov.au/dataset/trip-planner-apis/resource/917c66c3-8123-4a0f-b1b1-b4220f32585d
  */
-internal const val NSW_TRANSPORT_BASE_URL = "https://api.transport.nsw.gov.au"
-
 interface TripPlanningService {
 
     suspend fun trip(

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -17,6 +17,8 @@ sealed interface SavedTripUiEvent {
     data object AnalyticsReverseSavedTrip : SavedTripUiEvent
 
     data object AnalyticsSettingsButtonClick : SavedTripUiEvent
+
     data object AnalyticsFromButtonClick : SavedTripUiEvent
+
     data object AnalyticsToButtonClick : SavedTripUiEvent
 }

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -31,6 +31,7 @@ kotlin {
                 implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.remoteConfig)
+                implementation(projects.feature.parkRide.network)
                 implementation(projects.feature.tripPlanner.network)
                 implementation(projects.feature.tripPlanner.state)
                 implementation(projects.platform.ops)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -37,7 +37,6 @@ val viewModelsModule = module {
             sandook = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
-            parkRideService = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -37,6 +37,7 @@ val viewModelsModule = module {
             sandook = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
+            parkRideService = get(),
         )
     }
 


### PR DESCRIPTION
### TL;DR

Added Park & Ride API integration to fetch car park facility information from NSW Transport API.

### What changed?

- Created a new Park & Ride network module with API service to fetch car park facilities data
- Added data models for car park facilities responses
- Implemented platform-specific HTTP clients for Android and iOS with proper API key handling
- Extracted `NSW_TRANSPORT_BASE_URL` to a common location in core/network for reuse
- Integrated the new module into the app's dependency injection system

### How to test?

1. Build and run the app
2. Verify that the Park & Ride service can be injected where needed
3. Test API calls to fetch car park facilities:
   - `getCarParkFacilities()` to get all facilities
   - `getCarParkFacilities(facilityId)` to get details for a specific facility

### Why make this change?

This change enables the app to access real-time information about car park facilities from the NSW Transport API, which will allow users to check parking availability at transport hubs. This is a prerequisite for implementing the Park & Ride feature that will help users plan their journeys with parking considerations.