### PR TITLE
Add firebase config defaults NSW_PARK_RIDE_FACILITIES

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -14,7 +14,7 @@ import xyz.ksharma.krail.core.di.coroutineDispatchersModule
 import xyz.ksharma.krail.core.network.coreNetworkModule
 import xyz.ksharma.krail.core.remote_config.di.remoteConfigModule
 import xyz.ksharma.krail.io.gtfs.di.gtfsModule
-import xyz.ksharma.krail.park.ride.network.parkRideNetworkModule
+import xyz.ksharma.krail.park.ride.network.di.parkRideNetworkModule
 import xyz.ksharma.krail.platform.ops.di.opsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
 import xyz.ksharma.krail.splash.SplashViewModel

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -45,7 +45,51 @@ object RemoteConfigDefaults {
                 """
     Important to note: Real-time data in KRAIL is provided by Transport for NSW. While I strive to ensure accuracy, I cannot guarantee it will always be correct. For the latest and most up-to-date information, please visit www.transportnsw.info
     """.trimMargin(),
-            )
+            ),
+            Pair(
+                FlagKeys.NSW_PARK_RIDE_FACILITIES.key,
+                """[{"stopId":"207210","parkRideFacilityId":"6","parkRideName":"Park&Ride - Gordon Henry St (north)"},
+                    |{"stopId":"253330","parkRideFacilityId":"7","parkRideName":"Park&Ride - Kiama"},
+                    |{"stopId":"225040","parkRideFacilityId":"8","parkRideName":"Park&Ride - Gosford"},
+                    |{"stopId":"221210","parkRideFacilityId":"9","parkRideName":"Park&Ride - Revesby"},
+                    |{"stopId":"210120","parkRideFacilityId":"10","parkRideName":"Park&Ride - Warriewood"},
+                    |{"stopId":"210115","parkRideFacilityId":"11","parkRideName":"Park&Ride - Narrabeen"},
+                    |{"stopId":"210318","parkRideFacilityId":"12","parkRideName":"Park&Ride - Mona Vale"},
+                    |{"stopId":"209913","parkRideFacilityId":"13","parkRideName":"Park&Ride - Dee Why"},
+                    |{"stopId":"211420","parkRideFacilityId":"14","parkRideName":"Park&Ride - West Ryde"},
+                    |{"stopId":"223210","parkRideFacilityId":"15","parkRideName":"Park&Ride - Sutherland"},
+                    |{"stopId":"2232126","parkRideFacilityId":"15","parkRideName":"Park&Ride - Sutherland"},
+                    |{"stopId":"2232254","parkRideFacilityId":"15","parkRideName":"Park&Ride - Sutherland"},
+                    |{"stopId":"217933","parkRideFacilityId":"16","parkRideName":"Park&Ride - Leppington"},
+                    |{"stopId":"217426","parkRideFacilityId":"17","parkRideName":"Park&Ride - Edmondson Park (south)"},
+                    |{"stopId":"276010","parkRideFacilityId":"18","parkRideName":"Park&Ride - St Marys"},
+                    |{"stopId":"256020","parkRideFacilityId":"19","parkRideName":"Park&Ride - Campbelltown Farrow Rd (north)"},
+                    |{"stopId":"256020","parkRideFacilityId":"20","parkRideName":"Park&Ride - Campbelltown Hurley St"},
+                    |{"stopId":"275010","parkRideFacilityId":"21","parkRideName":"Park&Ride - Penrith (at-grade)"},
+                    |{"stopId":"275010","parkRideFacilityId":"22","parkRideName":"Park&Ride - Penrith (multi-level)"},
+                    |{"stopId":"217010","parkRideFacilityId":"23","parkRideName":"Park&Ride - Warwick Farm"},
+                    |{"stopId":"276220","parkRideFacilityId":"24","parkRideName":"Park&Ride - Schofields"},
+                    |{"stopId":"207763","parkRideFacilityId":"25","parkRideName":"Park&Ride - Hornsby"},
+                    |{"stopId":"2155384","parkRideFacilityId":"26","parkRideName":"Park&Ride - Tallawong P1"},
+                    |{"stopId":"2155384","parkRideFacilityId":"27","parkRideName":"Park&Ride - Tallawong P2"},
+                    |{"stopId":"2155384","parkRideFacilityId":"28","parkRideName":"Park&Ride - Tallawong P3"},
+                    |{"stopId":"2155382","parkRideFacilityId":"29","parkRideName":"Park&Ride - Kellyville (north)"},
+                    |{"stopId":"2155382","parkRideFacilityId":"30","parkRideName":"Park&Ride - Kellyville (south)"},
+                    |{"stopId":"2153478","parkRideFacilityId":"31","parkRideName":"Park&Ride - Bella Vista"},
+                    |{"stopId":"2154392","parkRideFacilityId":"32","parkRideName":"Park&Ride - Hills Showground"},
+                    |{"stopId":"2126158","parkRideFacilityId":"33","parkRideName":"Park&Ride - Cherrybrook"},
+                    |{"stopId":"207010","parkRideFacilityId":"34","parkRideName":"Park&Ride - Lindfield Village Green"},
+                    |{"stopId":"220910","parkRideFacilityId":"35","parkRideName":"Park&Ride - Beverly Hills"},
+                    |{"stopId":"275020","parkRideFacilityId":"36","parkRideName":"Park&Ride - Emu Plains"},
+                    |{"stopId":"221010","parkRideFacilityId":"37","parkRideName":"Park&Ride - Riverwood"},
+                    |{"stopId":"213110","parkRideFacilityId":"486","parkRideName":"Park&Ride - Ashfield"},
+                    |{"stopId":"221710","parkRideFacilityId":"487","parkRideName":"Park&Ride - Kogarah"},
+                    |{"stopId":"214710","parkRideFacilityId":"488","parkRideName":"Park&Ride - Seven Hills"},
+                    |{"stopId":"209325","parkRideFacilityId":"489","parkRideName":"Park&Ride - Manly Vale"},
+                    |{"stopId":"209324","parkRideFacilityId":"489","parkRideName":"Park&Ride - Manly Vale"},
+                    |{"stopId":"210017","parkRideFacilityId":"490","parkRideName":"Park&Ride - Brookvale"}]"""
+                    .trimMargin()
+            ),
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
@@ -5,4 +5,5 @@ enum class FlagKeys(val key: String) {
     HIGH_PRIORITY_STOP_IDS("high_priority_stop_ids"),
     OUR_STORY_TEXT("our_story_text"),
     DISCLAIMER_TEXT("disclaimer_text"),
+    NSW_PARK_RIDE_FACILITIES("nsw_park_ride_facilities"),
 }

--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
                 implementation(projects.core.log)
                 implementation(projects.core.remoteConfig)
                 implementation(projects.sandook)
+                implementation(projects.feature.parkRide.network)
                 implementation(projects.feature.tripPlanner.ui)
                 implementation(projects.feature.tripPlanner.state)
                 implementation(projects.feature.tripPlanner.network)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideFacilityManager.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideFacilityManager.kt
@@ -1,0 +1,24 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
+
+class FakeParkRideFacilityManager : NswParkRideFacilityManager {
+
+    var facilities: List<NswParkRideFacility> = listOf(
+        NswParkRideFacility(
+            stopId = "207210",
+            parkRideFacilityId = "6",
+            parkRideName = "Sample Park & Ride 1"
+        ),
+        NswParkRideFacility(
+            stopId = "207211",
+            parkRideFacilityId = "7",
+            parkRideName = "Sample Park & Ride 2"
+        )
+    )
+
+    override fun getParkRideFacilities(): List<NswParkRideFacility> {
+        return facilities
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.fakes.FakeParkRideFacilityManager
 import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -32,13 +34,14 @@ class SavedTripsViewModelTest {
     private val sandook: Sandook = FakeSandook()
     private val fakeAnalytics: Analytics = FakeAnalytics()
     private lateinit var viewModel: SavedTripsViewModel
+    private val fakeParkRideManager: NswParkRideFacilityManager = FakeParkRideFacilityManager()
 
     private val testDispatcher = StandardTestDispatcher()
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = SavedTripsViewModel(sandook, fakeAnalytics, testDispatcher)
+        viewModel = SavedTripsViewModel(sandook, fakeAnalytics, testDispatcher, fakeParkRideManager)
     }
 
     @AfterTest

--- a/feature/park-ride/network/build.gradle.kts
+++ b/feature/park-ride/network/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
                 implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.network)
+                implementation(projects.core.remoteConfig)
 
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/NswParkRideFacilityManager.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/NswParkRideFacilityManager.kt
@@ -1,0 +1,9 @@
+package xyz.ksharma.krail.park.ride.network
+
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+
+interface NswParkRideFacilityManager {
+
+    fun getParkRideFacilities(): List<NswParkRideFacility>
+
+}

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.park.ride.network
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.FlagValue
@@ -21,10 +22,9 @@ class RealNswParkRideFacilityManager(
                 jsonArray.map { element ->
                     val obj = element.jsonObject
                     NswParkRideFacility(
-                        stopId = obj["stopId"]?.toString()?.trim('"') ?: "",
-                        parkRideFacilityId = obj["parkRideFacilityId"]?.toString()?.trim('"')
-                            ?: "",
-                        parkRideName = obj["parkRideName"]?.toString()?.trim('"') ?: ""
+                        stopId = obj["stopId"]?.jsonPrimitive?.content ?: "",
+                        parkRideFacilityId = obj["parkRideFacilityId"]?.jsonPrimitive?.content ?: "",
+                        parkRideName = obj["parkRideName"]?.jsonPrimitive?.content ?: ""
                     )
                 }
             }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
@@ -1,0 +1,35 @@
+package xyz.ksharma.krail.park.ride.network
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import xyz.ksharma.krail.core.remote_config.flag.Flag
+import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
+import xyz.ksharma.krail.core.remote_config.flag.FlagValue
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+
+class RealNswParkRideFacilityManager(
+    private val flag: Flag,
+) : NswParkRideFacilityManager {
+
+    override fun getParkRideFacilities(): List<NswParkRideFacility> {
+        val flagValue: FlagValue = flag.getFlagValue(FlagKeys.NSW_PARK_RIDE_FACILITIES.key)
+
+        return when (flagValue) {
+            is FlagValue.JsonValue -> {
+                val jsonArray = Json.parseToJsonElement(flagValue.value).jsonArray
+                jsonArray.map { element ->
+                    val obj = element.jsonObject
+                    NswParkRideFacility(
+                        stopId = obj["stopId"]?.toString()?.trim('"') ?: "",
+                        parkRideFacilityId = obj["parkRideFacilityId"]?.toString()?.trim('"')
+                            ?: "",
+                        parkRideName = obj["parkRideName"]?.toString()?.trim('"') ?: ""
+                    )
+                }
+            }
+
+            else -> emptyList()
+        }
+    }
+}

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/di/ParkRideNetworkModule.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/di/ParkRideNetworkModule.kt
@@ -1,9 +1,12 @@
-package xyz.ksharma.krail.park.ride.network
+package xyz.ksharma.krail.park.ride.network.di
 
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
+import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
+import xyz.ksharma.krail.park.ride.network.RealNswParkRideFacilityManager
+import xyz.ksharma.krail.park.ride.network.parkRideHttpClient
 import xyz.ksharma.krail.park.ride.network.service.ParkRideService
 import xyz.ksharma.krail.park.ride.network.service.RealParkRideService
 
@@ -14,4 +17,10 @@ val parkRideNetworkModule = module {
             ioDispatcher = get(named(IODispatcher)),
         )
     } bind ParkRideService::class
+
+    single<NswParkRideFacilityManager> {
+        RealNswParkRideFacilityManager(
+            flag = get(),
+        )
+    }
 }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/NswParkRideFacility.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/NswParkRideFacility.kt
@@ -1,0 +1,7 @@
+package xyz.ksharma.krail.park.ride.network.model
+
+data class NswParkRideFacility(
+    val stopId: String,
+    val parkRideFacilityId: String,
+    val parkRideName: String
+)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -37,6 +37,7 @@ val viewModelsModule = module {
             sandook = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
+            nswParkRideFacilityManager = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -36,9 +36,9 @@ class SavedTripsViewModel(
     val uiState: StateFlow<SavedTripsState> = _uiState
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
+            // TODO - remove this when park and ride is not needed
             val x = nswParkRideFacilityManager.getParkRideFacilities()
             log("Park Ride Facilities: ${x.size}")
-            println("park ride fac: " + x)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
 
     fun onEvent(event: SavedTripUiEvent) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -18,6 +18,7 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -28,12 +29,16 @@ class SavedTripsViewModel(
     private val sandook: Sandook,
     private val analytics: Analytics,
     private val ioDispatcher: CoroutineDispatcher,
+    private val nswParkRideFacilityManager: NswParkRideFacilityManager,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
+            val x = nswParkRideFacilityManager.getParkRideFacilities()
+            log("Park Ride Facilities: ${x.size}")
+            println("park ride fac: " + x)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
 
     fun onEvent(event: SavedTripUiEvent) {


### PR DESCRIPTION
# Add NSW Park & Ride Facilities Support

This PR adds support for NSW Park & Ride facilities by:

- Adding a new remote config flag `NSW_PARK_RIDE_FACILITIES` with default values for all NSW Park & Ride locations
- Creating a new `NswParkRideManager` interface and implementation to retrieve Park & Ride facility data
- Restructuring the Park & Ride network module to include the new manager in the DI setup
- Integrating the Park & Ride manager with the SavedTripsViewModel for future functionality

The implementation parses facility data from remote config, providing a clean way to update facility information without app updates.

### Result Log

> 
> 2025-06-01 22:33:17.859 15687-15687 SavedTripsViewModel     xyz.ksharma.krail.debug              D  Park Ride Facilities: 40
> 2025-06-01 22:33:17.860 15687-15687 System.out              xyz.ksharma.krail.debug              I  park ride fac: [NswParkRideFacility(stopId=207210, parkRideFacilityId=6, parkRideName=Park&Ride - Gordon Henry St (north)), NswParkRideFacility(stopId=253330, parkRideFacilityId=7, parkRideName=Park&Ride - Kiama), NswParkRideFacility(stopId=225040, parkRideFacilityId=8, parkRideName=Park&Ride - Gosford), NswParkRideFacility(stopId=221210, parkRideFacilityId=9, parkRideName=Park&Ride - Revesby), NswParkRideFacility(stopId=210120, parkRideFacilityId=10, parkRideName=Park&Ride - Warriewood), NswParkRideFacility(stopId=210115, parkRideFacilityId=11, parkRideName=Park&Ride - Narrabeen), NswParkRideFacility(stopId=210318, parkRideFacilityId=12, parkRideName=Park&Ride - Mona Vale), NswParkRideFacility(stopId=209913, parkRideFacilityId=13, parkRideName=Park&Ride - Dee Why), NswParkRideFacility(stopId=211420, parkRideFacilityId=14, parkRideName=Park&Ride - West Ryde), NswParkRideFacility(stopId=223210, parkRideFacilityId=15, parkRideName=Park&Ride - Sutherland), NswParkRideFacility(stopId=2232126, parkRideFacilityId=15, parkRideName=Park&Ride - Sutherland), NswParkRideFacility(stopId=2232254, parkRideFacilityId=15, parkRideName=Park&Ride - Sutherland), NswParkRideFacility(stopId=217933, parkRideFacilityId=16, parkRideName=Park&Ride - Leppington), NswParkRideFacility(stopId=217426, parkRideFacilityId=17, parkRideName=Park&Ride - Edmondson Park (south)), NswParkRideFacility(stopId=276010, parkRideFacilityId=18, parkRideName=Park&Ride - St Marys), NswParkRideFacility(stopId=256020, parkRideFacilityId=19, parkRideName=Park&Ride - Campbelltown Farrow Rd (north)), NswParkRideFacility(stopId=256020, parkRideFacilityId=20, parkRideName=Park&Ride - Campbelltown Hurley St), NswParkRideFacility(stopId=275010, parkRideFacilityId=21, parkRideName=Park&Ride - Penrith (at-grade)), NswParkRideFacility(stopId=275010, parkRideFacilityId=22, parkRideName=Park&Ride - Penrith (multi-level)), NswParkRideFacility(stopId=217010, parkRideFacilityId=23, parkRideName=Park&Ride - Warwick Farm), NswParkRideFacility(stopId=276220, parkRideFacilityId=24, parkRideName=Park&Ride - Schofields), NswParkRideFacility(stopId=207763, parkRideFacilityId=25, parkRideName=Park&Ride - Hornsby), NswParkRideFacility(stopId=2155384, parkRideFacilityId=26, parkRideName=Park&Ride - Tallawong P1), NswParkRideFacility(stopId=2155384, parkRideFacilityId=27, parkRideName=Park&Ride - Tallawong P2), NswParkRideFacility(stopId=2155384, parkRideFacilityId=28, parkRideName=Park&Ride - Tallawong P3), NswParkRideFacility(stopId=2155382, parkRideFacilityId=29, parkRideName=Park&Ride - Kellyville (north)), NswParkRideFacility(stopId=2155382, parkRideFacilityId=30, parkRideName=Park&Ride - Kellyville (south)), NswParkRideFacility(stopId=2153478, parkRideFacilityId=31, parkRideName=Park&Ride - Bella Vista), NswParkRideFacility(stopId=2154392, parkRideFacilityId=32, parkRideName=Park&Ride - Hills Showground), NswParkRideFacility(stopId=2126158, parkRideFacilityId=33, parkRideName=Park&Ride - Cherrybrook), NswParkRideFacility(stopId=207010, parkRideFacilityId=34, parkRideName=Park&Ride - Lindfield Village Green), NswParkRideFacility(stopId=220910, parkRideFacilityId=35, parkRideName=Park&Ride - Beverly Hills), NswParkRideFacility(stopId=275020, parkRideFacilityId=36, parkRideName=Park&Ride - Emu Plains), NswParkRideFacility(stopId=221010, parkRideFacilityId=37, parkRideName=Park&Ride - Riverwood), NswParkRideFacility(stopId=213110, parkRideFacilityId=486, parkRideName=Park&Ride - Ashfield), NswParkRideFacility(stopId=221710, parkRideFacilityId=487, parkRideName=Park&Ride - Kogarah), NswParkRideFacility(stopId=214710, parkRideFacilityId=488, parkRideName=Park&Ride - Seven Hills), NswParkRideFacility(stopId=209325, parkRideFacilityId=489, parkRideName=Park&Ride - Manly Vale), NswParkRideFacility(stopId=209324, parkRideFacilityId=489, parkRideName=Park&Ride - Manly Vale), NswParkRideFacility(stopId=210017, parkRideFacilityId=490, parkRideName=Park&Ride - Brookvale)]
