### PR TITLE
Add androidx.ui.tooling dependency for Compose previews

### DIFF
--- a/feature/park-ride/ui/build.gradle.kts
+++ b/feature/park-ride/ui/build.gradle.kts
@@ -56,3 +56,8 @@ kotlin {
 android {
     namespace = "xyz.ksharma.krail.park.ride.ui"
 }
+
+dependencies {
+    // https://youtrack.jetbrains.com/issue/KTIJ-32720/Support-common-org.jetbrains.compose.ui.tooling.preview.Preview-in-IDEA-and-Android-Studio#focus=Comments-27-11400795.0-0Add commentMore actions
+    debugImplementation(libs.androidx.ui.tooling)
+}

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
     }
 
     sourceSets {
-        commonMain  {
+        commonMain {
             dependencies {
                 implementation(projects.core.appInfo)
                 implementation(projects.core.analytics)
@@ -38,6 +38,7 @@ kotlin {
                 implementation(projects.sandook)
                 implementation(projects.taj)
 
+
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)
                 implementation(compose.animation)
@@ -45,6 +46,7 @@ kotlin {
                 implementation(compose.material3)
                 implementation(compose.ui)
 
+                implementation(libs.androidx.ui.geometry.android)
                 api(libs.di.koinComposeViewmodel)
                 implementation(libs.kotlinx.collections.immutable)
                 implementation(libs.kotlinx.datetime)
@@ -70,7 +72,8 @@ kotlin {
 android {
     namespace = "xyz.ksharma.krail.trip.planner.ui"
 }
+
 dependencies {
-    implementation(libs.androidx.ui.geometry.android)
-    testImplementation(project(":sandook"))
+    // https://youtrack.jetbrains.com/issue/KTIJ-32720/Support-common-org.jetbrains.compose.ui.tooling.preview.Preview-in-IDEA-and-Android-Studio#focus=Comments-27-11400795.0-0Add commentMore actions
+    debugImplementation(libs.androidx.ui.tooling)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ koin = "4.0.4"
 firebaseGitLive = "2.1.0"
 uiGeometryAndroid = "1.8.1"
 foundationLayoutAndroid = "1.8.1"
+ui-tooling = "1.7.6"
 
 [libraries]
 buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildkonfigGradlePlugin" }
@@ -94,6 +95,9 @@ androidx-ui-geometry-android = { group = "androidx.compose.ui", name = "ui-geome
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "moleculeRuntime" }
+
+# Compose
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "ui-tooling" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/taj/build.gradle.kts
+++ b/taj/build.gradle.kts
@@ -45,3 +45,8 @@ kotlin {
         }
     }
 }
+
+dependencies {
+    // https://youtrack.jetbrains.com/issue/KTIJ-32720/Support-common-org.jetbrains.compose.ui.tooling.preview.Preview-in-IDEA-and-Android-Studio#focus=Comments-27-11400795.0-0Add commentMore actions
+    debugImplementation(libs.androidx.ui.tooling)
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
@@ -73,6 +74,7 @@ fun Text(
 
 // region Previews
 
+@Preview
 @Composable
 private fun TextPreview() {
     KrailTheme {
@@ -85,6 +87,7 @@ private fun TextPreview() {
     }
 }
 
+@Preview
 @Composable
 private fun TextWithColorPreview() {
     KrailTheme {


### PR DESCRIPTION
# Add Compose UI Tooling for Preview Support

This PR adds the necessary dependencies to support `@Preview` annotations in the `commonMain` sourceSet. It includes:

- Added `androidx.ui.tooling` dependency to the `debugImplementation` configuration in multiple modules
- Added a new entry in `libs.versions.toml` for the UI tooling library
- Applied `@Preview` annotations to existing preview composables in `Text.kt`
- Moved `androidx.ui.geometry.android` dependency from the root dependencies to the `commonMain` sourceSet in the trip-planner module

https://youtrack.jetbrains.com/issue/CMP-2045/Preview-annotation-in-commonMain-sourceSet


This change addresses the issue described in the YouTrack ticket regarding support for common Compose UI preview annotations.