### PR TITLE
Feature: Add closeHttpConnection method to TripPlanningService

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
@@ -30,4 +30,6 @@ class FakeTripPlanningService : TripPlanningService {
         return if (isSuccess) FakeStopFinderResponseBuilder.buildStopFinderResponse()
         else throw IllegalStateException("Failed to fetch stops")
     }
+
+    override fun closeHttpConnection() {}
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -57,6 +57,27 @@ class RealTripPlanningService(
         }.body()
     }
 
+    override suspend fun stopFinder(
+        stopSearchQuery: String,
+        stopType: StopType,
+    ): StopFinderResponse = withContext(ioDispatcher) {
+        httpClient.get("${NSW_TRANSPORT_BASE_URL}/v1/tp/stop_finder") {
+            url {
+                parameters.append(StopFinderRequestParams.nameSf, stopSearchQuery)
+
+                parameters.append(StopFinderRequestParams.typeSf, stopType.type)
+                parameters.append(StopFinderRequestParams.coordOutputFormat, "EPSG:4326")
+                parameters.append(StopFinderRequestParams.outputFormat, "rapidJSON")
+//                parameters.append(StopFinderRequestParams.version, "10.2.1.42")
+                parameters.append(StopFinderRequestParams.tfNSWSF, "true")
+            }
+        }.body()
+    }
+
+    override fun closeHttpConnection() {
+        httpClient.close()
+    }
+
     private fun addExcludedTransportModes(
         excludeProductClassSet: Set<Int>,
         parameters: ParametersBuilder,
@@ -83,27 +104,6 @@ class RealTripPlanningService(
         if (excludeProductClassSet.contains(9)) {
             parameters.append(TripRequestParams.exclMOT9, "9")
         }
-    }
-
-    override suspend fun stopFinder(
-        stopSearchQuery: String,
-        stopType: StopType,
-    ): StopFinderResponse = withContext(ioDispatcher) {
-        httpClient.get("${NSW_TRANSPORT_BASE_URL}/v1/tp/stop_finder") {
-            url {
-                parameters.append(StopFinderRequestParams.nameSf, stopSearchQuery)
-
-                parameters.append(StopFinderRequestParams.typeSf, stopType.type)
-                parameters.append(StopFinderRequestParams.coordOutputFormat, "EPSG:4326")
-                parameters.append(StopFinderRequestParams.outputFormat, "rapidJSON")
-//                parameters.append(StopFinderRequestParams.version, "10.2.1.42")
-                parameters.append(StopFinderRequestParams.tfNSWSF, "true")
-            }
-        }.body()
-    }
-
-    override fun closeHttpConnection() {
-        httpClient.close()
     }
 }
 

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -101,6 +101,10 @@ class RealTripPlanningService(
             }
         }.body()
     }
+
+    override fun closeHttpConnection() {
+        httpClient.close()
+    }
 }
 
 enum class DepArr(val macro: String) {

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
@@ -38,6 +38,8 @@ interface TripPlanningService {
         stopSearchQuery: String,
         stopType: StopType = StopType.STOP,
     ): StopFinderResponse
+
+    fun closeHttpConnection()
 }
 
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -505,6 +505,7 @@ class TimeTableViewModel(
     override fun onCleared() {
         super.onCleared()
         sandook.clearAlerts()
+        tripPlanningService.closeHttpConnection()
     }
 
     companion object {


### PR DESCRIPTION
### TL;DR

Added HTTP connection cleanup functionality to the TripPlanningService to prevent resource leaks.

### What changed?

- Added a `closeHttpConnection()` method to the `TripPlanningService` interface
- Implemented the method in `RealTripPlanningService` to close the HTTP client
- Called this method in the `TimeTableViewModel.onCleared()` to ensure proper cleanup when the ViewModel is destroyed
- Reordered methods in `RealTripPlanningService` for better code organization

### How to test?

1. Navigate through the trip planner UI
2. Close the trip planner screen
3. Verify no HTTP connection leaks occur (can be monitored using network debugging tools)
4. Check for any unexpected behavior when reopening the trip planner after closing it

### Why make this change?

This change prevents potential memory leaks and resource exhaustion by properly closing HTTP connections when they're no longer needed. Without explicit cleanup, the HTTP client connections might remain open, leading to resource leaks over time, especially if users frequently open and close the trip planner feature.