### PR TITLE
Remove closeHttpConnection method from TripPlanningService

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeTripPlanningService.kt
@@ -30,6 +30,4 @@ class FakeTripPlanningService : TripPlanningService {
         return if (isSuccess) FakeStopFinderResponseBuilder.buildStopFinderResponse()
         else throw IllegalStateException("Failed to fetch stops")
     }
-
-    override fun closeHttpConnection() {}
 }

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -57,27 +57,6 @@ class RealTripPlanningService(
         }.body()
     }
 
-    override suspend fun stopFinder(
-        stopSearchQuery: String,
-        stopType: StopType,
-    ): StopFinderResponse = withContext(ioDispatcher) {
-        httpClient.get("${NSW_TRANSPORT_BASE_URL}/v1/tp/stop_finder") {
-            url {
-                parameters.append(StopFinderRequestParams.nameSf, stopSearchQuery)
-
-                parameters.append(StopFinderRequestParams.typeSf, stopType.type)
-                parameters.append(StopFinderRequestParams.coordOutputFormat, "EPSG:4326")
-                parameters.append(StopFinderRequestParams.outputFormat, "rapidJSON")
-//                parameters.append(StopFinderRequestParams.version, "10.2.1.42")
-                parameters.append(StopFinderRequestParams.tfNSWSF, "true")
-            }
-        }.body()
-    }
-
-    override fun closeHttpConnection() {
-        httpClient.close()
-    }
-
     private fun addExcludedTransportModes(
         excludeProductClassSet: Set<Int>,
         parameters: ParametersBuilder,
@@ -104,6 +83,23 @@ class RealTripPlanningService(
         if (excludeProductClassSet.contains(9)) {
             parameters.append(TripRequestParams.exclMOT9, "9")
         }
+    }
+
+    override suspend fun stopFinder(
+        stopSearchQuery: String,
+        stopType: StopType,
+    ): StopFinderResponse = withContext(ioDispatcher) {
+        httpClient.get("${NSW_TRANSPORT_BASE_URL}/v1/tp/stop_finder") {
+            url {
+                parameters.append(StopFinderRequestParams.nameSf, stopSearchQuery)
+
+                parameters.append(StopFinderRequestParams.typeSf, stopType.type)
+                parameters.append(StopFinderRequestParams.coordOutputFormat, "EPSG:4326")
+                parameters.append(StopFinderRequestParams.outputFormat, "rapidJSON")
+//                parameters.append(StopFinderRequestParams.version, "10.2.1.42")
+                parameters.append(StopFinderRequestParams.tfNSWSF, "true")
+            }
+        }.body()
     }
 }
 

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/TripPlanningService.kt
@@ -38,8 +38,6 @@ interface TripPlanningService {
         stopSearchQuery: String,
         stopType: StopType = StopType.STOP,
     ): StopFinderResponse
-
-    fun closeHttpConnection()
 }
 
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -505,7 +505,6 @@ class TimeTableViewModel(
     override fun onCleared() {
         super.onCleared()
         sandook.clearAlerts()
-        tripPlanningService.closeHttpConnection()
     }
 
     companion object {


### PR DESCRIPTION
# Remove `closeHttpConnection` method from TripPlanningService

Removes the `closeHttpConnection` method from the `TripPlanningService` interface and its implementations. Also removes the call to this method in the `TimeTableViewModel.onCleared()` function.

Seeing issues if http connection is closed, therefore reverting it.