### PR TITLE
Add Park & Ride facility information to saved trips

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideService.kt
@@ -1,0 +1,102 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.model.Location
+import xyz.ksharma.krail.park.ride.network.model.Occupancy
+import xyz.ksharma.krail.park.ride.network.model.Zone
+import xyz.ksharma.krail.park.ride.network.service.ParkRideService
+
+class FakeParkRideService(
+    private val facilityResponses: Map<String, CarParkFacilityDetailResponse> = Companion.facilityResponses,
+) : ParkRideService {
+
+    override suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
+        return this@FakeParkRideService.facilityResponses[facilityId]
+            ?: error("No fake response for facilityId: $facilityId")
+    }
+
+    override suspend fun getCarParkFacilities(): Map<String, String> {
+        return this@FakeParkRideService.facilityResponses.mapValues { it.value.facilityName }
+    }
+
+    companion object {
+        val facilityResponses = mapOf(
+            "31" to CarParkFacilityDetailResponse(
+                tsn = "2153478",
+                time = "803037917",
+                spots = "774",
+                zones = listOf(
+                    Zone(
+                        spots = "774",
+                        zoneId = "1",
+                        occupancy = Occupancy(
+                            loop = "32707",
+                            total = "200",
+                            monthlies = null,
+                            openGate = null,
+                            transients = "100"
+                        ),
+                        zoneName = "SYD392 Bella Vista Car Park",
+                        parentZoneId = "0"
+                    )
+                ),
+                parkID = 1,
+                location = Location(
+                    suburb = "Bella Vista",
+                    address = "Byles Place",
+                    latitude = "-33.727438",
+                    longitude = "150.941761"
+                ),
+                occupancy = Occupancy(
+                    loop = "32707",
+                    total = "200",
+                    monthlies = null,
+                    openGate = null,
+                    transients = "100"
+                ),
+                messageDate = "2025-06-12T20:05:17",
+                facilityId = "31",
+                facilityName = "Park&Ride - Bella Vista",
+                tfnswFacilityId = "2153478TPR001"
+            ),
+            "42" to CarParkFacilityDetailResponse(
+                tsn = "9999999",
+                time = "803037999",
+                spots = "500",
+                zones = listOf(
+                    Zone(
+                        spots = "500",
+                        zoneId = "2",
+                        occupancy = Occupancy(
+                            loop = "12345",
+                            total = "50",
+                            monthlies = "10",
+                            openGate = null,
+                            transients = "40"
+                        ),
+                        zoneName = "SYD400 Norwest Car Park",
+                        parentZoneId = "0"
+                    )
+                ),
+                parkID = 2,
+                location = Location(
+                    suburb = "Norwest",
+                    address = "Norwest Blvd",
+                    latitude = "-33.733333",
+                    longitude = "150.950000"
+                ),
+                occupancy = Occupancy(
+                    loop = "12345",
+                    total = "50",
+                    monthlies = "10",
+                    openGate = null,
+                    transients = "40"
+                ),
+                messageDate = "2025-06-13T10:00:00",
+                facilityId = "42",
+                facilityName = "Park&Ride - Norwest",
+                tfnswFacilityId = "9999999TPR002"
+            )
+        )
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -104,7 +104,7 @@ class SavedTripsViewModelTest {
                 val item = awaitItem()
 
                 // THEN Verify that the state is updated after loading trips
-                assertFalse(item.isLoading)
+                assertFalse(item.isSavedTripsLoading)
                 assertTrue(item.savedTrips.isNotEmpty())
 
                 cancelAndIgnoreRemainingEvents()
@@ -140,7 +140,7 @@ class SavedTripsViewModelTest {
 
                 // THEN verify that the trip is deleted and the state is updated
                 val item = awaitItem()
-                assertFalse(item.isLoading)
+                assertFalse(item.isSavedTripsLoading)
                 assertTrue(item.savedTrips.isEmpty())
                 cancelAndIgnoreRemainingEvents()
             }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -11,11 +11,13 @@ import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
 import xyz.ksharma.core.test.fakes.FakeParkRideFacilityManager
+import xyz.ksharma.core.test.fakes.FakeParkRideService
 import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
+import xyz.ksharma.krail.park.ride.network.service.ParkRideService
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -36,12 +38,20 @@ class SavedTripsViewModelTest {
     private lateinit var viewModel: SavedTripsViewModel
     private val fakeParkRideManager: NswParkRideFacilityManager = FakeParkRideFacilityManager()
 
+    private val fakeParkRideService: ParkRideService = FakeParkRideService()
+
     private val testDispatcher = StandardTestDispatcher()
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
-        viewModel = SavedTripsViewModel(sandook, fakeAnalytics, testDispatcher, fakeParkRideManager)
+        viewModel = SavedTripsViewModel(
+            sandook = sandook,
+            analytics = fakeAnalytics,
+            ioDispatcher = testDispatcher,
+            nswParkRideFacilityManager = fakeParkRideManager,
+            parkRideService = fakeParkRideService,
+        )
     }
 
     @AfterTest

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
@@ -6,12 +6,22 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CarParkFacilityDetailResponse(
 
+    /**
+     * This respresents the  GTFS Stop ID.
+     */
     @SerialName("tsn")
     val tsn: String,
 
+    /**
+     * e.g. 803068391
+     */
     @SerialName("time")
     val time: String,
 
+    /**
+     * The total number of parking spots available in the facility.
+     * E.g. "spots": "100",
+     */
     @SerialName("spots")
     val spots: String,
 
@@ -30,12 +40,24 @@ data class CarParkFacilityDetailResponse(
     @SerialName("MessageDate")
     val messageDate: String,
 
+    /**
+     * This represents the unique identifier for the facility.
+     * Use this value as parameter for the API endpoint
+     * E.g.   "facility_id": "488",
+     */
     @SerialName("facility_id")
     val facilityId: String,
 
+    /**
+     * This represents the name of the facility.
+     * E.g.  "facility_name": "Park&Ride - Seven Hills",
+     */
     @SerialName("facility_name")
     val facilityName: String,
 
+    /**
+     * "tfnsw_facility_id": "214710TPR001"
+     */
     @SerialName("tfnsw_facility_id")
     val tfnswFacilityId: String
 )
@@ -59,21 +81,29 @@ data class Zone(
     val parentZoneId: String
 )
 
+/**
+ * Represents occupancy details for a parking facility or zone.
+ */
 @Serializable
 data class Occupancy(
-
+    /** Number of vehicles detected by loop sensors (real-time count).
+     * Mostly the data here is null, as sensors are not accurate.  */
     @SerialName("loop")
     val loop: String?,
 
+    /** Total number of parking spots available. */
     @SerialName("total")
     val total: String?,
 
+    /** Number of spots reserved for monthly permit holders. */
     @SerialName("monthlies")
     val monthlies: String?,
 
+    /** Number of spots accessible via open gate (unrestricted access). */
     @SerialName("open_gate")
     val openGate: String?,
 
+    /** Number of spots available for short-term or transient parkers. */
     @SerialName("transients")
     val transients: String?
 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/parkride/ParkRideState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/parkride/ParkRideState.kt
@@ -1,8 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.state.parkride
 
 import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
 
 @Stable
+@Serializable
 data class ParkRideState(
     val spotsAvailable: Int,
     val totalSpots: Int,

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/parkride/ParkRideState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/parkride/ParkRideState.kt
@@ -1,6 +1,13 @@
 package xyz.ksharma.krail.trip.planner.ui.state.parkride
 
+import androidx.compose.runtime.Stable
+
+@Stable
 data class ParkRideState(
-    val stopId: String = "",
-    val stopName: String = "",
+    val spotsAvailable: Int,
+    val totalSpots: Int,
+    val facilityName: String,
+    val percentageFull: Int,
+    val stopId: String,
+    // TODO - add location details.
 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -21,4 +21,8 @@ sealed interface SavedTripUiEvent {
     data object AnalyticsFromButtonClick : SavedTripUiEvent
 
     data object AnalyticsToButtonClick : SavedTripUiEvent
+
+    data class LoadParkRideFacilities(
+        val fromStopId: String, val toStopId: String
+    ) : SavedTripUiEvent
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -8,6 +8,4 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 data class SavedTripsState(
     val savedTrips: ImmutableList<Trip> = persistentListOf(),
     val isSavedTripsLoading: Boolean = true,
-    val parkRideList: ImmutableList<ParkRideState> = persistentListOf(),
-    val isParkRideLoading: Boolean = false,
 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -2,9 +2,12 @@ package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
 
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.trip.planner.ui.state.parkride.ParkRideState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 data class SavedTripsState(
     val savedTrips: ImmutableList<Trip> = persistentListOf(),
-    val isLoading: Boolean = true,
+    val isSavedTripsLoading: Boolean = true,
+    val parkRideList: ImmutableList<ParkRideState> = persistentListOf(),
+    val isParkRideLoading: Boolean = false,
 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
@@ -11,6 +11,7 @@ data class Trip(
     val fromStopName: String,
     val toStopId: String,
     val toStopName: String,
+    val hasParkRide: Boolean = false,
 ) {
     val tripId: String
         get() = "$fromStopId$toStopId"

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
@@ -1,8 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.state.timetable
 
 import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import xyz.ksharma.krail.trip.planner.ui.state.parkride.ParkRideState
 
 @Serializable
 @Stable
@@ -11,7 +13,7 @@ data class Trip(
     val fromStopName: String,
     val toStopId: String,
     val toStopName: String,
-    val hasParkRide: Boolean = false,
+    val parkRideUiState: ParkRideUiState = ParkRideUiState.NotAvailable,
 ) {
     val tripId: String
         get() = "$fromStopId$toStopId"
@@ -22,4 +24,44 @@ data class Trip(
         fun fromJsonString(json: String) =
             kotlin.runCatching { Json.decodeFromString(serializer(), json) }.getOrNull()
     }
+}
+
+@Serializable
+sealed class ParkRideUiState {
+
+    /**
+     * Park&Ride is not available for the current trip.
+     */
+    @Serializable
+    data object NotAvailable : ParkRideUiState()
+
+    /**
+     * Park&Ride is available, but not loaded from api yet.
+     */
+    @Serializable
+    data object Available : ParkRideUiState() // Park&Ride available, but not loaded
+
+    /**
+     * Park&Ride data is being loaded from the api.
+     */
+    @Serializable
+    data object Loading : ParkRideUiState() // Loading Park&Ride data
+
+    /**
+     * Park&Ride data is loaded successfully.
+     *
+     * @param parkRideList List of Park&Ride facilities available for the trip.
+     */
+    @Serializable
+    data class Loaded(
+        val parkRideList: ImmutableList<ParkRideState>
+    ) : ParkRideUiState()
+
+    /**
+     * Park&Ride data failed to load.
+     *
+     * @param message Error message describing the failure.
+     */
+    @Serializable
+    data class Error(val message: String) : ParkRideUiState()
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -318,7 +318,7 @@ private fun SavedTripCardPreview_Single_ParkRideAvailable() {
                     primaryTransportMode = TransportMode.Metro(),
                     onCardClick = {},
                     onStarClick = {},
-                    parkRideState = ParkRideState(),
+                    parkRideState = parkRideStatePreview,
                     modifier = Modifier,
                     // Modifier for SavedTripCard itself
                 )
@@ -326,5 +326,13 @@ private fun SavedTripCardPreview_Single_ParkRideAvailable() {
         }
     }
 }
+
+private val parkRideStatePreview = ParkRideState(
+    facilityName = "Park & Ride Facility",
+    spotsAvailable = 50,
+    totalSpots = 100,
+    percentageFull = 50,
+    stopId = "12345",
+)
 
 // endregion

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -38,6 +38,7 @@ val viewModelsModule = module {
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
             nswParkRideFacilityManager = get(),
+            parkRideService = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -125,7 +125,14 @@ fun SavedTripsScreen(
                                 )
                             },
                             primaryTransportMode = null, // TODO
-                            parkRideState = savedTripsState.parkRideList.firstOrNull { it.stopId == trip.fromStopId || it.stopId == trip.toStopId },
+                            onLoadParkRideClick = {
+                                onEvent(
+                                    SavedTripUiEvent.LoadParkRideFacilities(
+                                        fromStopId = trip.fromStopId,
+                                        toStopId = trip.toStopId,
+                                    )
+                                )
+                            },
                             modifier = Modifier
                                 .padding(horizontal = 16.dp),
                         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -92,7 +92,7 @@ fun SavedTripsScreen(
                     Spacer(modifier = Modifier.height(12.dp))
                 }
 
-                if (savedTripsState.savedTrips.isEmpty() && savedTripsState.isLoading.not()) {
+                if (savedTripsState.savedTrips.isEmpty() && savedTripsState.isSavedTripsLoading.not()) {
                     item(key = "empty_state") {
                         ErrorMessage(
                             emoji = "🌟",
@@ -125,6 +125,7 @@ fun SavedTripsScreen(
                                 )
                             },
                             primaryTransportMode = null, // TODO
+                            parkRideState = savedTripsState.parkRideList.firstOrNull { it.stopId == trip.fromStopId || it.stopId == trip.toStopId },
                             modifier = Modifier
                                 .padding(horizontal = 16.dp),
                         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -18,9 +18,13 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.service.ParkRideService
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
+import xyz.ksharma.krail.trip.planner.ui.state.parkride.ParkRideState
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
@@ -30,15 +34,13 @@ class SavedTripsViewModel(
     private val analytics: Analytics,
     private val ioDispatcher: CoroutineDispatcher,
     private val nswParkRideFacilityManager: NswParkRideFacilityManager,
+    private val parkRideService: ParkRideService
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
-            // TODO - remove this when park and ride is not needed
-            val x = nswParkRideFacilityManager.getParkRideFacilities()
-            log("Park Ride Facilities: ${x.size}")
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
 
     fun onEvent(event: SavedTripUiEvent) {
@@ -76,19 +78,21 @@ class SavedTripsViewModel(
             SavedTripUiEvent.AnalyticsToButtonClick -> {
                 analytics.track(AnalyticsEvent.ToFieldClickEvent)
             }
+
+            is SavedTripUiEvent.LoadParkRideFacilities -> {
+                onLoadParkRideFacilities(event.fromStopId, event.toStopId)
+            }
         }
     }
 
     private fun loadSavedTrips() {
         viewModelScope.launch(ioDispatcher) {
-            updateUiState { copy(isLoading = true) }
+            updateUiState { copy(isSavedTripsLoading = true) }
             val trips = mutableSetOf<Trip>()
 
             val savedTrips = sandook.selectAllTrips()
 //            log("SavedTrips: $savedTrips")
             savedTrips.forEachIndexed { index, savedTrip ->
-                val trip = savedTrip.toTrip()
-                log("Trip: #$index $trip")
                 trips.add(savedTrip.toTrip())
             }
 
@@ -99,7 +103,12 @@ class SavedTripsViewModel(
                 log("\t SavedTrip: #$index ${trip.fromStopName} -> ${trip.toStopName}")
             }
 
-            updateUiState { copy(savedTrips = trips.toImmutableList(), isLoading = false) }
+            updateUiState {
+                copy(
+                    savedTrips = trips.toImmutableList(),
+                    isSavedTripsLoading = false
+                )
+            }
         }
     }
 
@@ -113,6 +122,69 @@ class SavedTripsViewModel(
                 toStopId = savedTrip.toStopId,
             )
         }
+    }
+
+    private fun onLoadParkRideFacilities(fromStopId: String, toStopId: String) {
+        // todo analytics
+        updateUiState { copy(isParkRideLoading = true) }
+
+        // if from stop id and toStopId are part of the park ride facility list
+        // then call api for details for both stops else only the one that is part of the list.
+
+        // If none is part of list then throw error as this method cannot be called for such stops in first place from the UI.
+        // because the ui for expanding park ride facility is only shown when the stops are part of the park ride facility list.
+
+        viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+
+            val parkRideFacilityList = nswParkRideFacilityManager.getParkRideFacilities()
+            log("Park Ride Facilities: ${parkRideFacilityList.size}")
+
+            val facilityIdList = parkRideFacilityList
+                .filter { it.stopId == fromStopId || it.stopId == toStopId }
+                .map { it.parkRideFacilityId }
+                .toSet()
+
+            val parkRideStates = facilityIdList.map { facilityId ->
+                parkRideService
+                    .getCarParkFacilities(facilityId = facilityId)
+                    .toParkRideState()
+            }.toImmutableList()
+
+            updateUiState {
+                copy(
+                    parkRideList = parkRideStates,
+                    isParkRideLoading = false,
+                )
+            }
+        }
+    }
+
+    private fun CarParkFacilityDetailResponse.toParkRideState(): ParkRideState {
+        val totalSpots = spots.toIntOrNull() ?: 0
+
+        // Sum occupied spots from all zones (using loop sensor)
+        val occupiedSpots = zones.sumOf { it.occupancy.transients?.toIntOrNull() ?: 0 }
+
+        val spotsAvailable = totalSpots - occupiedSpots
+        val percentFull = if (totalSpots > 0) {
+            (occupiedSpots * 100) / totalSpots
+        } else {
+            0
+        }
+
+        log(
+            "[$facilityName - $facilityId] \nTotal spots: $totalSpots, " +
+                    "Occupied spots: $occupiedSpots, Spots available: $spotsAvailable, " +
+                    "Percentage full: $percentFull%"
+        )
+
+        return ParkRideState(
+            spotsAvailable = spotsAvailable,
+            totalSpots = totalSpots,
+            facilityName = facilityName,
+            percentageFull = percentFull,
+            stopId = tsn,
+        )
     }
 
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {


### PR DESCRIPTION
# Add Park & Ride Facility Support to Saved Trips

This PR adds Park & Ride facility information to saved trips:

- Added `ParkRideUiState` sealed class to represent different states of Park & Ride data (NotAvailable, Available, Loading, Loaded, Error)
- Added `LoadParkRideFacilities` event to load Park & Ride data for a specific trip
- Enhanced `SavedTripCard` to display Park & Ride information when available
- Implemented Park & Ride data loading and processing in `SavedTripsViewModel`
- Added documentation to `CarParkFacilitiesResponse` model classes
- Expanded `ParkRideState` with necessary fields for UI display
- Renamed `isLoading` to `isSavedTripsLoading` for clarity in state management

The implementation checks if a saved trip has Park & Ride facilities available at either the origin or destination stop, and allows users to load and view real-time parking availability information.