### PR TITLE
Add Unit tests for Park & Ride in SavedTripsViewModel

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/data/ParkRideTestData.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/data/ParkRideTestData.kt
@@ -1,0 +1,61 @@
+package xyz.ksharma.core.test.data
+
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.model.Location
+import xyz.ksharma.krail.park.ride.network.model.Occupancy
+import xyz.ksharma.krail.park.ride.network.model.Zone
+
+fun buildOccupancy(
+    loop: String? = "32707",
+    total: String? = "200",
+    monthlies: String? = null,
+    openGate: String? = null,
+    transients: String? = "100"
+) = Occupancy(loop, total, monthlies, openGate, transients)
+
+fun buildZone(
+    spots: String = "774",
+    zoneId: String = "1",
+    occupancy: Occupancy = buildOccupancy(),
+    zoneName: String = "SYD392 Bella Vista Car Park",
+    parentZoneId: String = "0"
+) = Zone(spots, zoneId, occupancy, zoneName, parentZoneId)
+
+fun buildLocation(
+    suburb: String = "Bella Vista",
+    address: String = "Byles Place",
+    latitude: String = "-33.727438",
+    longitude: String = "150.941761"
+) = Location(suburb, address, latitude, longitude)
+
+fun buildCarParkFacilityDetailResponse(
+    tsn: String = "2153478",
+    time: String = "803037917",
+    spots: String = "774",
+    zones: List<Zone> = listOf(buildZone()),
+    parkID: Int = 1,
+    location: Location = buildLocation(),
+    occupancy: Occupancy = buildOccupancy(),
+    messageDate: String = "2025-06-12T20:05:17",
+    facilityId: String = "31",
+    facilityName: String = "Park&Ride - Bella Vista",
+    tfnswFacilityId: String = "2153478TPR001"
+) = CarParkFacilityDetailResponse(
+    tsn,
+    time,
+    spots,
+    zones,
+    parkID,
+    location,
+    occupancy,
+    messageDate,
+    facilityId,
+    facilityName,
+    tfnswFacilityId
+)
+
+val facilityResponse = buildCarParkFacilityDetailResponse(
+    facilityName = "Test Facility",
+    spots = "1000",
+    occupancy = buildOccupancy(transients = "200")
+)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideFacilityManager.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideFacilityManager.kt
@@ -15,6 +15,11 @@ class FakeParkRideFacilityManager : NswParkRideFacilityManager {
             stopId = "207211",
             parkRideFacilityId = "7",
             parkRideName = "Sample Park & Ride 2"
+        ),
+        NswParkRideFacility(
+            stopId = "2153478",
+            parkRideFacilityId = "31",
+            parkRideName = "Park and Ride - Bella Vista"
         )
     )
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideService.kt
@@ -20,6 +20,45 @@ class FakeParkRideService(
     }
 
     companion object {
+        val facilityResponse = CarParkFacilityDetailResponse(
+            tsn = "2153478",
+            time = "803037917",
+            spots = "774",
+            zones = listOf(
+                Zone(
+                    spots = "774",
+                    zoneId = "1",
+                    occupancy = Occupancy(
+                        loop = "32707",
+                        total = "200",
+                        monthlies = null,
+                        openGate = null,
+                        transients = "100"
+                    ),
+                    zoneName = "SYD392 Bella Vista Car Park",
+                    parentZoneId = "0"
+                )
+            ),
+            parkID = 1,
+            location = Location(
+                suburb = "Bella Vista",
+                address = "Byles Place",
+                latitude = "-33.727438",
+                longitude = "150.941761"
+            ),
+            occupancy = Occupancy(
+                loop = "32707",
+                total = "200",
+                monthlies = null,
+                openGate = null,
+                transients = "100"
+            ),
+            messageDate = "2025-06-12T20:05:17",
+            facilityId = "31",
+            facilityName = "Park&Ride - Bella Vista",
+            tfnswFacilityId = "2153478TPR001"
+        )
+
         val facilityResponses = mapOf(
             "31" to CarParkFacilityDetailResponse(
                 tsn = "2153478",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt
@@ -1,0 +1,48 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.Companion.PACKAGE_PRIVATE
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.trip.planner.ui.state.parkride.ParkRideState
+
+/**
+ * Converts a [CarParkFacilityDetailResponse] to a [ParkRideState] for UI display.
+ *
+ * This method calculates the number of available spots, total spots, and percentage full
+ * for a Park&Ride facility using the occupancy data from all zones.
+ *
+ * Occupied spots are determined by summing the `transients` field from each zone's occupancy.
+ * If `transients` is `null` or missing, it is treated as 0.
+ *
+ * @return [ParkRideState] containing available spots, total spots, facility name, percentage
+ * full, and stop ID
+ **/
+@VisibleForTesting(otherwise = PACKAGE_PRIVATE)
+fun CarParkFacilityDetailResponse.toParkRideState(): ParkRideState {
+    val totalSpots = spots.toIntOrNull() ?: 0
+
+    // Sum occupied spots from all zones (using loop sensor)
+    val occupiedSpots = zones.sumOf { it.occupancy.transients?.toIntOrNull() ?: 0 }
+
+    val spotsAvailable = totalSpots - occupiedSpots
+    val percentFull = if (totalSpots > 0) {
+        (occupiedSpots * 100) / totalSpots
+    } else {
+        0
+    }
+
+    log(
+        "[$facilityName - $facilityId] \nTotal spots: $totalSpots, " +
+                "Occupied spots: $occupiedSpots, Spots available: $spotsAvailable, " +
+                "Percentage full: $percentFull%"
+    )
+
+    return ParkRideState(
+        spotsAvailable = spotsAvailable,
+        totalSpots = totalSpots,
+        facilityName = facilityName,
+        percentageFull = percentFull,
+        stopId = tsn,
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.ImmutableList
@@ -185,46 +186,6 @@ class SavedTripsViewModel(
                 }
             }
         }
-    }
-
-    /**
-     * Converts a [CarParkFacilityDetailResponse] to a [ParkRideState] for UI display.
-     *
-     * This method calculates the number of available spots, total spots, and percentage full
-     * for a Park&Ride facility using the occupancy data from all zones.
-     *
-     * Occupied spots are determined by summing the `transients` field from each zone's occupancy.
-     * If `transients` is `null` or missing, it is treated as 0.
-     *
-     * @return [ParkRideState] containing available spots, total spots, facility name, percentage
-     * full, and stop ID
-     **/
-    private fun CarParkFacilityDetailResponse.toParkRideState(): ParkRideState {
-        val totalSpots = spots.toIntOrNull() ?: 0
-
-        // Sum occupied spots from all zones (using loop sensor)
-        val occupiedSpots = zones.sumOf { it.occupancy.transients?.toIntOrNull() ?: 0 }
-
-        val spotsAvailable = totalSpots - occupiedSpots
-        val percentFull = if (totalSpots > 0) {
-            (occupiedSpots * 100) / totalSpots
-        } else {
-            0
-        }
-
-        log(
-            "[$facilityName - $facilityId] \nTotal spots: $totalSpots, " +
-                    "Occupied spots: $occupiedSpots, Spots available: $spotsAvailable, " +
-                    "Percentage full: $percentFull%"
-        )
-
-        return ParkRideState(
-            spotsAvailable = spotsAvailable,
-            totalSpots = totalSpots,
-            facilityName = facilityName,
-            percentageFull = percentFull,
-            stopId = tsn,
-        )
     }
 
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {


### PR DESCRIPTION
### TL;DR

Added Park & Ride facility support to the SavedTripsViewModel with test coverage.

### What changed?

- Created a new `ParkRideMapper.kt` file with a `toParkRideState()` extension function to convert `CarParkFacilityDetailResponse` to `ParkRideState`
- Added test data for Park & Ride facilities in `ParkRideTestData.kt`
- Enhanced `FakeParkRideFacilityManager` and `FakeParkRideService` with additional test data
- Added comprehensive tests for Park & Ride functionality in `SavedTripViewModelsTest.kt`
- Extracted the `toParkRideState()` function from the ViewModel to a separate file for better testability

### How to test?

1. Run the unit tests in `SavedTripViewModelsTest.kt` to verify Park & Ride functionality
2. Test the following scenarios:
   - Loading Park & Ride facilities for a saved trip with a valid Park & Ride stop
   - Error handling when the Park & Ride service fails
   - Verify loading state is shown while fetching Park & Ride data
   - Verify correct calculation of available spots and percentage full

### Why make this change?

This change improves the app's functionality by adding Park & Ride facility information to saved trips. Users can now see real-time parking availability at stations with Park & Ride facilities, helping them plan their journeys more effectively. The code is structured to be testable and maintainable, with proper separation of concerns.