### PR TITLE
Refactor Park & Ride API with source tracking and database persistence

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeNswParkRideSandook.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeNswParkRideSandook.kt
@@ -12,7 +12,7 @@ class FakeNswParkRideSandook : NswParkRideSandook {
     private val data = MutableStateFlow<List<NSWParkRide>>(emptyList())
 
     private val savedParkRides = MutableStateFlow<List<SavedParkRide>>(emptyList())
-    override fun getAllSavedParkRides(): Flow<List<SavedParkRide>> = savedParkRides.asStateFlow()
+    override fun observeSavedParkRides(): Flow<List<SavedParkRide>> = savedParkRides.asStateFlow()
 
     override fun getAll(): Flow<List<NSWParkRide>> = data
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideService.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeParkRideService.kt
@@ -10,12 +10,12 @@ class FakeParkRideService(
     private val facilityResponses: Map<String, CarParkFacilityDetailResponse> = Companion.facilityResponses,
 ) : ParkRideService {
 
-    override suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
+    override suspend fun fetchCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
         return this@FakeParkRideService.facilityResponses[facilityId]
             ?: error("No fake response for facilityId: $facilityId")
     }
 
-    override suspend fun getCarParkFacilities(): Map<String, String> {
+    override suspend fun fetchCarParkFacilities(): Map<String, String> {
         return this@FakeParkRideService.facilityResponses.mapValues { it.value.facilityName }
     }
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -317,11 +317,11 @@ class SavedTripsViewModelTest {
             )
 
             val errorService = object : ParkRideService {
-                override suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
+                override suspend fun fetchCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
                     throw RuntimeException("Network error")
                 }
 
-                override suspend fun getCarParkFacilities(): Map<String, String> {
+                override suspend fun fetchCarParkFacilities(): Map<String, String> {
                     throw RuntimeException("Network error")
                 }
             }
@@ -366,12 +366,12 @@ class SavedTripsViewModelTest {
             )
 
             val slowService = object : ParkRideService {
-                override suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
+                override suspend fun fetchCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse {
                     kotlinx.coroutines.delay(100)
                     return facilityResponses.values.first()
                 }
 
-                override suspend fun getCarParkFacilities(): Map<String, String> {
+                override suspend fun fetchCarParkFacilities(): Map<String, String> {
                     return mapOf()
                 }
             }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/model/CarParkFacilitiesResponse.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 data class CarParkFacilityDetailResponse(
 
     /**
-     * This respresents the  GTFS Stop ID.
+     * This represents the  GTFS Stop ID.
      */
     @SerialName("tsn")
     val tsn: String,
@@ -112,14 +112,14 @@ data class Occupancy(
 data class Location(
 
     @SerialName("suburb")
-    val suburb: String,
+    val suburb: String? = null,
 
     @SerialName("address")
-    val address: String,
+    val address: String? = null,
 
     @SerialName("latitude")
-    val latitude: String,
+    val latitude: String? = null,
 
     @SerialName("longitude")
-    val longitude: String
+    val longitude: String? = null,
 )

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/ParkRideService.kt
@@ -11,11 +11,11 @@ interface ParkRideService {
     /**
      * Returns the details of a car park facility by its ID.
      */
-    suspend fun getCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse
+    suspend fun fetchCarParkFacilities(facilityId: String): CarParkFacilityDetailResponse
 
     /**
      * Returns a map of facility ID to facility name for all car parks.
      * Since facility ID is not specified, a list of facility names with their ID will be returned.
      */
-    suspend fun getCarParkFacilities(): Map<String, String>
+    suspend fun fetchCarParkFacilities(): Map<String, String>
 }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/RealParkRideService.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/service/RealParkRideService.kt
@@ -13,7 +13,7 @@ internal class RealParkRideService(
     private val ioDispatcher: CoroutineDispatcher
 ) : ParkRideService {
 
-    override suspend fun getCarParkFacilities(
+    override suspend fun fetchCarParkFacilities(
         facilityId: String
     ): CarParkFacilityDetailResponse = withContext(ioDispatcher) {
         httpClient.get("$NSW_TRANSPORT_BASE_URL/v1/carpark") {
@@ -23,7 +23,7 @@ internal class RealParkRideService(
         }.body()
     }
 
-    override suspend fun getCarParkFacilities(): Map<String, String> =
+    override suspend fun fetchCarParkFacilities(): Map<String, String> =
         withContext(ioDispatcher) {
             httpClient.get("$NSW_TRANSPORT_BASE_URL/v1/carpark") {}.body()
         }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -4,11 +4,10 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
-import xyz.ksharma.krail.trip.planner.ui.state.parkride.ParkRideState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 data class SavedTripsState(
     val savedTrips: ImmutableList<Trip> = persistentListOf(),
     val isSavedTripsLoading: Boolean = true,
-    val observeParkRideStopIdList: ImmutableSet<String> = persistentSetOf(),
+    val observeParkRideStopIdSet: ImmutableSet<String> = persistentSetOf(),
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -22,8 +23,11 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
 import xyz.ksharma.krail.park.ride.network.service.ParkRideService
+import xyz.ksharma.krail.sandook.NSWParkRide
 import xyz.ksharma.krail.sandook.NswParkRideSandook
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SavedTrip
@@ -31,6 +35,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.parkride.ParkRideState
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import kotlin.time.Duration.Companion.minutes
 
 class SavedTripsViewModel(
     private val sandook: Sandook,
@@ -41,8 +46,26 @@ class SavedTripsViewModel(
     private val parkRideSandook: NswParkRideSandook,
 ) : ViewModel() {
 
+    /**
+     * Will observe expanded park ride cards.
+     * This is used to fetch park ride facilities for the expanded cards only.
+     */
     private var expandedParkRideCardObserveJob: Job? = null
+
+    /**
+     * Will observe saved trips from the database.
+     */
     private var observeSavedTripsJob: Job? = null
+
+    /**
+     * Will observe park ride facilities from the database.
+     */
+    private var observeParkRideFacilityFromDatabaseJob: Job? = null
+
+    /**
+     * Will fetch data from API every 60 seconds and update in DB.
+     */
+    private var pollParkRideFacilitiesJob: Job? = null
 
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
@@ -50,6 +73,8 @@ class SavedTripsViewModel(
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
             // TODO - call api once and save data in db.
             observeSavedTrips()
+            observeParkRideFacilityDatabase()
+            pollParkRideFacilities()
         }
         .onCompletion {
             expandedParkRideCardObserveJob?.cancel()
@@ -99,7 +124,7 @@ class SavedTripsViewModel(
                 log("Expand Park Ride : ${event.stopId}")
                 updateUiState {
                     copy(
-                        observeParkRideStopIdList = (observeParkRideStopIdList + event.stopId).toImmutableSet(),
+                        observeParkRideStopIdSet = (observeParkRideStopIdSet + event.stopId).toImmutableSet(),
                     )
                 }
             }
@@ -108,7 +133,7 @@ class SavedTripsViewModel(
                 log("Collapse Park Ride : ${event.stopId}")
                 updateUiState {
                     copy(
-                        observeParkRideStopIdList = (observeParkRideStopIdList - event.stopId).toImmutableSet(),
+                        observeParkRideStopIdSet = (observeParkRideStopIdSet - event.stopId).toImmutableSet(),
                     )
                 }
             }
@@ -141,41 +166,47 @@ class SavedTripsViewModel(
         }
     }
 
+    private fun observeParkRideFacilityDatabase() {
+        observeParkRideFacilityFromDatabaseJob?.cancel()
+        observeParkRideFacilityFromDatabaseJob =
+            viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+                parkRideSandook
+                    .observeSavedParkRides()
+                    .distinctUntilChanged()
+                    .collectLatest {
+                        // TODO - Update UI.
+                }
+            }
+    }
+
+    private fun pollParkRideFacilities() {
+        pollParkRideFacilitiesJob?.cancel()
+        pollParkRideFacilitiesJob = viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+            while (true) {
+                fetchParkRideFacilities()
+                delay(2.minutes)
+            }
+        }
+    }
+
     private suspend fun fetchParkRideFacilities() {
-
-
         val facilityIdList = getFacilityIdListToObserve()
 
         val parkRideList: ImmutableList<ParkRideState> =
             facilityIdList.map { facilityId ->
                 log("Fetching Park Ride facility for ID: $facilityId")
-                parkRideService
-                    .getCarParkFacilities(facilityId = facilityId)
+                parkRideService.fetchCarParkFacilities(facilityId = facilityId)
             }
                 .toParkRideStates()
                 .toImmutableList()
 
-        /*
-                updateUiState {
-                    copy(
-                        savedTrips = savedTrips.map { trip ->
-                            if (trip.fromStopId in stopIdList || trip.toStopId in stopIdList) {
-                                // Only show facilities relevant to this trip
-                                val relevantFacilities = parkRideList.filter { facility ->
-                                    facility.stopId == trip.fromStopId || facility.stopId == trip.toStopId
-                                }.toImmutableList()
-                                trip.copy(parkRideUiState = ParkRideUiState.Loaded(relevantFacilities))
-                            } else trip
-                        }.toImmutableList()
-                    )
-                }
-        */
+        // Save to database
+        parkRideSandook.insertOrReplaceAll(parkRideList.map { it.toParkRide() })
     }
 
-    fun getFacilityIdListToObserve(): Set<String> {
-        val stopIdList = uiState.value.savedTrips.map { it.fromStopId }.toSet()
-
-        val parkRideFacilityList = nswParkRideFacilityManager.getParkRideFacilities()
+    private fun getFacilityIdListToObserve(): Set<String> {
+        val stopIdList = uiState.value.observeParkRideStopIdSet
+        val parkRideFacilityList: List<NswParkRideFacility> = nswParkRideFacilityManager.getParkRideFacilities()
 
         val facilityIdList = parkRideFacilityList
             .filter { it.stopId in stopIdList }
@@ -184,31 +215,6 @@ class SavedTripsViewModel(
 
         return facilityIdList
     }
-
-    /*    private fun observeExpandedParkRideCards() {
-            var parkRidePollingJob: Job? = null
-            expandedParkRideCardObserveJob?.cancel()
-            expandedParkRideCardObserveJob =
-                viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
-                    expandedParkRideCards.collectLatest { expandedIds ->
-                        parkRidePollingJob?.cancel()
-
-                        log("Expanded Park Ride Cards: $expandedIds")
-                        if (expandedIds.isNotEmpty()) {
-                            log("Observing Park Ride Facilities for expanded cards: $expandedParkRideCards")
-                            parkRidePollingJob = launch {
-                                while (true) {
-                                    fetchParkRideFacilities(expandedIds)
-                                    delay(60.seconds)
-                                }
-                            }
-                        } else {
-                            log("No expanded Park Ride cards to observe. Cancelling parkRidePollingJob.")
-                            parkRidePollingJob?.cancel()
-                        }
-                    }
-                }
-        }*/
 
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {
         _uiState.update(block)
@@ -220,8 +226,11 @@ class SavedTripsViewModel(
         expandedParkRideCardObserveJob = null
         observeSavedTripsJob?.cancel()
         observeSavedTripsJob = null
+        observeParkRideFacilityFromDatabaseJob?.cancel()
+        observeParkRideFacilityFromDatabaseJob = null
     }
 }
+
 
 private fun SavedTrip.toTrip(): Trip = Trip(
     fromStopId = fromStopId,

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswParkRideSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswParkRideSandook.kt
@@ -15,11 +15,40 @@ interface NswParkRideSandook {
     suspend fun deleteAll()
 
     // SavedParkRide Table methods
+
     fun observeSavedParkRides(): Flow<List<SavedParkRide>>
-    fun getFacilitiesByStopId(stopId: String): Flow<List<String>>
-    suspend fun insertOrReplaceSavedParkRide(stopId: String, facilityId: String)
+
     suspend fun deleteSavedParkRide(stopId: String, facilityId: String)
-    suspend fun clearSavedParkRides()
+
+    fun getFacilitiesByStopIdAndSource(
+        stopId: String,
+        source: SavedParkRideSource
+    ): Flow<List<String>>
+
+    /**
+     * Inserts or replaces saved park rides with the given pairs of stopId and facilityId.
+     * If a pair already exists, it will be replaced with the new value.
+     */
+    suspend fun insertOrReplaceSavedParkRides(
+        pairs: Set<Pair<String, String>>,
+        source: SavedParkRideSource = SavedParkRideSource.SavedTrips
+    )
+
+    /**
+     * Clears all saved park rides where source is matching.
+     */
+    suspend fun clearAllSavedParkRidesBySource(source: SavedParkRideSource)
+
+    companion object {
+        /**
+         * Represents the source of the saved park ride.
+         * This is used to differentiate between saved trips and user-added Park and Ride facility.
+         */
+        sealed class SavedParkRideSource(val value: String) {
+            data object SavedTrips : SavedParkRideSource("saved_trip")
+            data object UserAdded : SavedParkRideSource("user")
+        }
+    }
 }
 
 internal class RealNswParkRideSandook(
@@ -82,22 +111,34 @@ internal class RealNswParkRideSandook(
     // endregion
 
     // region SavedParkRide Table methods
+
     override fun observeSavedParkRides(): Flow<List<SavedParkRide>> =
         parkRideQueries.selectAllSavedParkRides().asFlow().mapToList(ioDispatcher)
 
-    override fun getFacilitiesByStopId(stopId: String): Flow<List<String>> =
-        parkRideQueries.selectFacilitiesByStopId(stopId).asFlow().mapToList(ioDispatcher)
+    override fun getFacilitiesByStopIdAndSource(
+        stopId: String,
+        source: NswParkRideSandook.Companion.SavedParkRideSource,
+    ): Flow<List<String>> =
+        parkRideQueries.selectFacilitiesByStopIdAndSource(stopId, source.value).asFlow()
+            .mapToList(ioDispatcher)
 
-    override suspend fun insertOrReplaceSavedParkRide(stopId: String, facilityId: String) {
-        parkRideQueries.insertOrReplaceSavedParkRide(stopId, facilityId)
+    override suspend fun insertOrReplaceSavedParkRides(
+        pairs: Set<Pair<String, String>>,
+        source: NswParkRideSandook.Companion.SavedParkRideSource
+    ) {
+        parkRideQueries.transaction {
+            pairs.forEach { (stopId, facilityId) ->
+                parkRideQueries.insertOrReplaceSavedParkRide(stopId, facilityId, source.value)
+            }
+        }
     }
 
     override suspend fun deleteSavedParkRide(stopId: String, facilityId: String) {
         parkRideQueries.deleteSavedParkRide(stopId, facilityId)
     }
 
-    override suspend fun clearSavedParkRides() {
-        parkRideQueries.clearSavedParkRides()
+    override suspend fun clearAllSavedParkRidesBySource(source: NswParkRideSandook.Companion.SavedParkRideSource) {
+        parkRideQueries.clearSavedParkRidesBySource(source.value)
     }
 
     // endregion

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswParkRideSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswParkRideSandook.kt
@@ -15,7 +15,7 @@ interface NswParkRideSandook {
     suspend fun deleteAll()
 
     // SavedParkRide Table methods
-    fun getAllSavedParkRides(): Flow<List<SavedParkRide>>
+    fun observeSavedParkRides(): Flow<List<SavedParkRide>>
     fun getFacilitiesByStopId(stopId: String): Flow<List<String>>
     suspend fun insertOrReplaceSavedParkRide(stopId: String, facilityId: String)
     suspend fun deleteSavedParkRide(stopId: String, facilityId: String)
@@ -82,7 +82,7 @@ internal class RealNswParkRideSandook(
     // endregion
 
     // region SavedParkRide Table methods
-    override fun getAllSavedParkRides(): Flow<List<SavedParkRide>> =
+    override fun observeSavedParkRides(): Flow<List<SavedParkRide>> =
         parkRideQueries.selectAllSavedParkRides().asFlow().mapToList(ioDispatcher)
 
     override fun getFacilitiesByStopId(stopId: String): Flow<List<String>> =

--- a/sandook/src/commonMain/sqldelight/migrations/4.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/4.sqm
@@ -15,5 +15,6 @@ CREATE TABLE NSWParkRide (
 CREATE TABLE SavedParkRide (
     stopId TEXT NOT NULL,
     facilityId TEXT NOT NULL,
+    source TEXT NOT NULL,
     PRIMARY KEY (stopId, facilityId)
 );

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswParkRide.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswParkRide.sq
@@ -45,7 +45,7 @@ CREATE TABLE SavedParkRide (
 
 -- Insert or update a mapping between a stop and a facility, updating source if exists
 insertOrReplaceSavedParkRide:
-INSERT OR IGNORE INTO SavedParkRide(stopId, facilityId, source)
+INSERT OR REPLACE INTO SavedParkRide(stopId, facilityId, source)
 VALUES (?, ?, ?);
 
 -- Delete a specific mapping

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswParkRide.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswParkRide.sq
@@ -35,30 +35,31 @@ DELETE FROM NSWParkRide;
 
 
 -- SavedParkRide Table
--- Table for mapping between stops and facilities (many-to-many relationship).
+-- Table for mapping between stops and facilities (many-to-many relationship), with source info.
 CREATE TABLE SavedParkRide (
     stopId TEXT NOT NULL,                 -- Stop identifier
     facilityId TEXT NOT NULL,             -- Facility identifier
-    PRIMARY KEY (stopId, facilityId)      -- Composite primary key to prevent duplicates
+    source TEXT NOT NULL,                 -- Source is saved trips or user added see SavedParkRideSource
+    PRIMARY KEY (stopId, facilityId)      -- Uniqueness only on stopId + facilityId
 );
 
--- Insert or update a mapping between a stop and a facility
+-- Insert or update a mapping between a stop and a facility, updating source if exists
 insertOrReplaceSavedParkRide:
-INSERT OR REPLACE INTO SavedParkRide(stopId, facilityId)
-VALUES (?, ?);
+INSERT OR IGNORE INTO SavedParkRide(stopId, facilityId, source)
+VALUES (?, ?, ?);
 
 -- Delete a specific mapping
 deleteSavedParkRide:
 DELETE FROM SavedParkRide WHERE stopId = ? AND facilityId = ?;
 
--- Delete all mappings
-clearSavedParkRides:
-DELETE FROM SavedParkRide;
+-- Delete all mappings for a given source
+clearSavedParkRidesBySource:
+DELETE FROM SavedParkRide WHERE source = ?;
 
 -- Select all mappings
 selectAllSavedParkRides:
-SELECT stopId, facilityId FROM SavedParkRide;
+SELECT stopId, facilityId, source FROM SavedParkRide;
 
--- Select all unique facilities for a given stop
-selectFacilitiesByStopId:
-SELECT DISTINCT facilityId FROM SavedParkRide WHERE stopId = ?;
+-- Select all unique facilities for a given stop and source
+selectFacilitiesByStopIdAndSource:
+SELECT DISTINCT facilityId FROM SavedParkRide WHERE stopId = ? AND source = ?;

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter4.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter4.kt
@@ -27,6 +27,7 @@ internal object SandookMigrationAfter4 : SandookMigration {
                 CREATE TABLE SavedParkRide (
                     stopId TEXT NOT NULL,
                     facilityId TEXT NOT NULL,
+                    source TEXT NOT NULL,
                     PRIMARY KEY (stopId, facilityId)
                 );
             """.trimIndent(),


### PR DESCRIPTION
# Rename API methods and improve Park & Ride data handling

This PR renames API methods to better reflect their purpose (`get` → `fetch`) and enhances Park & Ride data handling:

- Adds a polling mechanism to fetch Park & Ride facility data every 2 minutes
- Implements database storage for Park & Ride facilities with source tracking
- Adds a mapper to convert API responses to database entities
- Makes location fields nullable in API response model to handle missing data
- Improves handling of expanded Park & Ride cards by tracking them in a Set
- Adds source tracking to saved Park & Ride facilities (user-added vs. saved trips)

The PR also fixes a typo in a comment ("respresents" → "represents") and renames some variables for clarity.