### PR TITLE
Add analytics tracking for Park & Ride card clicks

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -250,4 +250,29 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         name = "our_story",
     )
     // endregion
+
+    // region Park and Ride
+
+    /**
+     * Analytics event for the Park and Ride card click.
+     * @param stopId The ID of the stop associated with the Park and Ride facility.
+     * @param facilityId The ID of the Park and Ride facility.
+     * @param expand Indicates whether the card is being expanded or collapsed.
+     * @param time - when the card was clicked, format - epoch time in seconds.
+     */
+    data class ParkRideCardClickEvent(
+        val stopId: String,
+        val facilityId: String,
+        val expand: Boolean,
+        val time: Long = Clock.System.now().epochSeconds,
+    ) : AnalyticsEvent(
+        name = "park_ride_card_click",
+        properties = mapOf(
+            "stopId" to stopId.trim(),
+            "facilityId" to facilityId.trim(),
+            "expand" to expand.toString().trim(),
+            "time" to time.toString().trim(),
+        ),
+    )
+    // endregion
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -123,11 +123,18 @@ class SavedTripsViewModel(
         }
     }
 
-    // TODO - if card stays open, it won't refresh automatically. - okay for now.
     private fun onParkRideCardClick(
         parkRideState: ParkRideUiState,
         isExpanded: Boolean,
     ) {
+        analytics.track(
+            event = AnalyticsEvent.ParkRideCardClickEvent(
+                stopId = parkRideState.stopId,
+                expand = isExpanded,
+                facilityId = parkRideState.facilities.joinToString(),
+            )
+        )
+
         if (isExpanded) {
             updateUiState {
                 copy(


### PR DESCRIPTION
### TL;DR

Added analytics tracking for Park and Ride card interactions.

### What changed?

- Created a new `ParkRideCardClickEvent` analytics event in `AnalyticsEvent.kt` to track when users interact with Park and Ride cards
- Implemented the analytics tracking in `SavedTripsViewModel.kt` by calling the analytics tracker when a Park and Ride card is clicked
- The event captures important data including stop ID, facility ID, whether the card is being expanded or collapsed, and the timestamp

### How to test?

1. Navigate to a screen with Park and Ride cards
2. Click on a Park and Ride card to expand/collapse it
3. Verify in analytics logs that the `park_ride_card_click` event is being tracked with the correct parameters

### Why make this change?

This change enables tracking user interactions with Park and Ride cards, which will provide valuable insights into how users engage with this feature. The collected data will help understand usage patterns and inform future improvements to the Park and Ride functionality.