### PR TITLE
Increment version codes for Android and iOS builds

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 98
+        versionCode = 99
         versionName = "1.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version codes for Android and iOS apps for the next release.

### What changed?

- Incremented Android `versionCode` from 98 to 99 in `composeApp/build.gradle.kts`
- Incremented iOS `CFBundleVersion` from 4 to 5 in `iosApp/iosApp/Info.plist`

### How to test?

- Build the Android app and verify the version code is 99
- Build the iOS app and verify the build number is 5
- Ensure both apps can be submitted to their respective app stores

### Why make this change?

Preparing for the next app release by incrementing the build numbers while maintaining the same version name (1.7.0). This is required for submitting new builds to the app stores.