### PR TITLE
Add Park & Ride beta mode with informational message

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -92,6 +92,12 @@ object RemoteConfigDefaults {
             ),
             Pair(FlagKeys.NSW_PARK_RIDE_PEAK_TIME_COOLDOWN.key, 120),
             Pair(FlagKeys.NSW_PARK_RIDE_NON_PEAK_TIME_COOLDOWN.key, 600),
+            Pair(first = FlagKeys.NSW_PARK_RIDE_BETA.key, false),
+            Pair(
+                first = FlagKeys.NSW_PARK_RIDE_BETA_MESSAGE_DESC.key,
+                second = "🅿️\uD83D\uDE99 Park & Ride is in beta! We’ve just rolled it out and we’d love your help making it better. " +
+                        "If something’s not quite right (or you just have thoughts), email us anytime at hey@krail.app or reach out via LinkedIn. 💕",
+            ),
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
@@ -10,4 +10,8 @@ enum class FlagKeys(val key: String) {
     NSW_PARK_RIDE_PEAK_TIME_COOLDOWN("nsw_park_ride_peak_time_cooldown"),
 
     NSW_PARK_RIDE_NON_PEAK_TIME_COOLDOWN("nsw_park_ride_non_peak_time_cooldown"),
+
+    NSW_PARK_RIDE_BETA("nsw_park_ride_beta"),
+
+    NSW_PARK_RIDE_BETA_MESSAGE_DESC("nsw_park_ride_beta_message_desc"),
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagValue.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagValue.kt
@@ -7,11 +7,11 @@ sealed class FlagValue {
     data class NumberValue(val value: Long) : FlagValue()
 }
 
-fun FlagValue.asBoolean(): Boolean {
+fun FlagValue.asBoolean(fallback: Boolean = false): Boolean {
     return when (this) {
         is FlagValue.BooleanValue -> this.value
         is FlagValue.StringValue -> this.value.toBoolean()
-        else -> false
+        else -> fallback
     }
 }
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -117,7 +117,7 @@ class SavedTripsViewModelTest {
 
             // Observe state
             viewModel.uiState.test {
-                skipItems(1)
+                skipItems(2)
 
                 val item = awaitItem()
 
@@ -150,7 +150,7 @@ class SavedTripsViewModelTest {
 
             // Ensure initial state
             viewModel.uiState.test {
-                skipItems(1)
+                skipItems(3)
 
                 // WHEN the DeleteSavedTrip event is triggered
                 viewModel.onEvent(

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -13,4 +13,10 @@ data class SavedTripsState(
     val isSavedTripsLoading: Boolean = true,
     val observeParkRideStopIdSet: ImmutableSet<String> = persistentSetOf(),
     val parkRideUiState: ImmutableList<ParkRideUiState> = persistentListOf(),
-)
+    val isParkRideBeta: Boolean = false,
+    val parkRideBetaInfo: ParkRideBetaInfo? = null,
+) {
+    data class ParkRideBetaInfo(
+        val message: String,
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,10 +1,15 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,17 +20,25 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_info
 import krail.feature.trip_planner.ui.generated.resources.ic_settings
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
@@ -62,6 +75,8 @@ fun SavedTripsScreen(
             }
             onDispose {}
         }*/
+
+    var displayParkRideBetaInfo by rememberSaveable { mutableStateOf(false) }
 
     Box(
         modifier = modifier
@@ -151,16 +166,59 @@ fun SavedTripsScreen(
                         }
 
                         stickyHeader(key = "park_ride_title") {
-                            Box(
+                            Row(
                                 modifier = Modifier.fillMaxWidth()
                                     .background(color = KrailTheme.colors.surface)
-                                    .padding(vertical = 12.dp, horizontal = 16.dp),
-                                contentAlignment = Alignment.CenterStart,
+                                    .padding(vertical = 12.dp, horizontal = 16.dp)
+                                    .clickable(
+                                        enabled = savedTripsState.isParkRideBeta,
+                                        indication = null,
+                                        interactionSource = remember { MutableInteractionSource() }) {
+                                        displayParkRideBetaInfo =
+                                            if (savedTripsState.parkRideBetaInfo != null) {
+                                                !displayParkRideBetaInfo
+                                            } else false
+                                    },
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
                                 Text(
-                                    text = "Park & Ride",
+                                    text = "Park & Ride ${if (savedTripsState.isParkRideBeta) "(Beta)" else ""}",
                                     style = KrailTheme.typography.titleMedium,
+                                    modifier = Modifier.align(Alignment.CenterVertically),
                                 )
+
+                                if (savedTripsState.isParkRideBeta) {
+                                    Image(
+                                        painter = painterResource(Res.drawable.ic_info),
+                                        contentDescription = "Park & Ride Beta Info",
+                                        colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                                        modifier = Modifier
+                                            .align(Alignment.CenterVertically)
+                                            .size(16.dp)
+                                    )
+                                }
+                            }
+                        }
+
+                        item {
+                            AnimatedVisibility(
+                                visible = displayParkRideBetaInfo,
+                            ) {
+                                Column(
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    modifier = Modifier.fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                        .klickable(indication = null) {
+                                            displayParkRideBetaInfo = false
+                                        }
+                                        .padding(bottom = 24.dp, top = 12.dp),
+                                ) {
+                                    Text(
+                                        text = savedTripsState.parkRideBetaInfo?.message!!,
+                                        style = KrailTheme.typography.bodySmall,
+                                    )
+                                }
                             }
                         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -32,7 +32,9 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
+import xyz.ksharma.krail.core.remote_config.flag.asBoolean
 import xyz.ksharma.krail.core.remote_config.flag.asNumber
+import xyz.ksharma.krail.core.remote_config.flag.asString
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
@@ -72,6 +74,16 @@ class SavedTripsViewModel(
             .asNumber(fallback = 120)
     }
 
+    private val isParkRideInBeta: Boolean by lazy {
+        flag.getFlagValue(FlagKeys.NSW_PARK_RIDE_BETA.key)
+            .asBoolean()
+    }
+
+    private val parkRideBetaInfoDesc: String by lazy {
+        flag.getFlagValue(FlagKeys.NSW_PARK_RIDE_BETA_MESSAGE_DESC.key)
+            .asString()
+    }
+
     /**
      * Will observe saved trips from the database.
      */
@@ -86,7 +98,7 @@ class SavedTripsViewModel(
     val uiState: StateFlow<SavedTripsState> = _uiState
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
-            log("")
+            updateParkRideBetaState()
             observeSavedTrips()
             observeFacilityDetailsFromDb()
             refreshFacilityDetails()
@@ -472,6 +484,17 @@ class SavedTripsViewModel(
             nonPeakTimeCooldownSeconds.seconds
         } else {
             peakTimeCooldownSeconds.seconds
+        }
+    }
+
+    private fun updateParkRideBetaState() {
+        updateUiState {
+            copy(
+                isParkRideBeta = isParkRideInBeta,
+                parkRideBetaInfo = SavedTripsState.ParkRideBetaInfo(
+                    message = parkRideBetaInfoDesc,
+                )
+            )
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
@@ -11,19 +11,15 @@ object ReferFriendManager {
         return referTextOptions[randomIndex]
     }
 
-    private const val SUFFIX = "Download KRAIL here \uD83D\uDC47 \n" +
+    private const val SUFFIX = "\n\nDownload KRAIL here \uD83D\uDC47 \n" +
         "Apple - $KRAIL_APP_STORE\n" +
         "Android - $KRAIL_GOOGLE_PLAY\n\n" +
         "KRAIL - Ride the rail without fail"
 
     // TODO - fetch these from Firebase.
     private val referTextOptions: List<String> = listOf(
-        "Hey mate,\n" +
-            "Sydney’s best public transport app is here. Like TripView but ad-free\n\n" +
-            SUFFIX,
-
         "Not all heroes wear capes.\n" +
-            "Some just show you when your bus is actually coming.\n\n" +
+            "Some just show you when your bus is actually coming." +
             SUFFIX,
 
         "With great power, comes great public transport.\n" +
@@ -35,11 +31,11 @@ object ReferFriendManager {
             SUFFIX,
 
         "I’m not the transport app Sydney deserves. \n" +
-            "I’m the one it needs - KRAIL App. \uD83D\uDE87" +
+            "I’m the one it needs. \uD83D\uDE87" +
             SUFFIX,
 
-        "\uD83D\uDCA3 Your mission, should you choose to accept it is to \n" +
-            "Invite two mates to KRAIL App and upgrade their Sydney experience.\n" +
+        "\uD83D\uDCA3 Your mission, should you choose to accept it is to " +
+            "invite two mates to KRAIL App and upgrade their Sydney experience.\n\n" +
             "⏱\uFE0F This message will self-destruct in 2 minutes." +
             SUFFIX,
 


### PR DESCRIPTION
### TL;DR

Added Park & Ride beta mode with informational message for users.

### What changed?

- Added new remote config flags for Park & Ride beta mode:
  - `NSW_PARK_RIDE_BETA` - Boolean flag to enable/disable beta mode
  - `NSW_PARK_RIDE_BETA_MESSAGE_DESC` - Message to display to users about the beta

- Enhanced `FlagValue.asBoolean()` to accept a fallback parameter

- Updated `SavedTripsState` to include beta-related fields:
  - `isParkRideBeta` flag
  - `ParkRideBetaInfo` data class with message

- Added UI components to display beta status and info message:
  - Beta indicator next to "Park & Ride" title
  - Info icon that toggles the beta message visibility
  - Animated message display with beta information

- Refined the refer-a-friend message options

### How to test?

1. Enable the `NSW_PARK_RIDE_BETA` flag in remote config
2. Navigate to the Saved Trips screen
3. Verify "Park & Ride (Beta)" appears with an info icon
4. Tap the title or info icon to toggle the beta message
5. Confirm the beta message appears and disappears correctly

### Why make this change?

To inform users that the Park & Ride feature is in beta testing phase and to solicit feedback. The beta message encourages users to report issues or provide thoughts via email or LinkedIn, helping improve the feature before full release.