### PR TITLE
Increment version codes for Android and iOS builds

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 99
+        versionCode = 100
         versionName = "1.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version codes for Android and iOS apps for the 1.7.0 release.

### What changed?

- Incremented Android `versionCode` from 99 to 100
- Incremented iOS `CFBundleVersion` from 5 to 6
- Maintained version name/string as "1.7.0" on both platforms

### How to test?

- Build the Android app and verify the version code is 100 in the APK manifest
- Build the iOS app and verify the build number is 6 in the app's Info.plist
- Ensure both apps display version 1.7.0 in their respective UIs

### Why make this change?

Version codes need to be incremented for each new app store submission. This change prepares both Android and iOS apps for the next release while maintaining the same semantic version (1.7.0).