### PR TITLE
Add LinkedIn social connection analytics and update Settings screen icons

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -249,6 +249,20 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data object OurStoryClick : AnalyticsEvent(
         name = "our_story",
     )
+
+    data class SocialConnectionLinkClickEvent(
+        val socialPlatform: SocialPlatform,
+    ) : AnalyticsEvent(
+        name = "social_connection_link_click",
+        properties = mapOf(
+            "socialPlatform" to socialPlatform.platform,
+        ),
+    ) {
+        enum class SocialPlatform(val platform: String) {
+            LINKEDIN("linkedin"),
+        }
+    }
+
     // endregion
 
     // region Park and Ride

--- a/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_wifi.xml
+++ b/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_wifi.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M10,25.101C13.953,21.808 18.935,20.005 24.08,20.005C29.225,20.005 34.207,21.808 38.16,25.101M2.84,18.001C8.685,12.849 16.208,10.006 24,10.006C31.791,10.006 39.315,12.849 45.16,18.001M17.06,32.221C19.09,30.778 21.519,30.003 24.01,30.003C26.5,30.003 28.929,30.778 30.96,32.221M24,40.001H24.02"
+      android:strokeLineJoin="round"
+      android:strokeWidth="4"
+      android:fillColor="#00000000"
+      android:strokeColor="#1E1E1E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
@@ -32,6 +31,7 @@ import krail.feature.trip_planner.ui.generated.resources.ic_info
 import krail.feature.trip_planner.ui.generated.resources.ic_linkedin
 import krail.feature.trip_planner.ui.generated.resources.ic_paint
 import krail.feature.trip_planner.ui.generated.resources.ic_pen
+import krail.feature.trip_planner.ui.generated.resources.ic_wifi
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Divider
@@ -97,9 +97,7 @@ fun SettingsScreen(
                 item {
                     Text(
                         text = "About",
-                        style = KrailTheme.typography.title.copy(
-                            fontWeight = FontWeight.Normal,
-                        ),
+                        style = KrailTheme.typography.title,
                         modifier = Modifier
                             .padding(top = 24.dp, bottom = 16.dp)
                             .padding(horizontal = 26.dp),
@@ -124,7 +122,7 @@ fun SettingsScreen(
 
                 item {
                     SettingsItem(
-                        icon = painterResource(Res.drawable.ic_pen),
+                        icon = painterResource(Res.drawable.ic_wifi),
                         text = "Stay connected",
                         detailContent = {
                             Row(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.stateIn
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent.SocialPlatform.LINKEDIN
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.remote_config.flag.Flag
@@ -42,6 +43,9 @@ class SettingsViewModel(
         when (event) {
             SettingsEvent.LinkedInLogoClick -> {
                 platformOps.openUrl(linkedInProfileLink)
+                analytics.track(
+                    event = AnalyticsEvent.SocialConnectionLinkClickEvent(socialPlatform = LINKEDIN)
+                )
             }
         }
     }


### PR DESCRIPTION
### TL;DR

Added LinkedIn social connection analytics tracking and updated the Settings screen UI.

### What changed?

- Added a new `SocialConnectionLinkClickEvent` analytics event with a `SocialPlatform` enum
- Added tracking for LinkedIn logo clicks in the Settings screen
- Added a new WiFi icon (`ic_wifi.xml`) for the "Stay connected" section
- Updated the Settings screen UI:
  - Changed the icon for "Stay connected" from pen to WiFi
  - Removed custom font weight from the "About" section title

### How to test?

1. Navigate to the Settings screen
2. Click on the LinkedIn logo in the "Stay connected" section
3. Verify that the app opens the LinkedIn profile link
4. Check analytics logs to confirm the `social_connection_link_click` event is tracked with `socialPlatform: linkedin`

### Why make this change?

This change improves analytics tracking for social media engagement and enhances the UI by using more appropriate iconography for the "Stay connected" section. The WiFi icon better represents connectivity than the previous pen icon, making the UI more intuitive.