### PR TITLE
Bump version to 1.7.1 for Android and iOS

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 100
-        versionName = "1.7.0"
+        versionCode = 102
+        versionName = "1.7.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeNswParkRideSandook.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeNswParkRideSandook.kt
@@ -17,7 +17,7 @@ class FakeNswParkRideSandook : NswParkRideSandook {
     override fun getAllParkRideFacilityDetail(): Flow<List<NSWParkRideFacilityDetail>> = data.asStateFlow()
 
     override fun getByStopIds(stopIds: List<String>): List<NSWParkRideFacilityDetail> =
-        data.value.filter { it.stopId in stopIds }
+        data.value.filter { it.carParkTsnId in stopIds }
 
     override suspend fun insertOrReplace(parkRide: NSWParkRideFacilityDetail) {
         data.value = data.value.filterNot { it.facilityId == parkRide.facilityId } + parkRide

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeNswParkRideSandook.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeNswParkRideSandook.kt
@@ -17,7 +17,7 @@ class FakeNswParkRideSandook : NswParkRideSandook {
     override fun getAllParkRideFacilityDetail(): Flow<List<NSWParkRideFacilityDetail>> = data.asStateFlow()
 
     override fun getByStopIds(stopIds: List<String>): List<NSWParkRideFacilityDetail> =
-        data.value.filter { it.carParkTsnId in stopIds }
+        data.value.filter { it.stopId in stopIds }
 
     override suspend fun insertOrReplace(parkRide: NSWParkRideFacilityDetail) {
         data.value = data.value.filterNot { it.facilityId == parkRide.facilityId } + parkRide

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.0</string>
+	<string>1.7.1</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version to 1.7.1 for both Android and iOS apps

### What changed?

- Android:
  - Updated `versionCode` from 100 to 101
  - Updated `versionName` from "1.7.0" to "1.7.1"

- iOS:
  - Updated `CFBundleShortVersionString` from "1.7.0" to "1.7.1"
  - Reset `CFBundleVersion` (build number) from "6" to "1"

### How to test?

- Build the Android app and verify the version appears as 1.7.1 (101) in app info
- Build the iOS app and verify the version appears as 1.7.1 (1) in app info

### Why make this change?

Preparing for a new patch release with version 1.7.1 across both platforms. This ensures consistent versioning between Android and iOS apps.