### PR TITLE
Improve LinkedIn logo UI and fix iOS URL opening implementation

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -127,18 +127,19 @@ fun SettingsScreen(
                         detailContent = {
                             Row(
                                 modifier = Modifier
-                                    .padding(start = (24 + 16 + 16).dp, end = 16.dp, top = 8.dp),
+                                    .padding(start = (24 + 16 + 4).dp, end = 16.dp,),
                             ) {
                                 Box(
                                     modifier = Modifier
-                                        .size(32.dp)
+                                        .size(44.dp)
                                         .klickable(
                                             indication = null,
                                             onClick = {
-                                               onLinkedInLogoClick()
+                                                onLinkedInLogoClick()
                                             },
                                         )
-                                        .semantics(mergeDescendants = true) {}
+                                        .semantics(mergeDescendants = true) {},
+                                    contentAlignment = Alignment.Center,
                                 ) {
                                     Image(
                                         painter = painterResource(Res.drawable.ic_linkedin),

--- a/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
+++ b/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
@@ -10,6 +10,7 @@ import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.UIKit.popoverPresentationController
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.log.logError
 
 class IosPlatformOps : PlatformOps {
     override fun sharePlainText(text: String) {
@@ -17,11 +18,21 @@ class IosPlatformOps : PlatformOps {
     }
 
     override fun openUrl(url: String) {
-        if (url.isBlank()) return
+        if (url.isBlank()) {
+            logError("Cannot open URL: URL is blank")
+            return
+        }
 
         val nsUrl = NSURL.URLWithString(url)
         if (nsUrl != null) {
-            UIApplication.sharedApplication.openURL(nsUrl)
+            // openUrl() is deprecated so using other overload
+            // https://developer.apple.com/documentation/uikit/uiapplication/openurl(_:)
+            UIApplication.sharedApplication.openURL(
+                nsUrl,
+                options = mapOf<Any?, Any?>(),
+                completionHandler = { result: Boolean ->
+                    log("Attempted to open URL: $url, result: $result")
+                })
         }
     }
 


### PR DESCRIPTION
### TL;DR

Improved LinkedIn logo clickability in Settings screen and enhanced iOS URL handling.

### What changed?

- **Settings Screen**:
  - Increased LinkedIn logo touch target from 32dp to 44dp
  - Adjusted padding for better visual alignment
  - Added `contentAlignment = Alignment.Center` to properly center the logo

- **iOS Platform Operations**:
  - Replaced deprecated URL opening method with the recommended approach
  - Added error logging for blank URLs
  - Implemented completion handler to log URL opening results

### How to test?

1. Open the Settings screen and verify the LinkedIn logo is properly centered and easier to tap
2. On iOS, test URL opening functionality by clicking on links throughout the app
3. Check logs to confirm URL opening attempts are properly recorded

### Why make this change?

The LinkedIn logo touch target was too small, making it difficult for users to tap accurately. The iOS URL handling was using a deprecated method and lacked proper error handling and logging. These changes improve usability and follow platform best practices.