### PR TITLE
Bump version to 1.7.2 for iOS and increment Android version code

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 103
+        versionCode = 104
         versionName = "1.7.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.1</string>
+	<string>1.7.2</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Version bump for Android and iOS apps

### What changed?

- Android: Incremented `versionCode` from 103 to 104 in `composeApp/build.gradle.kts`
- iOS: Updated `CFBundleShortVersionString` from 1.7.1 to 1.7.2 and reset `CFBundleVersion` from 3 to 1 in `iosApp/iosApp/Info.plist`

### How to test?

- Build both Android and iOS apps
- Verify the version information in the app settings or about screen
- Ensure the apps can be properly submitted to their respective app stores with the new version numbers

### Why make this change?

Preparing for a new release with version updates to maintain proper versioning sequence across platforms. The Android app maintains the same version name while incrementing the build number, while the iOS app moves to a new minor version with a reset build number.