### PR TITLE
Bump version to 1.7.3 for Android and iOS

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,8 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 104
-        versionName = "1.7.1"
+        versionCode = 105
+        versionName = "1.7.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.2</string>
+	<string>1.7.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### TL;DR

Bump version numbers for Android and iOS apps to 1.7.3

### What changed?

- Android: 
  - Increased `versionCode` from 104 to 105
  - Updated `versionName` from "1.7.1" to "1.7.3"
- iOS:
  - Updated `CFBundleShortVersionString` from "1.7.2" to "1.7.3"

### How to test?

- Build both Android and iOS apps
- Verify the version numbers appear correctly in app info/settings
- Ensure the apps can be properly submitted to respective app stores with the new version numbers

### Why make this change?

Version bump needed for the next release to ensure proper versioning across platforms. This aligns both Android and iOS apps to the same version number (1.7.3).