### PR TITLE
Add UT for OurStoryViewModel

### DIFF
--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 
 android {
     namespace = "xyz.ksharma.krail.core.test"
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 kotlin {
@@ -54,6 +58,7 @@ kotlin {
                 implementation(libs.test.turbine)
                 implementation(libs.kotlinx.collections.immutable)
                 implementation(libs.kotlinx.datetime)
+                implementation(libs.molecule.runtime)
             }
         }
     }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeFlag.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeFlag.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.core.test.fakes
 
 import xyz.ksharma.krail.core.remote_config.flag.Flag
+import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.FlagValue
 
 class FakeFlag : Flag {
@@ -11,6 +12,10 @@ class FakeFlag : Flag {
     }
 
     override fun getFlagValue(key: String): FlagValue {
-        return flagValues[key] ?: FlagValue.BooleanValue(false)
+        return flagValues[key] ?: when (key) {
+            FlagKeys.OUR_STORY_TEXT.key -> FlagValue.StringValue("Story Text")
+            FlagKeys.DISCLAIMER_TEXT.key -> FlagValue.StringValue("Disclaimer Text")
+            else -> FlagValue.BooleanValue(false)
+        }
     }
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/OurStoryviewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/OurStoryviewModelTest.kt
@@ -1,0 +1,39 @@
+package xyz.ksharma.core.test.viewmodels
+
+import app.cash.molecule.RecompositionMode
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeFlag
+import xyz.ksharma.krail.trip.planner.ui.settings.story.OurStoryViewModel
+import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryEvent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class OurStoryViewModelTest {
+
+    private val analytics = FakeAnalytics()
+    private val flag = FakeFlag()
+
+    @Test
+    fun `models emits correct state on init`() = runTest {
+        val viewModel = OurStoryViewModel(analytics, flag)
+        val events = MutableSharedFlow<OurStoryEvent>()
+
+        moleculeFlow(RecompositionMode.Immediate) { viewModel.models(events) }.distinctUntilChanged()
+            .test {
+                val state = awaitItem()
+                println("Initial state: $state")
+                assertEquals("Story Text", state.story)
+                assertEquals("Disclaimer Text", state.disclaimer)
+                assertFalse(state.isLoading)
+                cancelAndIgnoreRemainingEvents()
+            }
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/MoleculeViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/MoleculeViewModel.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui
 
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.Companion.PROTECTED
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -32,5 +34,6 @@ abstract class MoleculeViewModel<Event, Model> : ViewModel() {
     }
 
     @Composable
-    protected abstract fun models(events: Flow<Event>): Model
+    @VisibleForTesting(otherwise = PROTECTED)
+    abstract fun models(events: Flow<Event>): Model
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryViewModel.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.Flow
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
-import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.asString
@@ -21,35 +20,6 @@ class OurStoryViewModel(
     private val analytics: Analytics,
     private val flag: Flag,
 ) : MoleculeViewModel<OurStoryEvent, OurStoryState>() {
-
-    /*
-        private val _uiState: MutableStateFlow<OurStoryState> = MutableStateFlow(OurStoryState())
-        val uiState: StateFlow<OurStoryState> = _uiState
-            .onStart {
-                updateOurStoryState()
-                analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
-            }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), OurStoryState())
-     */
-
-    /*
-        private fun updateOurStoryState() {
-            if (storyText.isNotBlank() && disclaimerText.isNotBlank()) {
-                updateUiState {
-                    copy(
-                        story = storyText,
-                        disclaimer = disclaimerText,
-                        isLoading = false,
-                    )
-                }
-            }
-        }
-     */
-
-    /*
-        private fun updateUiState(block: OurStoryState.() -> OurStoryState) {
-            _uiState.update(block)
-        }
-     */
 
     @Composable
     override fun models(events: Flow<OurStoryEvent>): OurStoryState {
@@ -67,7 +37,6 @@ class OurStoryViewModel(
         }
 
         LaunchedEffect(Unit) {
-            log("OurStoryViewModel-  Our Story Text: ${storyText.take(10)}")
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.OurStory)
         }
 


### PR DESCRIPTION
### TL;DR

Added unit tests for OurStoryViewModel and made necessary modifications to support testing.

### What changed?

- Added a unit test for OurStoryViewModel that verifies the correct initial state
- Enhanced FakeFlag implementation to return default values for story and disclaimer text
- Modified MoleculeViewModel to make the models function visible for testing
- Removed commented-out code and unnecessary logging from OurStoryViewModel
- Added molecule.runtime dependency to the test module
- Configured unitTests.isReturnDefaultValues = true in test build.gradle.kts

### How to test?

1. Run the new OurStoryViewModelTest to verify it passes
2. Verify that the OurStoryViewModel still functions correctly in the app

### Why make this change?

To improve test coverage for the OurStoryViewModel component and ensure it correctly initializes with the expected state. This change also makes the codebase more testable by exposing necessary components for testing while cleaning up unused code.