### PR TITLE
CI: Add run ID to artifact names and use PR title for release notes

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -75,7 +75,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: |
-            ${{ inputs.variant == 'debug' && format('composeApp-{0}-apk', inputs.variant) || 'composeApp-release-aab' }}
+            ${{ inputs.variant == 'debug' && format('composeApp-{0}-apk-{1}', inputs.variant, github.run_id) || format('composeApp-release-aab-{0}', github.run_id) }}
           path: |
             ${{ inputs.variant == 'debug' && format('composeApp/build/outputs/apk/{0}/composeApp-{0}.apk', inputs.variant) || steps.signed_release_aab.outputs.signedReleaseFile }}
-

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Download APK artifact
         uses: actions/download-artifact@v4
         with:
-          name: composeApp-debug-apk
+          name: composeApp-debug-apk-${{ github.run_id }}
 
       - name: Download Firebase CLI
         run: curl -sL https://firebase.tools | upgrade=true bash
@@ -40,6 +40,6 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID_DEBUG: ${{ secrets.FIREBASE_APP_ID_DEBUG }}
         run: |
-          firebase appdistribution:distribute composeApp-debug.apk \
+          firebase appdistribution:distribute composeApp-debug-apk/composeApp-debug.apk \
             --app "$FIREBASE_APP_ID_DEBUG" \
-            --release-notes "Test notes"
+            --release-notes "${{ github.event.pull_request.title }}"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -65,6 +65,10 @@ class SavedTripsViewModel(
     private val flag: Flag,
 ) : ViewModel() {
 
+    init {
+        log("Temp log for CI builds")
+    }
+
     private val nonPeakTimeCooldownSeconds: Long by lazy {
         flag.getFlagValue(FlagKeys.NSW_PARK_RIDE_NON_PEAK_TIME_COOLDOWN.key)
             .asNumber(600)


### PR DESCRIPTION
# Improve CI/CD Workflow and Add Firebase App Distribution Integration

### TL;DR
Enhanced CI/CD workflow with unique artifact naming and improved Firebase App Distribution integration.

### What changed?
- Added unique run IDs to artifact names in the Android build workflow to prevent conflicts
- Updated Firebase App Distribution workflow to use the correct artifact path
- Changed Firebase release notes to use the PR title instead of static "Test notes"
- Added a temporary log statement in SavedTripsViewModel for CI build verification

### How to test?
1. Create a PR and verify that the CI workflow runs successfully
2. Check that artifacts are properly named with run IDs
3. Verify that Firebase App Distribution receives the build with the PR title as release notes

### Why make this change?
This change prevents CI artifact naming conflicts when multiple workflows run simultaneously and improves the Firebase App Distribution process by using meaningful release notes from PR titles. The temporary log statement helps verify that CI builds are working correctly.