### PR TITLE
CI: Use GitHub run number for Android version code

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -55,9 +55,9 @@ jobs:
           ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
         run: |
           if [[ "${{ inputs.variant }}" == "debug" ]]; then
-            ./gradlew :composeApp:assembleDebug testDebug --rerun-tasks
+            ./gradlew :composeApp:assembleDebug -PversionCode="${{ github.run_number }}" testDebug --rerun-tasks
           elif [[ "${{ inputs.variant }}" == "release" ]]; then
-            ./gradlew :composeApp:bundleRelease
+            ./gradlew :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
           fi
 
       - name: Sign Android Release AAB

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           name: composeApp-debug-apk-${{ github.run_id }}
 
+      - name: List files in extracted artifact
+        run: ls
+
       - name: Download Firebase CLI
         run: curl -sL https://firebase.tools | upgrade=true bash
 
@@ -40,6 +43,6 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID_DEBUG: ${{ secrets.FIREBASE_APP_ID_DEBUG }}
         run: |
-          firebase appdistribution:distribute composeApp-debug-apk/composeApp-debug.apk \
+          firebase appdistribution:distribute composeApp-debug.apk \
             --app "$FIREBASE_APP_ID_DEBUG" \
             --release-notes "${{ github.event.pull_request.title }}"

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,6 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 105
-        versionName = "1.7.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
@@ -5,9 +5,6 @@ import com.android.build.gradle.BaseExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.configureAndroid() {
     extensions.configure<BaseExtension> {

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -1,18 +1,31 @@
 package xyz.ksharma.krail.gradle
 
+import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
+
             with(pluginManager) {
                 apply("com.android.application")
                 apply("io.gitlab.arturbosch.detekt")
             }
 
+            androidAppExtension().apply {
+                defaultConfig {
+                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 105
+                    versionName = "1.7.3"
+                }
+            }
+
             configureAndroid()
             configureDetekt()
         }
+    }
+
+    private fun Project.androidAppExtension(): ApplicationExtension {
+        return extensions.getByType(ApplicationExtension::class.java)
     }
 }


### PR DESCRIPTION
# Dynamic Version Code for Android Builds and Firebase Distribution Improvements

## TL;DR

Updated Android build configuration to use dynamic version codes from GitHub run numbers and fixed Firebase App Distribution workflow to run on PRs before merging.

## What changed?

- Added dynamic version code parameter to Gradle build commands using GitHub run number
- Removed hardcoded version code from composeApp/build.gradle.kts
- Modified the AndroidApplicationConventionPlugin to read version code from Gradle property
- Updated Firebase App Distribution workflow to:
  - Run on PRs before they're merged (commented out merge conditions)
  - Fixed the APK file path for distribution
  - Added a debugging step to list files in the extracted artifact

## How to test?

1. Create a PR targeting the main branch
2. Verify that the Firebase App Distribution workflow triggers automatically
3. Check that the APK is properly built with the correct version code
4. Confirm the APK is properly distributed to Firebase

## Why make this change?

This change provides two key improvements:
1. Automatic version code incrementation based on GitHub workflow run numbers, eliminating manual version management
2. Earlier testing of app distribution during PR review rather than waiting until after merge, with fixed file paths to ensure proper distribution