### PR TITLE
Use versionCode as github run number

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -55,9 +55,9 @@ jobs:
           ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
         run: |
           if [[ "${{ inputs.variant }}" == "debug" ]]; then
-            ./gradlew :composeApp:assembleDebug testDebug --rerun-tasks
+            ./gradlew :composeApp:assembleDebug -PversionCode="${{ github.run_number }}" testDebug --rerun-tasks
           elif [[ "${{ inputs.variant }}" == "release" ]]; then
-            ./gradlew :composeApp:bundleRelease
+            ./gradlew :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
           fi
 
       - name: Sign Android Release AAB

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,8 +5,6 @@ android {
 
     defaultConfig {
         applicationId = "xyz.ksharma.krail"
-        versionCode = 105
-        versionName = "1.7.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
@@ -5,9 +5,6 @@ import com.android.build.gradle.BaseExtension
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun Project.configureAndroid() {
     extensions.configure<BaseExtension> {

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -1,18 +1,31 @@
 package xyz.ksharma.krail.gradle
 
+import com.android.build.api.dsl.ApplicationExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
+
             with(pluginManager) {
                 apply("com.android.application")
                 apply("io.gitlab.arturbosch.detekt")
             }
 
+            androidAppExtension().apply {
+                defaultConfig {
+                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 105
+                    versionName = "1.7.3"
+                }
+            }
+
             configureAndroid()
             configureDetekt()
         }
+    }
+
+    private fun Project.androidAppExtension(): ApplicationExtension {
+        return extensions.getByType(ApplicationExtension::class.java)
     }
 }


### PR DESCRIPTION
# Use GitHub Run Number for Android Version Code

### TL;DR
Update Android build configuration to use GitHub Actions run number as the app's version code.

### What changed?
- Removed hardcoded `versionCode = 105` from `composeApp/build.gradle.kts`
- Modified Gradle commands in GitHub workflow to pass version code as a parameter: `-PversionCode="${{ github.run_number }}"`
- Updated `AndroidApplicationConventionPlugin` to dynamically set the version code from the property or fall back to 105
- Kept version name at "1.7.3"
- Removed unused imports from `Android.kt`

### How to test?
1. Run a GitHub workflow build
2. Verify that the generated APK/AAB has a version code matching the GitHub run number
3. Test a local build to ensure it falls back to version code 105

### Why make this change?
Using the GitHub run number as the version code ensures each build has a unique, incrementing version code without manual updates. This is particularly important for Play Store releases where each new version must have a higher version code than the previous one.