### PR TITLE
CI: Automate debug APK distribution to Firebase for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,3 +27,9 @@ jobs:
   build-ios:
     uses: ./.github/workflows/build-ios.yml
     secrets: inherit
+
+  distribute-debug-apk:
+    needs: build-android-debug
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/firebase-app-distribution.yml
+    secrets: inherit

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -1,21 +1,10 @@
 name: Firebase App Distribution
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
-    # Only run if PR is merged
-    if: github.event.pull_request.merged == true
+  workflow_call:
 
 jobs:
-  build-android-debug:
-    uses: ./.github/workflows/build-android.yml
-    with:
-      variant: debug
-    secrets: inherit
-
   distribute-apk:
-    needs: build-android-debug
     runs-on: ubuntu-latest
     environment: Firebase
     steps:
@@ -45,4 +34,5 @@ jobs:
         run: |
           firebase appdistribution:distribute composeApp-debug.apk \
             --app "$FIREBASE_APP_ID_DEBUG" \
+            --groups "Friends"
             --release-notes "${{ github.event.pull_request.title }}"


### PR DESCRIPTION
# Automate Firebase App Distribution for Debug APK

This PR adds automatic distribution of debug APK to Firebase App Distribution when changes are pushed to the main branch:

- Adds a new `distribute-debug-apk` job to the main build workflow that runs after successful Android debug build
- Configures the job to only run on pushes to the main branch
- Converts the Firebase App Distribution workflow to be callable from other workflows
- Adds the "Friends" group to the Firebase distribution configuration

The change will ensure that every time code is merged to main, the debug APK is automatically distributed to testers in the "Friends" group.