### PR TITLE
Remove passed 2025 festival dates from LoadingEmojiManager

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiManager.kt
@@ -104,20 +104,6 @@ object LoadingEmojiManager {
         MonthDay.of(12, 3) to FestivalType.A11Y_DAY,
 
         // Can change dates
-        MonthDay.of(3, 30) to FestivalType.EID,
-        MonthDay.of(3, 31) to FestivalType.EID,
-
-        // Easter 2025
-        MonthDay.of(4, 20) to FestivalType.EASTER,
-
-        // Vivid Sydney 2025
-        MonthDay.of(5, 23) to FestivalType.VIVID_SYDNEY,
-        MonthDay.of(5, 24) to FestivalType.VIVID_SYDNEY,
-        MonthDay.of(5, 25) to FestivalType.VIVID_SYDNEY,
-        MonthDay.of(5, 26) to FestivalType.VIVID_SYDNEY,
-        MonthDay.of(5, 27) to FestivalType.VIVID_SYDNEY,
-        MonthDay.of(5, 28) to FestivalType.VIVID_SYDNEY,
-        MonthDay.of(5, 29) to FestivalType.VIVID_SYDNEY, // till 14 June
     )
 
     @OptIn(ExperimentalTime::class)


### PR DESCRIPTION
### TL;DR

Removed future festival dates from the loading emoji manager.

### What changed?

Removed several festival dates from the `LoadingEmojiManager` that were scheduled for 2025:
- Eid (March 30-31)
- Easter (April 20)
- Vivid Sydney (May 23-29)

### How to test?

1. Run the app and verify that the loading emoji animations don't show special festival-themed emojis on the removed dates
2. Confirm that other festival dates still in the list continue to work as expected

### Why make this change?

These festival dates were likely removed because they were either:
- Too far in the future and subject to change
- No longer needed for the current release cycle
- Being managed in a different way or will be added back closer to the actual dates