### PR TITLE
Remove LOCAL_STOPS_ENABLED flag and simplify StopResultsManager

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -15,7 +15,6 @@ object RemoteConfigDefaults {
      */
     fun getDefaults(): Array<Pair<String, Any?>> {
         return arrayOf(
-            Pair(FlagKeys.LOCAL_STOPS_ENABLED.key, true),
             Pair(
                 FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
                 """["200060", "200070", "200080", "206010", "2150106", "200017", "200039", "201016", "201039", "201080", "200066", "200030", "200046", "200050"]""".trimMargin()

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.core.remote_config.flag
 
 enum class FlagKeys(val key: String) {
-    LOCAL_STOPS_ENABLED("local_stops_enabled"),
     HIGH_PRIORITY_STOP_IDS("high_priority_stop_ids"),
     OUR_STORY_TEXT("our_story_text"),
     DISCLAIMER_TEXT("disclaimer_text"),

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/StopResultsManagerTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/StopResultsManagerTest.kt
@@ -1,125 +1,85 @@
 package xyz.ksharma.core.test
 
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.test.runTest
 import xyz.ksharma.core.test.fakes.FakeFlag
 import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeTripPlanningService
-import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
-import xyz.ksharma.krail.core.remote_config.flag.FlagValue
-import xyz.ksharma.krail.sandook.SelectProductClassesForStop
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 // TODO Write UTs separately
 class RealStopResultsManagerTest {
-
-    private lateinit var tripPlanningService: FakeTripPlanningService
     private lateinit var sandook: FakeSandook
     private lateinit var flag: FakeFlag
     private lateinit var stopResultsManager: RealStopResultsManager
 
     fun setUp() {
-        tripPlanningService = FakeTripPlanningService()
         sandook = FakeSandook()
         flag = FakeFlag()
-        stopResultsManager = RealStopResultsManager(tripPlanningService, sandook, flag)
+        stopResultsManager = RealStopResultsManager(sandook, flag)
     }
-/*
+    /*
 
-    @Test
-    fun `fetchStopResults should fetch from local stops when enabled`() = runTest {
-        setUp()
+        @Test
+        fun `fetchStopResults should fetch from local stops when enabled`() = runTest {
+            setUp()
 
-        // Set flag values
-        flag.setFlagValue(FlagKeys.LOCAL_STOPS_ENABLED.key, FlagValue.BooleanValue(true))
-        flag.setFlagValue(
-            FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
-            FlagValue.JsonValue("[\"200060\", \"200070\"]")
-        )
-
-        // Set Sandook response
-        sandook.insertNswStop(stopId = "200060", stopName = "Stop A", stopLat = 1.0, stopLon = 1.0)
-
-        // Call the method
-        val results = stopResultsManager.fetchStopResults("query")
-
-        // Verify the results
-        assertEquals(1, results.size)
-        assertEquals("200060", results[0].stopId)
-        assertEquals("Stop A", results[0].stopName)
-    }
-*/
-
-/*
-    @Test
-    fun `fetchStopResults should fetch from remote when local stops are disabled`() = runTest {
-        setUp()
-
-        // Set flag values
-        flag.setFlagValue(FlagKeys.LOCAL_STOPS_ENABLED.key, FlagValue.BooleanValue(false))
-        flag.setFlagValue(
-            FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
-            FlagValue.JsonValue("[\"200060\", \"200070\"]")
-        )
-
-        // Set TripPlanningService response
-        tripPlanningService.stopFinderResponse = listOf(
-            SearchStopState.StopResult(
-                "200080",
-                "Stop B",
-                listOf(TransportMode.Bus().toTransportModeType()).toImmutableList()
+            // Set flag values
+            flag.setFlagValue(FlagKeys.LOCAL_STOPS_ENABLED.key, FlagValue.BooleanValue(true))
+            flag.setFlagValue(
+                FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
+                FlagValue.JsonValue("[\"200060\", \"200070\"]")
             )
-        )
 
-        // Call the method
-        val results = stopResultsManager.fetchStopResults("query")
+            // Set Sandook response
+            sandook.insertNswStop(stopId = "200060", stopName = "Stop A", stopLat = 1.0, stopLon = 1.0)
 
-        // Verify the results
-        assertEquals(1, results.size)
-        assertEquals("200080", results[0].stopId)
-        assertEquals("Stop B", results[0].stopName)
-    }
+            // Call the method
+            val results = stopResultsManager.fetchStopResults("query")
 
-    @Test
-    fun `prioritiseStops should prioritize stops correctly`() {
-        setUp()
+            // Verify the results
+            assertEquals(1, results.size)
+            assertEquals("200060", results[0].stopId)
+            assertEquals("Stop A", results[0].stopName)
+        }
 
-        // Set flag values
-        flag.setFlagValue(
-            FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
-            FlagValue.JsonValue("[\"200060\", \"200070\"]")
-        )
 
-        // Create test data
-        val stopResults = listOf(
-            createStopResult("200060", "Stop A", listOf(TransportMode.Train())),
-            createStopResult("200080", "Stop B", listOf(TransportMode.Bus())),
-            createStopResult("200070", "Stop C", listOf(TransportMode.Ferry())),
-            createStopResult("200090", "Stop D", listOf(TransportMode.Train(), TransportMode.Bus()))
-        )
+        @Test
+        fun `prioritiseStops should prioritize stops correctly`() {
+            setUp()
 
-        val expectedResults = listOf(
-            createStopResult("200060", "Stop A", listOf(TransportMode.Train())),
-            createStopResult("200070", "Stop C", listOf(TransportMode.Ferry())),
-            createStopResult(
-                "200090",
-                "Stop D",
-                listOf(TransportMode.Train(), TransportMode.Bus())
-            ),
-            createStopResult("200080", "Stop B", listOf(TransportMode.Bus()))
-        )
+            // Set flag values
+            flag.setFlagValue(
+                FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
+                FlagValue.JsonValue("[\"200060\", \"200070\"]")
+            )
 
-        // Call the method
-        val actualResults = stopResultsManager.prioritiseStops(stopResults)
+            // Create test data
+            val stopResults = listOf(
+                createStopResult("200060", "Stop A", listOf(TransportMode.Train())),
+                createStopResult("200080", "Stop B", listOf(TransportMode.Bus())),
+                createStopResult("200070", "Stop C", listOf(TransportMode.Ferry())),
+                createStopResult("200090", "Stop D", listOf(TransportMode.Train(), TransportMode.Bus()))
+            )
 
-        // Verify the results
-        assertEquals(expectedResults, actualResults)
-    }
-*/
+            val expectedResults = listOf(
+                createStopResult("200060", "Stop A", listOf(TransportMode.Train())),
+                createStopResult("200070", "Stop C", listOf(TransportMode.Ferry())),
+                createStopResult(
+                    "200090",
+                    "Stop D",
+                    listOf(TransportMode.Train(), TransportMode.Bus())
+                ),
+                createStopResult("200080", "Stop B", listOf(TransportMode.Bus()))
+            )
+
+            // Call the method
+            val actualResults = stopResultsManager.prioritiseStops(stopResults)
+
+            // Verify the results
+            assertEquals(expectedResults, actualResults)
+        }
+    */
 
     private fun createStopResult(
         stopId: String,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -72,5 +72,5 @@ val viewModelsModule = module {
         )
     }
 
-    single<StopResultsManager> { RealStopResultsManager(get(), get(), get()) }
+    single<StopResultsManager> { RealStopResultsManager(get(), get()) }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -9,47 +9,33 @@ import xyz.ksharma.krail.core.remote_config.RemoteConfigDefaults
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.FlagValue
-import xyz.ksharma.krail.core.remote_config.flag.asBoolean
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SelectProductClassesForStop
-import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
-import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultMapper.toStopResults
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 
 class RealStopResultsManager(
-    private val tripPlanningService: TripPlanningService,
     private val sandook: Sandook,
     private val flag: Flag,
 ) : StopResultsManager {
-
-    private val isLocalStopsEnabled: Boolean by lazy {
-        flag.getFlagValue(FlagKeys.LOCAL_STOPS_ENABLED.key).asBoolean()
-    }
 
     private val highPriorityStopIdList: List<String> by lazy {
         flag.getFlagValue(FlagKeys.HIGH_PRIORITY_STOP_IDS.key).toStopsIdList()
     }
 
-    override suspend fun fetchStopResults(query: String): List<SearchStopState.StopResult> =
-        if (isLocalStopsEnabled) {
-            log("fetchStopResults from LOCAL_STOPS")
-            val resultsDb: List<SelectProductClassesForStop> =
-                sandook.selectStops(stopName = query, excludeProductClassList = listOf())
+    override suspend fun fetchStopResults(query: String): List<SearchStopState.StopResult> {
+        log("fetchStopResults from LOCAL_STOPS")
+        val resultsDb: List<SelectProductClassesForStop> =
+            sandook.selectStops(stopName = query, excludeProductClassList = listOf())
 
-            val results = resultsDb
-                .map { it.toStopResult() }
-                .let(::prioritiseStops)
-                .take(50)
+        val results = resultsDb
+            .map { it.toStopResult() }
+            .let(::prioritiseStops)
+            .take(50)
 
-            results
-        } else {
-            log("fetchStopResults from REMOTE")
-            val response = tripPlanningService.stopFinder(stopSearchQuery = query)
-            log("response VM: $response")
-            response.toStopResults()
-        }
+        return results
+    }
 
     // TODO - move to another file and add UT for it. Inject and use.
     override fun prioritiseStops(stopResults: List<SearchStopState.StopResult>): List<SearchStopState.StopResult> {


### PR DESCRIPTION
### TL;DR

Removed the `LOCAL_STOPS_ENABLED` flag and simplified the stop results fetching logic to always use local stops.

### What changed?

- Removed the `LOCAL_STOPS_ENABLED` flag key from `FlagKeys` enum
- Removed the corresponding default value in `RemoteConfigDefaults`
- Simplified `RealStopResultsManager` to always fetch stop results from local database:
  - Removed the `tripPlanningService` dependency
  - Removed conditional logic that checked if local stops were enabled
  - Updated the constructor to no longer require `tripPlanningService`
- Updated the DI module to reflect the new constructor signature

### How to test?

1. Verify that stop search functionality works correctly
2. Confirm that stop results are being fetched from the local database
3. Ensure no regressions in stop search functionality across the app

### Why make this change?

This change streamlines the stop results fetching logic by removing the feature flag that controlled whether to use local or remote stops. The application will now consistently use local stops, which likely provides better performance and reliability compared to remote fetching.