### PR TITLE
Add NoFestival class and replace emoji with festival in TimeTableState

### DIFF
--- a/core/festival/src/commonMain/kotlin/xyz/ksharma/krail/core/festival/model/Festival.kt
+++ b/core/festival/src/commonMain/kotlin/xyz/ksharma/krail/core/festival/model/Festival.kt
@@ -47,3 +47,9 @@ data class VariableDateFestival(
 
     @SerialName("greeting") override val greeting: String,
 ) : Festival()
+
+data class NoFestival(
+    override val type: String = "NoFestival",
+    override val emojiList: List<String>,
+    override val greeting: String,
+) : Festival()

--- a/feature/trip-planner/state/build.gradle.kts
+++ b/feature/trip-planner/state/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.core.dateTime)
+                implementation(projects.core.festival)
                 implementation(projects.taj)
                 implementation(projects.core.analytics)
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -4,6 +4,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import xyz.ksharma.krail.core.festival.model.Festival
 import kotlin.time.Clock
 import kotlin.time.Instant
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -18,7 +19,7 @@ data class TimeTableState(
     val trip: Trip? = null,
     val isError: Boolean = false,
     val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
-    val emoji: String? = null,
+    val festival: Festival? = null,
 ) {
     @OptIn(ExperimentalTime::class)
     data class JourneyCardInfo(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -307,20 +307,20 @@ fun TimeTableScreen(
                 item(key = "loading") {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
 
-                        timeTableState.emoji?.let{ emoji ->
+                        timeTableState.festival?.let { festival ->
                             LoadingEmojiAnim(
-                                emoji = emoji,
+                                emoji = festival.emojiList.first(),
                                 modifier = Modifier.padding(vertical = 60.dp).animateItem(),
                             )
-                        }
 
-                        Text(
-                            text = "Hop on, mate!",
-                            style = KrailTheme.typography.bodyLarge,
-                            textAlign = TextAlign.Center,
-                            color = KrailTheme.colors.onSurface,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                        )
+                            Text(
+                                text = festival.greeting,
+                                style = KrailTheme.typography.bodyLarge,
+                                textAlign = TextAlign.Center,
+                                color = KrailTheme.colors.onSurface,
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                            )
+                        }
                     }
                 }
             } else if (timeTableState.journeyList.isNotEmpty()) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -18,8 +18,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.time.Clock
-import kotlin.time.Instant
 import kotlinx.datetime.TimeZone.Companion.currentSystemDefault
 import kotlinx.datetime.toLocalDateTime
 import xyz.ksharma.krail.core.analytics.Analytics
@@ -33,6 +31,7 @@ import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeStri
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toHHMM
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
 import xyz.ksharma.krail.core.festival.FestivalManager
+import xyz.ksharma.krail.core.festival.model.NoFestival
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.sandook.Sandook
@@ -48,9 +47,11 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.business.buildJourneyList
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 class TimeTableViewModel(
     private val tripPlanningService: TripPlanningService,
@@ -512,8 +513,16 @@ class TimeTableViewModel(
     }
 
     private fun updateLoadingEmoji() {
-        festivalManager.emojiForDate().let { emoji ->
-            updateUiState { copy(emoji = emoji) }
+        festivalManager.festivalOnDate().let { festival ->
+            if (festival != null) {
+                updateUiState { copy(festival = festival) }
+            } else {
+                val festival = NoFestival(
+                    emojiList = FestivalManager.commonEmojiList.toList(),
+                    greeting = "Hop on, mate!",
+                )
+                updateUiState { copy(festival = festival) }
+            }
         }
     }
 


### PR DESCRIPTION
### TL;DR

Added support for festival-based loading screens in the trip planner with customizable emojis and greetings.

### What changed?

- Created a new `NoFestival` data class that extends the `Festival` interface to handle cases when no specific festival is active
- Updated `TimeTableState` to replace the simple `emoji` string with a full `Festival` object
- Modified the TimeTableScreen to display both the emoji and greeting from the festival object
- Enhanced the TimeTableViewModel to use the festival system for loading screens, falling back to a default "Hop on, mate!" greeting with common emojis when no festival is active

### How to test?

1. Open the trip planner and observe the loading screen
2. Verify that the loading screen displays the appropriate festival emoji and greeting
3. Test during different dates to ensure festival-specific content appears when applicable
4. Confirm that the default "Hop on, mate!" greeting appears when no festival is active

### Why make this change?

This change improves the user experience by providing contextually relevant and festive loading screens. By integrating with the festival system, the app can now display themed loading screens that change based on holidays or special events, making the waiting experience more engaging and personalized.