### PR TITLE
Fix date formatting in festivals2025.json and improve festival date parsing

### DIFF
--- a/core/festival/src/androidDebug/assets/festivals2025.json
+++ b/core/festival/src/androidDebug/assets/festivals2025.json
@@ -173,7 +173,7 @@
     {
       "type": "CHINESE_NEW_YEAR",
       "startDate": "2026-02-17",
-      "endDate": "2026-03-3",
+      "endDate": "2026-03-03",
       "emojiList": ["🧧"],
       "greeting": "Chinese New Year"
     },
@@ -187,7 +187,7 @@
     {
       "type": "MARDI_GRAS",
       "startDate": "2026-02-13",
-      "endDate": "2026-03-1",
+      "endDate": "2026-03-01",
       "emojiList": ["🏳️‍🌈", "🪩", "🌈"],
       "greeting": "Happy Mardi Gras"
     }

--- a/core/festival/src/commonTest/kotlin/xyz/ksharma/krail/core/festival/RealFestivalManagerTest.kt
+++ b/core/festival/src/commonTest/kotlin/xyz/ksharma/krail/core/festival/RealFestivalManagerTest.kt
@@ -175,6 +175,19 @@ class RealFestivalManagerTest {
         assertEquals("One Day Festival", (result as VariableDateFestival).greeting)
     }
 
+    @Test
+    fun testFestivalOnDate_withMalformedDateFormat_ignoresFestival() {
+        val data = FestivalData(
+            variableDates = listOf(
+                VariableDateFestival("MALFORMED", "20205-01-1", "20205-01-2", listOf("❌"), "Malformed Date")
+            )
+        )
+        val json = Json.encodeToString(data)
+        fakeFlag.setFlagValue(FlagKeys.FESTIVALS.key, FlagValue.JsonValue(json))
+        val result = manager.festivalOnDate(LocalDate.parse("2024-06-05"))
+        assertNull(result)
+    }
+
     private class FakeFlag : Flag {
         private val flagValues = mutableMapOf<String, FlagValue>()
         fun setFlagValue(key: String, value: FlagValue) {


### PR DESCRIPTION
### TL;DR

Fixed date format issues in festival data and improved error handling and logging for date parsing.

### What changed?

- Fixed malformed date formats in `festivals2025.json` by adding leading zeros to single-digit days:
  - Changed `2026-03-3` to `2026-03-03` for Chinese New Year
  - Changed `2026-03-1` to `2026-03-01` for Mardi Gras
- Enhanced error handling in `RealFestivalManager` for date parsing:
  - Added detailed error logging when date parsing fails
  - Added logging for festival date range checks
  - Improved logging throughout the festival data fetching process

### How to test?

1. Run the app with debug configuration to verify festivals load correctly
2. Check logs to confirm proper date parsing for all festivals
3. Run the unit tests, including the new test for malformed date handling

### Why make this change?

The application was potentially failing silently when encountering malformed date formats in festival data. These changes ensure proper date parsing, provide better diagnostics through enhanced logging, and prevent crashes when invalid date formats are encountered. The additional test case verifies that the system gracefully handles malformed dates.