### PR TITLE
Update 2025 festivals with new events and improved greetings

### DIFF
--- a/core/festival/src/androidDebug/assets/festivals2025.json
+++ b/core/festival/src/androidDebug/assets/festivals2025.json
@@ -4,155 +4,387 @@
       "type": "CHRISTMAS",
       "month": 12,
       "day": 25,
-      "emojiList": ["🎄", "🎅"],
+      "emojiList": [
+        "🎄",
+        "🎅"
+      ],
       "greeting": "Merry Christmas"
     },
     {
       "type": "NEW_YEAR",
       "month": 1,
       "day": 1,
-      "emojiList": ["🎉"],
+      "emojiList": [
+        "🎉"
+      ],
       "greeting": "Happy New Year"
     },
     {
       "type": "NEW_YEAR_EVE",
       "month": 12,
       "day": 31,
-      "emojiList": ["🎆"],
+      "emojiList": [
+        "🎆"
+      ],
       "greeting": "New Year's Eve"
     },
     {
       "type": "ANZAC_DAY",
       "month": 4,
       "day": 25,
-      "emojiList": ["🌺", "🇦🇺", "🎖️"],
-      "greeting": "ANZAC Day"
+      "emojiList": [
+        "🌺",
+        "🇦🇺",
+        "🎖️"
+      ],
+      "greeting": "Lest we forget"
     },
     {
       "type": "HALLOWEEN",
       "month": 10,
       "day": 31,
-      "emojiList": ["🎃", "👻"],
-      "greeting": "Halloween"
+      "emojiList": [
+        "🎃",
+        "👻"
+      ],
+      "greeting": "Spooktacular vibes only!"
     },
     {
       "type": "ROSE_DAY",
       "month": 2,
       "day": 7,
-      "emojiList": ["🌹"],
+      "emojiList": [
+        "🌹"
+      ],
       "greeting": "Rose Day"
     },
     {
       "type": "PROPOSE_DAY",
       "month": 2,
       "day": 8,
-      "emojiList": ["💍", "💞", "💌"],
+      "emojiList": [
+        "💍",
+        "💞",
+        "💌"
+      ],
       "greeting": "Propose Day"
     },
     {
       "type": "CHOCOLATE_DAY",
       "month": 2,
       "day": 9,
-      "emojiList": ["🍫", "💞"],
+      "emojiList": [
+        "🍫",
+        "💞"
+      ],
       "greeting": "Chocolate Day"
     },
     {
       "type": "TEDDY_DAY",
       "month": 2,
       "day": 10,
-      "emojiList": ["🧸"],
+      "emojiList": [
+        "🧸"
+      ],
       "greeting": "Teddy Day"
     },
     {
       "type": "PROMISE_DAY",
       "month": 2,
       "day": 11,
-      "emojiList": ["🤝"],
+      "emojiList": [
+        "🤝"
+      ],
       "greeting": "Promise Day"
     },
     {
       "type": "HUG_DAY",
       "month": 2,
       "day": 12,
-      "emojiList": ["🤗"],
+      "emojiList": [
+        "🤗"
+      ],
       "greeting": "Hug Day"
     },
     {
       "type": "KISS_DAY",
       "month": 2,
       "day": 13,
-      "emojiList": ["😘"],
+      "emojiList": [
+        "😘"
+      ],
       "greeting": "Kiss Day"
     },
     {
       "type": "VALENTINES_DAY",
       "month": 2,
       "day": 14,
-      "emojiList": ["❤️", "🌹"],
-      "greeting": "Valentine's Day"
+      "emojiList": [
+        "❤️",
+        "🌹"
+      ],
+      "greeting": "Love is in the air"
     },
     {
       "type": "AUSTRALIA_DAY",
       "month": 1,
       "day": 26,
-      "emojiList": ["🇦🇺", "🎉", "🎆"],
+      "emojiList": [
+        "🇦🇺",
+        "🎉",
+        "🎆"
+      ],
       "greeting": "Australia Day"
     },
     {
       "type": "WOMENS_DAY",
       "month": 3,
       "day": 8,
-      "emojiList": ["💜", "♀️", "👩", "👩‍🚀", "👩‍🚒", "👩‍✈️"],
+      "emojiList": [
+        "💜",
+        "♀️",
+        "👩",
+        "👩‍🚀",
+        "👩‍🚒",
+        "👩‍✈️"
+      ],
       "greeting": "International Women's Day"
     },
     {
       "type": "MENS_DAY",
       "month": 11,
       "day": 19,
-      "emojiList": ["💙", "♂️", "🚹", "👨‍🚒", "👨‍🌾", "👨‍🚀"],
+      "emojiList": [
+        "💙",
+        "♂️",
+        "🚹",
+        "👨‍🚒",
+        "👨‍🌾",
+        "👨‍🚀"
+      ],
       "greeting": "International Men's Day"
     },
     {
       "type": "ENGINEERS_DAY",
       "month": 9,
       "day": 15,
-      "emojiList": ["⚙️", "🔧"],
+      "emojiList": [
+        "⚙️",
+        "🔧"
+      ],
       "greeting": "Engineers Day"
     },
     {
       "type": "NURSES_DAY",
       "month": 5,
       "day": 12,
-      "emojiList": ["🏥", "🩺"],
+      "emojiList": [
+        "🏥",
+        "🩺"
+      ],
       "greeting": "Nurses Day"
     },
     {
       "type": "FRIENDSHIP_DAY",
       "month": 8,
       "day": 3,
-      "emojiList": ["🤝", "💛"],
+      "emojiList": [
+        "🤝",
+        "💛"
+      ],
       "greeting": "Friendship Day"
     },
     {
       "type": "PEACE_DAY",
       "month": 9,
       "day": 21,
-      "emojiList": ["☮️", "✌️"],
+      "emojiList": [
+        "☮️",
+        "✌️"
+      ],
       "greeting": "International Peace Day"
     },
     {
       "type": "A11Y_DAY",
       "month": 5,
       "day": 16,
-      "emojiList": ["♿️"],
+      "emojiList": [
+        "♿️"
+      ],
       "greeting": "Global Accessibility Awareness Day"
     },
     {
       "type": "PI_DAY",
       "month": 3,
       "day": 14,
-      "emojiList": ["🥧", "π"],
+      "emojiList": [
+        "🥧",
+        "π"
+      ],
       "greeting": "Pi Day"
+    },
+    {
+      "type": "INTERNATIONAL_YOGA_DAY",
+      "month": 6,
+      "day": 21,
+      "emojiList": [
+        "🧘",
+        "🧘‍♀️",
+        "🧘‍♂️",
+        "🕉️"
+      ],
+      "greeting": "International Yoga Day"
+    },
+    {
+      "type": "WORLD_ENVIRONMENT_DAY",
+      "month": 6,
+      "day": 5,
+      "emojiList": [
+        "🌍",
+        "🌱",
+        "🌳"
+      ],
+      "greeting": "World Environment Day"
+    },
+    {
+      "type": "MENTAL_HEALTH_DAY",
+      "month": 10,
+      "day": 10,
+      "emojiList": [
+        "🧠"
+      ],
+      "greeting": "World Mental Health Day"
+    },
+    {
+      "type": "WORLD_OCEANS_DAY",
+      "month": 6,
+      "day": 8,
+      "emojiList": [
+        "🌊",
+        "🐬",
+        "🐠"
+      ],
+      "greeting": "World Oceans Day"
+    },
+    {
+      "type": "STAR_WARS_DAY",
+      "month": 5,
+      "day": 4,
+      "emojiList": [
+        "🌌",
+        "🚀",
+        "⚔️",
+        "🪐"
+      ],
+      "greeting": "May the Force Ride With You"
+    },
+    {
+      "type": "MARIO_DAY",
+      "month": 3,
+      "day": 10,
+      "emojiList": [
+        "🍄",
+        "🎮"
+      ],
+      "greeting": "It's-a me, Mario! Let's-a go! \uD83C\uDF44"
+    },
+    {
+      "type": "HOBBIT_DAY",
+      "month": 9,
+      "day": 22,
+      "emojiList": [
+        "🧙",
+        "🧝",
+        "🌋"
+      ],
+      "greeting": "Happy Hobbit Day"
+    },
+    {
+      "type": "HARRY_POTTER_DAY",
+      "month": 5,
+      "day": 2,
+      "emojiList": [
+        "🪄",
+        "🧙‍♂️",
+        "⚡️"
+      ],
+      "greeting": "Hop on Platform 9¾ — Magic Awaits!"
+    },
+    {
+      "type": "POKEMON_DAY",
+      "month": 2,
+      "day": 27,
+      "emojiList": [
+        "🎮",
+        "🧢",
+        "⚡️"
+      ],
+      "greeting": "Gotta Catch 'Em All"
+    },
+    {
+      "type": "BARBIE_DAY",
+      "month": 3,
+      "day": 9,
+      "emojiList": [
+        "👠",
+        "💖",
+        "👗",
+        "🎀"
+      ],
+      "greeting": "Be anything. Go everywhere. \uD83D\uDC96"
+    },
+    {
+      "type": "TEACHERS_DAY",
+      "month": 9,
+      "day": 5,
+      "emojiList": [
+        "👩‍🏫",
+        "👨‍🏫",
+        "📚"
+      ],
+      "greeting": "Happy Teachers' Day"
+    },
+    {
+      "type": "WORLD_EMOJI_DAY",
+      "month": 7,
+      "day": 17,
+      "emojiList": [
+        "😎",
+        "🫶"
+      ],
+      "greeting": "World Emoji Day"
+    },
+    {
+      "type": "INTERNATIONAL_CAT_DAY",
+      "month": 8,
+      "day": 8,
+      "emojiList": [
+        "😸",
+        "😻"
+      ],
+      "greeting": "Purrfect day to ride"
+    },
+    {
+      "type": "INTERNATIONAL_DOG_DAY",
+      "month": 8,
+      "day": 26,
+      "emojiList": [
+        "🐶",
+        "🐾",
+        "🦴"
+      ],
+      "greeting": "International Dog Day"
+    },
+    {
+      "type": "TAYLOR_SWIFT_DAY",
+      "month": 12,
+      "day": 13,
+      "emojiList": [
+        "🎤",
+        "🎶",
+        "🩷"
+      ],
+      "greeting": "Happy Taylor Swift Day"
     }
   ],
   "variableDates": [
@@ -160,36 +392,98 @@
       "type": "EASTER",
       "startDate": "2026-04-05",
       "endDate": "2026-04-05",
-      "emojiList": ["🐰", "🐣", "🥚"],
+      "emojiList": [
+        "🐰",
+        "🐣",
+        "🥚"
+      ],
       "greeting": "Happy Easter"
     },
     {
       "type": "EID",
       "startDate": "2026-03-19",
       "endDate": "2026-03-20",
-      "emojiList": ["🌙", "🕌"],
-      "greeting": "Eid"
+      "emojiList": [
+        "🌙",
+        "🕌"
+      ],
+      "greeting": "Eid Mubarak!"
     },
     {
       "type": "CHINESE_NEW_YEAR",
       "startDate": "2026-02-17",
       "endDate": "2026-03-03",
-      "emojiList": ["🧧"],
+      "emojiList": [
+        "🧧"
+      ],
       "greeting": "Chinese New Year"
     },
     {
       "type": "VIVID_SYDNEY",
       "startDate": "2026-05-22",
       "endDate": "2026-06-13",
-      "emojiList": ["🎆", "🌈", "🌟", "✨"],
+      "emojiList": [
+        "🎆",
+        "🌈",
+        "🌟",
+        "✨"
+      ],
       "greeting": "Vivid Sydney"
     },
     {
       "type": "MARDI_GRAS",
       "startDate": "2026-02-13",
       "endDate": "2026-03-01",
-      "emojiList": ["🏳️‍🌈", "🪩", "🌈"],
+      "emojiList": [
+        "🏳️‍🌈",
+        "🪩",
+        "🌈"
+      ],
       "greeting": "Happy Mardi Gras"
+    },
+    {
+      "type": "NAIDOC_WEEK",
+      "startDate": "2025-07-06",
+      "endDate": "2025-07-13",
+      "emojiList": [
+        "🖤",
+        "💛",
+        "❤️"
+      ],
+      "greeting": "NAIDOC Week"
+    },
+    {
+      "type": "HOLI",
+      "startDate": "2025-03-14",
+      "endDate": "2025-03-14",
+      "emojiList": [
+        "🌈",
+        "🫧",
+        "🎈"
+      ],
+      "greeting": "Happy Holi"
+    },
+    {
+      "type": "MELBOURNE_CUP",
+      "startDate": "2025-11-04",
+      "endDate": "2025-11-04",
+      "emojiList": [
+        "🐎",
+        "💸"
+      ],
+      "greeting": "Melbourne Cup Day"
+    },
+    {
+      "type": "RECONCILIATION_WEEK",
+      "startDate": "2026-05-27",
+      "endDate": "2026-06-03",
+      "emojiList": [
+        "🪃",
+        "🖤",
+        "💛",
+        "❤️"
+      ],
+      "greeting": "Reconciliation Week"
     }
   ]
 }

--- a/core/festival/src/commonTest/kotlin/xyz/ksharma/krail/core/festival/RealFestivalManagerTest.kt
+++ b/core/festival/src/commonTest/kotlin/xyz/ksharma/krail/core/festival/RealFestivalManagerTest.kt
@@ -123,8 +123,20 @@ class RealFestivalManagerTest {
     fun testFestivalOnDate_withInvalidDateFormat_ignoresFestival() {
         val data = FestivalData(
             variableDates = listOf(
-                VariableDateFestival("BAD_START", "invalid-date", "2024-06-10", listOf("🎉"), "Bad Start Date"),
-                VariableDateFestival("BAD_END", "2024-06-01", "invalid-date", listOf("🎊"), "Bad End Date")
+                VariableDateFestival(
+                    "BAD_START",
+                    "invalid-date",
+                    "2024-06-10",
+                    listOf("🎉"),
+                    "Bad Start Date"
+                ),
+                VariableDateFestival(
+                    "BAD_END",
+                    "2024-06-01",
+                    "invalid-date",
+                    listOf("🎊"),
+                    "Bad End Date"
+                )
             )
         )
         val json = Json.encodeToString(data)
@@ -137,7 +149,13 @@ class RealFestivalManagerTest {
     fun testFestivalOnDate_withStartDateAfterEndDate_ignoresFestival() {
         val data = FestivalData(
             variableDates = listOf(
-                VariableDateFestival("INVALID_RANGE", "2024-06-10", "2024-06-01", listOf("❌"), "Invalid Range")
+                VariableDateFestival(
+                    "INVALID_RANGE",
+                    "2024-06-10",
+                    "2024-06-01",
+                    listOf("❌"),
+                    "Invalid Range"
+                )
             )
         )
         val json = Json.encodeToString(data)
@@ -150,8 +168,20 @@ class RealFestivalManagerTest {
     fun testFestivalOnDate_multipleFestivalsOnSameDate_returnsFirst() {
         val data = FestivalData(
             variableDates = listOf(
-                VariableDateFestival("FIRST", "2024-06-01", "2024-06-10", listOf("🎉"), "First Festival"),
-                VariableDateFestival("SECOND", "2024-06-01", "2024-06-10", listOf("🎊"), "Second Festival")
+                VariableDateFestival(
+                    "FIRST",
+                    "2024-06-01",
+                    "2024-06-10",
+                    listOf("🎉"),
+                    "First Festival"
+                ),
+                VariableDateFestival(
+                    "SECOND",
+                    "2024-06-01",
+                    "2024-06-10",
+                    listOf("🎊"),
+                    "Second Festival"
+                )
             )
         )
         val json = Json.encodeToString(data)
@@ -165,7 +195,13 @@ class RealFestivalManagerTest {
     fun testFestivalOnDate_singleDayFestival_foundOnThatDay() {
         val data = FestivalData(
             variableDates = listOf(
-                VariableDateFestival("ONE_DAY", "2024-06-05", "2024-06-05", listOf("🥳"), "One Day Festival")
+                VariableDateFestival(
+                    "ONE_DAY",
+                    "2024-06-05",
+                    "2024-06-05",
+                    listOf("🥳"),
+                    "One Day Festival"
+                )
             )
         )
         val json = Json.encodeToString(data)
@@ -179,7 +215,13 @@ class RealFestivalManagerTest {
     fun testFestivalOnDate_withMalformedDateFormat_ignoresFestival() {
         val data = FestivalData(
             variableDates = listOf(
-                VariableDateFestival("MALFORMED", "20205-01-1", "20205-01-2", listOf("❌"), "Malformed Date")
+                VariableDateFestival(
+                    "MALFORMED",
+                    "20205-01-1",
+                    "20205-01-2",
+                    listOf("❌"),
+                    "Malformed Date"
+                )
             )
         )
         val json = Json.encodeToString(data)
@@ -188,11 +230,51 @@ class RealFestivalManagerTest {
         assertNull(result)
     }
 
+    @Test
+    fun testFestivalData_withExtraUnknownField_parsesSuccessfully() {
+        // JSON with extra unknown fields at both root and object level
+        val jsonWithExtraField = """
+        {
+            "confirmedDates": [
+                {
+                    "type": "EXTRA_FIELD_TEST",
+                    "month": 7,
+                    "day": 7,
+                    "emojiList": ["🎉"],
+                    "greeting": "Extra Field Festival",
+                    "extraField": "This is an extra field that should be ignored"
+                }
+            ],
+            "variableDates": [
+                {
+                    "type": "EXTRA_VARIABLE",
+                    "startDate": "2025-07-01",
+                    "endDate": "2025-07-10",
+                    "emojiList": ["🎊"],
+                    "greeting": "Extra Variable Festival",
+                    "extraField": "This is an extra field that should be ignored"
+                }
+            ],
+            "extraField": "This is an extra field that should be ignored"
+        }
+    """.trimIndent()
+        fakeFlag.setFlagValue(FlagKeys.FESTIVALS.key, FlagValue.JsonValue(jsonWithExtraField))
+        // Should match the fixed date festival on 2025-07-07
+        val result = manager.festivalOnDate(LocalDate.parse("2025-07-07"))
+        assertNotNull(
+            result,
+            "Festival should not be null when date matches and extra fields are present"
+        )
+        assertTrue(result is FixedDateFestival)
+        assertEquals("Extra Field Festival", result.greeting)
+    }
+
     private class FakeFlag : Flag {
         private val flagValues = mutableMapOf<String, FlagValue>()
         fun setFlagValue(key: String, value: FlagValue) {
             flagValues[key] = value
         }
+
         override fun getFlagValue(key: String): FlagValue {
             return flagValues[key] ?: FlagValue.BooleanValue(false)
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -307,20 +307,18 @@ fun TimeTableScreen(
                 item(key = "loading") {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
 
-                        timeTableState.festival?.let { festival ->
-                            LoadingEmojiAnim(
-                                emoji = festival.emojiList.first(),
-                                modifier = Modifier.padding(vertical = 60.dp).animateItem(),
-                            )
+                        LoadingEmojiAnim(
+                            emoji = timeTableState.festival?.emojiList?.first() ?: "♠",
+                            modifier = Modifier.padding(vertical = 60.dp).animateItem(),
+                        )
 
-                            Text(
-                                text = festival.greeting,
-                                style = KrailTheme.typography.bodyLarge,
-                                textAlign = TextAlign.Center,
-                                color = KrailTheme.colors.onSurface,
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                            )
-                        }
+                        Text(
+                            text = timeTableState.festival?.greeting ?: "Hop on, mate!",
+                            style = KrailTheme.typography.bodyLarge,
+                            textAlign = TextAlign.Center,
+                            color = KrailTheme.colors.onSurface,
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                        )
                     }
                 }
             } else if (timeTableState.journeyList.isNotEmpty()) {


### PR DESCRIPTION
### TL;DR

Enhanced festival greetings and added new celebrations for 2025.

### What changed?

- Updated the `festivals2025.json` file with:
  - More personalized greetings (e.g., "Spooktacular vibes only!" for Halloween)
  - Added 16 new fixed-date festivals including International Yoga Day, Star Wars Day, World Emoji Day, and Taylor Swift Day
  - Added 4 new variable-date festivals including NAIDOC Week, Holi, Melbourne Cup, and Reconciliation Week
  - Updated existing festival greetings with more engaging messages

- Improved the TimeTableScreen loading state to:
  - Handle cases when no festival is available by showing a default "Hop on, mate!" message
  - Simplify the festival emoji and greeting display logic

- Enhanced the `RealFestivalManager` to be more lenient when parsing JSON:
  - Added configuration to ignore unknown keys
  - Changed some error logs to regular logs for non-critical issues

### How to test?

1. Run the app in debug mode
2. Navigate to the TimeTableScreen
3. Verify that festival greetings appear correctly during loading
4. Test on different dates to see various festival messages

### Why make this change?

This update enhances the user experience by providing more culturally diverse and engaging festival greetings throughout the year. The additional festivals and improved messaging create a more personalized feel for users in different regions and with varied interests, from pop culture references to important cultural celebrations.