### PR TITLE
Simplify festival handling in TimeTableState with default NoFestival

### DIFF
--- a/core/festival/src/commonMain/kotlin/xyz/ksharma/krail/core/festival/model/Festival.kt
+++ b/core/festival/src/commonMain/kotlin/xyz/ksharma/krail/core/festival/model/Festival.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.core.festival.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import xyz.ksharma.krail.core.festival.FestivalManager
 
 @Serializable
 sealed class Festival {
@@ -50,6 +51,6 @@ data class VariableDateFestival(
 
 data class NoFestival(
     override val type: String = "NoFestival",
-    override val emojiList: List<String>,
-    override val greeting: String,
+    override val emojiList: List<String> = FestivalManager.commonEmojiList.toList(),
+    override val greeting: String = "Hop on, mate!",
 ) : Festival()

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -4,7 +4,9 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import xyz.ksharma.krail.core.festival.FestivalManager
 import xyz.ksharma.krail.core.festival.model.Festival
+import xyz.ksharma.krail.core.festival.model.NoFestival
 import kotlin.time.Clock
 import kotlin.time.Instant
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -19,7 +21,10 @@ data class TimeTableState(
     val trip: Trip? = null,
     val isError: Boolean = false,
     val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
-    val festival: Festival? = null,
+    val festival: Festival = NoFestival(
+        emojiList = FestivalManager.commonEmojiList.toList(),
+        greeting = "Hop on, mate!",
+    ),
 ) {
     @OptIn(ExperimentalTime::class)
     data class JourneyCardInfo(

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -21,10 +21,7 @@ data class TimeTableState(
     val trip: Trip? = null,
     val isError: Boolean = false,
     val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
-    val festival: Festival = NoFestival(
-        emojiList = FestivalManager.commonEmojiList.toList(),
-        greeting = "Hop on, mate!",
-    ),
+    val festival: Festival = NoFestival(),
 ) {
     @OptIn(ExperimentalTime::class)
     data class JourneyCardInfo(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -51,6 +51,7 @@ import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.core.festival.FestivalManager
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Button
@@ -306,14 +307,13 @@ fun TimeTableScreen(
             } else if (timeTableState.isLoading) {
                 item(key = "loading") {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-
                         LoadingEmojiAnim(
-                            emoji = timeTableState.festival?.emojiList?.first() ?: "♠",
+                            emoji = timeTableState.festival.emojiList.first(),
                             modifier = Modifier.padding(vertical = 60.dp).animateItem(),
                         )
 
                         Text(
-                            text = timeTableState.festival?.greeting ?: "Hop on, mate!",
+                            text = timeTableState.festival.greeting,
                             style = KrailTheme.typography.bodyLarge,
                             textAlign = TextAlign.Center,
                             color = KrailTheme.colors.onSurface,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -308,7 +308,7 @@ fun TimeTableScreen(
                 item(key = "loading") {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         LoadingEmojiAnim(
-                            emoji = timeTableState.festival.emojiList.first(),
+                            emoji = timeTableState.festival.emojiList.random(),
                             modifier = Modifier.padding(vertical = 60.dp).animateItem(),
                         )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -51,7 +51,6 @@ import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.core.festival.FestivalManager
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Button

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -513,17 +513,11 @@ class TimeTableViewModel(
     }
 
     private fun updateLoadingEmoji() {
-        festivalManager.festivalOnDate().let { festival ->
-            if (festival != null) {
-                updateUiState { copy(festival = festival) }
-            } else {
-                val festival = NoFestival(
-                    emojiList = FestivalManager.commonEmojiList.toList(),
-                    greeting = "Hop on, mate!",
-                )
-                updateUiState { copy(festival = festival) }
-            }
-        }
+        val festival = festivalManager.festivalOnDate() ?: NoFestival(
+            emojiList = FestivalManager.commonEmojiList.toList(),
+            greeting = "Hop on, mate!",
+        )
+        updateUiState { copy(festival = festival) }
     }
 
     override fun onCleared() {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -513,10 +513,7 @@ class TimeTableViewModel(
     }
 
     private fun updateLoadingEmoji() {
-        val festival = festivalManager.festivalOnDate() ?: NoFestival(
-            emojiList = FestivalManager.commonEmojiList.toList(),
-            greeting = "Hop on, mate!",
-        )
+        val festival = festivalManager.festivalOnDate() ?: NoFestival()
         updateUiState { copy(festival = festival) }
     }
 


### PR DESCRIPTION
### TL;DR

Simplified festival handling in the TimeTable feature by making Festival a non-nullable property with a default value.

### What changed?

- Changed `festival` property in `TimeTableState` from nullable (`Festival?`) to non-nullable with a default `NoFestival` value
- Removed null checks in `TimeTableScreen` when accessing festival properties
- Simplified the `updateLoadingEmoji()` method in `TimeTableViewModel` by removing unnecessary conditional logic

### How to test?

1. Navigate to the TimeTable screen
2. Verify that loading animations display correctly with the default "Hop on, mate!" greeting
3. Test during different festival periods to ensure festival-specific emojis and greetings appear correctly

### Why make this change?

This change eliminates unnecessary null checks and simplifies the codebase by ensuring the `festival` property always has a valid value. By providing a default `NoFestival` implementation, we maintain consistent behavior while reducing defensive coding patterns throughout the feature.