### PR TITLE
Add Park and Ride to how to krail

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -241,6 +241,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             PLAN_TRIP,
             SELECT_MODE,
             INVITE_FRIENDS,
+            PARK_RIDE,
         }
     }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
@@ -28,6 +28,8 @@ data class IntroState(
         PLAN_TRIP,
         SELECT_MODE,
         INVITE_FRIENDS,
+
+        PARK_RIDE,
     }
 
     companion object {
@@ -69,12 +71,12 @@ data class IntroState(
                         "#FFC800", // Yellow
                         KrailThemeStyle.Bus.hexColorCode,
                     ),
-                    title = "Service Alerts",
-                    tagline = "DELAYS?\nDETOURS?\nWE'LL TELL YOU.",
-                    emoji = "⚠",
+                    title = "Park & Ride",
+                    tagline = "PARKING?\nTOTAL PAIN\nWE GOT YOU",
+                    emoji = "\uD83C\uDD7F\uFE0F",
                     ctaText = "LET'S KRAIL",
                     primaryStyle = KrailThemeStyle.Bus.hexColorCode,
-                    type = IntroPageType.ALERTS,
+                    type = IntroPageType.PARK_RIDE,
                 ),
                 IntroPage(
                     id = 3,
@@ -94,6 +96,20 @@ data class IntroState(
                 IntroPage(
                     id = 4,
                     colorsList = persistentListOf(
+                        KrailThemeStyle.Ferry.hexColorCode,
+                        TransportMode.LightRail().colorCode,
+                        KrailThemeStyle.Ferry.hexColorCode,
+                    ),
+                    title = "Service Alerts",
+                    tagline = "DELAYS?\nDETOURS?\nWE'LL TELL YOU.",
+                    emoji = "⚠",
+                    ctaText = "LET'S KRAIL",
+                    primaryStyle = TransportMode.LightRail().colorCode,
+                    type = IntroPageType.ALERTS,
+                ),
+                IntroPage(
+                    id = 5,
+                    colorsList = persistentListOf(
                         KrailThemeStyle.PurpleDrip.hexColorCode,
                         "#FFC800", // Yellow
                         KrailThemeStyle.PurpleDrip.hexColorCode,
@@ -106,7 +122,7 @@ data class IntroState(
                     type = IntroPageType.PLAN_TRIP,
                 ),
                 IntroPage(
-                    id = 5,
+                    id = 6,
                     colorsList = persistentListOf(
                         KrailThemeStyle.BarbiePink.hexColorCode,
                         "#FFC800", // Yellow

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
@@ -1,0 +1,60 @@
+package xyz.ksharma.krail.trip.planner.ui.intro
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.persistentSetOf
+import xyz.ksharma.krail.taj.LocalThemeColor
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState.ParkRideFacilityDetail
+
+@Composable
+fun IntroParkRide(tagline: String, style: String, modifier: Modifier, onInteraction: () -> Unit) {
+    val themeColor = remember { mutableStateOf(style) }
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            CompositionLocalProvider(LocalThemeColor provides themeColor) {
+                ParkRideCard(
+                    ParkRideUiState(
+                        stopId = "park-ride-stop-id",
+                        stopName = "Bella Vista Station",
+                        facilities = persistentSetOf(
+                            ParkRideFacilityDetail(
+                                spotsAvailable = 658,
+                                totalSpots = 700,
+                                facilityName = "Bella Vista",
+                                percentageFull = 14,
+                                stopId = "stopId1",
+                                timeText = "8:00 AM",
+                                facilityId = "facilityId1",
+                            ),
+                        ),
+                    ),
+                    onClick = { onInteraction() },
+                )
+            }
+        }
+
+        TagLineWithEmoji(
+            tagline = tagline,
+            emoji = "🚗",
+            emojiColor = style.hexToComposeColor(),
+            tagColor = style.hexToComposeColor(),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -45,6 +44,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.modifier.gradientBorder
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState.IntroPageType
@@ -209,7 +209,10 @@ fun IntroScreen(
                     ),
                     modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
                 ) {
-                    Text(text = state.pages[startPage].ctaText)
+                    Text(
+                        text = state.pages[startPage].ctaText,
+                        color = getForegroundColor(backgroundColor = animatedButtonColor),
+                    )
                 }
             }
         }
@@ -316,6 +319,17 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 onShareClick = onShareClick,
+                modifier = modifier.padding(20.dp),
+                onInteraction = {
+                    onInteraction(pageData.type)
+                }
+            )
+        }
+
+        IntroPageType.PARK_RIDE -> {
+            IntroParkRide(
+                tagline = pageData.tagline,
+                style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
                 onInteraction = {
                     onInteraction(pageData.type)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -77,6 +77,7 @@ class IntroViewModel(
             IntroState.IntroPageType.PLAN_TRIP -> InteractionPage.PLAN_TRIP
             IntroState.IntroPageType.SELECT_MODE -> InteractionPage.SELECT_MODE
             IntroState.IntroPageType.INVITE_FRIENDS -> InteractionPage.INVITE_FRIENDS
+            IntroState.IntroPageType.PARK_RIDE -> InteractionPage.PARK_RIDE
         }
 
     private fun updateUiState(block: IntroState.() -> IntroState) {


### PR DESCRIPTION
### TL;DR

Added a new Park & Ride intro page to the onboarding flow with corresponding analytics tracking.

### What changed?

- Added a new `PARK_RIDE` enum value to `AnalyticsEvent` for tracking
- Added a new `PARK_RIDE` page type to `IntroState`
- Created a new `IntroParkRide.kt` component to display Park & Ride information
- Updated the intro page order, adding the Park & Ride page and moving the Service Alerts page
- Updated the intro page content with Park & Ride specific text and styling
- Added support for the new page type in `IntroScreen` and `IntroViewModel`

### How to test?

1. Launch the app and go through the onboarding flow
2. Verify the new Park & Ride page appears with the correct styling and content
3. Confirm the page shows a sample Park & Ride card for "Bella Vista Station"
4. Check that tapping the CTA button properly tracks the analytics event
5. Ensure the page transitions smoothly in the sequence

### Why make this change?

To highlight the Park & Ride feature during onboarding, helping users discover this functionality early in their app experience. This addition provides users with information about parking availability at transit stations, addressing a common pain point for commuters who drive part of their journey.