### PR TITLE
Fix APK artifact path in Android build workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: composeApp-release-apk-${{ github.run_id }}
-          path: composeApp/build/outputs/apk/release/composeApp-release.apk
+          path: composeApp/release/composeApp-release.apk
 
       - name: Upload Release AAB
         if: ${{ inputs.variant == 'release' }}


### PR DESCRIPTION
### TL;DR

Updated the path for the release APK artifact in the Android build workflow.

### What changed?

Modified the upload-artifact action in the build-android.yml workflow to use the correct path for the release APK. The path was changed from `composeApp/build/outputs/apk/release/composeApp-release.apk` to `composeApp/release/composeApp-release.apk`.

### How to test?

1. Trigger the Android build workflow with the release variant
2. Verify that the APK artifact is successfully uploaded
3. Download the artifact and confirm it's the correct APK file

### Why make this change?

The previous path was incorrect, causing the workflow to fail when trying to upload the release APK artifact. This change ensures the workflow correctly locates and uploads the APK file from its actual location in the build directory structure.