### PR TITLE
Add logs to find path of release apk on CI/CD

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -61,6 +61,15 @@ jobs:
             ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
           fi
 
+      - name: List files in composeApp/release
+        run: ls -lR composeApp/release || echo "Directory not found"
+
+      - name: List files in composeApp/build/outputs/apk/release
+        run: ls -lR composeApp/build/outputs/apk/release || echo "Directory not found"
+
+      - name: List files in composeApp/build/outputs/bundle/release
+        run: ls -lR composeApp/build/outputs/bundle/release || echo "Directory not found"
+
       - name: Sign Android Release AAB
         if: ${{ inputs.variant == 'release' }}
         id: signed_release_aab


### PR DESCRIPTION
### TL;DR

Added file listing steps to the Android build workflow to improve debugging capabilities.

### What changed?

Added three new steps to the `build-android.yml` workflow that list the contents of key output directories:
- `composeApp/release`
- `composeApp/build/outputs/apk/release`
- `composeApp/build/outputs/bundle/release`

Each step uses `ls -lR` to recursively list directory contents and includes a fallback message if the directory doesn't exist.

### How to test?

1. Trigger the Android build workflow
2. Check the workflow logs to verify the new steps are executed
3. Confirm that the output shows the expected files in each directory or appropriate "Directory not found" messages

### Why make this change?

This change helps with debugging build issues by providing visibility into the output directories where APKs and AABs are generated. This makes it easier to verify that the expected artifacts are being created before the signing step runs.