### PR TITLE
Add APK signing and improve Firebase distribution workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -61,15 +61,38 @@ jobs:
             ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
           fi
 
-      - name: List files in composeApp/release
-        run: ls -lR composeApp/release || echo "Directory not found"
+      - name: Upload Debug APK
+        if: ${{ inputs.variant == 'debug' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: composeApp-debug-apk-${{ github.run_id }}
+          path: composeApp/build/outputs/apk/debug/composeApp-debug.apk
 
+      # Release APK Signing and Uploading
       - name: List files in composeApp/build/outputs/apk/release
         run: ls -lR composeApp/build/outputs/apk/release || echo "Directory not found"
 
-      - name: List files in composeApp/build/outputs/bundle/release
-        run: ls -lR composeApp/build/outputs/bundle/release || echo "Directory not found"
+      - name: Check jarsigner
+        run: jarsigner -help
 
+      - name: Sign Release APK
+        if: ${{ inputs.variant == 'release' }}
+        run: |
+          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
+            -keystore ${{ secrets.ANDROID_KEYSTORE_FILE }} \
+            -storepass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
+            -keypass ${{ secrets.ANDROID_KEY_PASSWORD }} \
+            composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk ${{ secrets.ANDROID_KEY_ALIAS }}
+          mv composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk composeApp/build/outputs/apk/release/composeApp-release.apk
+
+      - name: Upload Release APK
+        if: ${{ inputs.variant == 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: composeApp-release-apk-${{ github.run_id }}
+          path: composeApp/build/outputs/apk/release/composeApp-release.apk
+
+      # Release AAB Signing and Uploading
       - name: Sign Android Release AAB
         if: ${{ inputs.variant == 'release' }}
         id: signed_release_aab
@@ -80,20 +103,6 @@ jobs:
           alias: ${{ secrets.ANDROID_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-
-      - name: Upload Debug APK
-        if: ${{ inputs.variant == 'debug' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: composeApp-debug-apk-${{ github.run_id }}
-          path: composeApp/build/outputs/apk/debug/composeApp-debug.apk
-
-      - name: Upload Release APK
-        if: ${{ inputs.variant == 'release' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: composeApp-release-apk-${{ github.run_id }}
-          path: composeApp/release/composeApp-release.apk
 
       - name: Upload Release AAB
         if: ${{ inputs.variant == 'release' }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -114,3 +114,6 @@ jobs:
         with:
           name: composeApp-release-aab-${{ github.run_id }}
           path: ${{ steps.signed_release_aab.outputs.signedReleaseFile }}
+
+      - name: Cleanup sensitive files
+        run: rm -f keystore.jks

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -75,11 +75,15 @@ jobs:
       - name: Check jarsigner
         run: jarsigner -help
 
+      - name: Decode Keystore
+        if: ${{ inputs.variant == 'release' }}
+        run: echo "${{ secrets.ANDROID_KEYSTORE_FILE }}" | base64 -d > keystore.jks
+
       - name: Sign Release APK
         if: ${{ inputs.variant == 'release' }}
         run: |
           jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
-            -keystore ${{ secrets.ANDROID_KEYSTORE_FILE }} \
+            -keystore keystore.jks \
             -storepass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
             -keypass ${{ secrets.ANDROID_KEY_PASSWORD }} \
             composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk ${{ secrets.ANDROID_KEY_ALIAS }}

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -44,7 +44,14 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
         run: |
-          firebase appdistribution:distribute composeApp-${{ inputs.variant }}.apk \
-            --app "$FIREBASE_APP_ID" \
-            --groups "Friends" \
-            --release-notes "${{ github.event.head_commit.message }}"
+          if [ "${{ inputs.variant }}" = "debug" ]; then
+            firebase appdistribution:distribute composeApp-debug.apk \
+              --app "$FIREBASE_APP_ID" \
+              --groups "Internal" \
+              --release-notes "Debug: ${{ github.event.head_commit.message }}"
+          else
+            firebase appdistribution:distribute composeApp-release.apk \
+              --app "$FIREBASE_APP_ID" \
+              --groups "Friends" \
+              --release-notes "Release: ${{ github.event.head_commit.message }}"
+          fi

--- a/.github/workflows/firebase-app-distribution.yml
+++ b/.github/workflows/firebase-app-distribution.yml
@@ -55,3 +55,6 @@ jobs:
               --groups "Friends" \
               --release-notes "Release: ${{ github.event.head_commit.message }}"
           fi
+
+      - name: Cleanup sensitive files
+        run: rm -f gcloud.json


### PR DESCRIPTION
# Improved Android Build and Distribution Workflow

### TL;DR

Enhanced the Android build workflow with proper APK signing and improved Firebase distribution targeting.

### What changed?

- Added proper APK signing for release builds using jarsigner
- Fixed the path for release APK artifacts
- Reorganized the workflow steps for better readability
- Updated Firebase distribution to use different groups for debug vs release builds
  - Debug builds now go to "Internal" group
  - Release builds continue to go to "Friends" group
- Added a check for jarsigner availability
- Removed unnecessary directory listing steps

### How to test?

1. Trigger a debug build workflow and verify the APK is uploaded as an artifact
2. Trigger a release build workflow and verify both signed APK and AAB are uploaded as artifacts
3. Verify Firebase distribution sends debug builds to "Internal" group and release builds to "Friends" group

### Why make this change?

The previous workflow had issues with APK signing and artifact paths, causing release APKs to be unavailable or improperly signed. This change ensures that both debug and release builds are properly processed, signed, and distributed to the appropriate testing groups.