### PR TITLE
Delete artifacts after 1 days

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -65,6 +65,7 @@ jobs:
         if: ${{ inputs.variant == 'debug' }}
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: composeApp-debug-apk-${{ github.run_id }}
           path: composeApp/build/outputs/apk/debug/composeApp-debug.apk
 
@@ -93,6 +94,7 @@ jobs:
         if: ${{ inputs.variant == 'release' }}
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: composeApp-release-apk-${{ github.run_id }}
           path: composeApp/build/outputs/apk/release/composeApp-release.apk
 
@@ -112,6 +114,7 @@ jobs:
         if: ${{ inputs.variant == 'release' }}
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 1
           name: composeApp-release-aab-${{ github.run_id }}
           path: ${{ steps.signed_release_aab.outputs.signedReleaseFile }}
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Sign Android Release AAB
         if: ${{ inputs.variant == 'release' }}
         id: signed_release_aab
-        uses: r0adkll/sign-android-release@v1.0.4
+        uses: r0adkll/sign-android-release@v1.0.7
         with:
           releaseDirectory: composeApp/build/outputs/bundle/release
           signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE_FILE }}


### PR DESCRIPTION
Delete artifacts after 1 days

fix The warning is about the deprecated set-output command in GitHub Actions.
To fix this, use the latest version of the r0adkll/sign-android-release action, which supports environment files.