### PR TITLE
Replace Android signing action with filippoLeporati93/android-release-signer

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Sign Android Release AAB
         if: ${{ inputs.variant == 'release' }}
         id: signed_release_aab
-        uses: r0adkll/sign-android-release@v1.0.4
+        uses: filippoLeporati93/android-release-signer@v1
         with:
           releaseDirectory: composeApp/build/outputs/bundle/release
           signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE_FILE }}


### PR DESCRIPTION
### TL;DR

Updated the Android release signing action in the GitHub workflow.

### What changed?

Replaced the Android release signing GitHub action from `r0adkll/sign-android-release@v1.0.4` to `filippoLeporati93/android-release-signer@v1` in the build-android.yml workflow file. The action is used for signing the Android Release AAB in the release variant.

### Why make this change?

The previous signing action (`r0adkll/sign-android-release`) had following issues
This action causes some warnings due to outdated dependencies and deprecated commands. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
The new action (`filippoLeporati93/android-release-signer`) has this fixed.