### PR TITLE
Fix loading emoji state for TimeTableScreen and update festival emojis list

### DIFF
--- a/core/festival/src/androidDebug/assets/festivals2025.json
+++ b/core/festival/src/androidDebug/assets/festivals2025.json
@@ -294,7 +294,7 @@
       "day": 22,
       "emojiList": [
         "🧙",
-        "🧝",
+        "🍄",
         "🌋"
       ],
       "greeting": "Happy Hobbit Day"
@@ -350,7 +350,9 @@
       "day": 17,
       "emojiList": [
         "😎",
-        "🫶"
+        "🤩",
+        "🔥",
+        "🫠"
       ],
       "greeting": "World Emoji Day"
     },

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -1,18 +1,17 @@
 package xyz.ksharma.krail.trip.planner.ui.state.timetable
 
+import androidx.compose.runtime.Stable
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
-import xyz.ksharma.krail.core.festival.FestivalManager
-import xyz.ksharma.krail.core.festival.model.Festival
-import xyz.ksharma.krail.core.festival.model.NoFestival
 import kotlin.time.Clock
 import kotlin.time.Instant
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import kotlin.time.ExperimentalTime
 
+@Stable
 data class TimeTableState(
     val isLoading: Boolean = true,
     val silentLoading: Boolean = false, // Loading anim while still displaying TimeTable results.
@@ -21,9 +20,12 @@ data class TimeTableState(
     val trip: Trip? = null,
     val isError: Boolean = false,
     val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
-    val festival: Festival = NoFestival(),
+    // has to be null, otherwise it will switch from default to a festival.
+    // It should load only once whether it is a festival or not.
+    val loadingEmoji: LoadingEmoji? = null,
 ) {
     @OptIn(ExperimentalTime::class)
+    @Stable
     data class JourneyCardInfo(
         val timeText: String, // "in x mins"
 
@@ -82,6 +84,7 @@ data class TimeTableState(
         val hasJourneyEnded: Boolean
             get() = Instant.parse(destinationUtcDateTime) < Clock.System.now()
 
+        @Stable
         sealed class Leg {
             data class WalkingLeg(
                 val duration: String, // "10mins"
@@ -137,10 +140,17 @@ data class TimeTableState(
             IDEST("IDEST"),
         }
 
+        @Stable
         data class Stop(
             val name: String, // "xx Station, Platform 1" - stopSequence.disassembledName ?: stopSequence.name
             val time: String, // "12:00pm" - stopSequence.departureTimeEstimated ?: stopSequence.departureTimePlanned
             val isWheelchairAccessible: Boolean,
         )
     }
+
+    @Stable
+    data class LoadingEmoji(
+        val emoji: String,
+        val greeting: String,
+    )
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -99,6 +99,7 @@ fun TimeTableScreen(
         mutableStateListOf(*timeTableState.unselectedModes.toTypedArray())
     }
     var isReverseButtonRotated by rememberSaveable { mutableStateOf(false) }
+    val loadingEmoji by rememberSaveable { mutableStateOf(timeTableState.festival.emojiList.random()) }
 
     Column(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
@@ -307,7 +308,7 @@ fun TimeTableScreen(
                 item(key = "loading") {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         LoadingEmojiAnim(
-                            emoji = timeTableState.festival.emojiList.random(),
+                            emoji = loadingEmoji,
                             modifier = Modifier.padding(vertical = 60.dp).animateItem(),
                         )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -99,7 +99,6 @@ fun TimeTableScreen(
         mutableStateListOf(*timeTableState.unselectedModes.toTypedArray())
     }
     var isReverseButtonRotated by rememberSaveable { mutableStateOf(false) }
-    val loadingEmoji by rememberSaveable { mutableStateOf(timeTableState.festival.emojiList.random()) }
 
     Column(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
@@ -305,20 +304,23 @@ fun TimeTableScreen(
                     )
                 }
             } else if (timeTableState.isLoading) {
-                item(key = "loading") {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        LoadingEmojiAnim(
-                            emoji = loadingEmoji,
-                            modifier = Modifier.padding(vertical = 60.dp).animateItem(),
-                        )
 
-                        Text(
-                            text = timeTableState.festival.greeting,
-                            style = KrailTheme.typography.bodyLarge,
-                            textAlign = TextAlign.Center,
-                            color = KrailTheme.colors.onSurface,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                        )
+                timeTableState.loadingEmoji?.let { emoji ->
+                    item(key = "loading") {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            LoadingEmojiAnim(
+                                emoji = emoji.emoji,
+                                modifier = Modifier.padding(vertical = 60.dp).animateItem(),
+                            )
+
+                            Text(
+                                text = emoji.greeting,
+                                style = KrailTheme.typography.bodyLarge,
+                                textAlign = TextAlign.Center,
+                                color = KrailTheme.colors.onSurface,
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                            )
+                        }
                     }
                 }
             } else if (timeTableState.journeyList.isNotEmpty()) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -514,7 +514,14 @@ class TimeTableViewModel(
 
     private fun updateLoadingEmoji() {
         val festival = festivalManager.festivalOnDate() ?: NoFestival()
-        updateUiState { copy(festival = festival) }
+        updateUiState {
+            copy(
+                loadingEmoji = TimeTableState.LoadingEmoji(
+                    emoji = festival.emojiList.random(),
+                    greeting = festival.greeting,
+                )
+            )
+        }
     }
 
     override fun onCleared() {


### PR DESCRIPTION
# 🎭 Update festival emojis and fix loading animation

- Replace elf emoji 🧝 with mushroom emoji 🍄 for Hobbit Day
- Add more emojis (🤩, 🔥, 🫠) to World Emoji Day
- Make `festival` property nullable in `TimeTableState` to prevent unwanted transitions
- Fix loading animation to properly handle null festival state
- Prevent split-second display of common emoji list before showing festival emojis