### PR TITLE
Simplify Android APK signing process using Gradle signingConfig

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Clean Gradle Build
         run: ./gradlew clean
 
+      - name: Decode Keystore
+        if: ${{ inputs.variant == 'release' }}
+        run: echo "${{ secrets.ANDROID_KEYSTORE_FILE }}" | base64 -d > keystore.jks
+
+      - name: Export signing secrets for Gradle
+        run: |
+          echo "ANDROID_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+          echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
+          echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
+
       - name: Build ${{ inputs.variant }}
         env:
           ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
@@ -72,16 +82,6 @@ jobs:
       # Release APK Signing and Uploading
       - name: List files in composeApp/build/outputs/apk/release
         run: ls -lR composeApp/build/outputs/apk/release || echo "Directory not found"
-
-      - name: Decode Keystore
-        if: ${{ inputs.variant == 'release' }}
-        run: echo "${{ secrets.ANDROID_KEYSTORE_FILE }}" | base64 -d > keystore.jks
-
-      - name: Export signing secrets for Gradle
-        run: |
-          echo "ANDROID_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
-          echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
-          echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
 
       - name: Upload Release APK
         if: ${{ inputs.variant == 'release' }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -83,16 +83,6 @@ jobs:
           echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
           echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
 
-      - name: Sign Release APK
-        if: ${{ inputs.variant == 'release' }}
-        run: |
-          jarsigner -verbose -sigalg SHA256withRSA -digestalg SHA-256 \
-            -keystore keystore.jks \
-            -storepass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
-            -keypass ${{ secrets.ANDROID_KEY_PASSWORD }} \
-            composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk ${{ secrets.ANDROID_KEY_ALIAS }}
-          mv composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk composeApp/build/outputs/apk/release/composeApp-release.apk
-
       - name: Upload Release APK
         if: ${{ inputs.variant == 'release' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -55,6 +55,7 @@ jobs:
         run: echo "${{ secrets.ANDROID_KEYSTORE_FILE }}" | base64 -d > keystore.jks
 
       - name: Export signing secrets for Gradle
+        if: ${{ inputs.variant == 'release' }}
         run: |
           echo "ANDROID_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
           echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -73,12 +73,15 @@ jobs:
       - name: List files in composeApp/build/outputs/apk/release
         run: ls -lR composeApp/build/outputs/apk/release || echo "Directory not found"
 
-      - name: Check jarsigner
-        run: jarsigner -help
-
       - name: Decode Keystore
         if: ${{ inputs.variant == 'release' }}
         run: echo "${{ secrets.ANDROID_KEYSTORE_FILE }}" | base64 -d > keystore.jks
+
+      - name: Export signing secrets for Gradle
+        run: |
+          echo "ANDROID_KEYSTORE_PASSWORD=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+          echo "ANDROID_KEY_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> $GITHUB_ENV
+          echo "ANDROID_KEY_PASSWORD=${{ secrets.ANDROID_KEY_PASSWORD }}" >> $GITHUB_ENV
 
       - name: Sign Release APK
         if: ${{ inputs.variant == 'release' }}
@@ -89,18 +92,6 @@ jobs:
             -keypass ${{ secrets.ANDROID_KEY_PASSWORD }} \
             composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk ${{ secrets.ANDROID_KEY_ALIAS }}
           mv composeApp/build/outputs/apk/release/composeApp-release-unsigned.apk composeApp/build/outputs/apk/release/composeApp-release.apk
-
-      - name: Install Android Build Tools (for zipalign)
-        if: ${{ inputs.variant == 'release' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y zipalign || true
-
-      - name: Zipalign Release APK
-        if: ${{ inputs.variant == 'release' }}
-        run: |
-          zipalign -v -p 4 composeApp/build/outputs/apk/release/composeApp-release.apk composeApp/build/outputs/apk/release/composeApp-release-aligned.apk
-          mv composeApp/build/outputs/apk/release/composeApp-release-aligned.apk composeApp/build/outputs/apk/release/composeApp-release.apk
 
       - name: Upload Release APK
         if: ${{ inputs.variant == 'release' }}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -12,6 +12,15 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file("keystore.jks")
+            storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+            keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
 
         debug {
@@ -41,7 +50,11 @@ android {
                     keepDebugSymbols += "**/*.so"
                 }
             }
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+            signingConfig = signingConfigs.getByName("release")
         }
     }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file("keystore.jks")
+            storeFile = rootProject.file("keystore.jks")
             storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
             keyAlias = System.getenv("ANDROID_KEY_ALIAS")
             keyPassword = System.getenv("ANDROID_KEY_PASSWORD")


### PR DESCRIPTION
# Improve Android APK Signing Process

Refactor the Android release signing process to use Gradle's built-in signing configuration instead of manual jarsigner and zipalign steps in the GitHub workflow.

- Add proper signing configuration in `composeApp/build.gradle.kts`
- Remove manual jarsigner and zipalign steps from the GitHub workflow
- Export signing secrets as environment variables for Gradle to use
- Connect the release build type to the signing configuration

This approach is more maintainable and follows Android build best practices.