### PR TITLE
Remove clean step and update Gradle test commands in Android build workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -67,9 +67,9 @@ jobs:
         run: |
           set -e
           if [[ "${{ inputs.variant }}" == "debug" ]]; then
-            ./gradlew :composeApp:assembleDebug :composeApp:testDebug -PversionCode="${{ github.run_number }}" --rerun-tasks --stacktrace
+            ./gradlew :composeApp:assembleDebug testDebug -PversionCode="${{ github.run_number }}" --rerun-tasks --stacktrace
           elif [[ "${{ inputs.variant }}" == "release" ]]; then
-            ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
+            ./gradlew :composeApp:assembleRelease testRelease :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
           fi
 
       - name: Upload Debug APK

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -47,8 +47,8 @@ jobs:
           DATA: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON_DEBUG }}
         run: echo $DATA | base64 -di > composeApp/src/debug/google-services.json
 
-      - name: Clean Gradle Build
-        run: ./gradlew clean
+#      - name: Clean Gradle Build
+#        run: ./gradlew clean
 
       - name: Decode Keystore
         if: ${{ inputs.variant == 'release' }}


### PR DESCRIPTION
# Run Unit tests on CI

- Commented out the `./gradlew clean` step to speed up CI builds and make it optional for future use
- Added unit test execution for release builds with `testRelease` task
- Fixed test command for debug builds by removing redundant module prefix