### PR TITLE
Bump version to 1.7.4 and reset iOS build number

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -15,8 +15,8 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             androidAppExtension().apply {
                 defaultConfig {
-                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 106
-                    versionName = "1.7.3"
+                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 107
+                    versionName = "1.7.4"
                 }
             }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.3</string>
+	<string>1.7.4</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.7.3 to 1.7.4

### What changed?

- Android: Incremented `versionCode` from 106 to 107 and `versionName` from "1.7.3" to "1.7.4"
- iOS: Updated `CFBundleShortVersionString` from "1.7.3" to "1.7.4" and reset `CFBundleVersion` from "2" to "1"

### How to test?

- Build the Android app and verify the version appears as 1.7.4 (107) in the app info
- Build the iOS app and verify the version appears as 1.7.4 (1) in the app info

### Why make this change?

Preparing for the next release version of the application across both platforms.