### PR TITLE
Automate intro screens and refactor ParkRideCard to use external expansion state

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ParkRideCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ParkRideCard.kt
@@ -38,18 +38,19 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
 @Composable
 fun ParkRideCard(
     parkRideUiState: ParkRideUiState,
+    isExpanded: Boolean,
     modifier: Modifier = Modifier,
-    onClick: (Boolean) -> Unit = {},
+    onClick: () -> Unit = {},
 ) {
-    var isExpanded by rememberSaveable { mutableStateOf(false) }
+//    var isExpanded by rememberSaveable { mutableStateOf(false) }
 
     Row(
         modifier = modifier.fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
             .background(themeBackgroundColor())
             .klickable {
-                isExpanded = !isExpanded
-                onClick(isExpanded)
+                //isExpanded = !isExpanded
+                onClick()
             }
             .animateContentSize()
             .padding(top = 20.dp, start = 16.dp, end = 12.dp, bottom = 20.dp),
@@ -146,7 +147,11 @@ fun ParkRideCard(
 @Composable
 private fun ParkRideCardPreview() {
     PreviewTheme(KrailThemeStyle.BarbiePink) {
-        ParkRideCard(previewParkRideUiState)
+        ParkRideCard(
+            parkRideUiState = previewParkRideUiState,
+            isExpanded = false,
+            onClick = { }
+        )
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
@@ -33,6 +33,17 @@ fun IntroContentAlerts(
     modifier: Modifier = Modifier,
     onInteraction: () -> Unit = {},
 ) {
+    var displayAlert by rememberSaveable { mutableStateOf(false) }
+
+    // Auto-toggle every 3 seconds
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(2000)
+            displayAlert = !displayAlert
+            onInteraction()
+        }
+    }
+
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
@@ -41,8 +52,6 @@ fun IntroContentAlerts(
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            var displayAlert by rememberSaveable { mutableStateOf(false) }
-
             AlertButton(
                 dimensions = ButtonDefaults.smallButtonSize(),
                 onClick = {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
@@ -6,18 +6,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberTimePickerState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import xyz.ksharma.krail.core.datetime.rememberCurrentDateTime
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -30,29 +26,48 @@ import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptio
 @Composable
 fun IntroContentPlanTrip(
     tagline: String,
-    style: String, // hexCode - // todo - see if it can be color instead.
+    style: String, // hexCode
     modifier: Modifier = Modifier,
     onInteraction: () -> Unit = {},
 ) {
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            var journeyTimeOption by remember { mutableStateOf(JourneyTimeOptions.LEAVE) }
-            val currentDateTime = rememberCurrentDateTime()
-            val timePickerState = rememberTimePickerState(
-                initialHour = currentDateTime.hour,
-                initialMinute = currentDateTime.minute,
-                is24Hour = false,
-            )
+    val density = LocalDensity.current
 
-            val density = LocalDensity.current
-            val themeColor = rememberSaveable { mutableStateOf(TransportMode.Coach().colorCode) }
+    // Only automate if font scale is small
+    if (density.fontScale < 1.5f) {
+        val allOptions = JourneyTimeOptions.entries.toTypedArray()
+        var journeyTimeOption by remember { mutableStateOf(JourneyTimeOptions.LEAVE) }
+        val currentDateTime = rememberCurrentDateTime()
+        val timeStates = listOf(
+            10 to 10, // 10:10 AM
+            currentDateTime.hour to currentDateTime.minute // system time
+        )
+        var timeStep by remember { mutableStateOf(0) }
+        val timePickerState = rememberTimePickerState(
+            initialHour = timeStates[timeStep].first,
+            initialMinute = timeStates[timeStep].second,
+            is24Hour = false,
+        )
 
-            if (density.fontScale < 1.5f) {
-                // Not required to display if font size is large.
+        // Automate toggling
+        LaunchedEffect(Unit) {
+            var optionStep = 0
+            while (true) {
+                journeyTimeOption = allOptions[optionStep % allOptions.size]
+                timeStep = (optionStep % timeStates.size)
+                timePickerState.hour = timeStates[timeStep].first
+                timePickerState.minute = timeStates[timeStep].second
+                onInteraction()
+                optionStep++
+                delay(2500)
+            }
+        }
+
+        Column(
+            modifier = modifier
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 JourneyTimeOptionsGroup(
                     selectedOption = journeyTimeOption,
                     themeColor = style.hexToComposeColor(),
@@ -61,27 +76,27 @@ fun IntroContentPlanTrip(
                         onInteraction()
                     },
                 )
+
+                CompositionLocalProvider(
+                    LocalThemeColor provides rememberSaveable { mutableStateOf(TransportMode.Coach().colorCode) },
+                    LocalDensity provides Density(
+                        (density.density - 0.6f).coerceIn(1.5f, 2.5f),
+                        fontScale = 1f,
+                    ),
+                ) {
+                    TimeSelection(
+                        timePickerState = timePickerState,
+                        displayTitle = false,
+                        modifier = Modifier.align(Alignment.CenterHorizontally),
+                    )
+                }
             }
 
-            CompositionLocalProvider(
-                LocalThemeColor provides themeColor,
-                LocalDensity provides Density(
-                    (density.density - 0.6f).coerceIn(1.5f, 2.5f),
-                    fontScale = 1f,
-                ),
-            ) {
-                TimeSelection(
-                    timePickerState = timePickerState,
-                    displayTitle = false,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                )
-            }
+            TagLineWithEmoji(
+                tagline = tagline,
+                emoji = "\uD83D\uDD2E",
+                tagColor = style.hexToComposeColor()
+            )
         }
-
-        TagLineWithEmoji(
-            tagline = tagline,
-            emoji = "\uD83D\uDD2E",
-            tagColor = style.hexToComposeColor()
-        )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.TransportModeChip
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -22,31 +24,63 @@ fun IntroContentSelectTransportMode(
     modifier: Modifier = Modifier,
     onInteraction: () -> Unit = {},
 ) {
+    val allModes = TransportMode.values().sortedBy { it.priority }
+    val selectedProductClasses = remember { mutableStateSetOf<String>() }
+
+    LaunchedEffect(Unit) {
+        val total = allModes.size
+        var step = 0
+        var forward = true
+        while (true) {
+            selectedProductClasses.clear()
+            when {
+                step == 0 -> { /* none selected */ }
+                step in 1..total -> {
+                    selectedProductClasses.addAll(allModes.take(step).map { it.productClass.toString() })
+                }
+                step == total + 1 -> { // all selected
+                    selectedProductClasses.addAll(allModes.map { it.productClass.toString() })
+                }
+            }
+            delay(1000)
+            if (forward) {
+                step++
+                if (step > total + 1) {
+                    forward = false
+                    step = total + 1
+                }
+            } else {
+                step--
+                if (step < 0) {
+                    forward = true
+                    step = 0
+                }
+            }
+        }
+    }
+
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            val selectedProductClasses: MutableSet<Int> = remember {
-                mutableStateSetOf(TransportMode.Train().productClass)
-            }
 
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                TransportMode.values().sortedBy { it.priority }.forEach { mode ->
+                allModes.forEach { mode ->
                     TransportModeChip(
                         transportMode = mode,
-                        selected = selectedProductClasses.contains(mode.productClass),
+                        selected = selectedProductClasses.contains(mode.productClass.toString()),
                         onClick = {
                             onInteraction()
-                            if (selectedProductClasses.contains(mode.productClass)) {
-                                selectedProductClasses.removeAll(setOf(mode.productClass))
+                            if (selectedProductClasses.contains(mode.productClass.toString())) {
+                                selectedProductClasses.remove(mode.productClass.toString())
                             } else {
-                                selectedProductClasses.add(mode.productClass)
+                                selectedProductClasses.add(mode.productClass.toString())
                             }
                         },
                     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
@@ -6,8 +6,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentSetOf
@@ -20,6 +23,16 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState.ParkRid
 @Composable
 fun IntroParkRide(tagline: String, style: String, modifier: Modifier, onInteraction: () -> Unit) {
     val themeColor = remember { mutableStateOf(style) }
+    var isExpanded by remember { mutableStateOf(false) }
+
+    // Auto toggle every 2 seconds
+    LaunchedEffect(Unit) {
+        while (true) {
+            isExpanded = !isExpanded
+            kotlinx.coroutines.delay(2000)
+        }
+    }
+
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
@@ -30,7 +43,8 @@ fun IntroParkRide(tagline: String, style: String, modifier: Modifier, onInteract
         ) {
             CompositionLocalProvider(LocalThemeColor provides themeColor) {
                 ParkRideCard(
-                    ParkRideUiState(
+                    isExpanded = isExpanded,
+                    parkRideUiState = ParkRideUiState(
                         stopId = "park-ride-stop-id",
                         stopName = "Bella Vista Station",
                         facilities = persistentSetOf(
@@ -45,7 +59,10 @@ fun IntroParkRide(tagline: String, style: String, modifier: Modifier, onInteract
                             ),
                         ),
                     ),
-                    onClick = { onInteraction() },
+                    onClick = {
+                        isExpanded = !isExpanded
+                        onInteraction()
+                    },
                 )
             }
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -89,6 +91,8 @@ fun SavedTripsScreen(
                     }
                 }
             )
+
+            val expandedMap = remember { mutableStateMapOf<String, Boolean>() }
 
             LazyColumn(
                 contentPadding = PaddingValues(bottom = 300.dp),
@@ -172,13 +176,18 @@ fun SavedTripsScreen(
                             items = savedTripsState.parkRideUiState,
                             key = { parkRide -> parkRide.stopId },
                         ) { parkRide ->
+
+                            val isExpanded = expandedMap[parkRide.stopId] ?: false
                             ParkRideCard(
+                                isExpanded = isExpanded,
                                 modifier = Modifier.padding(horizontal = 16.dp),
-                                onClick = { isExpanded ->
+                                onClick = {
+                                    val newExpanded = !isExpanded
+                                    expandedMap[parkRide.stopId] = newExpanded
                                     onEvent(
                                         SavedTripUiEvent.ParkRideCardClick(
                                             parkRideState = parkRide,
-                                            isExpanded = isExpanded,
+                                            isExpanded = newExpanded,
                                         ),
                                     )
                                 },


### PR DESCRIPTION
# Hoisted State Management and UI Automation

- Hoisted `isExpanded` state from `ParkRideCard` to parent components for better state control
- Added automation to transport mode selection with sequential selection patterns
- Implemented auto-toggling for alerts display with 2-second intervals
- Added journey time option automation in trip planning with cycling through options
- Implemented time picker state automation with predefined time values
- Added auto-expansion for park ride cards with 2-second toggle intervals

## Screenshots

https://github.com/user-attachments/assets/70233805-6942-4377-98a8-cdcd2c0c3e83


These changes improve the demo experience by automatically cycling through UI states without requiring manual interaction.