### PR TITLE
Remove interaction tracking from intro screens and simplify analytics event

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -225,13 +225,11 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class IntroLetsKrailClickEvent(
         val pageType: InteractionPage,
         val pageNumber: Int,
-        val interactionPages: Set<InteractionPage>,
     ) : AnalyticsEvent(
         name = "intro_lets_krail",
         properties = mapOf(
             "completedOnPage" to pageType.name,
             "completedOnPageNumber" to pageNumber,
-            "interaction" to interactionPages.joinToString { it.name },
         )
     ) {
         enum class InteractionPage {

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroUiEvent.kt
@@ -13,7 +13,4 @@ sealed interface IntroUiEvent {
         val pageType: IntroState.IntroPageType,
         val pageNumber: Int,
     ) : IntroUiEvent
-
-    // Represents the interaction with ui elements displayed for app usage / decoration in intro screen.
-    data class IntroElementsInteraction(val pageType: IntroState.IntroPageType) : IntroUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -298,7 +298,7 @@ fun ExpandedJourneyCardContent(
                             ),
                             onClick = {
                                 displayAllStops = !displayAllStops
-                                onLegClick.invoke(displayAllStops)
+                                onLegClick(displayAllStops)
                             },
                         )
                     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -157,7 +159,6 @@ fun JourneyCard(
                 )
 
                 JourneyCardState.EXPANDED -> ExpandedJourneyCardContent(
-                    displayAllStops = false,
                     timeToDeparture = timeToDeparture,
                     themeColor = themeColor,
                     platformText = platformText,
@@ -180,7 +181,6 @@ fun JourneyCard(
 
 @Composable
 fun ExpandedJourneyCardContent(
-    displayAllStops: Boolean,
     timeToDeparture: String,
     themeColor: Color,
     platformText: String?,
@@ -281,6 +281,7 @@ fun ExpandedJourneyCardContent(
                             )
                         }
                     } else {
+                        var displayAllStops by rememberSaveable { mutableStateOf(false) }
                         LegView(
                             routeText = leg.displayText,
                             transportModeLine = leg.transportModeLine,
@@ -295,7 +296,10 @@ fun ExpandedJourneyCardContent(
                                     0.dp
                                 }
                             ),
-                            onClick = onLegClick,
+                            onClick = {
+                                displayAllStops = !displayAllStops
+                                onLegClick.invoke(displayAllStops)
+                            },
                         )
                     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -55,13 +54,12 @@ fun LegView(
     stops: ImmutableList<TimeTableState.JourneyCardInfo.Stop>,
     modifier: Modifier = Modifier,
     displayAllStops: Boolean = false,
-    onClick: (Boolean) -> Unit = {},
+    onClick: () -> Unit = {},
 ) {
     val circleRadius = 8.dp
     val strokeWidth = 4.dp
     val timelineColor =
         remember(transportModeLine) { transportModeLine.lineColorCode.hexToComposeColor() }
-    var showIntermediateStops by rememberSaveable { mutableStateOf(displayAllStops) }
 
     // Content alpha to be 100% always, as it's only visible in the expanded state.
     // If it's visible, it should be full alpha
@@ -78,8 +76,7 @@ fun LegView(
                     interactionSource = remember { MutableInteractionSource() },
                     indication = null,
                     onClick = {
-                        showIntermediateStops = !showIntermediateStops
-                        onClick(showIntermediateStops)
+                        onClick()
                     },
                     role = Role.Button,
                 )
@@ -134,8 +131,7 @@ fun LegView(
                             stops = "$stopsCount stops",
                             line = transportModeLine,
                             onClick = {
-                                showIntermediateStops = !showIntermediateStops
-                                onClick(showIntermediateStops)
+                                onClick()
                             },
                         )
                     } else {
@@ -145,7 +141,7 @@ fun LegView(
                     }
                 }
 
-                if (showIntermediateStops) {
+                if (displayAllStops) {
                     stops.drop(1).dropLast(1).forEach { stop ->
 
                         Spacer(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
@@ -31,7 +31,6 @@ fun IntroContentAlerts(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
     modifier: Modifier = Modifier,
-    onInteraction: () -> Unit = {},
 ) {
     var displayAlert by rememberSaveable { mutableStateOf(false) }
 
@@ -40,7 +39,6 @@ fun IntroContentAlerts(
         while (true) {
             delay(2000)
             displayAlert = !displayAlert
-            onInteraction()
         }
     }
 
@@ -56,7 +54,6 @@ fun IntroContentAlerts(
                 dimensions = ButtonDefaults.smallButtonSize(),
                 onClick = {
                     displayAlert = !displayAlert
-                    onInteraction()
                 },
             ) { Text(text = "2 Alerts") }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
@@ -34,10 +34,9 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 @Composable
 fun IntroContentInviteFriends(
     tagline: String,
-    style: String, // hexCode - // todo - see if it can be color instead.
+    style: String,
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
-    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -68,7 +67,6 @@ fun IntroContentInviteFriends(
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = {
                             onShareClick()
-                            onInteraction()
                         }
                     ),
                 contentAlignment = Alignment.Center,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
@@ -6,8 +6,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberTimePickerState
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -28,7 +34,6 @@ fun IntroContentPlanTrip(
     tagline: String,
     style: String, // hexCode
     modifier: Modifier = Modifier,
-    onInteraction: () -> Unit = {},
 ) {
     val density = LocalDensity.current
 
@@ -56,7 +61,6 @@ fun IntroContentPlanTrip(
                 timeStep = (optionStep % timeStates.size)
                 timePickerState.hour = timeStates[timeStep].first
                 timePickerState.minute = timeStates[timeStep].second
-                onInteraction()
                 optionStep++
                 delay(2500)
             }
@@ -73,7 +77,6 @@ fun IntroContentPlanTrip(
                     themeColor = style.hexToComposeColor(),
                     onOptionSelected = {
                         journeyTimeOption = it
-                        onInteraction()
                     },
                 )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,16 +26,19 @@ fun IntroContentRealTime(
     tagline: String,
     style: String,
     modifier: Modifier = Modifier,
-    onInteraction: () -> Unit = {},
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val isActive = remember { mutableStateOf(true) }
 
-    // Auto-toggle every 2 seconds
-    LaunchedEffect(Unit) {
-        while (true) {
+    LaunchedEffect(isActive.value) {
+        while (isActive.value) {
             expanded = !expanded
-            onInteraction()
             delay(2000)
+        }
+    }
+    DisposableEffect(Unit) {
+        onDispose {
+            isActive.value = false
         }
     }
 
@@ -51,7 +55,9 @@ fun IntroContentRealTime(
                 ),
                 stops = stopsList(),
                 displayAllStops = expanded,
-                onClick = { expanded = !expanded }, // keep in sync if user clicks
+                onClick = {
+                    expanded = !expanded
+                },
             )
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
@@ -5,9 +5,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.delay
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.trip.planner.ui.components.LegView
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -17,24 +23,35 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 @Composable
 fun IntroContentRealTime(
     tagline: String,
-    style: String, // hexCode - // todo - see if it can be color instead.
+    style: String,
     modifier: Modifier = Modifier,
     onInteraction: () -> Unit = {},
 ) {
+    var expanded by remember { mutableStateOf(false) }
+
+    // Auto-toggle every 2 seconds
+    LaunchedEffect(Unit) {
+        while (true) {
+            expanded = !expanded
+            onInteraction()
+            delay(2000)
+        }
+    }
+
     Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState()),
+        modifier = modifier.verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             LegView(
-                routeText = "Manly to Circular Quay",
+                routeText = "Circular Quay to Mosman Bay",
                 transportModeLine = TransportModeLine(
                     transportMode = TransportMode.Ferry(),
-                    lineName = "MFF",
+                    lineName = "F6",
                 ),
                 stops = stopsList(),
-                onClick = { onInteraction() },
+                displayAllStops = expanded,
+                onClick = { expanded = !expanded }, // keep in sync if user clicks
             )
         }
 
@@ -48,13 +65,23 @@ fun IntroContentRealTime(
 
 private fun stopsList() = persistentListOf(
     TimeTableState.JourneyCardInfo.Stop(
-        name = "Manly, Wharf 2",
-        time = "10:10 AM",
+        name = "Circular Quay, Wharf 4, Side B",
+        time = "9:00 PM",
         isWheelchairAccessible = true,
     ),
     TimeTableState.JourneyCardInfo.Stop(
-        name = "Circular Quay, Wharf 2",
-        time = "10:30 AM",
+        name = "South Mosman Wharf",
+        time = "9:15 PM",
+        isWheelchairAccessible = true,
+    ),
+    TimeTableState.JourneyCardInfo.Stop(
+        name = "Old Cremorne Wharf",
+        time = "9:18 PM",
+        isWheelchairAccessible = true,
+    ),
+    TimeTableState.JourneyCardInfo.Stop(
+        name = "Mosman Bay Wharf",
+        time = "9:20 PM",
         isWheelchairAccessible = true,
     ),
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
@@ -1,6 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.intro
 
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -15,9 +15,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -28,6 +30,10 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
@@ -37,21 +43,12 @@ import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.OriginDestination
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.rememberCoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 
 @Composable
 fun IntroContentSaveTrips(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
     modifier: Modifier = Modifier,
-    onInteraction: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -114,7 +111,6 @@ fun IntroContentSaveTrips(
                                 startAutoRotation()
                             }
                             isTripSaved = !isTripSaved
-                            onInteraction()
                         }
                     ),
                 contentAlignment = Alignment.Center,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
@@ -22,7 +22,6 @@ fun IntroContentSelectTransportMode(
     tagline: String,
     style: String, // hexCode - // todo - see if it can be color instead.
     modifier: Modifier = Modifier,
-    onInteraction: () -> Unit = {},
 ) {
     val allModes = TransportMode.values().sortedBy { it.priority }
     val selectedProductClasses = remember { mutableStateSetOf<String>() }
@@ -76,7 +75,6 @@ fun IntroContentSelectTransportMode(
                         transportMode = mode,
                         selected = selectedProductClasses.contains(mode.productClass.toString()),
                         onClick = {
-                            onInteraction()
                             if (selectedProductClasses.contains(mode.productClass.toString())) {
                                 selectedProductClasses.remove(mode.productClass.toString())
                             } else {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
@@ -21,7 +21,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState.ParkRideFacilityDetail
 
 @Composable
-fun IntroParkRide(tagline: String, style: String, modifier: Modifier, onInteraction: () -> Unit) {
+fun IntroParkRide(tagline: String, style: String, modifier: Modifier) {
     val themeColor = remember { mutableStateOf(style) }
     var isExpanded by remember { mutableStateOf(false) }
 
@@ -61,7 +61,6 @@ fun IntroParkRide(tagline: String, style: String, modifier: Modifier, onInteract
                     ),
                     onClick = {
                         isExpanded = !isExpanded
-                        onInteraction()
                     },
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -172,9 +172,6 @@ fun IntroScreen(
                                 )
                             },
                             modifier = Modifier.fillMaxSize(),
-                            onInteraction = { pageType ->
-                                onEvent(IntroUiEvent.IntroElementsInteraction(pageType))
-                            }
                         )
                     }
                 }
@@ -256,7 +253,6 @@ private fun IntroPageContent(
     pageData: IntroState.IntroPage,
     modifier: Modifier = Modifier,
     onShareClick: () -> Unit = {},
-    onInteraction: (IntroPageType) -> Unit,
 ) {
     when (pageData.type) {
         IntroPageType.SAVE_TRIPS -> {
@@ -264,9 +260,6 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
 
@@ -275,9 +268,6 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
 
@@ -286,9 +276,6 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
 
@@ -297,9 +284,6 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
 
@@ -308,9 +292,6 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
 
@@ -320,9 +301,6 @@ private fun IntroPageContent(
                 style = pageData.primaryStyle,
                 onShareClick = onShareClick,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
 
@@ -331,9 +309,6 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 modifier = modifier.padding(20.dp),
-                onInteraction = {
-                    onInteraction(pageData.type)
-                }
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -34,9 +34,6 @@ class IntroViewModel(
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.Intro)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), IntroState.default())
 
-    // For analytics
-    private val interactionPages: MutableSet<InteractionPage> = mutableSetOf()
-
     fun onEvent(event: IntroUiEvent) {
         when (event) {
             is IntroUiEvent.ReferFriend -> {
@@ -48,10 +45,6 @@ class IntroViewModel(
                 )
             }
 
-            is IntroUiEvent.IntroElementsInteraction -> {
-                event.pageType.toInteractionPage().let { interactionPages.add(it) }
-            }
-
             is IntroUiEvent.Complete -> {
                 viewModelScope.launch {
                     stopsManager.insertStops()
@@ -60,10 +53,8 @@ class IntroViewModel(
                         AnalyticsEvent.IntroLetsKrailClickEvent(
                             pageType = event.pageType.toInteractionPage(),
                             pageNumber = event.pageNumber,
-                            interactionPages = interactionPages,
                         )
                     )
-                    interactionPages.clear()
                 }
             }
         }


### PR DESCRIPTION
### TL;DR

Fixed the journey card's "show all stops" functionality and improved the real-time intro demo.

### What changed?

- Refactored the `JourneyCard` and `LegView` components to properly handle the display of intermediate stops
- Moved the `displayAllStops` state from a parameter to a local state variable in the `ExpandedJourneyCardContent`
- Updated the `onClick` handler in `LegView` to toggle the display state and propagate it correctly
- Enhanced the `IntroContentRealTime` component with an auto-toggle feature that shows/hides stops every 2 seconds
- Updated the ferry route example in the intro content from "Manly to Circular Quay" to "Circular Quay to Mosman Bay" with more detailed stops
- Removed the `IntroElementsInteraction` event and related analytics tracking
- Simplified the `IntroLetsKrailClickEvent` by removing the `interactionPages` property

### How to test?

1. Open the trip planner and select a journey with multiple stops
2. Tap on a leg to verify that intermediate stops toggle correctly
3. Check the intro screen to see the auto-toggling ferry route demonstration
4. Verify that the state is preserved when navigating away and back to the screen

### Why make this change?

The previous implementation had issues with state management for displaying intermediate stops. This change improves the user experience by properly maintaining the expanded/collapsed state of journey legs and provides a more engaging demo in the intro screen that showcases the feature automatically.