### PR TITLE
Bump Android version code to 108 and iOS build number to 2

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -15,7 +15,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             androidAppExtension().apply {
                 defaultConfig {
-                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 107
+                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 108
                     versionName = "1.7.4"
                 }
             }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.4</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Increment version codes for Android and iOS apps

### What changed?

- Incremented Android app version code from 107 to 108 in `AndroidApplicationConventionPlugin.kt`
- Incremented iOS app build number from 1 to 2 in `Info.plist`
- Version name/string remains at 1.7.4 for both platforms

### How to test?

- Build the Android app and verify the version code is 108
- Build the iOS app and verify the build number is 2
- Verify both apps display version 1.7.4 to users

### Why make this change?

Preparing for a new app release while maintaining the same user-facing version number. This allows for deploying fixes or updates to app stores without changing the marketing version.