### PR TITLE
Bump version to 1.7.5 and reset iOS build number

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -16,7 +16,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             androidAppExtension().apply {
                 defaultConfig {
                     versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 108
-                    versionName = "1.7.4"
+                    versionName = "1.7.5"
                 }
             }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.7.4</string>
+	<string>1.7.5</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.7.4 to 1.7.5

### What changed?

- Updated Android app version name from 1.7.4 to 1.7.5 in `AndroidApplicationConventionPlugin.kt`
- Updated iOS app version from 1.7.4 to 1.7.5 in `Info.plist`
- Reset iOS bundle version from 2 to 1 for the new version

### How to test?

- Build the Android app and verify the version shows as 1.7.5 in app info
- Build the iOS app and verify the version shows as 1.7.5 with build number 1

### Why make this change?

Preparing for the next release with version 1.7.5 across both Android and iOS platforms.