### PR TITLE
Remove mission impossible theme

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/ReferFriendManager.kt
@@ -34,11 +34,6 @@ object ReferFriendManager {
             "I’m the one it needs. \uD83D\uDE87" +
             SUFFIX,
 
-        "\uD83D\uDCA3 Your mission, should you choose to accept it is to " +
-            "invite two mates to KRAIL App and upgrade their Sydney experience.\n\n" +
-            "⏱\uFE0F This message will self-destruct in 2 minutes." +
-            SUFFIX,
-
         "\uD83E\uDDF3 Still stuck at Platform 9¾?\n" +
             "Cast the real spell, say “KRAILiosa Commuta!” \uD83E\uDE84 ✨" +
             SUFFIX,


### PR DESCRIPTION
### TL;DR

Removed one of the refer-a-friend message templates from the app.

### What changed?

Removed the "mission impossible" themed refer-a-friend message template from `ReferFriendManager.kt`. This was the template that mentioned inviting two friends to KRAIL App and included the line about the message self-destructing in 2 minutes.

### How to test?

1. Navigate to the refer-a-friend section in the app settings
2. Verify that the removed message template no longer appears in the sharing options
3. Confirm that the remaining templates (including the Platform 9¾ reference) still work correctly

### Why make this change?

The removed template may have been outdated or not performing well with users. Streamlining the available sharing templates improves the user experience by focusing on the most effective messaging options.