### PR TITLE
Improve Firebase CLI installation in CI workflow

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -22,8 +22,12 @@ jobs:
       - name: List files in extracted artifact
         run: ls
 
-      - name: Download Firebase CLI
-        run: curl -sL https://firebase.tools | upgrade=true bash
+      - name: Install Firebase CLI
+        run: |
+          sudo rm -f /usr/local/bin/firebase
+          curl -sL https://firebase.tools | bash
+          ls -l /usr/local/bin/firebase
+          /usr/local/bin/firebase --version
 
       - name: Authenticate with Firebase
         env:


### PR DESCRIPTION
### TL;DR

Improved Firebase CLI installation in the GitHub workflow.

### What changed?

- Renamed step from "Download Firebase CLI" to "Install Firebase CLI"
- Added explicit removal of any existing Firebase CLI binary
- Added verification steps to list the installed binary and check its version
- Removed the `upgrade=true` flag from the installation command

### How to test?

Run the GitHub workflow and verify that:
1. The Firebase CLI installs correctly
2. The binary is properly located in `/usr/local/bin/firebase`
3. The version check command executes successfully

### Why make this change?

This change ensures a more reliable Firebase CLI installation by explicitly removing any existing installation before adding a new one and adding verification steps to confirm the installation was successful. This helps prevent potential issues with the distribution workflow caused by Firebase CLI installation problems.