### PR TITLE
Fix Firebase CLI installation URL in CI workflow

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Firebase CLI
         run: |
           sudo rm -f /usr/local/bin/firebase
-          curl -sL https://firebase.tools | bash
+          curl -sL firebase.tools | bash
           ls -l /usr/local/bin/firebase
           /usr/local/bin/firebase --version
 


### PR DESCRIPTION
### TL;DR

Fixed Firebase CLI installation in GitHub workflow by updating the curl command URL.

### What changed?

Modified the Firebase CLI installation command in the `distribute-firebase.yml` workflow file by removing the `https://` prefix from the URL. Changed from `curl -sL https://firebase.tools | bash` to `curl -sL firebase.tools | bash`.

### How to test?

Run the GitHub workflow manually to verify that the Firebase CLI installs correctly without any URL-related errors. Check that the subsequent commands (`ls -l` and `firebase --version`) execute successfully.

### Why make this change?

The Firebase CLI installation was likely failing because the URL format was incorrect. The `firebase.tools` domain appears to be directly accessible without the `https://` prefix, and this change ensures the installation script is properly downloaded and executed.