### PR TITLE
Update Firebase CLI installation for cross-platform support

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -24,10 +24,20 @@ jobs:
 
       - name: Install Firebase CLI
         run: |
-          sudo rm -f /usr/local/bin/firebase
-          curl -sL firebase.tools | bash
-          ls -l /usr/local/bin/firebase
-          /usr/local/bin/firebase --version
+          uname_out="$(uname -s)"
+          case "${uname_out}" in
+              Linux*)     platform=linux;;
+              Darwin*)    platform=mac;;
+              *)          echo "Unsupported OS: ${uname_out}"; exit 1;;
+          esac
+
+          echo "Detected platform: $platform"
+
+          curl -Lo firebase "https://firebase.tools/bin/${platform}/latest"
+          chmod +x firebase
+          sudo mv firebase /usr/local/bin/firebase
+
+          firebase --version
 
       - name: Authenticate with Firebase
         env:


### PR DESCRIPTION
### TL;DR

Improved Firebase CLI installation in GitHub workflow for better cross-platform compatibility.

### What changed?

- Replaced the generic `curl -sL firebase.tools | bash` installation method with a platform-specific approach
- Added detection for Linux and macOS platforms
- Downloads the appropriate binary directly from `firebase.tools/bin/{platform}/latest`
- Properly sets executable permissions and moves the binary to `/usr/local/bin/`
- Added error handling for unsupported operating systems

### How to test?

1. Run the GitHub workflow on both Linux and macOS runners
2. Verify that Firebase CLI installs correctly on both platforms
3. Confirm that the CLI version is displayed properly after installation

### Why make this change?

The previous installation method was less reliable and didn't account for platform differences. This change provides a more direct and controlled installation process by downloading platform-specific binaries, which should result in more consistent behavior across different CI environments.