### PR TITLE
Configure -Xannotation-default-target=param-property with Kotlin 2.2.0 and later 

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -81,6 +81,7 @@ kotlin {
     androidTarget {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
+            freeCompilerArgs.add("-Xannotation-default-target=param-property")
         }
     }
 

--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -17,6 +17,7 @@ java {
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_17)
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }
 


### PR DESCRIPTION
### TL;DR

Added Kotlin compiler flag for default annotation targets on parameter properties.

https://youtrack.jetbrains.com/issue/KT-73255

With Kotlin 2.2.0 Kotlin is starting to change how annotations are applied to the underlying bytecode, see https://youtrack.jetbrains.com/issue/KT-73255 for more details. In practice, that will make popular JVM libraries like Jackson and Hibernate Validator working with Kotlin like they do with Java.

In practice, that means with Kotlin 2.2+, most Kotlin/JVM users will need to either define a compiler flag kotlin.compilerOptions.freeCompilerArgs.add("-Xannotation-default-target=param-property") or change from @Annotation to @param:Annotation in their codebase.