### PR TITLE
Use first line of commit message for Firebase release notes

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -58,16 +58,17 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
         run: |
+          COMMIT_TITLE="$(echo "${{ github.event.head_commit.message }}" | head -n1)"
           if [ "${{ inputs.variant }}" = "debug" ]; then
             firebase appdistribution:distribute composeApp-debug.apk \
               --app "$FIREBASE_APP_ID" \
               --groups "Internal" \
-              --release-notes "Debug: ${{ github.event.head_commit.message }}"
+              --release-notes "Debug: $COMMIT_TITLE"
           else
             firebase appdistribution:distribute composeApp-release.apk \
               --app "$FIREBASE_APP_ID" \
               --groups "Friends" \
-              --release-notes "Release: ${{ github.event.head_commit.message }}"
+              ---release-notes "Release: $COMMIT_TITLE"
           fi
 
       - name: Cleanup sensitive files


### PR DESCRIPTION
### TL;DR

Fix Firebase distribution release notes to only include the first line of commit messages.

using commit message will result in errors sometimes. See - https://github.com/ksharma-xyz/KRAIL/actions/runs/16428593484/job/46425423650

### What changed?

- Modified the `distribute-firebase.yml` workflow to extract only the first line of commit messages using `head -n1`
- Stored the first line in a `COMMIT_TITLE` variable and used it in the release notes
- Fixed a typo in the release distribution command (extra dash in `---release-notes`)

### How to test?

1. Make a commit with a multi-line commit message
2. Trigger the Firebase distribution workflow
3. Verify that only the first line of the commit message appears in the release notes

### Why make this change?

Long commit messages with multiple lines were being included in full in the Firebase distribution release notes, making them difficult to read. This change improves readability by only including the commit title.