### PR TITLE
Pin Firebase CLI to version 14.11.0

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -23,7 +23,7 @@ jobs:
         run: ls
 
       - name: Download Firebase CLI
-        run: curl -sL https://firebase.tools | upgrade=true bash
+        run: curl -sL https://firebase.tools | sed s/latest/v14.11.0/ | bash
 
       - name: Authenticate with Firebase
         env:


### PR DESCRIPTION
### TL;DR

Pin Firebase CLI to version 14.11.0 instead of using the latest version as a workaround.

https://github.com/firebase/firebase-tools/issues/8887#issuecomment-3107612787