### PR TITLE
Fix Firebase release notes command and sanitize commit title

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -44,7 +44,8 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
         run: |
-          COMMIT_TITLE="$(echo "${{ github.event.head_commit.message }}" | head -n1)"
+          COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n1 | tr -d '\n' | tr -d '\r')
+
           if [ "${{ inputs.variant }}" = "debug" ]; then
             firebase appdistribution:distribute composeApp-debug.apk \
               --app "$FIREBASE_APP_ID" \
@@ -54,7 +55,7 @@ jobs:
             firebase appdistribution:distribute composeApp-release.apk \
               --app "$FIREBASE_APP_ID" \
               --groups "Friends" \
-              ---release-notes "Release: $COMMIT_TITLE"
+              --release-notes "Release: $COMMIT_TITLE"
           fi
 
       - name: Cleanup sensitive files


### PR DESCRIPTION
### TL;DR

Fixed Firebase app distribution workflow issues with commit message handling and release notes flag.

### What changed?

- head -n1 grabs the first line

- tr -d '\n' | tr -d '\r' removes trailing newlines (sometimes still sneak in via GitHub's internal formatting)

- --release-notes uses double dash now (fixed typo)

- Fixed the commit message extraction by adding proper handling for newlines and carriage returns
- Corrected a typo in the release distribution command where `---release-notes` (three dashes) was used instead of the correct `--release-notes` (two dashes)

### How to test?

1. Trigger a Firebase distribution workflow with a commit message containing newlines or carriage returns
2. Verify that the release distribution completes successfully without syntax errors
3. Check that the release notes are properly displayed in Firebase App Distribution

### Why make this change?

The workflow was failing due to two issues:
1. Commit messages with newlines were not being properly sanitized, causing errors in the distribution command
2. The release distribution command had a typo with three dashes instead of two for the release-notes flag, which would cause the command to fail