### PR TITLE
Remove Gradle caching and cleanup configurations from Android build workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -11,8 +11,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: Firebase
-    env:
-      GRADLE_USER_HOME: ${{ github.workspace }}/.gradle
     steps:
       - uses: actions/checkout@v4
 
@@ -27,15 +25,6 @@ jobs:
           distribution: zulu
           java-version: 21
 
-#      - name: Cache Gradle and wrapper
-#        uses: actions/cache@v4
-#        with:
-#          path: |
-#            ~/.gradle/caches
-#            ~/.gradle/wrapper
-#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-#          restore-keys: ""
-
       - name: Make Gradle executable
         run: chmod +x ./gradlew
 
@@ -49,13 +38,8 @@ jobs:
           DATA: ${{ secrets.FIREBASE_GOOGLE_SERVICES_JSON_DEBUG }}
         run: echo $DATA | base64 -di > composeApp/src/debug/google-services.json
 
-      - name: Clean Build Cache
-        run: |
-          ./gradlew clean --no-build-cache --no-configuration-cache
-          rm -rf ~/.gradle/caches/
-          rm -rf ~/.gradle/wrapper/
-          rm -rf .gradle/
-          rm -rf build/
+#      - name: Clean Gradle Build
+#        run: ./gradlew clean
 
       - name: Decode Keystore
         if: ${{ inputs.variant == 'release' }}
@@ -78,9 +62,9 @@ jobs:
         run: |
           set -e
           if [[ "${{ inputs.variant }}" == "debug" ]]; then
-            ./gradlew :composeApp:assembleDebug test -PversionCode="${{ github.run_number }}" --no-configuration-cache --rerun-tasks --stacktrace
+            ./gradlew :composeApp:assembleDebug test -PversionCode="${{ github.run_number }}" --rerun-tasks --stacktrace
           elif [[ "${{ inputs.variant }}" == "release" ]]; then
-            ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${{ github.run_number }}" --no-configuration-cache
+            ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${{ github.run_number }}"
           fi
 
       - name: Upload Debug APK


### PR DESCRIPTION
### TL;DR

Streamlined the Android build workflow by removing unnecessary caching configurations and simplifying Gradle commands.

### What changed?

- Removed the `GRADLE_USER_HOME` environment variable
- Removed commented-out Gradle and wrapper caching section
- Removed aggressive cache cleaning steps that were deleting all Gradle caches
- Simplified the Gradle build commands by removing the `--no-configuration-cache` flag
- Commented out the clean Gradle build step instead of removing it completely

### How to test?

1. Trigger the Android build workflow with both debug and release variants
2. Verify that builds complete successfully
3. Confirm that build artifacts (APK/AAB) are generated correctly
4. Check that the build times are similar or improved compared to previous runs

### Why make this change?

The previous workflow configuration included redundant cache cleaning steps and disabled Gradle's configuration cache, which can slow down builds. This change allows Gradle to use its default caching behavior, which should improve build performance while maintaining the same output quality. The simplified workflow is also easier to maintain and understand.