### PR TITLE
Add serialization support for DiscoverModel and implement ButtonListDeserializer

### DIFF
--- a/discover/network/api/build.gradle.kts
+++ b/discover/network/api/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.krail.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.krail.android.library)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -26,10 +27,12 @@ kotlin {
     sourceSets {
         commonMain  {
             dependencies {
+                implementation(projects.core.log)
                 implementation(projects.social.network.api)
 
                 implementation(compose.runtime)
                 implementation(libs.kotlinx.collections.immutable)
+                implementation(libs.kotlinx.serialization.json)
             }
         }
         commonTest {
@@ -37,6 +40,9 @@ kotlin {
                 implementation(libs.test.kotlin)
                 implementation(libs.test.kotlinxCoroutineTest)
             }
+        }
+        all {
+            languageSettings.enableLanguageFeature("PropertyParamAnnotationDefaultTargetMode")
         }
     }
 }

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/ButtonListDeserializer.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/ButtonListDeserializer.kt
@@ -1,0 +1,100 @@
+package xyz.ksharma.krail.discover.network.api
+
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.social.network.api.model.SocialType
+
+object ButtonListSerializer : KSerializer<List<DiscoverModel.Button>> {
+
+    @OptIn(InternalSerializationApi::class)
+    override val descriptor: SerialDescriptor =
+        buildSerialDescriptor("ButtonList", StructureKind.LIST)
+
+    override fun deserialize(decoder: Decoder): List<DiscoverModel.Button> {
+        val input = decoder as? JsonDecoder ?: error("Expected JsonDecoder")
+        val jsonArray = input.decodeJsonElement().jsonArray
+
+        return jsonArray.mapNotNull { buttonElement ->
+            val buttonObj = buttonElement.jsonObject
+
+            when (buttonObj["buttonType"]?.jsonPrimitive?.content) {
+                "Cta" -> {
+                    val label = buttonObj["label"]?.jsonPrimitive?.content
+                    val url = buttonObj["url"]?.jsonPrimitive?.content
+                    require(!label.isNullOrBlank()) { "Button Cta label cannot be null or blank" }
+                    require(!url.isNullOrBlank()) { "Button Cta URL cannot be null or blank" }
+
+                    DiscoverModel.Button.Cta(
+                        label = label,
+                        url = url,
+                    )
+                }
+
+                "Share" -> {
+                    val shareUrl = buttonObj["shareUrl"]?.jsonPrimitive?.content
+                    require(!shareUrl.isNullOrBlank()) { "Button Share URL cannot be null or blank" }
+
+                    DiscoverModel.Button.Share(
+                        shareUrl = shareUrl,
+                    )
+                }
+
+                "Feedback" -> {
+                    val label = buttonObj["label"]?.jsonPrimitive?.content
+                    val url = buttonObj["url"]?.jsonPrimitive?.content
+                    require(!label.isNullOrBlank()) { "Button Feedback label cannot be null or blank" }
+                    require(!url.isNullOrBlank()) { "Button Feedback URL cannot be null or blank" }
+
+                    DiscoverModel.Button.Feedback(
+                        label = label,
+                        url = url,
+                    )
+                }
+
+                "AppSocial" -> DiscoverModel.Button.Social.AppSocial
+
+                "PartnerSocial" -> {
+                    val partnerName = buttonObj["socialPartnerName"]?.jsonPrimitive?.content
+                    require(!partnerName.isNullOrBlank()) { "Button PartnerSocial socialPartnerName cannot be null or blank" }
+                    val linksA = buttonObj["links"]?.jsonArray
+                    require(!linksA.isNullOrEmpty()) { "Button PartnerSocial links cannot be null or empty" }
+
+                    val links = linksA.mapNotNull { linkElement ->
+                        val linkObj = linkElement.jsonObject
+                        val typeStr =
+                            linkObj["type"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                        val type = SocialType.valueOf(typeStr)
+
+                        val url = linkObj["url"]?.jsonPrimitive?.content
+                        require(!url.isNullOrBlank()) { "Button PartnerSocial link URL cannot be null or blank" }
+
+                        DiscoverModel.Button.Social.PartnerSocial.PartnerSocialType(type, url)
+                    }
+                    DiscoverModel.Button.Social.PartnerSocial(
+                        socialPartnerName = partnerName,
+                        links = links
+                    )
+                }
+
+                else -> {
+                    logError("Unknown button type: ${buttonObj["buttonType"]?.jsonPrimitive?.content}")
+                    null
+                }
+            }
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: List<DiscoverModel.Button>) {
+        error("Serialization not supported")
+    }
+}

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverData.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverData.kt
@@ -20,7 +20,7 @@ val previewDiscoverCardList = listOf(
     DiscoverModel(
         title = "No Buttons Card Title",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
-        imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752367225760-34f565f0720f"),
+        imageList = persistentListOf("https://images.unsplash.com/photo-1741851373856-67a519f0c014"),
         type = DiscoverModel.DiscoverCardType.Events,
         buttons = persistentListOf(),
     ),
@@ -59,7 +59,7 @@ val previewDiscoverCardList = listOf(
     DiscoverModel(
         title = "Cta + Share Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
-        imageList = persistentListOf("https://images.unsplash.com/photo-1752939124510-e444139e6404"),
+        imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1730005745671-dbbfddfe387e"),
         type = DiscoverModel.DiscoverCardType.Sports,
         buttons = persistentListOf(
             DiscoverModel.Button.Cta(
@@ -79,6 +79,19 @@ val previewDiscoverCardList = listOf(
         buttons = persistentListOf(
             DiscoverModel.Button.Feedback(
                 label = "Feedback",
+                url = "https://example.com/feedback",
+            ),
+        )
+    ),
+    DiscoverModel(
+        title = "Credits Disclaimer Card",
+        description = "This is a sample description for the Discover Card. It can be used to display additional information.",
+        imageList = persistentListOf("https://images.unsplash.com/photo-1735746693939-586a9d7558e1"),
+        type = DiscoverModel.DiscoverCardType.Events,
+        disclaimer = "Image credits: Unsplash",
+        buttons = persistentListOf(
+            DiscoverModel.Button.Cta(
+                label = "Cta Button",
                 url = "https://example.com/feedback",
             ),
         )

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverData.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverData.kt
@@ -9,6 +9,7 @@ val previewDiscoverCardList = listOf(
         title = "Cta only card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://images.unsplash.com/photo-1749751234397-41ee8a7887c2"),
+        type = DiscoverModel.DiscoverCardType.Travel,
         buttons = persistentListOf(
             DiscoverModel.Button.Cta(
                 label = "Click Me",
@@ -20,18 +21,21 @@ val previewDiscoverCardList = listOf(
         title = "No Buttons Card Title",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752367225760-34f565f0720f"),
+        type = DiscoverModel.DiscoverCardType.Events,
         buttons = persistentListOf(),
     ),
     DiscoverModel(
         title = "App Social Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"),
+        type = DiscoverModel.DiscoverCardType.Krail,
         buttons = persistentListOf(DiscoverModel.Button.Social.AppSocial)
     ),
     DiscoverModel(
         title = "Partner Social Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"),
+        type = DiscoverModel.DiscoverCardType.Events,
         buttons = persistentListOf(
             DiscoverModel.Button.Social.PartnerSocial(
                 socialPartnerName = "XYZ Place",
@@ -45,6 +49,7 @@ val previewDiscoverCardList = listOf(
         title = "Share Only Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014"),
+        type = DiscoverModel.DiscoverCardType.Kids,
         buttons = persistentListOf(
             DiscoverModel.Button.Share(
                 shareUrl = "https://example.com/share",
@@ -55,6 +60,7 @@ val previewDiscoverCardList = listOf(
         title = "Cta + Share Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://images.unsplash.com/photo-1752939124510-e444139e6404"),
+        type = DiscoverModel.DiscoverCardType.Sports,
         buttons = persistentListOf(
             DiscoverModel.Button.Cta(
                 label = "Click Me",
@@ -69,6 +75,7 @@ val previewDiscoverCardList = listOf(
         title = "Feedback Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752832756659-4dd7c40f5ae7"),
+        type = DiscoverModel.DiscoverCardType.Events,
         buttons = persistentListOf(
             DiscoverModel.Button.Feedback(
                 label = "Feedback",

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
@@ -3,8 +3,11 @@ package xyz.ksharma.krail.discover.network.api
 import androidx.compose.runtime.Stable
 import kotlinx.collections.immutable.ImmutableList
 import xyz.ksharma.krail.social.network.api.model.SocialType
+import kotlinx.serialization.Serializable
+import xyz.ksharma.krail.discover.network.api.DiscoverModel.Button
 
 @Stable
+@Serializable
 data class DiscoverModel(
 
     val title: String,
@@ -25,7 +28,8 @@ data class DiscoverModel(
      */
     val imageList: ImmutableList<String>,
 
-    val buttons: ImmutableList<Button>? = null,
+    @Serializable(with = ButtonListSerializer::class)
+    val buttons: List<Button>? = null,
 
     val type: DiscoverCardType,
 ) {
@@ -88,77 +92,77 @@ data class DiscoverCardButtonRowState(
     val right: RightButtonType?,
 ) {
     sealed interface LeftButtonType {
-        data class Cta(val button: DiscoverModel.Button.Cta) : LeftButtonType
-        data class Social(val button: DiscoverModel.Button.Social) : LeftButtonType
-        data class Feedback(val button: DiscoverModel.Button.Feedback) : LeftButtonType
+        data class Cta(val button: Button.Cta) : LeftButtonType
+        data class Social(val button: Button.Social) : LeftButtonType
+        data class Feedback(val button: Button.Feedback) : LeftButtonType
     }
 
     sealed interface RightButtonType {
-        data class Share(val button: DiscoverModel.Button.Share) : RightButtonType
+        data class Share(val button: Button.Share) : RightButtonType
     }
 }
 
-fun List<DiscoverModel.Button>.toButtonRowState(): DiscoverCardButtonRowState? {
+fun List<Button>.toButtonRowState(): DiscoverCardButtonRowState? {
     if (!isValidButtonCombo()) return null
     var left: DiscoverCardButtonRowState.LeftButtonType? = null
     var right: DiscoverCardButtonRowState.RightButtonType? = null
     for (button in this) {
         when (button) {
-            is DiscoverModel.Button.Cta -> left =
+            is Button.Cta -> left =
                 DiscoverCardButtonRowState.LeftButtonType.Cta(button)
 
-            is DiscoverModel.Button.Social -> left =
+            is Button.Social -> left =
                 DiscoverCardButtonRowState.LeftButtonType.Social(button)
 
-            is DiscoverModel.Button.Feedback -> left =
+            is Button.Feedback -> left =
                 DiscoverCardButtonRowState.LeftButtonType.Feedback(button)
 
-            is DiscoverModel.Button.Share -> right =
+            is Button.Share -> right =
                 DiscoverCardButtonRowState.RightButtonType.Share(button)
         }
     }
     return DiscoverCardButtonRowState(left, right)
 }
 
-fun List<DiscoverModel.Button>.isValidButtonCombo(): Boolean {
+fun List<Button>.isValidButtonCombo(): Boolean {
     val types = this.map { it::class }
 
     val leftTypes = listOf(
-        DiscoverModel.Button.Cta::class,
-        DiscoverModel.Button.Feedback::class,
-        DiscoverModel.Button.Social::class
+        Button.Cta::class,
+        Button.Feedback::class,
+        Button.Social::class
     )
     if (types.count { it in leftTypes } > 1) return false
 
     // Only one Share allowed, can be alone or with Cta
-    if (types.count { it == DiscoverModel.Button.Share::class } > 1) return false
-    if (types.contains(DiscoverModel.Button.Share::class)) {
+    if (types.count { it == Button.Share::class } > 1) return false
+    if (types.contains(Button.Share::class)) {
         val leftCount = types.count { it in leftTypes }
         if (leftCount > 1) return false
-        if (leftCount == 1 && !types.contains(DiscoverModel.Button.Cta::class)) return false
+        if (leftCount == 1 && !types.contains(Button.Cta::class)) return false
     }
 
     // Cta cannot be combined with Social or Feedback
-    if (types.contains(DiscoverModel.Button.Cta::class) &&
-        (types.contains(DiscoverModel.Button.Social::class) || types.contains(
-            DiscoverModel.Button.Feedback::class
+    if (types.contains(Button.Cta::class) &&
+        (types.contains(Button.Social::class) || types.contains(
+            Button.Feedback::class
         ))
     ) return false
 
     // Social cannot be combined with Feedback or Cta
-    if (types.contains(DiscoverModel.Button.Social::class) &&
-        (types.contains(DiscoverModel.Button.Feedback::class) || types.contains(DiscoverModel.Button.Cta::class))
+    if (types.contains(Button.Social::class) &&
+        (types.contains(Button.Feedback::class) || types.contains(Button.Cta::class))
     ) return false
 
     // Feedback cannot be combined with Social or Cta
-    if (types.contains(DiscoverModel.Button.Feedback::class) &&
-        (types.contains(DiscoverModel.Button.Social::class) || types.contains(DiscoverModel.Button.Cta::class))
+    if (types.contains(Button.Feedback::class) &&
+        (types.contains(Button.Social::class) || types.contains(Button.Cta::class))
     ) return false
 
     // Only one of each type allowed
-    if (types.count { it == DiscoverModel.Button.Cta::class } > 1) return false
-    if (types.count { it == DiscoverModel.Button.Feedback::class } > 1) return false
-    if (types.count { it == DiscoverModel.Button.Social::class } > 1) return false
+    if (types.count { it == Button.Cta::class } > 1) return false
+    if (types.count { it == Button.Feedback::class } > 1) return false
+    if (types.count { it == Button.Social::class } > 1) return false
 
     return true
 }

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
@@ -6,9 +6,15 @@ import xyz.ksharma.krail.social.network.api.model.SocialType
 
 @Stable
 data class DiscoverModel(
+
     val title: String,
+
     val description: String,
+
+    // ISO 8601 date format
     val startDate: String? = null,
+
+    // ISO 8601 date format
     val endDate: String? = null,
 
     // image credits etc.
@@ -18,17 +24,24 @@ data class DiscoverModel(
      * List of image URLs to be displayed in the card.
      */
     val imageList: ImmutableList<String>,
+
     val buttons: ImmutableList<Button>? = null,
+
     val type: DiscoverCardType,
 ) {
 
     enum class DiscoverCardType {
-        Krail,
-        Travel,
-        Events,
-        Food,
-        Sports,
-        Kids
+        Krail, // general Krail related content
+
+        Travel, // places to visit, travel tips etc.
+
+        Events, // concerts, festivals etc.
+
+        Food, // restaurants, cafes etc.
+
+        Sports, // football, cricket etc.
+
+        Kids // pokemon, games etc..
         ;
     }
 

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
@@ -8,13 +8,30 @@ import xyz.ksharma.krail.social.network.api.model.SocialType
 data class DiscoverModel(
     val title: String,
     val description: String,
+    val startDate: String? = null,
+    val endDate: String? = null,
+
+    // image credits etc.
+    val disclaimer: String? = null,
 
     /**
      * List of image URLs to be displayed in the card.
      */
     val imageList: ImmutableList<String>,
     val buttons: ImmutableList<Button>? = null,
+    val type: DiscoverCardType,
 ) {
+
+    enum class DiscoverCardType {
+        Krail,
+        Travel,
+        Events,
+        Food,
+        Sports,
+        Kids
+        ;
+    }
+
     sealed class Button {
         data class Cta(
             val label: String,

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverModel.kt
@@ -38,6 +38,12 @@ data class DiscoverModel(
                 val socialPartnerName: String,
                 val links: List<PartnerSocialType>
             ) : Social() {
+
+                init {
+                    require(socialPartnerName.isNotBlank()) { "socialPartnerName must not be empty or blank" }
+                    require(links.isNotEmpty()) { "links list must not be empty" }
+                }
+
                 data class PartnerSocialType(
                     val type: SocialType,
                     val url: String,

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -26,10 +26,10 @@ internal class RealDiscoverSydneyManager(
     private fun FlagValue.toDiscoverCards(): List<DiscoverModel> {
         return when (this) {
             is FlagValue.JsonValue -> {
-                log("flagValue: ${this.value}")
                 val jsonArray = Json.parseToJsonElement(value).jsonArray
                 jsonArray.map { Json.decodeFromJsonElement<DiscoverModel>(it) }
             }
+
             else -> {
                 log("FlagValue is not JsonValue, using default value for ${FlagKeys.DISCOVER_SYDNEY.key}")
                 val defaultJson = RemoteConfigDefaults.getDefaults()
@@ -39,5 +39,5 @@ internal class RealDiscoverSydneyManager(
                 jsonArray.map { Json.decodeFromJsonElement<DiscoverModel>(it) }
             }
         }
-    }}
-
+    }
+}

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -45,6 +45,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.discoverCardHeight
+import xyz.ksharma.krail.taj.isLargeFontScale
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
@@ -64,7 +65,7 @@ fun DiscoverCard(
     ) {
         BoxWithConstraints {
             val maxCardWidth = maxWidth
-            val imageHeight = discoverCardHeight * 0.6f
+            val imageHeight = discoverCardHeight * if (isLargeFontScale()) 0.5f else 0.6f
 
             AsyncImage(
                 model = discoverModel.imageList.firstOrNull(),
@@ -73,25 +74,25 @@ fun DiscoverCard(
                 modifier = Modifier
                     .width(maxCardWidth)
                     .height(imageHeight)
-                    .padding(horizontal = 12.dp, vertical = 12.dp).clip(RoundedCornerShape(16.dp)),
+                    .padding(horizontal = 12.dp, vertical = 12.dp)
+                    .clip(RoundedCornerShape(16.dp)),
             )
         }
 
-        // todo - auto suze to fit one line
-        // text can be max 5-6 words
         Text(
             text = discoverModel.title,
             modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp),
-            maxLines = 2, // for large font size 2, // for small font size 3
-            style = KrailTheme.typography.headlineSmall,
+            maxLines = if(isLargeFontScale()) 2 else 3,
+            style = if (isLargeFontScale()) KrailTheme.typography.titleMedium
+            else KrailTheme.typography.headlineSmall,
         )
 
-        // max 18-20 words
         Text(
             text = discoverModel.description,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            maxLines = 2, // for large font size 2, // for small font size 3
-            style = KrailTheme.typography.bodyMedium,
+            maxLines = if(isLargeFontScale()) 2 else 3,
+            style = if (isLargeFontScale()) KrailTheme.typography.bodySmall
+            else KrailTheme.typography.bodyMedium,
         )
 
         discoverModel.disclaimer?.let { disclaimer ->
@@ -103,7 +104,7 @@ fun DiscoverCard(
             )
         }
 
-        Spacer(modifier = Modifier.weight(1f)) // Pushes buttons to bottom
+        Spacer(modifier = Modifier.weight(1f))
 
         discoverModel.buttons?.let { buttonsList ->
             DiscoverCardButtonRow(buttonsList)
@@ -189,7 +190,7 @@ private fun DiscoverCardButtonRow(buttonsList: List<DiscoverModel.Button>) {
                 }
             }
 
-            null -> Box(modifier = Modifier) // Empty box to keep slot
+            null -> Unit
         }
     }
 }
@@ -208,6 +209,8 @@ private fun FeedbackCircleBox(
         }
     }
 }
+
+// region Previews
 
 @Preview(showBackground = true)
 @Composable
@@ -261,3 +264,5 @@ private class DiscoverCardProvider : PreviewParameterProvider<DiscoverModel> {
     override val values: Sequence<DiscoverModel>
         get() = previewDiscoverCardList.asSequence()
 }
+
+// endregion Previews

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -98,9 +98,9 @@ fun DiscoverCard(
         discoverModel.disclaimer?.let { disclaimer ->
             Text(
                 text = disclaimer,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                modifier = Modifier.padding(horizontal = 16.dp),
                 maxLines = 1,
-                style = KrailTheme.typography.labelMedium,
+                style = KrailTheme.typography.labelSmall,
             )
         }
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -94,6 +94,15 @@ fun DiscoverCard(
             style = KrailTheme.typography.bodyMedium,
         )
 
+        discoverModel.disclaimer?.let { disclaimer ->
+            Text(
+                text = disclaimer,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                maxLines = 1,
+                style = KrailTheme.typography.labelMedium,
+            )
+        }
+
         Spacer(modifier = Modifier.weight(1f)) // Pushes buttons to bottom
 
         discoverModel.buttons?.let { buttonsList ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsDestination.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
-import xyz.ksharma.krail.social.network.api.model.KrailSocialType
 import androidx.navigation.compose.composable
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
@@ -48,7 +48,7 @@ fun SocialConnectionRow(
                 Image(
                     painter = painterResource(resource = socialType.resource()),
                     contentDescription = "${socialType.socialType} Page for KRAIL App",
-                    colorFilter = ColorFilter.tint(color = getForegroundColor(backgroundColor = themeBackgroundColor())),
+                    colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
                     modifier = Modifier.size(24.dp),
                 )
             }
@@ -75,7 +75,7 @@ fun SocialConnectionRow(
                 Image(
                     painter = painterResource(resource = socialType.resource()),
                     contentDescription = "${socialType.name} Page for $socialPartnerName",
-                    colorFilter = ColorFilter.tint(color = getForegroundColor(backgroundColor = themeBackgroundColor())),
+                    colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
                     modifier = Modifier.size(24.dp),
                 )
             }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
@@ -1,0 +1,13 @@
+package xyz.ksharma.krail.taj
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+
+const val LARGE_FONT_SCALE_THRESHOLD = 1.3f
+
+@Composable
+fun isLargeFontScale(): Boolean {
+    val density = LocalDensity.current
+    val fontScale = density.fontScale
+    return fontScale > LARGE_FONT_SCALE_THRESHOLD
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
@@ -9,5 +9,5 @@ const val LARGE_FONT_SCALE_THRESHOLD = 1.3f
 fun isLargeFontScale(): Boolean {
     val density = LocalDensity.current
     val fontScale = density.fontScale
-    return fontScale > LARGE_FONT_SCALE_THRESHOLD
+    return fontScale >= LARGE_FONT_SCALE_THRESHOLD
 }


### PR DESCRIPTION
# Add Serialization Support for Discover Cards

This PR adds Kotlin serialization support for the Discover feature, enabling JSON deserialization of discover cards from remote config.

Key changes:
- Added `ButtonListSerializer` to handle complex button type deserialization
- Made `DiscoverModel` serializable with proper annotations
- Added card type enum to categorize different discover cards
- Added support for date ranges and disclaimers in discover cards
- Improved accessibility by adjusting text styles and layout for large font scales
- Fixed social icon colors to use theme-appropriate colors

The PR also updates the preview data to showcase the new card types and features.