### PR TITLE
Add animated feedback buttons to DiscoverCard with thumbs up/down interaction

### DIFF
--- a/discover/ui/build.gradle.kts
+++ b/discover/ui/build.gradle.kts
@@ -7,6 +7,12 @@ plugins {
 
 android {
     namespace = "xyz.ksharma.krail.discover.ui"
+
+    // Required when using Firebase GitLive RemoteConfig. Adding here for running previews on device.
+    // https://developer.android.com/studio/write/java8-support#library-desugaring
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 kotlin {
@@ -71,4 +77,8 @@ kotlin {
 dependencies {
     // https://youtrack.jetbrains.com/issue/KTIJ-32720/Support-common-org.jetbrains.compose.ui.tooling.preview.Preview-in-IDEA-and-Android-Studio#focus=Comments-27-11400795.0-0Add commentMore actions
     debugImplementation(libs.androidx.ui.tooling)
+
+    // Required when using Firebase GitLive RemoteConfig.
+    // https://developer.android.com/studio/write/java8-support#library-desugaring
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
 }

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -80,16 +80,14 @@ fun DiscoverCard(
             text = discoverModel.title,
             modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp),
             maxLines = if (isLargeFontScale()) 2 else 3,
-            style = if (isLargeFontScale()) KrailTheme.typography.titleMedium
-            else KrailTheme.typography.headlineSmall,
+            style = KrailTheme.typography.headlineSmall,
         )
 
         Text(
             text = discoverModel.description,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             maxLines = if (isLargeFontScale()) 2 else 3,
-            style = if (isLargeFontScale()) KrailTheme.typography.bodySmall
-            else KrailTheme.typography.bodyMedium,
+            style = KrailTheme.typography.bodyMedium,
         )
 
         discoverModel.disclaimer?.let { disclaimer ->

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -2,8 +2,6 @@ package xyz.ksharma.krail.discover.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,10 +11,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,14 +38,12 @@ import xyz.ksharma.krail.discover.state.toButtonRowState
 import xyz.ksharma.krail.social.state.KrailSocialType
 import xyz.ksharma.krail.social.state.SocialType
 import xyz.ksharma.krail.social.ui.SocialConnectionRow
-import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.discoverCardHeight
 import xyz.ksharma.krail.taj.isLargeFontScale
-import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 import app.krail.taj.resources.Res as TajRes
@@ -85,7 +79,7 @@ fun DiscoverCard(
         Text(
             text = discoverModel.title,
             modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp),
-            maxLines = if(isLargeFontScale()) 2 else 3,
+            maxLines = if (isLargeFontScale()) 2 else 3,
             style = if (isLargeFontScale()) KrailTheme.typography.titleMedium
             else KrailTheme.typography.headlineSmall,
         )
@@ -93,7 +87,7 @@ fun DiscoverCard(
         Text(
             text = discoverModel.description,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            maxLines = if(isLargeFontScale()) 2 else 3,
+            maxLines = if (isLargeFontScale()) 2 else 3,
             style = if (isLargeFontScale()) KrailTheme.typography.bodySmall
             else KrailTheme.typography.bodyMedium,
         )
@@ -131,7 +125,9 @@ private fun DiscoverCardButtonRow(buttonsList: List<Button>) {
         when (val left = state.left) {
             is DiscoverCardButtonRowState.LeftButtonType.Cta -> {
                 Button(
-                    dimensions = ButtonDefaults.mediumButtonSize(), onClick = {}) {
+                    dimensions = ButtonDefaults.mediumButtonSize(),
+                    onClick = {},
+                ) {
                     Text(text = left.button.label)
                 }
             }
@@ -155,17 +151,14 @@ private fun DiscoverCardButtonRow(buttonsList: List<Button>) {
             }
 
             is DiscoverCardButtonRowState.LeftButtonType.Feedback -> {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(20.dp)
-                ) {
-                    FeedbackCircleBox {
-                        Text("👍")
-                    }
+                FeedbackButtonsRow(
+                    onNegative = {
 
-                    FeedbackCircleBox {
-                        Text("👎")
+                    },
+                    onPositive = {
+
                     }
-                }
+                )
             }
 
             null -> Unit
@@ -174,10 +167,12 @@ private fun DiscoverCardButtonRow(buttonsList: List<Button>) {
         Spacer(modifier = Modifier.weight(1f))
 
         // Right button (always right-aligned)
-        when (state.right) {
+        when (val rightButton = state.right) {
             is DiscoverCardButtonRowState.RightButtonType.Share -> {
                 RoundIconButton(
-                    onClick = {},
+                    onClick = {
+                        rightButton.button.shareUrl
+                    },
                     color = Color.Transparent,
                 ) {
                     Image(
@@ -194,21 +189,6 @@ private fun DiscoverCardButtonRow(buttonsList: List<Button>) {
             }
 
             null -> Unit
-        }
-    }
-}
-
-@Composable
-private fun FeedbackCircleBox(
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    Box(
-        modifier = modifier.size(40.dp).clip(shape = CircleShape).klickable(indication = null) {},
-        contentAlignment = Alignment.Center,
-    ) {
-        CompositionLocalProvider(LocalTextStyle provides KrailTheme.typography.title) {
-            content()
         }
     }
 }

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -79,7 +79,7 @@ fun DiscoverCard(
         Text(
             text = discoverModel.title,
             modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp),
-            maxLines = if (isLargeFontScale()) 2 else 3,
+            maxLines = 2,
             style = KrailTheme.typography.headlineSmall,
         )
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
@@ -1,8 +1,6 @@
 package xyz.ksharma.krail.discover.ui
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,19 +8,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Button
@@ -31,42 +25,118 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
-@OptIn(ExperimentalAnimationApi::class)
+private enum class FeedbackAnimState {
+    Idle, Rotating, ScalingOut, ShowButton
+}
+
 @Composable
 fun FeedbackButtonsRow(
     modifier: Modifier = Modifier,
     onPositive: () -> Unit,
     onNegative: () -> Unit,
 ) {
-    var state by remember { mutableStateOf(FeedbackState.Idle) }
+    var selected by remember { mutableStateOf<FeedbackSelectedState?>(null) }
+    var animState by remember { mutableStateOf(FeedbackAnimState.Idle) }
+    val scope = rememberCoroutineScope()
+
+    val leftRotation = remember { Animatable(0f) }
+    val leftScale = remember { Animatable(1f) }
+    val rightScale = remember { Animatable(1f) }
+    val buttonScale = remember { Animatable(0.8f) }
+
+    fun startAnimation(feedback: FeedbackSelectedState) {
+        selected = feedback
+        animState = FeedbackAnimState.Rotating
+        scope.launch {
+            if (feedback == FeedbackSelectedState.Positive) {
+                launch { leftRotation.animateTo(360f, tween(400)) }
+                launch { rightScale.animateTo(0f, tween(300)) }
+                delay(400)
+                animState = FeedbackAnimState.ScalingOut
+                leftScale.animateTo(0f, tween(250))
+            } else {
+                // 👎: both scale out, no rotation
+                launch { leftScale.animateTo(0f, tween(300)) }
+                launch { rightScale.animateTo(0f, tween(300)) }
+                //delay(300)
+                animState = FeedbackAnimState.ScalingOut
+            }
+            animState = FeedbackAnimState.ShowButton
+            buttonScale.snapTo(0.8f)
+            buttonScale.animateTo(1f, tween(350))
+        }
+    }
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(20.dp),
         modifier = modifier,
     ) {
-        AnimatedContent(targetState = state, label = "feedback") { feedbackState ->
-            when (feedbackState) {
-                FeedbackState.Idle -> {
-                    Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
-                        FeedbackCircleBox(
-                            modifier = Modifier.klickable {
-                                state = FeedbackState.Positive
+        when (animState) {
+            FeedbackAnimState.Idle -> {
+                FeedbackCircleBox(
+                    modifier = Modifier
+                        .graphicsLayer {
+                            rotationZ = leftRotation.value
+                            scaleX = leftScale.value
+                            scaleY = leftScale.value
+                        }
+                        .klickable {
+                            if (animState == FeedbackAnimState.Idle) {
                                 onPositive()
+                                startAnimation(FeedbackSelectedState.Positive)
                             }
-                        ) { Text("👍") }
+                        }
+                ) { Text("👍") }
 
-                        FeedbackCircleBox(
-                            modifier = Modifier.klickable {
-                                state = FeedbackState.Negative
+                FeedbackCircleBox(
+                    modifier = Modifier
+                        .graphicsLayer {
+                            rotationZ = 0f
+                            scaleX = rightScale.value
+                            scaleY = rightScale.value
+                        }
+                        .klickable {
+                            if (animState == FeedbackAnimState.Idle) {
                                 onNegative()
+                                startAnimation(FeedbackSelectedState.Negative)
                             }
-                        ) { Text("👎") }
-                    }
+                        }
+                ) { Text("👎") }
+            }
+
+            FeedbackAnimState.Rotating, FeedbackAnimState.ScalingOut -> {
+                FeedbackCircleBox(
+                    modifier = Modifier
+                        .graphicsLayer {
+                            rotationZ = leftRotation.value
+                            scaleX = leftScale.value
+                            scaleY = leftScale.value
+                        }
+                ) { Text("👍") }
+
+                FeedbackCircleBox(
+                    modifier = Modifier
+                        .graphicsLayer {
+                            rotationZ = 0f
+                            scaleX = rightScale.value
+                            scaleY = rightScale.value
+                        }
+                ) { Text("👎") }
+            }
+
+            FeedbackAnimState.ShowButton -> {
+                val text = when (selected) {
+                    FeedbackSelectedState.Positive -> "Write a review"
+                    FeedbackSelectedState.Negative -> "Send feedback"
+                    else -> ""
                 }
-
-                FeedbackState.Positive -> AnimatedFeedbackButton("Write a review")
-
-                FeedbackState.Negative -> AnimatedFeedbackButton("Share feedback")
+                Button(
+                    dimensions = ButtonDefaults.mediumButtonSize(),
+                    onClick = {},
+                    modifier = Modifier.scale(buttonScale.value)
+                ) {
+                    Text(text)
+                }
             }
         }
     }
@@ -87,26 +157,7 @@ private fun FeedbackCircleBox(
     }
 }
 
-@Composable
-private fun AnimatedFeedbackButton(text: String) {
-    var startAnim by remember { mutableStateOf(false) }
-    val scale by animateFloatAsState(if (startAnim) 1f else 0.8f, animationSpec = tween(400))
-    val alpha by animateFloatAsState(if (startAnim) 1f else 0f, animationSpec = tween(400))
-
-    LaunchedEffect(Unit) { startAnim = true }
-
-    Button(
-        dimensions = ButtonDefaults.mediumButtonSize(),
-        onClick = {},
-        modifier = Modifier
-            .scale(scale)
-            .alpha(alpha)
-    ) {
-        Text(text)
-    }
-}
-
-enum class FeedbackState { Idle, Positive, Negative }
+enum class FeedbackSelectedState { Positive, Negative }
 
 @Preview(showBackground = true)
 @Composable

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
@@ -1,0 +1,121 @@
+package xyz.ksharma.krail.discover.ui
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.taj.LocalTextStyle
+import xyz.ksharma.krail.taj.components.Button
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun FeedbackButtonsRow(
+    modifier: Modifier = Modifier,
+    onPositive: () -> Unit,
+    onNegative: () -> Unit,
+) {
+    var state by remember { mutableStateOf(FeedbackState.Idle) }
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+        modifier = modifier,
+    ) {
+        AnimatedContent(targetState = state, label = "feedback") { feedbackState ->
+            when (feedbackState) {
+                FeedbackState.Idle -> {
+                    Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
+                        FeedbackCircleBox(
+                            modifier = Modifier.klickable {
+                                state = FeedbackState.Positive
+                                onPositive()
+                            }
+                        ) { Text("👍") }
+
+                        FeedbackCircleBox(
+                            modifier = Modifier.klickable {
+                                state = FeedbackState.Negative
+                                onNegative()
+                            }
+                        ) { Text("👎") }
+                    }
+                }
+
+                FeedbackState.Positive -> AnimatedFeedbackButton("Write a review")
+
+                FeedbackState.Negative -> AnimatedFeedbackButton("Share feedback")
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeedbackCircleBox(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier.size(40.dp).clip(shape = CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        CompositionLocalProvider(LocalTextStyle provides KrailTheme.typography.title) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun AnimatedFeedbackButton(text: String) {
+    var startAnim by remember { mutableStateOf(false) }
+    val scale by animateFloatAsState(if (startAnim) 1f else 0.8f, animationSpec = tween(400))
+    val alpha by animateFloatAsState(if (startAnim) 1f else 0f, animationSpec = tween(400))
+
+    LaunchedEffect(Unit) { startAnim = true }
+
+    Button(
+        dimensions = ButtonDefaults.mediumButtonSize(),
+        onClick = {},
+        modifier = Modifier
+            .scale(scale)
+            .alpha(alpha)
+    ) {
+        Text(text)
+    }
+}
+
+enum class FeedbackState { Idle, Positive, Negative }
+
+@Preview(showBackground = true)
+@Composable
+private fun FeedbackButtonsRowPreview() {
+    PreviewContent {
+        FeedbackButtonsRow(
+            onPositive = {},
+            onNegative = {},
+            modifier = Modifier.systemBarsPadding(),
+        )
+    }
+}


### PR DESCRIPTION
# Add Animated Feedback Buttons for Discover Cards

This PR adds a new `FeedbackButtonsRow` component with animated thumbs up/down buttons that transform into action buttons after selection. When users provide feedback:

- Thumbs up: Animates with rotation and scaling, then shows "Write a review" button
- Thumbs down: Animates with scaling, then shows "Send feedback" button

Additional changes:
- Simplified text styling in `DiscoverCard` component
- Set consistent max lines for title and description
- Added core library desugaring support for Firebase GitLive RemoteConfig
- Implemented share URL functionality in the share button