### PR TITLE
Add social link tracking in Discover cards with source attribution

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -253,10 +253,12 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     data class SocialConnectionLinkClickEvent(
         val socialPlatform: SocialPlatform,
+        val source: SocialConnectionSource,
     ) : AnalyticsEvent(
         name = "social_connection_link_click",
         properties = mapOf(
             "socialPlatform" to socialPlatform.platform,
+            "source" to source.source,
         ),
     ) {
         enum class SocialPlatform(val platform: String) {
@@ -264,6 +266,11 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             REDDIT("reddit"),
             INSTAGRAM("instagram"),
             FACEBOOK("facebook"),
+        }
+
+        enum class SocialConnectionSource(val source: String) {
+            SETTINGS("settings"),
+            DISCOVER_CARD("discover_card"),
         }
     }
 

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/serializer/ButtonListDeserializer.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/serializer/ButtonListDeserializer.kt
@@ -79,7 +79,7 @@ object ButtonListSerializer : KSerializer<List<Button>> {
                         val url = linkObj["url"]?.jsonPrimitive?.content
                         require(!url.isNullOrBlank()) { "Button PartnerSocial link URL cannot be null or blank" }
 
-                        Button.Social.PartnerSocial.PartnerSocialType(type, url)
+                        Button.Social.PartnerSocial.PartnerSocialLink(type, url)
                     }
                     Button.Social.PartnerSocial(
                         socialPartnerName = partnerName,

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -1,13 +1,15 @@
 package xyz.ksharma.krail.discover.state
 
 import xyz.ksharma.krail.social.state.KrailSocialType
-import xyz.ksharma.krail.social.state.SocialType
+import  xyz.ksharma.krail.discover.state.Button.Social.PartnerSocial.PartnerSocialLink
 
 sealed interface DiscoverEvent {
 
     data class AppSocialLinkClicked(val krailSocialType: KrailSocialType) : DiscoverEvent
 
-    data class PartnerSocialLinkClicked(val socialType: SocialType, val url: String) : DiscoverEvent
+    data class PartnerSocialLinkClicked(
+        val partnerSocialLink: PartnerSocialLink,
+    ) : DiscoverEvent
 
     data class ShareButtonClicked(val url: String) : DiscoverEvent
 

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -1,5 +1,23 @@
 package xyz.ksharma.krail.discover.state
 
+import xyz.ksharma.krail.social.state.KrailSocialType
+import xyz.ksharma.krail.social.state.SocialType
+
 sealed interface DiscoverEvent {
-    data object ButtonClicked: DiscoverEvent
+
+    data class AppSocialLinkClicked(val krailSocialType: KrailSocialType) : DiscoverEvent
+
+    data class PartnerSocialLinkClicked(val socialType: SocialType, val url: String) : DiscoverEvent
+
+    data class ShareButtonClicked(val url: String) : DiscoverEvent
+
+    data class CtaButtonClicked(val url: String) : DiscoverEvent
+
+    /**
+     * Event triggered when the user clicks on the feedback thumbs up/down button.
+     * @param isPositive
+     *          true if the user clicked the thumbs up button,
+     *          false if they clicked the thumbs down button.
+     */
+    data class FeedbackThumbButtonClicked(val isPositive: Boolean) : DiscoverEvent
 }

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
@@ -72,7 +72,7 @@ sealed class Button {
 
         data class PartnerSocial(
             val socialPartnerName: String,
-            val links: List<PartnerSocialType>
+            val links: List<PartnerSocialLink>
         ) : Social() {
 
             init {
@@ -80,7 +80,7 @@ sealed class Button {
                 require(links.isNotEmpty()) { "links list must not be empty" }
             }
 
-            data class PartnerSocialType(
+            data class PartnerSocialLink(
                 val type: SocialType,
                 val url: String,
             )

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -53,6 +53,7 @@ fun DiscoverCard(
     discoverModel: DiscoverState.DiscoverUiModel,
     modifier: Modifier = Modifier,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit = {},
+    onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit = {},
     onClick: (DiscoverState.DiscoverUiModel) -> Unit = {},
 ) {
     Column(
@@ -106,6 +107,7 @@ fun DiscoverCard(
             DiscoverCardButtonRow(
                 buttonsList = buttonsList,
                 onAppSocialLinkClicked = onAppSocialLinkClicked,
+                onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
             )
         }
     }
@@ -115,6 +117,7 @@ fun DiscoverCard(
 private fun DiscoverCardButtonRow(
     buttonsList: List<Button>,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
+    onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit,
 ) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
@@ -150,9 +153,12 @@ private fun DiscoverCardButtonRow(
 
                     is Button.Social.PartnerSocial -> {
                         SocialConnectionRow(
-                            onClick = { },
+                            onClick = { partnerSocialType ->
+                                onPartnerSocialLinkClicked(partnerSocialType)
+                            },
                             socialPartnerName = socialButton.socialPartnerName,
-                            socialLinks = socialButton.links.map { it.type })
+                            partnerSocialLinks = socialButton.links,
+                        )
                     }
                 }
             }
@@ -291,7 +297,7 @@ val previewDiscoverCardList = listOf(
             Button.Social.PartnerSocial(
                 socialPartnerName = "XYZ Place",
                 links = persistentListOf(
-                    Button.Social.PartnerSocial.PartnerSocialType(
+                    Button.Social.PartnerSocial.PartnerSocialLink(
                         type = SocialType.Facebook,
                         url = "https://example.com"
                     ),

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -52,6 +52,7 @@ import app.krail.taj.resources.Res as TajRes
 fun DiscoverCard(
     discoverModel: DiscoverState.DiscoverUiModel,
     modifier: Modifier = Modifier,
+    onAppSocialLinkClicked: (KrailSocialType) -> Unit = {},
     onClick: (DiscoverState.DiscoverUiModel) -> Unit = {},
 ) {
     Column(
@@ -102,13 +103,19 @@ fun DiscoverCard(
         Spacer(modifier = Modifier.weight(1f))
 
         discoverModel.buttons?.let { buttonsList ->
-            DiscoverCardButtonRow(buttonsList)
+            DiscoverCardButtonRow(
+                buttonsList = buttonsList,
+                onAppSocialLinkClicked = onAppSocialLinkClicked,
+            )
         }
     }
 }
 
 @Composable
-private fun DiscoverCardButtonRow(buttonsList: List<Button>) {
+private fun DiscoverCardButtonRow(
+    buttonsList: List<Button>,
+    onAppSocialLinkClicked: (KrailSocialType) -> Unit,
+) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
         logError("Invalid button combination or no buttons provided: ${buttonsList.map { it::class.simpleName }}")
@@ -134,14 +141,16 @@ private fun DiscoverCardButtonRow(buttonsList: List<Button>) {
                 when (val socialButton = left.button) {
                     Button.Social.AppSocial -> {
                         SocialConnectionRow(
-                            onClick = {},
+                            onClick = { krailSocialType ->
+                                onAppSocialLinkClicked(krailSocialType)
+                            },
                             socialLinks = KrailSocialType.entries,
                         )
                     }
 
                     is Button.Social.PartnerSocial -> {
                         SocialConnectionRow(
-                            onClick = {},
+                            onClick = { },
                             socialPartnerName = socialButton.socialPartnerName,
                             socialLinks = socialButton.links.map { it.type })
                     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -77,6 +77,8 @@ val viewModelsModule = module {
         DiscoverViewModel(
             discoverSydneyManager = get(),
             ioDispatcher = get(named(IODispatcher)),
+            analytics = get(),
+            platformOps = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -23,6 +23,13 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                 viewModel.onEvent(
                     event = DiscoverEvent.AppSocialLinkClicked(krailSocialType = krailSocialType)
                 )
+            },
+            onPartnerSocialLinkClicked = { partnerSocialLink ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.PartnerSocialLinkClicked(
+                        partnerSocialLink = partnerSocialLink,
+                    )
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import org.koin.compose.viewmodel.koinViewModel
+import xyz.ksharma.krail.discover.state.DiscoverEvent
 import xyz.ksharma.krail.trip.planner.ui.navigation.DiscoverRoute
 
 internal fun NavGraphBuilder.discoverDestination(navController: NavHostController) {
@@ -17,6 +18,11 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
             state = discoverState,
             onBackClick = {
                 navController.navigateUp()
+            },
+            onAppSocialLinkClicked = { krailSocialType ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.AppSocialLinkClicked(krailSocialType = krailSocialType)
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.discover.state.Button
 import xyz.ksharma.krail.discover.state.DiscoverState
 import xyz.ksharma.krail.discover.ui.DiscoverCard
 import xyz.ksharma.krail.social.state.KrailSocialType
@@ -28,6 +29,7 @@ fun DiscoverScreen(
     state: DiscoverState,
     onBackClick: () -> Unit,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
+    onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -44,6 +46,7 @@ fun DiscoverScreen(
                         DiscoverCard(
                             discoverModel = cardModel,
                             onAppSocialLinkClicked = onAppSocialLinkClicked,
+                            onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
                         )
                     }
                 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.discover.state.DiscoverState
 import xyz.ksharma.krail.discover.ui.DiscoverCard
+import xyz.ksharma.krail.social.state.KrailSocialType
 import xyz.ksharma.krail.taj.components.DiscoverCardVerticalPager
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
@@ -26,6 +27,7 @@ fun DiscoverScreen(
     modifier: Modifier = Modifier,
     state: DiscoverState,
     onBackClick: () -> Unit,
+    onAppSocialLinkClicked: (KrailSocialType) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -39,7 +41,10 @@ fun DiscoverScreen(
                     pages = state.discoverCardsList,
                     modifier = Modifier.fillMaxSize(),
                     content = { cardModel ->
-                        DiscoverCard(discoverModel = cardModel)
+                        DiscoverCard(
+                            discoverModel = cardModel,
+                            onAppSocialLinkClicked = onAppSocialLinkClicked,
+                        )
                     }
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -2,7 +2,6 @@ package xyz.ksharma.krail.trip.planner.ui.discover
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineDispatcher
@@ -14,6 +13,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent.SocialConnectionSource
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
@@ -43,13 +43,25 @@ class DiscoverViewModel(
                 analytics.track(
                     event = AnalyticsEvent.SocialConnectionLinkClickEvent(
                         socialPlatform = event.krailSocialType.toAnalyticsEventPlatform(),
+                        source = SocialConnectionSource.DISCOVER_CARD,
+                    ),
+                )
+            }
+
+            is DiscoverEvent.PartnerSocialLinkClicked -> {
+                platformOps.openUrl(url = event.partnerSocialLink.url)
+                analytics.track(
+                    event = AnalyticsEvent.SocialConnectionLinkClickEvent(
+                        socialPlatform = event.partnerSocialLink.type.toAnalyticsEventPlatform(),
+                        source = SocialConnectionSource.DISCOVER_CARD,
                     ),
                 )
             }
 
             is DiscoverEvent.CtaButtonClicked -> {}
+
             is DiscoverEvent.FeedbackThumbButtonClicked -> {}
-            is DiscoverEvent.PartnerSocialLinkClicked -> {}
+
             is DiscoverEvent.ShareButtonClicked -> {}
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -12,16 +12,22 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
 import xyz.ksharma.krail.discover.state.DiscoverEvent
 import xyz.ksharma.krail.discover.state.DiscoverState
+import xyz.ksharma.krail.platform.ops.PlatformOps
+import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
 
 class DiscoverViewModel(
     private val discoverSydneyManager: DiscoverSydneyManager,
     private val ioDispatcher: CoroutineDispatcher,
+    private val analytics: Analytics,
+    private val platformOps: PlatformOps,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<DiscoverState> = MutableStateFlow(DiscoverState())
@@ -32,7 +38,19 @@ class DiscoverViewModel(
 
     fun onEvent(event: DiscoverEvent) {
         when (event) {
-            DiscoverEvent.ButtonClicked -> {}
+            is DiscoverEvent.AppSocialLinkClicked -> {
+                platformOps.openUrl(url = event.krailSocialType.url)
+                analytics.track(
+                    event = AnalyticsEvent.SocialConnectionLinkClickEvent(
+                        socialPlatform = event.krailSocialType.toAnalyticsEventPlatform(),
+                    ),
+                )
+            }
+
+            is DiscoverEvent.CtaButtonClicked -> {}
+            is DiscoverEvent.FeedbackThumbButtonClicked -> {}
+            is DiscoverEvent.PartnerSocialLinkClicked -> {}
+            is DiscoverEvent.ShareButtonClicked -> {}
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -10,10 +10,11 @@ import kotlinx.coroutines.flow.stateIn
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
-import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
 import xyz.ksharma.krail.platform.ops.PlatformOps
+import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
 import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
 import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsEvent
 import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
@@ -36,8 +37,9 @@ class SettingsViewModel(
             is SettingsEvent.SocialLinkClick -> {
                 platformOps.openUrl(url = event.krailSocialType.url)
                 analytics.track(
-                    event = AnalyticsEvent.SocialConnectionLinkClickEvent(
+                    event = SocialConnectionLinkClickEvent(
                         socialPlatform = event.krailSocialType.toAnalyticsEventPlatform(),
+                        source = SocialConnectionLinkClickEvent.SocialConnectionSource.SETTINGS,
                     ),
                 )
             }

--- a/social/ui/build.gradle.kts
+++ b/social/ui/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
             dependencies {
                 implementation(projects.core.analytics)
                 implementation(projects.core.log)
+                implementation(projects.discover.state)
                 implementation(projects.social.network.api)
                 implementation(projects.social.state)
                 implementation(projects.taj)

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
@@ -63,12 +63,12 @@ fun SocialConnectionRow(
     ) {
         socialLinks.forEach { socialType ->
             SocialConnectionIcon(
-                onClick = { onClick(socialType) },
+                onClick = { },
                 modifier = Modifier.padding(vertical = 4.dp),
             ) {
                 Image(
                     painter = painterResource(resource = socialType.resource()),
-                    contentDescription = "${socialType.name} Page for $socialPartnerName",
+                    contentDescription = "${socialType.displayName} Page for $socialPartnerName",
                     colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
                     modifier = Modifier.size(24.dp),
                 )

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
@@ -10,17 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
-import krail.social.ui.generated.resources.Res
-import krail.social.ui.generated.resources.ic_facebook
-import krail.social.ui.generated.resources.ic_instagram
-import krail.social.ui.generated.resources.ic_linkedin
-import krail.social.ui.generated.resources.ic_reddit
-import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.discover.state.Button.Social.PartnerSocial.PartnerSocialLink
 import xyz.ksharma.krail.social.state.KrailSocialType
-import xyz.ksharma.krail.social.state.SocialType
-import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
 import xyz.ksharma.krail.taj.components.SocialConnectionIcon
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
@@ -41,7 +34,7 @@ fun SocialConnectionRow(
             ) {
                 Image(
                     painter = painterResource(resource = socialType.resource()),
-                    contentDescription = "${socialType.socialType} Page for KRAIL App",
+                    contentDescription = "${socialType.socialType.displayName} Page for KRAIL App",
                     colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
                     modifier = Modifier.size(24.dp),
                 )
@@ -53,22 +46,22 @@ fun SocialConnectionRow(
 @Composable
 fun SocialConnectionRow(
     socialPartnerName: String,
-    socialLinks: List<SocialType>,
+    partnerSocialLinks: List<PartnerSocialLink>,
     modifier: Modifier = Modifier,
-    onClick: (SocialType) -> Unit,
+    onClick: (PartnerSocialLink) -> Unit,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        socialLinks.forEach { socialType ->
+        partnerSocialLinks.forEach { socialType ->
             SocialConnectionIcon(
-                onClick = { },
+                onClick = { onClick(socialType) },
                 modifier = Modifier.padding(vertical = 4.dp),
             ) {
                 Image(
-                    painter = painterResource(resource = socialType.resource()),
-                    contentDescription = "${socialType.displayName} Page for $socialPartnerName",
+                    painter = painterResource(resource = socialType.type.resource()),
+                    contentDescription = "${socialType.type.displayName} Page for $socialPartnerName",
                     colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
                     modifier = Modifier.size(24.dp),
                 )
@@ -83,29 +76,7 @@ private fun SocialConnectionRowPreview() {
     KrailTheme {
         SocialConnectionRow(
             socialLinks = KrailSocialType.entries,
-            onClick = { /* Handle click */ },
+            onClick = {},
         )
     }
 }
-
-fun KrailSocialType.resource(): DrawableResource = when (this) {
-    KrailSocialType.LinkedIn -> Res.drawable.ic_linkedin
-    KrailSocialType.Reddit -> Res.drawable.ic_reddit
-    KrailSocialType.Instagram -> Res.drawable.ic_instagram
-    KrailSocialType.Facebook -> Res.drawable.ic_facebook
-}
-
-fun SocialType.resource(): DrawableResource = when (this) {
-    SocialType.LinkedIn -> Res.drawable.ic_linkedin
-    SocialType.Reddit -> Res.drawable.ic_reddit
-    SocialType.Instagram -> Res.drawable.ic_instagram
-    SocialType.Facebook -> Res.drawable.ic_facebook
-}
-
-fun KrailSocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatform =
-    when (this) {
-        KrailSocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatform.LINKEDIN
-        KrailSocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatform.REDDIT
-        KrailSocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatform.INSTAGRAM
-        KrailSocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatform.FACEBOOK
-    }

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialTypeExt.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialTypeExt.kt
@@ -1,0 +1,42 @@
+package xyz.ksharma.krail.social.ui
+
+import krail.social.ui.generated.resources.Res
+import krail.social.ui.generated.resources.ic_facebook
+import krail.social.ui.generated.resources.ic_instagram
+import krail.social.ui.generated.resources.ic_linkedin
+import krail.social.ui.generated.resources.ic_reddit
+import org.jetbrains.compose.resources.DrawableResource
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
+import xyz.ksharma.krail.social.state.KrailSocialType
+import xyz.ksharma.krail.social.state.SocialType
+
+internal fun KrailSocialType.resource(): DrawableResource = when (this) {
+    KrailSocialType.LinkedIn -> Res.drawable.ic_linkedin
+    KrailSocialType.Reddit -> Res.drawable.ic_reddit
+    KrailSocialType.Instagram -> Res.drawable.ic_instagram
+    KrailSocialType.Facebook -> Res.drawable.ic_facebook
+}
+
+internal fun SocialType.resource(): DrawableResource = when (this) {
+    SocialType.LinkedIn -> Res.drawable.ic_linkedin
+    SocialType.Reddit -> Res.drawable.ic_reddit
+    SocialType.Instagram -> Res.drawable.ic_instagram
+    SocialType.Facebook -> Res.drawable.ic_facebook
+}
+
+fun SocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatform =
+    when (this) {
+        SocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatform.LINKEDIN
+        SocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatform.REDDIT
+        SocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatform.INSTAGRAM
+        SocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatform.FACEBOOK
+    }
+
+fun KrailSocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatform =
+    when (this) {
+        KrailSocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatform.LINKEDIN
+        KrailSocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatform.REDDIT
+        KrailSocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatform.INSTAGRAM
+        KrailSocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatform.FACEBOOK
+    }
+


### PR DESCRIPTION
# Add Social Connection Click Events to Discover Cards

This PR adds click handling for social connection links in the Discover feature:

- Added a `source` parameter to `SocialConnectionLinkClickEvent` to track where social links are clicked (settings vs discover card)
- Renamed `PartnerSocialType` to `PartnerSocialLink` for clarity
- Implemented click handlers for both app social links and partner social links in the Discover UI
- Added analytics tracking for social link clicks from Discover cards
- Refactored social type extension functions into a dedicated file