### PR TITLE
BUG: Fix negative spots available in park ride facility data

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt
@@ -30,7 +30,10 @@ import kotlin.time.ExperimentalTime
  **/
 @OptIn(ExperimentalTime::class)
 @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-fun CarParkFacilityDetailResponse.toNSWParkRideFacilityDetail(stopName: String, stopId: String): NSWParkRideFacilityDetail {
+fun CarParkFacilityDetailResponse.toNSWParkRideFacilityDetail(
+    stopName: String,
+    stopId: String
+): NSWParkRideFacilityDetail {
     val totalSpots = spots.toIntOrNull() ?: 0
     val occupiedSpots = zones.sumOf {
         it.occupancy.total?.toIntOrNull() ?: it.occupancy.transients?.toIntOrNull() ?: 0
@@ -47,7 +50,7 @@ fun CarParkFacilityDetailResponse.toNSWParkRideFacilityDetail(stopName: String, 
 
     return NSWParkRideFacilityDetail(
         facilityId = facilityId,
-        spotsAvailable = spotsAvailable.toLong(),
+        spotsAvailable = spotsAvailable.toLong().coerceAtLeast(0),
         totalSpots = totalSpots.toLong(),
         facilityName = facilityName.toDisplayFacilityName(),
         percentageFull = percentageFull.toLong(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -421,7 +421,7 @@ class SavedTripsViewModel(
                     )
 
                     parkRideSandook.insertOrReplaceAll(listOf(detail))
-                    log("Fetched and saved facility $facilityId for stop $stopId")
+                    log("Fetched and saved facility $facilityId for stop $stopId - $detail")
                 } else {
                     // reset timestamp to DISTANT_PAST as API call failed, so we can retry
                     // earlier than cooldown would end.


### PR DESCRIPTION
BUG: ### TL;DR

Fixed negative spots available in Park & Ride facility data and improved logging for debugging.

## What was happening?

For the facility the loading ui was being displayed always even though data was successfully fetched form API's. Issue is the total spots value is -ve. Fixed that by using coerceatleast 0. cannot ensure that total available spots will always be non negative. 

### What changed?

- Added a `coerceAtLeast(0)` to ensure `spotsAvailable` is never negative in `NSWParkRideFacilityDetail`
- Added a TODO comment to debug Sutherland facility id 15 data
- Enhanced logging to include the full facility detail object when saving Park & Ride facility data
- Improved code formatting by breaking parameters into multiple lines for better readability

### How to test?

1. Check Park & Ride information for Sutherland station (facility id 15)
2. Verify that spots available is never shown as a negative number
3. Review logs to confirm the enhanced debugging information is present

### Why make this change?

The Park & Ride facility data was sometimes showing negative available spots, which is logically impossible. This fix ensures that the displayed value is always at least zero, preventing confusing information from being shown to users. The improved logging will help with debugging the underlying issue with the Sutherland facility data.