### PR TITLE
Add analytics tracking to Discover cards with app store links and social interactions

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -319,7 +319,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         ).apply {
             partnerSocialLink?.let { socialLink ->
                 put("partnerSocialPlatformName", socialLink.type.platformName)
-                put("partnerSocialPlatformName", socialLink.url)
+                put("partnerSocialPlatformUrl", socialLink.url)
             }
         }
     ) {

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -252,16 +252,16 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     )
 
     data class SocialConnectionLinkClickEvent(
-        val socialPlatform: SocialPlatform,
+        val socialPlatformType: SocialPlatformType,
         val source: SocialConnectionSource,
     ) : AnalyticsEvent(
         name = "social_connection_link_click",
         properties = mapOf(
-            "socialPlatform" to socialPlatform.platform,
+            "socialPlatform" to socialPlatformType.platformName,
             "source" to source.source,
         ),
     ) {
-        enum class SocialPlatform(val platform: String) {
+        enum class SocialPlatformType(val platformName: String) {
             LINKEDIN("linkedin"),
             REDDIT("reddit"),
             INSTAGRAM("instagram"),
@@ -303,17 +303,49 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // region Discover
 
-    data class FeedbackClick(val action: FeedbackAction) : AnalyticsEvent(
-        name = "discover_feedback_provided",
-        properties = mapOf(
-            "action" to action.actionName,
-        )
+    data class DiscoverCardClick(
+        val location: String = "SYD",
+        val source: Source,
+        val cardId: String,
+        val cardType: CardType,
+        val partnerSocialLink: PartnerSocialLink? = null,
+    ) : AnalyticsEvent(
+        name = "discover_click",
+        properties = mutableMapOf(
+            "location" to location,
+            "source" to source.actionName,
+            "cardId" to cardId,
+            "cardType" to cardType,
+        ).apply {
+            partnerSocialLink?.let { socialLink ->
+                put("partnerSocialPlatformName", socialLink.type.platformName)
+                put("partnerSocialPlatformName", socialLink.url)
+            }
+        }
     ) {
-        enum class FeedbackAction(val actionName: String) {
-            POSITIVE_THUMB("positive"),
-            NEGATIVE_THUMB("negative"),
-            SHARE_FEEDBACK("share_feedback"),
-            WRITE_REVIEW("write_review"),
+        data class PartnerSocialLink(
+            val type: SocialConnectionLinkClickEvent.SocialPlatformType,
+            val url: String,
+        )
+
+        enum class CardType(val type: String) {
+            KRAIL("krail"),
+            TRAVEL("travel"),
+            EVENTS("events"),
+            FOOD("food"),
+            SPORTS("sports"),
+            KIDS("kids"),
+            UNKNOWN("unknown"),
+        }
+
+        enum class Source(val actionName: String) {
+            FEEDBACK_POSITIVE_THUMB("feedback_positive"),
+            FEEDBACK_NEGATIVE_THUMB("feedback_negative"),
+            FEEDBACK_SHARE_FEEDBACK("share_feedback"),
+            FEEDBACK_WRITE_REVIEW("write_review"),
+            CTA_CLICK("cta_click"),
+            SHARE_CLICK("share"),
+            PARTNER_SOCIAL_LINK("partner_social_link"),
         }
     }
 

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -66,6 +66,9 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
     override val timeZone: String
         get() = java.util.TimeZone.getDefault().id
 
+    override val appStoreUrl: String
+        get() = "https://play.google.com/store/apps/details?id=xyz.ksharma.krail"
+
     override fun toString() =
         "AndroidAppInfo(type=$devicePlatformType, isDebug=$isDebug, appVersion=$appVersion, osVersion=$osVersion, " +
             "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -72,6 +72,8 @@ interface AppInfo {
      * E.g. "Australia/Sydney"
      */
     val timeZone: String
+
+    val appStoreUrl: String
 }
 
 enum class DevicePlatformType {

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -66,6 +66,9 @@ class IOSAppInfo : AppInfo {
     override val timeZone: String
         get() = NSTimeZone.localTimeZone.name
 
+    override val appStoreUrl: String
+        get() = "https://apps.apple.com/us/app/krail-app/id6738934832"
+
     override fun toString() =
         "iOSAppInfo(type=$devicePlatformType, isDebug=$isDebug, appVersion=$appVersion, osVersion=$osVersion, " +
             "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/model/DiscoverModel.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/model/DiscoverModel.kt
@@ -41,4 +41,7 @@ data class DiscoverModel(
 
     @SerialName("type")
     val type: DiscoverCardType,
+
+    @SerialName("cardId")
+    val cardId: String,
 )

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -14,6 +14,7 @@ sealed interface DiscoverEvent {
     ) : DiscoverEvent
 
     data class ShareButtonClicked(
+        val cardTitle: String,
         val url: String,
         val cardId: String,
         val cardType: DiscoverCardType,

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -9,11 +9,21 @@ sealed interface DiscoverEvent {
 
     data class PartnerSocialLinkClicked(
         val partnerSocialLink: PartnerSocialLink,
+        val cardId: String,
+        val cardType: DiscoverCardType,
     ) : DiscoverEvent
 
-    data class ShareButtonClicked(val url: String) : DiscoverEvent
+    data class ShareButtonClicked(
+        val url: String,
+        val cardId: String,
+        val cardType: DiscoverCardType,
+    ) : DiscoverEvent
 
-    data class CtaButtonClicked(val url: String) : DiscoverEvent
+    data class CtaButtonClicked(
+        val url: String,
+        val cardId: String,
+        val cardType: DiscoverCardType,
+    ) : DiscoverEvent
 
     /**
      * Event triggered when the user clicks on the feedback thumbs up/down button.
@@ -21,7 +31,15 @@ sealed interface DiscoverEvent {
      *          true if the user clicked the thumbs up button,
      *          false if they clicked the thumbs down button.
      */
-    data class FeedbackThumbButtonClicked(val isPositive: Boolean, val feedbackId: String) : DiscoverEvent
+    data class FeedbackThumbButtonClicked(
+        val isPositive: Boolean,
+        val cardId: String,
+        val cardType: DiscoverCardType,
+    ) : DiscoverEvent
 
-    data class FeedbackCtaButtonClicked(val isPositive: Boolean, val feedbackId: String) : DiscoverEvent
+    data class FeedbackCtaButtonClicked(
+        val isPositive: Boolean,
+        val cardId: String,
+        val cardType: DiscoverCardType,
+    ) : DiscoverEvent
 }

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
@@ -33,6 +33,8 @@ data class DiscoverState(
         val buttons: ImmutableList<Button>? = null,
 
         val type: DiscoverCardType,
+
+        val cardId: String,
     )
 }
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -58,7 +58,9 @@ fun DiscoverCard(
         String,
         DiscoverCardType
     ) -> Unit = { _, _, _ -> },
-    onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit = { _, _, _ -> }
+    onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit = { _, _, _ -> },
+    onFeedbackCta: (Boolean) -> Unit = {},
+    onFeedbackThumb: (Boolean) -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -118,7 +120,9 @@ fun DiscoverCard(
                 },
                 onCtaClicked = { url ->
                     onCtaClicked(url, discoverModel.cardId, discoverModel.type)
-                }
+                },
+                onFeedbackCta = onFeedbackCta,
+                onFeedbackThumb = onFeedbackThumb
             )
         }
     }
@@ -130,6 +134,8 @@ private fun DiscoverCardButtonRow(
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
     onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit,
     onCtaClicked: (String) -> Unit,
+    onFeedbackThumb: (Boolean) -> Unit,
+    onFeedbackCta: (Boolean) -> Unit,
 ) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
@@ -179,12 +185,18 @@ private fun DiscoverCardButtonRow(
 
             is DiscoverCardButtonRowState.LeftButtonType.Feedback -> {
                 FeedbackButtonsRow(
-                    onNegative = {
-
+                    onNegativeThumb = {
+                        onFeedbackThumb(false)
                     },
-                    onPositive = {
-
-                    }
+                    onPositiveThumb = {
+                        onFeedbackThumb(true)
+                    },
+                    onNegativeCta = {
+                        onFeedbackCta(false)
+                    },
+                    onPositiveCta = {
+                        onFeedbackCta(true)
+                    },
                 )
             }
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -53,8 +53,11 @@ fun DiscoverCard(
     discoverModel: DiscoverState.DiscoverUiModel,
     modifier: Modifier = Modifier,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit = {},
-    onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit = {},
-    onClick: (DiscoverState.DiscoverUiModel) -> Unit = {},
+    onPartnerSocialLinkClicked: (
+        Button.Social.PartnerSocial.PartnerSocialLink,
+        String,
+        DiscoverCardType
+    ) -> Unit = { _, _, _ -> },
 ) {
     Column(
         modifier = modifier
@@ -107,7 +110,11 @@ fun DiscoverCard(
             DiscoverCardButtonRow(
                 buttonsList = buttonsList,
                 onAppSocialLinkClicked = onAppSocialLinkClicked,
-                onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
+                onPartnerSocialLinkClicked = { partnerSocialLink ->
+                    onPartnerSocialLinkClicked(
+                        partnerSocialLink, discoverModel.cardId, discoverModel.type
+                    )
+                }
             )
         }
     }
@@ -263,6 +270,7 @@ private class DiscoverCardProvider : PreviewParameterProvider<DiscoverState.Disc
 
 val previewDiscoverCardList = listOf(
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_1",
         title = "Cta only card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://images.unsplash.com/photo-1749751234397-41ee8a7887c2"),
@@ -275,6 +283,7 @@ val previewDiscoverCardList = listOf(
         ),
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_2",
         title = "No Buttons Card Title",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://images.unsplash.com/photo-1741851373856-67a519f0c014"),
@@ -282,6 +291,7 @@ val previewDiscoverCardList = listOf(
         buttons = persistentListOf(),
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_3",
         title = "App Social Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"),
@@ -289,6 +299,7 @@ val previewDiscoverCardList = listOf(
         buttons = persistentListOf(Button.Social.AppSocial)
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_3",
         title = "Partner Social Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"),
@@ -306,6 +317,7 @@ val previewDiscoverCardList = listOf(
         )
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_4",
         title = "Share Only Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014"),
@@ -317,6 +329,7 @@ val previewDiscoverCardList = listOf(
         )
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_5",
         title = "Cta + Share Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1730005745671-dbbfddfe387e"),
@@ -332,6 +345,7 @@ val previewDiscoverCardList = listOf(
         )
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_6",
         title = "Feedback Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752832756659-4dd7c40f5ae7"),
@@ -344,6 +358,7 @@ val previewDiscoverCardList = listOf(
         )
     ),
     DiscoverState.DiscoverUiModel(
+        cardId = "cta_card_7",
         title = "Credits Disclaimer Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://images.unsplash.com/photo-1735746693939-586a9d7558e1"),

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -58,6 +58,7 @@ fun DiscoverCard(
         String,
         DiscoverCardType
     ) -> Unit = { _, _, _ -> },
+    onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit = { _, _, _ -> }
 ) {
     Column(
         modifier = modifier
@@ -114,6 +115,9 @@ fun DiscoverCard(
                     onPartnerSocialLinkClicked(
                         partnerSocialLink, discoverModel.cardId, discoverModel.type
                     )
+                },
+                onCtaClicked = { url ->
+                    onCtaClicked(url, discoverModel.cardId, discoverModel.type)
                 }
             )
         }
@@ -125,6 +129,7 @@ private fun DiscoverCardButtonRow(
     buttonsList: List<Button>,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
     onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit,
+    onCtaClicked: (String) -> Unit,
 ) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
@@ -141,7 +146,9 @@ private fun DiscoverCardButtonRow(
             is DiscoverCardButtonRowState.LeftButtonType.Cta -> {
                 Button(
                     dimensions = ButtonDefaults.mediumButtonSize(),
-                    onClick = {},
+                    onClick = {
+                        onCtaClicked(left.button.url)
+                    },
                 ) {
                     Text(text = left.button.label)
                 }

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -61,6 +61,7 @@ fun DiscoverCard(
     onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit = { _, _, _ -> },
     onFeedbackCta: (Boolean) -> Unit = {},
     onFeedbackThumb: (Boolean) -> Unit = {},
+    onShareClick: (String) -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -122,7 +123,8 @@ fun DiscoverCard(
                     onCtaClicked(url, discoverModel.cardId, discoverModel.type)
                 },
                 onFeedbackCta = onFeedbackCta,
-                onFeedbackThumb = onFeedbackThumb
+                onFeedbackThumb = onFeedbackThumb,
+                onShareClick = onShareClick,
             )
         }
     }
@@ -136,6 +138,7 @@ private fun DiscoverCardButtonRow(
     onCtaClicked: (String) -> Unit,
     onFeedbackThumb: (Boolean) -> Unit,
     onFeedbackCta: (Boolean) -> Unit,
+    onShareClick: (String) -> Unit,
 ) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
@@ -209,9 +212,7 @@ private fun DiscoverCardButtonRow(
         when (val rightButton = state.right) {
             is DiscoverCardButtonRowState.RightButtonType.Share -> {
                 RoundIconButton(
-                    onClick = {
-                        rightButton.button.shareUrl
-                    },
+                    onClick = { onShareClick(rightButton.button.shareUrl) },
                     color = Color.Transparent,
                 ) {
                     Image(
@@ -318,7 +319,7 @@ val previewDiscoverCardList = listOf(
         buttons = persistentListOf(Button.Social.AppSocial)
     ),
     DiscoverState.DiscoverUiModel(
-        cardId = "cta_card_3",
+        cardId = "cta_card_4",
         title = "Partner Social Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1752624906994-d94727d34c9b"),

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
@@ -32,8 +32,10 @@ private enum class FeedbackAnimState {
 @Composable
 fun FeedbackButtonsRow(
     modifier: Modifier = Modifier,
-    onPositive: () -> Unit,
-    onNegative: () -> Unit,
+    onPositiveThumb: () -> Unit,
+    onNegativeThumb: () -> Unit,
+    onPositiveCta: () -> Unit,
+    onNegativeCta: () -> Unit,
 ) {
     var selected by remember { mutableStateOf<FeedbackSelectedState?>(null) }
     var animState by remember { mutableStateOf(FeedbackAnimState.Idle) }
@@ -82,7 +84,7 @@ fun FeedbackButtonsRow(
                         }
                         .klickable {
                             if (animState == FeedbackAnimState.Idle) {
-                                onPositive()
+                                onPositiveThumb()
                                 startAnimation(FeedbackSelectedState.Positive)
                             }
                         }
@@ -97,7 +99,7 @@ fun FeedbackButtonsRow(
                         }
                         .klickable {
                             if (animState == FeedbackAnimState.Idle) {
-                                onNegative()
+                                onNegativeThumb()
                                 startAnimation(FeedbackSelectedState.Negative)
                             }
                         }
@@ -132,7 +134,13 @@ fun FeedbackButtonsRow(
                 }
                 Button(
                     dimensions = ButtonDefaults.mediumButtonSize(),
-                    onClick = {},
+                    onClick = {
+                        when (selected) {
+                            FeedbackSelectedState.Positive -> onPositiveCta()
+                            FeedbackSelectedState.Negative -> onNegativeCta()
+                            null -> Unit
+                        }
+                    },
                     modifier = Modifier.scale(buttonScale.value)
                 ) {
                     Text(text)
@@ -164,9 +172,11 @@ enum class FeedbackSelectedState { Positive, Negative }
 private fun FeedbackButtonsRowPreview() {
     PreviewContent {
         FeedbackButtonsRow(
-            onPositive = {},
-            onNegative = {},
+            onPositiveThumb = {},
+            onNegativeThumb = {},
             modifier = Modifier.systemBarsPadding(),
+            onPositiveCta = {},
+            onNegativeCta = {},
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -79,6 +79,7 @@ val viewModelsModule = module {
             ioDispatcher = get(named(IODispatcher)),
             analytics = get(),
             platformOps = get(),
+            appInfoProvider = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapper.kt
@@ -1,0 +1,25 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.social.state.SocialType
+
+internal fun DiscoverCardType.toAnalyticsCardType(): DiscoverCardClick.CardType {
+    return when (this) {
+        DiscoverCardType.Events -> DiscoverCardClick.CardType.EVENTS
+        DiscoverCardType.Sports -> DiscoverCardClick.CardType.SPORTS
+        DiscoverCardType.Krail -> DiscoverCardClick.CardType.KRAIL
+        DiscoverCardType.Kids -> DiscoverCardClick.CardType.KIDS
+        DiscoverCardType.Travel -> DiscoverCardClick.CardType.TRAVEL
+        DiscoverCardType.Food -> DiscoverCardClick.CardType.FOOD
+    }
+}
+
+internal fun SocialType.toAnalyticsSocialType(): SocialConnectionLinkClickEvent.SocialPlatformType =
+    when (this) {
+        SocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatformType.LINKEDIN
+        SocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT
+        SocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM
+        SocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatformType.FACEBOOK
+    }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -41,6 +41,24 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                         cardType = cardType,
                     )
                 )
+            },
+            onFeedbackCta = { isPositive, cardId, cardType ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.FeedbackCtaButtonClicked(
+                        isPositive = isPositive,
+                        cardId = cardId,
+                        cardType = cardType,
+                    )
+                )
+            },
+            onFeedbackThumb = { isPositive, cardId, cardType ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.FeedbackThumbButtonClicked(
+                        isPositive = isPositive,
+                        cardId = cardId,
+                        cardType = cardType,
+                    )
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -24,10 +24,12 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                     event = DiscoverEvent.AppSocialLinkClicked(krailSocialType = krailSocialType)
                 )
             },
-            onPartnerSocialLinkClicked = { partnerSocialLink ->
+            onPartnerSocialLinkClicked = { partnerSocialLink, cardId, cardType ->
                 viewModel.onEvent(
                     event = DiscoverEvent.PartnerSocialLinkClicked(
                         partnerSocialLink = partnerSocialLink,
+                        cardId = cardId,
+                        cardType = cardType,
                     )
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -59,6 +59,16 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                         cardType = cardType,
                     )
                 )
+            },
+            onShareClick = { shareUrl, cardId, cardType ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.ShareButtonClicked(
+                        cardTitle = shareUrl,
+                        cardId = cardId,
+                        cardType = cardType,
+                        url = shareUrl,
+                    )
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -32,6 +32,15 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                         cardType = cardType,
                     )
                 )
+            },
+            onCtaClicked = { url, cardId, cardType ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.CtaButtonClicked(
+                        url = url,
+                        cardId = cardId,
+                        cardType = cardType,
+                    )
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -31,6 +31,7 @@ fun DiscoverScreen(
     onBackClick: () -> Unit,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
     onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink, String, DiscoverCardType) -> Unit,
+    onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -48,6 +49,7 @@ fun DiscoverScreen(
                             discoverModel = cardModel,
                             onAppSocialLinkClicked = onAppSocialLinkClicked,
                             onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
+                            onCtaClicked = onCtaClicked,
                         )
                     }
                 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -34,6 +34,7 @@ fun DiscoverScreen(
     onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit,
     onFeedbackCta: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
     onFeedbackThumb: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
+    onShareClick: (shareUrl: String, cardId: String, cardType: DiscoverCardType) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -66,6 +67,13 @@ fun DiscoverScreen(
                                     cardModel.type,
                                 )
                             },
+                            onShareClick = { shareUrl ->
+                                onShareClick(
+                                    shareUrl,
+                                    cardModel.cardId,
+                                    cardModel.type,
+                                )
+                            }
                         )
                     }
                 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.discover.state.Button
+import xyz.ksharma.krail.discover.state.DiscoverCardType
 import xyz.ksharma.krail.discover.state.DiscoverState
 import xyz.ksharma.krail.discover.ui.DiscoverCard
 import xyz.ksharma.krail.social.state.KrailSocialType
@@ -29,7 +30,7 @@ fun DiscoverScreen(
     state: DiscoverState,
     onBackClick: () -> Unit,
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
-    onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink) -> Unit,
+    onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink, String, DiscoverCardType) -> Unit,
 ) {
     Box(
         modifier = modifier

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -32,6 +32,8 @@ fun DiscoverScreen(
     onAppSocialLinkClicked: (KrailSocialType) -> Unit,
     onPartnerSocialLinkClicked: (Button.Social.PartnerSocial.PartnerSocialLink, String, DiscoverCardType) -> Unit,
     onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit,
+    onFeedbackCta: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
+    onFeedbackThumb: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -50,6 +52,20 @@ fun DiscoverScreen(
                             onAppSocialLinkClicked = onAppSocialLinkClicked,
                             onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
                             onCtaClicked = onCtaClicked,
+                            onFeedbackThumb = { isPositive ->
+                                onFeedbackThumb(
+                                    isPositive,
+                                    cardModel.cardId,
+                                    cardModel.type,
+                                )
+                            },
+                            onFeedbackCta = { isPositive ->
+                                onFeedbackCta(
+                                    isPositive,
+                                    cardModel.cardId,
+                                    cardModel.type,
+                                )
+                            },
                         )
                     }
                 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -23,6 +23,7 @@ import xyz.ksharma.krail.discover.state.DiscoverEvent
 import xyz.ksharma.krail.discover.state.DiscoverState
 import xyz.ksharma.krail.platform.ops.PlatformOps
 import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
+import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
 
 class DiscoverViewModel(
     private val discoverSydneyManager: DiscoverSydneyManager,
@@ -64,7 +65,16 @@ class DiscoverViewModel(
                 )
             }
 
-            is DiscoverEvent.CtaButtonClicked -> {}
+            is DiscoverEvent.CtaButtonClicked -> {
+                platformOps.openUrl(url = event.url)
+                analytics.track(
+                    event = DiscoverCardClick(
+                        source = DiscoverCardClick.Source.CTA_CLICK,
+                        cardType = event.cardType.toAnalyticsCardType(),
+                        cardId = event.cardId,
+                    ),
+                )
+            }
 
             is DiscoverEvent.FeedbackThumbButtonClicked -> {
                 // save to db, feedback button id clicked. so that we don't show the same
@@ -84,7 +94,16 @@ class DiscoverViewModel(
                 )
             }
 
-            is DiscoverEvent.ShareButtonClicked -> {}
+            is DiscoverEvent.ShareButtonClicked -> {
+                platformOps.sharePlainText(event.url, title = event.cardTitle)
+                analytics.track(
+                    event = DiscoverCardClick(
+                        source = DiscoverCardClick.Source.SHARE_CLICK,
+                        cardType = event.cardType.toAnalyticsCardType(),
+                        cardId = event.cardId,
+                    ),
+                )
+            }
 
             is DiscoverEvent.FeedbackCtaButtonClicked -> {}
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -37,7 +37,10 @@ class IntroViewModel(
     fun onEvent(event: IntroUiEvent) {
         when (event) {
             is IntroUiEvent.ReferFriend -> {
-                platformOps.sharePlainText(getReferText())
+                platformOps.sharePlainText(
+                    text = getReferText(),
+                    title = "Tell your mates about KRAIL App",
+                )
                 analytics.track(
                     AnalyticsEvent.ReferFriend(
                         entryPoint = event.analyticsEntryPoint,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -52,7 +52,7 @@ class SettingsViewModel(
     }
 
     fun onReferFriendClick() {
-        platformOps.sharePlainText(getReferText())
+        platformOps.sharePlainText(text = getReferText(), title = "Tell your mates about KRAIL App")
         analytics.track(
             AnalyticsEvent.ReferFriend(
                 entryPoint = AnalyticsEvent.ReferFriend.EntryPoint.SETTINGS,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -38,7 +38,7 @@ class SettingsViewModel(
                 platformOps.openUrl(url = event.krailSocialType.url)
                 analytics.track(
                     event = SocialConnectionLinkClickEvent(
-                        socialPlatform = event.krailSocialType.toAnalyticsEventPlatform(),
+                        socialPlatformType = event.krailSocialType.toAnalyticsEventPlatform(),
                         source = SocialConnectionLinkClickEvent.SocialConnectionSource.SETTINGS,
                     ),
                 )

--- a/platform/ops/src/androidMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.android.kt
+++ b/platform/ops/src/androidMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.android.kt
@@ -7,8 +7,9 @@ import xyz.ksharma.krail.core.log.log
 
 class AndroidPlatformOps(private val context: Context) : PlatformOps {
 
-    override fun sharePlainText(text: String) {
-        handleShareClick(context = context, text = text, mimeType = "text/plain")
+    // "Tell your mates about KRAIL"
+    override fun sharePlainText(text: String, title: String) {
+        handleShareClick(context = context, text = text, mimeType = "text/plain", title = title)
     }
 
     override fun openUrl(url: String) {
@@ -24,7 +25,7 @@ class AndroidPlatformOps(private val context: Context) : PlatformOps {
 }
 
 // https://developer.android.com/training/sharing/send#why-to-use-system-sharesheet
-private fun handleShareClick(context: Context, text: String, mimeType: String) {
+private fun handleShareClick(context: Context, text: String, mimeType: String, title: String) {
     log("handleShareClick: $text")
 
     // Create and start the share intent
@@ -34,7 +35,7 @@ private fun handleShareClick(context: Context, text: String, mimeType: String) {
         type = mimeType
         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
-    val shareIntent = Intent.createChooser(intent, "Tell your mates about KRAIL")
+    val shareIntent = Intent.createChooser(intent, title)
     shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     context.startActivity(shareIntent)
 }

--- a/platform/ops/src/commonMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.kt
+++ b/platform/ops/src/commonMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.kt
@@ -7,7 +7,7 @@ interface PlatformOps {
      *
      * @param text - the text to share (can contain emoji and other characters)
      */
-    fun sharePlainText(text: String)
+    fun sharePlainText(text: String, title: String)
 
     /**
      * Will open the given URL in the system browser.

--- a/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
+++ b/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
@@ -13,8 +13,8 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 
 class IosPlatformOps : PlatformOps {
-    override fun sharePlainText(text: String) {
-        handleShareClick(text)
+    override fun sharePlainText(text: String, title: String) {
+        handleShareClick(text = text, title = title)
     }
 
     override fun openUrl(url: String) {
@@ -37,7 +37,8 @@ class IosPlatformOps : PlatformOps {
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    private fun handleShareClick(text: String) {
+    private fun handleShareClick(text: String, title: String) {
+        // TODO - test title or list etc.
         val activityItems = listOf(text)
         val activityViewController = UIActivityViewController(activityItems, null)
 

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialTypeExt.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialTypeExt.kt
@@ -24,19 +24,19 @@ internal fun SocialType.resource(): DrawableResource = when (this) {
     SocialType.Facebook -> Res.drawable.ic_facebook
 }
 
-fun SocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatform =
+fun SocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatformType =
     when (this) {
-        SocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatform.LINKEDIN
-        SocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatform.REDDIT
-        SocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatform.INSTAGRAM
-        SocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatform.FACEBOOK
+        SocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatformType.LINKEDIN
+        SocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT
+        SocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM
+        SocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatformType.FACEBOOK
     }
 
-fun KrailSocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatform =
+fun KrailSocialType.toAnalyticsEventPlatform(): SocialConnectionLinkClickEvent.SocialPlatformType =
     when (this) {
-        KrailSocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatform.LINKEDIN
-        KrailSocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatform.REDDIT
-        KrailSocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatform.INSTAGRAM
-        KrailSocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatform.FACEBOOK
+        KrailSocialType.LinkedIn -> SocialConnectionLinkClickEvent.SocialPlatformType.LINKEDIN
+        KrailSocialType.Reddit -> SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT
+        KrailSocialType.Instagram -> SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM
+        KrailSocialType.Facebook -> SocialConnectionLinkClickEvent.SocialPlatformType.FACEBOOK
     }
 


### PR DESCRIPTION
# Enhanced Analytics for Discover Cards

This PR enhances analytics tracking for Discover Card interactions by:

- Replacing `FeedbackClick` with a more comprehensive `DiscoverCardClick` event
- Renaming `SocialPlatform` to `SocialPlatformType` for better clarity
- Adding `cardId` field to `DiscoverModel` to track specific card interactions
- Implementing proper analytics tracking for all card interaction types:
  - CTA button clicks
  - Share button clicks
  - Feedback thumbs (positive/negative)
  - Feedback CTA buttons
  - Partner social link clicks

The PR also adds app store URLs to `AppInfo` to enable "Write Review" functionality when users provide positive feedback.