### PR TITLE
Simplify feedback animation with fade transitions instead of rotation effects

### DIFF
--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/FeedbackButtonsRow.kt
@@ -2,20 +2,26 @@ package xyz.ksharma.krail.discover.ui
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalTextStyle
@@ -24,10 +30,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
-
-private enum class FeedbackAnimState {
-    Idle, Rotating, ScalingOut, ShowButton
-}
+import xyz.ksharma.krail.taj.themeBackgroundColor
 
 @Composable
 fun FeedbackButtonsRow(
@@ -38,34 +41,19 @@ fun FeedbackButtonsRow(
     onNegativeCta: () -> Unit,
 ) {
     var selected by remember { mutableStateOf<FeedbackSelectedState?>(null) }
-    var animState by remember { mutableStateOf(FeedbackAnimState.Idle) }
     val scope = rememberCoroutineScope()
 
-    val leftRotation = remember { Animatable(0f) }
-    val leftScale = remember { Animatable(1f) }
-    val rightScale = remember { Animatable(1f) }
-    val buttonScale = remember { Animatable(0.8f) }
+    val thumbsAlpha = remember { Animatable(1f) }
+    val buttonAlpha = remember { Animatable(0f) }
+    val buttonScale = remember { Animatable(0.95f) }
 
     fun startAnimation(feedback: FeedbackSelectedState) {
-        selected = feedback
-        animState = FeedbackAnimState.Rotating
         scope.launch {
-            if (feedback == FeedbackSelectedState.Positive) {
-                launch { leftRotation.animateTo(360f, tween(400)) }
-                launch { rightScale.animateTo(0f, tween(300)) }
-                delay(400)
-                animState = FeedbackAnimState.ScalingOut
-                leftScale.animateTo(0f, tween(250))
-            } else {
-                // 👎: both scale out, no rotation
-                launch { leftScale.animateTo(0f, tween(300)) }
-                launch { rightScale.animateTo(0f, tween(300)) }
-                //delay(300)
-                animState = FeedbackAnimState.ScalingOut
-            }
-            animState = FeedbackAnimState.ShowButton
-            buttonScale.snapTo(0.8f)
-            buttonScale.animateTo(1f, tween(350))
+            thumbsAlpha.animateTo(0f, tween(250))
+            selected = feedback
+            // Animate alpha and scale together
+            launch { buttonAlpha.animateTo(1f, tween(350)) }
+            launch { buttonScale.animateTo(1f, tween(350)) }
         }
     }
 
@@ -73,78 +61,49 @@ fun FeedbackButtonsRow(
         horizontalArrangement = Arrangement.spacedBy(20.dp),
         modifier = modifier,
     ) {
-        when (animState) {
-            FeedbackAnimState.Idle -> {
-                FeedbackCircleBox(
-                    modifier = Modifier
-                        .graphicsLayer {
-                            rotationZ = leftRotation.value
-                            scaleX = leftScale.value
-                            scaleY = leftScale.value
+        if (selected == null) {
+            FeedbackCircleBox(
+                modifier = Modifier
+                    .graphicsLayer { alpha = thumbsAlpha.value }
+                    .klickable {
+                        if (selected == null) {
+                            onPositiveThumb()
+                            startAnimation(FeedbackSelectedState.Positive)
                         }
-                        .klickable {
-                            if (animState == FeedbackAnimState.Idle) {
-                                onPositiveThumb()
-                                startAnimation(FeedbackSelectedState.Positive)
-                            }
-                        }
-                ) { Text("👍") }
+                    }
+            ) { Text("👍") }
 
-                FeedbackCircleBox(
-                    modifier = Modifier
-                        .graphicsLayer {
-                            rotationZ = 0f
-                            scaleX = rightScale.value
-                            scaleY = rightScale.value
+            FeedbackCircleBox(
+                modifier = Modifier
+                    .graphicsLayer { alpha = thumbsAlpha.value }
+                    .klickable {
+                        if (selected == null) {
+                            onNegativeThumb()
+                            startAnimation(FeedbackSelectedState.Negative)
                         }
-                        .klickable {
-                            if (animState == FeedbackAnimState.Idle) {
-                                onNegativeThumb()
-                                startAnimation(FeedbackSelectedState.Negative)
-                            }
-                        }
-                ) { Text("👎") }
+                    }
+            ) { Text("👎") }
+
+        } else {
+            val text = when (selected) {
+                FeedbackSelectedState.Positive -> "Write a review"
+                FeedbackSelectedState.Negative -> "Send feedback"
+                else -> ""
             }
-
-            FeedbackAnimState.Rotating, FeedbackAnimState.ScalingOut -> {
-                FeedbackCircleBox(
-                    modifier = Modifier
-                        .graphicsLayer {
-                            rotationZ = leftRotation.value
-                            scaleX = leftScale.value
-                            scaleY = leftScale.value
-                        }
-                ) { Text("👍") }
-
-                FeedbackCircleBox(
-                    modifier = Modifier
-                        .graphicsLayer {
-                            rotationZ = 0f
-                            scaleX = rightScale.value
-                            scaleY = rightScale.value
-                        }
-                ) { Text("👎") }
-            }
-
-            FeedbackAnimState.ShowButton -> {
-                val text = when (selected) {
-                    FeedbackSelectedState.Positive -> "Write a review"
-                    FeedbackSelectedState.Negative -> "Send feedback"
-                    else -> ""
-                }
-                Button(
-                    dimensions = ButtonDefaults.mediumButtonSize(),
-                    onClick = {
-                        when (selected) {
-                            FeedbackSelectedState.Positive -> onPositiveCta()
-                            FeedbackSelectedState.Negative -> onNegativeCta()
-                            null -> Unit
-                        }
-                    },
-                    modifier = Modifier.scale(buttonScale.value)
-                ) {
-                    Text(text)
-                }
+            Button(
+                dimensions = ButtonDefaults.mediumButtonSize(),
+                onClick = {
+                    when (selected) {
+                        FeedbackSelectedState.Positive -> onPositiveCta()
+                        FeedbackSelectedState.Negative -> onNegativeCta()
+                        null -> Unit
+                    }
+                },
+                modifier = Modifier
+                    .scale(buttonScale.value)
+                    .graphicsLayer { alpha = buttonAlpha.value }
+            ) {
+                Text(text)
             }
         }
     }
@@ -156,7 +115,10 @@ private fun FeedbackCircleBox(
     content: @Composable () -> Unit,
 ) {
     Box(
-        modifier = modifier.size(40.dp).clip(shape = CircleShape),
+        modifier = modifier
+            .size(40.dp)
+            .clip(shape = CircleShape)
+            .background(color = themeBackgroundColor()),
         contentAlignment = Alignment.Center,
     ) {
         CompositionLocalProvider(LocalTextStyle provides KrailTheme.typography.title) {


### PR DESCRIPTION
### TL;DR

Simplified the feedback button animation with a cleaner fade transition

### What changed?

- Replaced the complex multi-state animation system with a simpler fade transition
- Removed the `FeedbackAnimState` enum and consolidated animation logic
- Added background color to the feedback circle buttons for better visibility
- Simplified the animation by using alpha transitions instead of rotation and scaling
- Improved code organization with more explicit imports

### How to test?

1. Navigate to a screen with the feedback buttons
2. Tap either the thumbs up or thumbs down button
3. Verify that the buttons fade out smoothly
4. Confirm that the appropriate CTA button ("Write a review" or "Send feedback") fades in

### Why make this change?

The previous animation was overly complex with multiple states and different behaviors for positive/negative feedback. This change provides a more consistent and cleaner user experience with simpler animations that are easier to maintain. The fade transition is more subtle and professional while still providing clear visual feedback to the user.