### PR TITLE
a11y: if disclaimer is visible then keep max lines as 2 for large font size

### DIFF
--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -106,7 +106,7 @@ fun DiscoverCard(
         Text(
             text = discoverModel.description,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            maxLines = if (isLargeFontScale()) 2 else 3,
+            maxLines = if (isLargeFontScale() && discoverModel.disclaimer != null) 2 else 3,
             style = KrailTheme.typography.bodyMedium,
         )
 


### PR DESCRIPTION
### TL;DR

Adjusted the maximum number of lines for description text in DiscoverCard based on font scale and disclaimer presence.

### What changed?

Modified the `maxLines` parameter in the `Text` component within `DiscoverCard.kt` to consider both the font scale and the presence of a disclaimer. Now, the description will be limited to 2 lines only when both large font scale is active AND a disclaimer is present. In all other cases, it will show 3 lines.

### How to test?

1. Test the DiscoverCard with various combinations:
   - Large font scale with a disclaimer (should show 2 lines of description)
   - Large font scale without a disclaimer (should show 3 lines of description)
   - Normal font scale with or without a disclaimer (should show 3 lines of description)

2. Verify that the text layout looks appropriate in all scenarios.

### Why make this change?

This change optimizes the space usage in the DiscoverCard component. By only reducing the description text to 2 lines when both large font scale is active and a disclaimer is present, we can show more content in scenarios where space isn't as constrained. This improves readability and information density when possible.