### PR TITLE
Update android gradle plugin version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ desugar_jdk_libs = "2.1.5"
 java = "17"
 # AGP - Android API level mapping https://developer.android.com/build/releases/gradle-plugin#api-level-support
 # AGP compatability https://developer.android.com/build/releases/gradle-plugin
-agp = "8.12.0" # Android Gradle Plugin
+agp = "8.11.1" # Android Gradle Plugin
 kotlin = "2.2.0"
 core-ktx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
### TL;DR

Downgrade Android Gradle Plugin from 8.12.0 to 8.11.1.

### What changed?

Modified the `gradle/libs.versions.toml` file to downgrade the Android Gradle Plugin (AGP) version from 8.12.0 to 8.11.1.

### How to test?

1. Sync the project with Gradle files
2. Build the project to ensure it compiles successfully
3. Run the app to verify it functions as expected

### Why make this change?

This downgrade addresses compatibility issues with the newer AGP version. Version 8.11.1 is more stable and resolves build failures or unexpected behavior that occurred with 8.12.0.