### PR TITLE
Add resetAllSeenCards functionality to DiscoverSydneyManager

### DIFF
--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverSydneyManager.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/DiscoverSydneyManager.kt
@@ -12,4 +12,6 @@ interface DiscoverSydneyManager {
     fun feedbackThumbButtonClicked(feedbackId: String, isPositive: Boolean)
 
     suspend fun markCardAsSeen(cardId: String)
+
+    suspend fun resetAllSeenCards()
 }

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/db/DiscoverCardOrderingEngine.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/db/DiscoverCardOrderingEngine.kt
@@ -7,5 +7,5 @@ interface DiscoverCardOrderingEngine {
 
     suspend fun markCardAsSeen(cardId: String)
 
-    suspend fun resetSeenCards()
+    suspend fun resetAllSeenCards()
 }

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -44,6 +44,11 @@ internal class RealDiscoverSydneyManager(
         discoverCardOrderingEngine.markCardAsSeen(cardId)
     }
 
+    override suspend fun resetAllSeenCards() {
+        log("Resetting all seen cards")
+        discoverCardOrderingEngine.resetAllSeenCards()
+    }
+
     override fun feedbackThumbButtonClicked(feedbackId: String, isPositive: Boolean) {
         // save in local db, so that we don't show the same feedback to user again.
         log("Feedback thumb button clicked: feedbackId=$feedbackId, isPositive=$isPositive")

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -21,49 +21,53 @@ internal class RealDiscoverSydneyManager(
     private val discoverCardOrderingEngine: DiscoverCardOrderingEngine
 ) : DiscoverSydneyManager {
 
-    private var cachedFlagValue: FlagValue? = null
-    private var cachedDiscoverModels: List<DiscoverModel>? = null
 
+    // Cache the parsed JSON card list to avoid repeated parsing.
+    private var cachedFlagValue: FlagValue? = null
+    private var cachedParsedCards: List<DiscoverModel>? = null
+
+    /**
+     * Fetches Discover cards for the UI.
+     * - Caches the parsed JSON card list to avoid repeated parsing.
+     * - Always sorts the cached list to reflect up-to-date "seen" status.
+     * - This ensures sorting is always correct, but parsing is only done when the flag changes.
+     */
     override suspend fun fetchDiscoverData(): List<DiscoverModel> {
         val currentFlagValue = flag.getFlagValue(FlagKeys.DISCOVER_SYDNEY.key)
-        if (cachedFlagValue == currentFlagValue && cachedDiscoverModels != null) {
-            return cachedDiscoverModels!!
-        }
-        val discoverModelList = currentFlagValue.toDiscoverCards()
-
-        // Sort cards using the ordering engine (which checks seen status)
-        val sortedModels = discoverCardOrderingEngine.getSortedCards(discoverModelList)
-        cachedFlagValue = currentFlagValue
-        cachedDiscoverModels = sortedModels
-
+        val parsedCards = getOrParseCards(currentFlagValue)
+        // Always sort the cached cards to reflect latest "seen" status.
+        val sortedModels = discoverCardOrderingEngine.getSortedCards(parsedCards)
+        log("Fetched and sorted Discover Sydney cards data: ${sortedModels.size} cards")
         return sortedModels
     }
 
-    override suspend fun markCardAsSeen(cardId: String) {
-        log("Marking card as seen: $cardId")
-        discoverCardOrderingEngine.markCardAsSeen(cardId)
+    /**
+     * Returns the cached parsed cards if the flag value hasn't changed,
+     * otherwise parses and caches the new card list.
+     * This avoids repeated JSON parsing for the same flag value.
+     */
+    private suspend fun getOrParseCards(currentFlagValue: FlagValue): List<DiscoverModel> {
+        if (cachedFlagValue == currentFlagValue && cachedParsedCards != null) {
+            // Return cached parsed cards if flag hasn't changed.
+            return cachedParsedCards!!
+        }
+        // Parse and cache new cards if flag value changed.
+        val discoverCards: List<DiscoverModel> = parseCardsFromFlag(currentFlagValue)
+        cachedFlagValue = currentFlagValue
+        cachedParsedCards = discoverCards
+        return discoverCards
     }
 
-    override suspend fun resetAllSeenCards() {
-        log("Resetting all seen cards")
-        discoverCardOrderingEngine.resetAllSeenCards()
-    }
-
-    override fun feedbackThumbButtonClicked(feedbackId: String, isPositive: Boolean) {
-        // save in local db, so that we don't show the same feedback to user again.
-        log("Feedback thumb button clicked: feedbackId=$feedbackId, isPositive=$isPositive")
-        // todo implement feedback saving logic
-    }
-
-    // todo - Move to another mapper file.
-    private suspend fun FlagValue.toDiscoverCards(): List<DiscoverModel> {
-        val flagValue = this
-        log("Fetching Discover Sydney data from flag: ${FlagKeys.DISCOVER_SYDNEY.key}: $flagValue")
-
+    /**
+     * Parses the Discover cards from the given flag value.
+     * Uses default value if flag is not a JSON value.
+     */
+    private suspend fun parseCardsFromFlag(flagValue: FlagValue): List<DiscoverModel> {
+        log("Parsing Discover Sydney data from flag: ${FlagKeys.DISCOVER_SYDNEY.key}")
         return withContext(defaultDispatcher) {
             when (flagValue) {
                 is FlagValue.JsonValue -> {
-                    val jsonArray = Json.parseToJsonElement(value).jsonArray
+                    val jsonArray = Json.parseToJsonElement(flagValue.value).jsonArray
                     jsonArray.map { Json.decodeFromJsonElement<DiscoverModel>(it) }
                 }
 
@@ -80,5 +84,21 @@ internal class RealDiscoverSydneyManager(
                 }
             }
         }
+    }
+
+    override suspend fun markCardAsSeen(cardId: String) {
+        log("Marking card as seen: $cardId")
+        discoverCardOrderingEngine.markCardAsSeen(cardId)
+    }
+
+    override suspend fun resetAllSeenCards() {
+        log("Resetting all seen cards")
+        discoverCardOrderingEngine.resetAllSeenCards()
+    }
+
+    override fun feedbackThumbButtonClicked(feedbackId: String, isPositive: Boolean) {
+        // Save in local db, so that we don't show the same feedback to user again.
+        log("Feedback thumb button clicked: feedbackId=$feedbackId, isPositive=$isPositive")
+        // TODO: implement feedback saving logic
     }
 }

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -29,10 +29,19 @@ internal class RealDiscoverSydneyManager(
         if (cachedFlagValue == currentFlagValue && cachedDiscoverModels != null) {
             return cachedDiscoverModels!!
         }
-        val models = currentFlagValue.toDiscoverCards()
+        val discoverModelList = currentFlagValue.toDiscoverCards()
+
+        // Sort cards using the ordering engine (which checks seen status)
+        val sortedModels = discoverCardOrderingEngine.getSortedCards(discoverModelList)
         cachedFlagValue = currentFlagValue
-        cachedDiscoverModels = models
-        return models
+        cachedDiscoverModels = sortedModels
+
+        return sortedModels
+    }
+
+    override suspend fun markCardAsSeen(cardId: String) {
+        log("Marking card as seen: $cardId")
+        discoverCardOrderingEngine.markCardAsSeen(cardId)
     }
 
     override fun feedbackThumbButtonClicked(feedbackId: String, isPositive: Boolean) {
@@ -41,11 +50,7 @@ internal class RealDiscoverSydneyManager(
         // todo implement feedback saving logic
     }
 
-    override suspend fun markCardAsSeen(cardId: String) {
-        log("Marking card as seen: $cardId")
-        discoverCardOrderingEngine.markCardAsSeen(cardId)
-    }
-
+    // todo - Move to another mapper file.
     private suspend fun FlagValue.toDiscoverCards(): List<DiscoverModel> {
         val flagValue = this
         log("Fetching Discover Sydney data from flag: ${FlagKeys.DISCOVER_SYDNEY.key}: $flagValue")

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
@@ -3,7 +3,6 @@ package xyz.ksharma.krail.discover.network.real.db
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.discover.network.api.db.DiscoverCardOrderingEngine
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
-import xyz.ksharma.krail.sandook.DiscoverCardQueries
 import xyz.ksharma.krail.sandook.DiscoverCardSeenPreferences
 
 internal class RealDiscoverCardOrderingEngine(
@@ -23,7 +22,7 @@ internal class RealDiscoverCardOrderingEngine(
         discoverCardPreferences.insertCardSeen(cardId)
     }
 
-    override suspend fun resetSeenCards() {
+    override suspend fun resetAllSeenCards() {
         log("Resetting all seen cards")
         discoverCardPreferences.deleteAllCardSeen()
     }

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
@@ -13,7 +13,12 @@ internal class RealDiscoverCardOrderingEngine(
         log("Sorting ${cards.size} discover cards")
         val seenCardIdList = discoverCardPreferences.selectAllCardSeen()
         val (seen, unseen) = cards.partition { it.cardId in seenCardIdList }
-        log("Seen discover cards: ${seen.size}, Unseen cards: ${unseen.size}")
+        seen.forEach {
+            log("\tSeen card: ${it.cardId}, Title: ${it.title.take(6)}")
+        }
+        unseen.forEach {
+            log("\tUnseen card: ${it.cardId}, Title: ${it.title.take(6)}")
+        }
         return unseen + seen
     }
 

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
@@ -4,14 +4,15 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.discover.network.api.db.DiscoverCardOrderingEngine
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
 import xyz.ksharma.krail.sandook.DiscoverCardQueries
+import xyz.ksharma.krail.sandook.DiscoverCardSeenPreferences
 
 internal class RealDiscoverCardOrderingEngine(
-    private val discoverCardQueries: DiscoverCardQueries,
+    private val discoverCardPreferences: DiscoverCardSeenPreferences,
 ) : DiscoverCardOrderingEngine {
 
     override suspend fun getSortedCards(cards: List<DiscoverModel>): List<DiscoverModel> {
         log("Sorting ${cards.size} discover cards")
-        val seenCardIdList = discoverCardQueries.selectAllCardSeen().executeAsList()
+        val seenCardIdList = discoverCardPreferences.selectAllCardSeen()
         val (seen, unseen) = cards.partition { it.cardId in seenCardIdList }
         log("Seen discover cards: ${seen.size}, Unseen cards: ${unseen.size}")
         return unseen + seen
@@ -19,11 +20,11 @@ internal class RealDiscoverCardOrderingEngine(
 
     override suspend fun markCardAsSeen(cardId: String) {
         log("$cardId card marked as seen")
-        discoverCardQueries.insertCardSeen(cardId)
+        discoverCardPreferences.insertCardSeen(cardId)
     }
 
     override suspend fun resetSeenCards() {
         log("Resetting all seen cards")
-        discoverCardQueries.deleteAllCardSeen()
+        discoverCardPreferences.deleteAllCardSeen()
     }
 }

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/di/DiscoverModule.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/di/DiscoverModule.kt
@@ -16,7 +16,7 @@ val discoverModule = module {
 
     single<DiscoverCardOrderingEngine> {
         RealDiscoverCardOrderingEngine(
-            discoverCardQueries = get(),
+            discoverCardPreferences = get(),
         )
     }
 }

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -45,4 +45,6 @@ sealed interface DiscoverEvent {
     ) : DiscoverEvent
 
     data class CardSeen(val cardId: String) : DiscoverEvent
+
+    data object ResetAllSeenCards: DiscoverEvent
 }

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -43,4 +43,6 @@ sealed interface DiscoverEvent {
         val cardId: String,
         val cardType: DiscoverCardType,
     ) : DiscoverEvent
+
+    data class CardSeen(val cardId: String) : DiscoverEvent
 }

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -153,7 +153,8 @@ private fun DiscoverCardButtonRow(
 ) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
-        logError("Invalid button combination or no buttons provided: ${buttonsList.map { it::class.simpleName }}")
+        logError("Invalid button combination or no buttons provided: " +
+                "${buttonsList.map { it::class.simpleName }}")
         return
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -69,6 +69,11 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                         url = shareUrl,
                     )
                 )
+            },
+            onCardSeen = { cardId ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.CardSeen(cardId = cardId)
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -74,6 +74,9 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
                 viewModel.onEvent(
                     event = DiscoverEvent.CardSeen(cardId = cardId)
                 )
+            },
+            resetAllSeenCards = {
+                viewModel.onEvent(event = DiscoverEvent.ResetAllSeenCards)
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -35,6 +36,7 @@ fun DiscoverScreen(
     onFeedbackCta: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
     onFeedbackThumb: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
     onShareClick: (shareUrl: String, cardId: String, cardType: DiscoverCardType) -> Unit,
+    onCardSeen: (cardId: String) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -48,6 +50,11 @@ fun DiscoverScreen(
                     pages = state.discoverCardsList,
                     modifier = Modifier.fillMaxSize(),
                     content = { cardModel ->
+
+                        LaunchedEffect(cardModel.cardId) {
+                            onCardSeen(cardModel.cardId)
+                        }
+
                         DiscoverCard(
                             discoverModel = cardModel,
                             onAppSocialLinkClicked = onAppSocialLinkClicked,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -1,6 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.discover
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -37,6 +40,7 @@ fun DiscoverScreen(
     onFeedbackThumb: (isPositive: Boolean, cardId: String, cardType: DiscoverCardType) -> Unit,
     onShareClick: (shareUrl: String, cardId: String, cardType: DiscoverCardType) -> Unit,
     onCardSeen: (cardId: String) -> Unit,
+    resetAllSeenCards: () -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -49,10 +53,12 @@ fun DiscoverScreen(
                 DiscoverCardVerticalPager(
                     pages = state.discoverCardsList,
                     modifier = Modifier.fillMaxSize(),
-                    content = { cardModel ->
+                    content = { cardModel, isCardSelected ->
 
-                        LaunchedEffect(cardModel.cardId) {
-                            onCardSeen(cardModel.cardId)
+                        if (isCardSelected) {
+                            LaunchedEffect(cardModel.cardId) {
+                                onCardSeen(cardModel.cardId)
+                            }
                         }
 
                         DiscoverCard(
@@ -105,6 +111,16 @@ fun DiscoverScreen(
                 modifier = Modifier.fillMaxWidth(),
                 onNavActionClick = onBackClick,
                 title = { },
+                actions = {
+                    // for debug only
+                    Text(
+                        "Reset", modifier = Modifier.clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() },
+                            onClick = resetAllSeenCards,
+                        )
+                    )
+                }
             )
 
             Text(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick.PartnerSocialLink
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick.Source
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent.SocialConnectionSource
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
@@ -55,10 +57,10 @@ class DiscoverViewModel(
                 platformOps.openUrl(url = event.partnerSocialLink.url)
                 analytics.track(
                     event = DiscoverCardClick(
-                        source = DiscoverCardClick.Source.PARTNER_SOCIAL_LINK,
+                        source = Source.PARTNER_SOCIAL_LINK,
                         cardType = event.cardType.toAnalyticsCardType(),
                         cardId = event.cardId,
-                        partnerSocialLink = DiscoverCardClick.PartnerSocialLink(
+                        partnerSocialLink = PartnerSocialLink(
                             type = event.partnerSocialLink.type.toAnalyticsSocialType(),
                             url = event.partnerSocialLink.url,
                         )
@@ -70,7 +72,7 @@ class DiscoverViewModel(
                 platformOps.openUrl(url = event.url)
                 analytics.track(
                     event = DiscoverCardClick(
-                        source = DiscoverCardClick.Source.CTA_CLICK,
+                        source = Source.CTA_CLICK,
                         cardType = event.cardType.toAnalyticsCardType(),
                         cardId = event.cardId,
                     ),
@@ -87,8 +89,8 @@ class DiscoverViewModel(
                 analytics.track(
                     event = DiscoverCardClick(
                         source = if (event.isPositive)
-                            DiscoverCardClick.Source.FEEDBACK_POSITIVE_THUMB
-                        else DiscoverCardClick.Source.FEEDBACK_NEGATIVE_THUMB,
+                            Source.FEEDBACK_POSITIVE_THUMB
+                        else Source.FEEDBACK_NEGATIVE_THUMB,
                         cardType = event.cardType.toAnalyticsCardType(),
                         cardId = event.cardId,
                     ),
@@ -99,7 +101,7 @@ class DiscoverViewModel(
                 platformOps.sharePlainText(event.url, title = event.cardTitle)
                 analytics.track(
                     event = DiscoverCardClick(
-                        source = DiscoverCardClick.Source.SHARE_CLICK,
+                        source = Source.SHARE_CLICK,
                         cardType = event.cardType.toAnalyticsCardType(),
                         cardId = event.cardId,
                     ),
@@ -116,14 +118,22 @@ class DiscoverViewModel(
                     platformOps.openUrl(url = url)
                     analytics.track(
                         event = DiscoverCardClick(
-                            source = if (event.isPositive) DiscoverCardClick.Source.FEEDBACK_WRITE_REVIEW else
-                                DiscoverCardClick.Source.FEEDBACK_SHARE_FEEDBACK,
+                            source = if (event.isPositive) Source.FEEDBACK_WRITE_REVIEW else
+                                Source.FEEDBACK_SHARE_FEEDBACK,
                             cardType = event.cardType.toAnalyticsCardType(),
                             cardId = event.cardId,
                         ),
                     )
                 }
             }
+
+            is DiscoverEvent.CardSeen -> onCardSeen(event.cardId)
+        }
+    }
+
+    private fun onCardSeen(cardId: String) {
+        viewModelScope.launchWithExceptionHandler<DiscoverViewModel>(ioDispatcher) {
+            discoverSydneyManager.markCardAsSeen(cardId)
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -5,12 +5,14 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick.PartnerSocialLink
@@ -128,6 +130,15 @@ class DiscoverViewModel(
             }
 
             is DiscoverEvent.CardSeen -> onCardSeen(event.cardId)
+
+            DiscoverEvent.ResetAllSeenCards -> onResetAllSeenCards()
+        }
+    }
+
+    private fun onResetAllSeenCards() {
+        // todo - debug functionality only
+        viewModelScope.launch {
+            discoverSydneyManager.resetAllSeenCards()
         }
     }
 

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealDiscoverCardSeenPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealDiscoverCardSeenPreferences.kt
@@ -1,22 +1,22 @@
 package xyz.ksharma.krail.sandook
 
 internal class RealDiscoverCardSeenPreferences(
-    private val queries: DiscoverCardQueries,
+    private val discoverCardQueries: DiscoverCardQueries,
 ) : DiscoverCardSeenPreferences {
 
     override fun insertCardSeen(cardId: String) {
-        queries.insertCardSeen(cardId)
+        discoverCardQueries.insertCardSeen(cardId)
     }
 
     override fun deleteCardSeenById(cardId: String) {
-        queries.deleteCardSeenById(cardId)
+        discoverCardQueries.deleteCardSeenById(cardId)
     }
 
     override fun deleteAllCardSeen() {
-        queries.deleteAllCardSeen()
+        discoverCardQueries.deleteAllCardSeen()
     }
 
     override fun selectAllCardSeen(): List<String> {
-        return queries.selectAllCardSeen().executeAsList()
+        return discoverCardQueries.selectAllCardSeen().executeAsList()
     }
 }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
@@ -35,7 +35,17 @@ val sandookModule = module {
     // Add the missing SandookPreferences dependency
     single<SandookPreferences> { RealSandookPreferences(get()) }
 
-    single<DiscoverCardSeenPreferences> { RealDiscoverCardSeenPreferences(get()) }
+    /**
+     * Important: Expose the queries otherwise they won't be available for injection
+     * E.g. If you wanna inject it in RealDiscoverCardSeenPreferences, then you need to expose
+     *      it here. Otherwise it will not be available for injection and Koin will throw an error.
+     */
+    single { get<KrailSandook>().discoverCardQueries }
+
+    // get for [DiscoverCardQueries] will only work, if we have exposed it to Koin separately.
+    single<DiscoverCardSeenPreferences> {
+        RealDiscoverCardSeenPreferences(get())
+    }
 
     // Provide repositories
     single<NswParkRideSandook> {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -30,7 +30,7 @@ val discoverCardHeight = 550.dp
 fun <T> DiscoverCardVerticalPager(
     pages: List<T>,
     modifier: Modifier = Modifier,
-    content: @Composable (T) -> Unit,
+    content: @Composable (T, isCardSelected: Boolean) -> Unit,
 ) {
     val initialPage = Int.MAX_VALUE / 2
     val pagerState = rememberPagerState(
@@ -61,6 +61,7 @@ fun <T> DiscoverCardVerticalPager(
             modifier = Modifier.fillMaxSize()
         ) { page ->
             val actualPage = page % pages.size
+            val isCardSelected = pagerState.currentPage == page
             val pageOffset = pagerState.calculateCurrentOffsetForPage(page).absoluteValue
             val width by animateDpAsState(
                 targetValue = lerpDp(
@@ -85,7 +86,7 @@ fun <T> DiscoverCardVerticalPager(
                     .zIndex(1f - pageOffset),
                 contentAlignment = Alignment.Center,
             ) {
-                content(pages[actualPage])
+                content(pages[actualPage], isCardSelected)
             }
         }
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -48,7 +48,7 @@ fun <T> DiscoverCardVerticalPager(
 
         // Calculate padding to center the selected item
         val screenHeight = maxHeight
-        val topPadding = (screenHeight - discoverCardHeight) / 2
+        val topPadding = ((screenHeight - discoverCardHeight) / 2).coerceAtLeast(0.dp)
 
         VerticalPager(
             state = pagerState,


### PR DESCRIPTION
# Card seen event handled

- Added `CardSeen` and `ResetAllSeenCards` events to track when cards are viewed
- Implemented card seen tracking in the UI with `LaunchedEffect` to mark cards as seen when displayed
- Added debug functionality to reset all seen cards with a clickable "Reset" text in the app bar
- Renamed `resetSeenCards()` to `resetAllSeenCards()` for clarity across the codebase

# Improved card management and caching

- Refactored `RealDiscoverSydneyManager` to separate card parsing from sorting
- Added caching for parsed JSON cards to avoid repeated parsing when flag value hasn't changed
- Always sorts the cached list to reflect up-to-date "seen" status
- Fixed crash when screen is rotated by ensuring padding is never negative
- Improved logging for better debugging of seen/unseen cards

# Code structure improvements

- Updated `DiscoverCardVerticalPager` to pass `isCardSelected` state to its content
- Switched from direct database queries to preferences interface for better abstraction
- Fixed dependency injection in `SandookModule` to properly expose `DiscoverCardQueries`