### PR TITLE
Add AppInfo provider with debug mode controls for Discover screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -14,22 +14,24 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
 fun KrailApp() {
-    val appInfoProvider: AppInfoProvider = koinInject()
+    val appInfo = rememberAppInfo()
 
-    val appInfoState = produceState<AppInfo?>(initialValue = null, appInfoProvider) {
-        value = appInfoProvider.getAppInfo()
-    }
-    val appInfo = appInfoState.value
-
-    CompositionLocalProvider(
-        LocalAppInfo provides appInfo,
-    ) {
+    CompositionLocalProvider(LocalAppInfo provides appInfo) {
         SetupCoilImageLoader()
 
         KrailTheme {
             KrailNavHost()
         }
     }
+}
+
+@Composable
+private fun rememberAppInfo(): AppInfo? {
+    val appInfoProvider: AppInfoProvider = koinInject()
+    val appInfoState = produceState<AppInfo?>(initialValue = null, appInfoProvider) {
+        value = appInfoProvider.getAppInfo()
+    }
+    return appInfoState.value
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -1,16 +1,34 @@
 package xyz.ksharma.krail
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.produceState
 import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.request.crossfade
+import org.koin.compose.koinInject
+import xyz.ksharma.krail.core.appinfo.AppInfo
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appinfo.LocalAppInfo
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
 @Composable
 fun KrailApp() {
-    KrailTheme {
+    val appInfoProvider: AppInfoProvider = koinInject()
+
+    val appInfoState = produceState<AppInfo?>(initialValue = null, appInfoProvider) {
+        value = appInfoProvider.getAppInfo()
+    }
+    val appInfo = appInfoState.value
+
+    CompositionLocalProvider(
+        LocalAppInfo provides appInfo,
+    ) {
         SetupCoilImageLoader()
-        KrailNavHost()
+
+        KrailTheme {
+            KrailNavHost()
+        }
     }
 }
 

--- a/core/app-info/build.gradle.kts
+++ b/core/app-info/build.gradle.kts
@@ -40,6 +40,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
                 implementation(projects.core.di)
+                implementation(projects.core.log)
 
                 implementation(compose.runtime)
                 api(libs.di.koinComposeViewmodel)

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/CompositionLocals.kt
@@ -1,3 +1,11 @@
 package xyz.ksharma.krail.core.appinfo
 
+import androidx.compose.runtime.staticCompositionLocalOf
+import xyz.ksharma.krail.core.log.logError
+
 expect fun getAppPlatformType(): DevicePlatformType
+
+val LocalAppInfo = staticCompositionLocalOf<AppInfo?> {
+    logError("LocalAppInfo not provided, using null")
+    null
+}

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -21,7 +21,6 @@ internal class RealDiscoverSydneyManager(
     private val discoverCardOrderingEngine: DiscoverCardOrderingEngine
 ) : DiscoverSydneyManager {
 
-
     // Cache the parsed JSON card list to avoid repeated parsing.
     private var cachedFlagValue: FlagValue? = null
     private var cachedParsedCards: List<DiscoverModel>? = null

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.core.appinfo.LocalAppInfo
 import xyz.ksharma.krail.discover.state.Button
 import xyz.ksharma.krail.discover.state.DiscoverCardType
 import xyz.ksharma.krail.discover.state.DiscoverState
@@ -112,14 +113,16 @@ fun DiscoverScreen(
                 onNavActionClick = onBackClick,
                 title = { },
                 actions = {
-                    // for debug only
-                    Text(
-                        "Reset", modifier = Modifier.clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() },
-                            onClick = resetAllSeenCards,
+                    val appInfo = LocalAppInfo.current
+                    if (appInfo?.isDebug == true) {
+                        Text(
+                            "Reset", modifier = Modifier.clickable(
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() },
+                                onClick = resetAllSeenCards,
+                            )
                         )
-                    )
+                    }
                 }
             )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -140,8 +140,10 @@ class DiscoverViewModel(
     private fun onResetAllSeenCards() {
         // todo - debug functionality only
         viewModelScope.launch {
-            log("Resetting all seen cards")
-            discoverSydneyManager.resetAllSeenCards()
+            if (appInfoProvider.getAppInfo().isDebug) {
+                log("Resetting all seen cards")
+                discoverSydneyManager.resetAllSeenCards()
+            }
         }
     }
 
@@ -157,11 +159,6 @@ class DiscoverViewModel(
             viewModelScope.launchWithExceptionHandler<DiscoverViewModel>(ioDispatcher) {
                 val data = discoverSydneyManager.fetchDiscoverData().toDiscoverUiModelList()
                 log("Fetched Discover Sydney data: ${data.size}")
-/*
-                data.forEach {
-                    log("\tDiscover Card: ${it.type}, ${it.title}")
-                }
-*/
                 updateUiState {
                     copy(
                         discoverCardsList = data.toImmutableList(),


### PR DESCRIPTION
### TL;DR

Added app info context to the app composition and restricted debug functionality to debug builds only.

### What changed?

- Added `LocalAppInfo` composition local to provide app information throughout the app
- Set up `CompositionLocalProvider` in `KrailApp` to provide app info to the entire app
- Added conditional rendering of the "Reset" button in the Discover screen based on debug status
- Added a check in `DiscoverViewModel` to only allow resetting seen cards in debug mode
- Removed commented-out debug logging code
- Added dependency on the log module to the app-info module

### How to test?

1. Run the app in debug mode and verify the "Reset" button appears in the Discover screen
2. Run the app in release mode and verify the "Reset" button is hidden
3. Verify that resetting seen cards only works in debug builds

### Why make this change?

This change improves the app's security and user experience by ensuring that debug-only functionality is not accessible in production builds. By using the app info context, we can conditionally render UI elements and restrict certain actions based on the build type, making the app more robust and preventing unintended functionality in release builds.