### PR TITLE
Bump version code for Android and iOS builds

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -15,7 +15,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             androidAppExtension().apply {
                 defaultConfig {
-                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 109
+                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 110
                     versionName = "1.7.5"
                 }
             }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.5</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version numbers for Android and iOS apps.

### What changed?

- Incremented Android app version code from 109 to 110 in `AndroidApplicationConventionPlugin.kt`
- Incremented iOS app build number from 3 to 4 in `Info.plist`
- Version name/string remains at 1.7.5 for both platforms

### How to test?

- Build the Android app and verify the version code is 110
- Build the iOS app and verify the build number is 4
- Verify both apps display version 1.7.5 in their respective UIs

### Why make this change?

Preparing for a new release by incrementing the build numbers while maintaining the same version name. This allows for new builds to be submitted to app stores while keeping the user-facing version consistent.