### PR TITLE
BUG: Fix Rendering Issues for DiscoverCard label text

### DIFF
--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -108,6 +108,7 @@ fun DiscoverCard(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
             maxLines = if (isLargeFontScale() && discoverModel.disclaimer != null) 2 else 3,
             style = KrailTheme.typography.bodyMedium,
+            color = KrailTheme.colors.secondaryLabel,
         )
 
         discoverModel.disclaimer?.let { disclaimer ->

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -154,8 +154,10 @@ private fun DiscoverCardButtonRow(
 ) {
     val state = buttonsList.toButtonRowState()
     if (state == null) {
-        logError("Invalid button combination or no buttons provided: " +
-                "${buttonsList.map { it::class.simpleName }}")
+        logError(
+            "Invalid button combination or no buttons provided: " +
+                "${buttonsList.map { it::class.simpleName }}"
+        )
         return
     }
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCardLabel.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCardLabel.kt
@@ -1,0 +1,53 @@
+package xyz.ksharma.krail.discover.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Constraints
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+@Composable
+fun DiscoverCardLabel(
+    text: String,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    val textMeasurer = rememberTextMeasurer()
+    val textLayoutResult = remember(text, style) {
+        textMeasurer.measure(
+            AnnotatedString(text),
+            style = style,
+            maxLines = 2
+        )
+    }
+
+    Layout(
+        content = {
+            Text(
+                text = text,
+                style = style,
+                maxLines = 2,
+                color = KrailTheme.colors.secondaryLabel,
+            )
+        },
+        modifier = modifier
+    ) { measurables, constraints ->
+        // Use measured width, but allow height to wrap up to 2 lines
+        val placeable = measurables.first().measure(
+            Constraints(
+                minWidth = 0,
+                maxWidth = textLayoutResult.size.width,
+                minHeight = 0,
+                maxHeight = Constraints.Infinity
+            )
+        )
+        layout(placeable.width, placeable.height) {
+            placeable.place(0, 0)
+        }
+    }
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -57,7 +57,7 @@ fun <T> DiscoverCardVerticalPager(
                 pageSize = discoverCardHeight,
             ),
             key = { (it % pages.size) },
-            contentPadding = PaddingValues(vertical = topPadding),
+            contentPadding = PaddingValues(vertical = topPadding.coerceAtLeast(0.dp)),
             modifier = Modifier.fillMaxSize()
         ) { page ->
             val actualPage = page % pages.size

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.taj.components
 
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,7 +11,6 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
@@ -43,8 +41,6 @@ fun <T> DiscoverCardVerticalPager(
             .fillMaxSize()
     ) {
         val maxCardWidth = maxWidth - 48.dp // 24.dp padding on each side
-        val selectedWidth = 1f * maxCardWidth.value
-        val unselectedWidth = 0.95f * maxCardWidth.value
 
         // Calculate padding to center the selected item
         val screenHeight = maxHeight
@@ -63,27 +59,21 @@ fun <T> DiscoverCardVerticalPager(
             val actualPage = page % pages.size
             val isCardSelected = pagerState.currentPage == page
             val pageOffset = pagerState.calculateCurrentOffsetForPage(page).absoluteValue
-            val width by animateDpAsState(
-                targetValue = lerpDp(
-                    selectedWidth.dp,
-                    unselectedWidth.dp,
-                    pageOffset.coerceIn(0f, 1f)
-                ),
-                label = "cardWidth"
-            )
-            val scale = lerp(1f, 0.98f, pageOffset.coerceIn(0f, 1f))
+
+            val scale = lerp(1f, 0.95f, pageOffset.coerceIn(0f, 1f))
             val alpha = lerp(1f, 0.2f, pageOffset.coerceIn(0f, 1f))
 
             Box(
                 modifier = Modifier
-                    .height(discoverCardHeight)
-                    .width(width)
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
                         this.alpha = alpha
                     }
-                    .zIndex(2f - pageOffset),
+                    .zIndex(2f - pageOffset)
+                    .height(discoverCardHeight)
+                    .width(maxCardWidth)
+                    .align(Alignment.Center),
                 contentAlignment = Alignment.Center,
             ) {
                 content(pages[actualPage], isCardSelected)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -71,19 +71,19 @@ fun <T> DiscoverCardVerticalPager(
                 ),
                 label = "cardWidth"
             )
-            val scale = lerp(1f, 0.95f, pageOffset.coerceIn(0f, 1f))
+            val scale = lerp(1f, 0.98f, pageOffset.coerceIn(0f, 1f))
             val alpha = lerp(1f, 0.2f, pageOffset.coerceIn(0f, 1f))
 
             Box(
                 modifier = Modifier
+                    .height(discoverCardHeight)
+                    .width(width)
                     .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
                         this.alpha = alpha
                     }
-                    .height(discoverCardHeight)
-                    .width(width)
-                    .zIndex(1f - pageOffset),
+                    .zIndex(2f - pageOffset),
                 contentAlignment = Alignment.Center,
             ) {
                 content(pages[actualPage], isCardSelected)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -14,6 +14,8 @@ val md_theme_light_scrim = Color(0xFF000000)
 val md_theme_light_alert = Color(0xFFFFBA27)
 val md_theme_light_softLabel = Color(0xFF767676)
 
+val md_theme_light_secondary_label = Color(0xFF404040)
+
 // Dark Color tokens
 val md_theme_dark_error = Color(0xFFFFB4AB)
 val md_theme_dark_errorContainer = Color(0xFF93000A)
@@ -24,6 +26,7 @@ val md_theme_dark_onSurface = Color(0xFFFCF6F1)
 val md_theme_dark_scrim = Color(0xFF000000)
 val md_theme_dark_alert = Color(0xFFF4B400)
 val md_theme_dark_softLabel = Color(0xFFB0B0B0)
+val md_theme_dark_secondary_label = Color(0xFFEBEBEB)
 
 val bus_theme = Color(0xFF00B5EF)
 val train_theme = Color(0xFFF6891F)
@@ -48,6 +51,7 @@ data class KrailColors(
     val scrim: Color,
     val alert: Color,
     val softLabel: Color,
+    val secondaryLabel: Color,
 )
 
 internal val KrailLightColors = KrailColors(
@@ -61,6 +65,7 @@ internal val KrailLightColors = KrailColors(
     scrim = md_theme_light_scrim,
     alert = md_theme_light_alert,
     softLabel = md_theme_light_softLabel,
+    secondaryLabel = md_theme_light_secondary_label,
 )
 
 internal val KrailDarkColors = KrailColors(
@@ -74,6 +79,7 @@ internal val KrailDarkColors = KrailColors(
     scrim = md_theme_dark_scrim,
     alert = md_theme_dark_alert,
     softLabel = md_theme_dark_softLabel,
+    secondaryLabel = md_theme_dark_secondary_label,
 )
 
 internal val LocalKrailColors = staticCompositionLocalOf {
@@ -88,5 +94,6 @@ internal val LocalKrailColors = staticCompositionLocalOf {
         scrim = Color.Unspecified,
         alert = Color.Unspecified,
         softLabel = Color.Unspecified,
+        secondaryLabel = Color.Unspecified,
     )
 }


### PR DESCRIPTION
# Fix: Prevent Text Reflow in DiscoverCard During Pager Animation

## Issue

Previously, when scrolling through the `DiscoverCardVerticalPager`, the text content (title and description) within the `DiscoverCard` would sometimes reflow. This means words would jump to the next line, or the ellipsis (...) truncation would change, as the card's width animated between its selected and unselected states.

For example, a description might show as "used..." when the card was smaller and then change to "use..." or "used some..." when the card became larger, or vice-versa. This created a visually jarring experience.

### Root Cause: Interaction of Animated Width and Text Layout

The problem stemmed from how Jetpack Compose handles UI rendering, specifically its layout and drawing phases, in conjunction with animations:

1.  **Composition Phase:** Compose determines *what* UI to show.
2.  **Layout Phase:** Compose determines *where* to place UI. This involves two steps:
    *   **Measurement:** Each composable determines its own size and the size of its children. `Text` composables, by default, measure themselves based on the available width provided by their parent. If the text content is too long for the available width, it will wrap to the next line (up to `maxLines`).
    *   **Placement:** Composables are positioned on the screen.
3.  **Drawing Phase:** Compose determines *how* the UI renders, drawing it onto a Canvas.

### EXACT ISSUE
In our previous implementation, we were using `animateDpAsState` to change the `width` of the `Box` containing the `DiscoverCard` content directly. This meant:

*   During the animation, as the `width` value changed frame by frame, the `Text` composables inside the card would go through the **measurement** step of the layout phase again with this new, fluctuating width.
*   If the new width was slightly different, the `Text` might decide to wrap differently or truncate at a different point.
*   The `Modifier.graphicsLayer { scaleX = ..., scaleY = ... }` was then applied. However, this scaling happens *after* the layout phase. So, it would scale down an already potentially re-wrapped/re-truncated text layout.

This is why the text appeared to change its structure "mid-flight" during the scroll animation. The `graphicsLayer` was scaling what was *already laid out* based on the animated width, not fixing the text layout itself.

## Solution: Consistent Layout Width with Post-Layout Scaling

To fix this, we've changed the approach to ensure the `Text` composables always layout themselves based on a consistent width, and then we scale the *entire rendered card* afterwards:

1.  **Consistent Width for Layout:**
    *   The `Box` that directly wraps the `content` (your `DiscoverCard`) inside the `VerticalPager` item is now always given a fixed `width(maxCardWidth)`. This `maxCardWidth` is the full width intended for a selected card.
    *   This ensures that during the **measurement** step of the layout phase, the `Text` composables within your `DiscoverCard` always calculate their line breaks and truncation based on this stable, maximum width. They will lay out once and decide "this is how I look at full size."

2.  **Scaling via `graphicsLayer`:**
    *   The `Modifier.graphicsLayer { scaleX = scale, scaleY = scale, alpha = alpha }` is still used, but it's now applied to this outer `Box` that has the fixed `width(maxCardWidth)`.
    *   The `scale` value (derived from `lerp` and `pageOffset`) now visually shrinks or expands this fully laid-out card.
    *   Since the text layout was already determined based on `maxCardWidth`, scaling the graphical representation of the card down doesn't cause the text to re-evaluate its wrapping or truncation. It simply makes the already-rendered text appear smaller, maintaining its original structure.

## Impact:

With this change, the text within each `DiscoverCard` will be laid out once based on the `maxCardWidth`. As the card scrolls and scales up or down, the text will scale smoothly with the rest of the card content without any distracting reflowing or changes to its line breaks or truncation. This provides a much smoother and more professional user experience.

## Visuals

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/adddfdfd-bd41-40f5-9430-0a83886f5e09" /> | <video src="https://github.com/user-attachments/assets/faa1c9b5-f60f-4c2f-89f9-466bb06ab8ae" /> |

