### PR TITLE
Add feature flag to control Discover button visibility

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -107,6 +107,10 @@ object RemoteConfigDefaults {
                 first = FlagKeys.DISCOVER_SYDNEY.key,
                 second = "[]",
             ),
+            Pair(
+                first = FlagKeys.DISCOVER_AVAILABLE.key,
+                second = true,
+            ),
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
@@ -17,4 +17,6 @@ enum class FlagKeys(val key: String) {
     FESTIVALS("festivals"),
 
     DISCOVER_SYDNEY("discover_sydney"),
+
+    DISCOVER_AVAILABLE("is_discover_available"),
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -13,4 +13,5 @@ data class SavedTripsState(
     val isSavedTripsLoading: Boolean = true,
     val observeParkRideStopIdSet: ImmutableSet<String> = persistentSetOf(),
     val parkRideUiState: ImmutableList<ParkRideUiState> = persistentListOf(),
+    val isDiscoverAvailable: Boolean = false,
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -83,15 +83,17 @@ fun SavedTripsScreen(
                     Text(text = "KRAIL", color = themeColor())
                 },
                 actions = {
-                    RoundIconButton(
-                        onClick = onDiscoverButtonClick,
-                    ) {
-                        Image(
-                            painter = painterResource(Res.drawable.ic_sydney),
-                            contentDescription = "Discover Sydney",
-                            colorFilter = ColorFilter.tint(LocalContentColor.current),
-                            modifier = Modifier.size(32.dp),
-                        )
+                    if (savedTripsState.isDiscoverAvailable) {
+                        RoundIconButton(
+                            onClick = onDiscoverButtonClick,
+                        ) {
+                            Image(
+                                painter = painterResource(Res.drawable.ic_sydney),
+                                contentDescription = "Discover Sydney",
+                                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                                modifier = Modifier.size(32.dp),
+                            )
+                        }
                     }
 
                     RoundIconButton(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -30,6 +30,7 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
+import xyz.ksharma.krail.core.remote_config.flag.asBoolean
 import xyz.ksharma.krail.core.remote_config.flag.asNumber
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
@@ -63,10 +64,6 @@ class SavedTripsViewModel(
     private val flag: Flag,
 ) : ViewModel() {
 
-    init {
-        log("Temp log for CI builds")
-    }
-
     private val nonPeakTimeCooldownSeconds: Long by lazy {
         flag.getFlagValue(FlagKeys.NSW_PARK_RIDE_NON_PEAK_TIME_COOLDOWN.key)
             .asNumber(600)
@@ -75,6 +72,10 @@ class SavedTripsViewModel(
     private val peakTimeCooldownSeconds: Long by lazy {
         flag.getFlagValue(FlagKeys.NSW_PARK_RIDE_PEAK_TIME_COOLDOWN.key)
             .asNumber(fallback = 120)
+    }
+
+    private val isDiscoverAvailable: Boolean by lazy {
+        flag.getFlagValue(FlagKeys.DISCOVER_AVAILABLE.key).asBoolean(false)
     }
 
     /**
@@ -94,6 +95,7 @@ class SavedTripsViewModel(
             observeSavedTrips()
             observeFacilityDetailsFromDb()
             refreshFacilityDetails()
+            updateDiscoverState()
         }
         .onCompletion {
             cleanupJobs()
@@ -506,6 +508,10 @@ class SavedTripsViewModel(
         } else {
             peakTimeCooldownSeconds.seconds
         }
+    }
+
+    private fun updateDiscoverState() {
+        updateUiState { copy(isDiscoverAvailable = this@SavedTripsViewModel.isDiscoverAvailable) }
     }
 
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {


### PR DESCRIPTION
### TL;DR

Added a feature flag to control the visibility of the Discover Sydney button in the Saved Trips screen.

### What changed?

- Added a new `DISCOVER_AVAILABLE` flag key in `FlagKeys.kt`
- Added the default value for this flag (set to `true`) in `RemoteConfigDefaults.kt`
- Added an `isDiscoverAvailable` property to `SavedTripsState`
- Modified the `SavedTripsViewModel` to read the flag value and update the UI state
- Updated the `SavedTripsScreen` to conditionally show the Discover button based on the flag value
- Removed a temporary log statement that was used for CI builds

### How to test?

1. Run the app and navigate to the Saved Trips screen
2. Verify that the Discover Sydney button is visible by default (flag is true)
3. Change the remote config flag value to false
4. Verify that the Discover Sydney button disappears from the Saved Trips screen

### Why make this change?

This change allows for dynamic control over the Discover Sydney feature's availability without requiring an app update. This is useful for feature rollouts, A/B testing, or temporarily disabling the feature if needed.