### PR TITLE
Add analytics tracking for Discover button click and session completion

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -303,6 +303,11 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // region Discover
 
+    data object DiscoverButtonClick : AnalyticsEvent(
+        name = "discover_button_click",
+        properties = mapOf("location" to "SYD")
+    )
+
     data class DiscoverCardClick(
         val location: String = "SYD",
         val source: Source,
@@ -310,7 +315,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val cardType: CardType,
         val partnerSocialLink: PartnerSocialLink? = null,
     ) : AnalyticsEvent(
-        name = "discover_click",
+        name = "discover_card_click",
         properties = mutableMapOf(
             "location" to location,
             "source" to source.actionName,
@@ -339,15 +344,22 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         }
 
         enum class Source(val actionName: String) {
-            FEEDBACK_POSITIVE_THUMB("feedback_positive"),
-            FEEDBACK_NEGATIVE_THUMB("feedback_negative"),
-            FEEDBACK_SHARE_FEEDBACK("share_feedback"),
-            FEEDBACK_WRITE_REVIEW("write_review"),
             CTA_CLICK("cta_click"),
             SHARE_CLICK("share"),
             PARTNER_SOCIAL_LINK("partner_social_link"),
         }
     }
+
+    data class DiscoverCardSessionComplete(
+        val cardSeenCount: Int,
+        val location: String = "SYD",
+    ) : AnalyticsEvent(
+        name = "discover_session_complete",
+        properties = mutableMapOf(
+            "cardSeenCount" to cardSeenCount,
+            "location" to location,
+        )
+    )
 
     // endregion
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -1,5 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.di
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
@@ -80,6 +83,7 @@ val viewModelsModule = module {
             analytics = get(),
             platformOps = get(),
             appInfoProvider = get(),
+            appCoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -142,7 +142,7 @@ class SavedTripsViewModel(
             )
 
             SavedTripUiEvent.AnalyticsDiscoverButtonClick -> {
-                // todo
+                analytics.track(AnalyticsEvent.DiscoverButtonClick)
             }
         }
     }


### PR DESCRIPTION
### TL;DR

Added analytics tracking for Discover feature including new events for button clicks, card interactions, and session completion.

### What changed?

- Added new `DiscoverButtonClick` analytics event
- Renamed `discover_click` event to `discover_card_click` for clarity
- Added `DiscoverCardSessionComplete` event to track the number of cards seen in a session
- Implemented tracking for discover button clicks in `SavedTripsViewModel`
- Added card session tracking in `DiscoverViewModel` that fires when the view model is cleared
- Added a mechanism to track seen card IDs during a discover session
- Removed unused feedback-related enum values from `Source`
- Added `appCoroutineScope` parameter to `DiscoverViewModel` to ensure analytics events are sent even after the view model is cleared

### How to test?

1. Click the Discover button from the Saved Trips screen and verify `discover_button_click` event is tracked
2. Interact with Discover cards and verify `discover_card_click` events are tracked with correct parameters
3. Exit the Discover screen and verify `discover_session_complete` event is tracked with the correct card count

### Why make this change?

These analytics events provide valuable insights into how users interact with the Discover feature, allowing us to measure engagement, understand user behavior patterns, and make data-driven improvements to the feature.