### PR TITLE
Add TODO comments for unit tests in Discover components

### DIFF
--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/serializer/ButtonListDeserializer.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/serializer/ButtonListDeserializer.kt
@@ -15,6 +15,7 @@ import xyz.ksharma.krail.social.state.SocialType
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.discover.state.Button
 
+// TODO - ADD UT TESTS FOR THIS SERIALIZER
 object ButtonListSerializer : KSerializer<List<Button>> {
 
     @OptIn(InternalSerializationApi::class)

--- a/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/serializer/ImagesListSerializer.kt
+++ b/discover/network/api/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/api/serializer/ImagesListSerializer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
+// TODO - ADD UT TESTS FOR THIS SERIALIZER
 object ImagesListSerializer : KSerializer<List<String>> {
     private val listSerializer = ListSerializer(String.Companion.serializer())
     override val descriptor: SerialDescriptor = listSerializer.descriptor

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -15,6 +15,7 @@ import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
 import xyz.ksharma.krail.discover.network.api.db.DiscoverCardOrderingEngine
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
 
+// TODO - ADD UT TESTS FOR THIS MANAGER
 internal class RealDiscoverSydneyManager(
     private val flag: Flag,
     private val defaultDispatcher: CoroutineDispatcher = DispatchersComponent().defaultDispatcher,

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
@@ -5,6 +5,7 @@ import xyz.ksharma.krail.discover.network.api.db.DiscoverCardOrderingEngine
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
 import xyz.ksharma.krail.sandook.DiscoverCardSeenPreferences
 
+// TODO - ADD UT TESTS FOR THIS ENGINE
 internal class RealDiscoverCardOrderingEngine(
     private val discoverCardPreferences: DiscoverCardSeenPreferences,
 ) : DiscoverCardOrderingEngine {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -31,6 +31,7 @@ import xyz.ksharma.krail.discover.state.DiscoverState
 import xyz.ksharma.krail.platform.ops.PlatformOps
 import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
 
+// TODO - Add UTs
 class DiscoverViewModel(
     private val discoverSydneyManager: DiscoverSydneyManager,
     private val ioDispatcher: CoroutineDispatcher,


### PR DESCRIPTION
### TL;DR

Added TODO comments to mark components that need unit tests across the discover feature.

### What changed?

Added TODO comments to several files in the discover feature to indicate that unit tests need to be created for:
- ButtonListSerializer
- ImagesListSerializer
- RealDiscoverSydneyManager
- RealDiscoverCardOrderingEngine
- DiscoverViewModel

### How to test?

No functional changes were made, so no testing is required for this PR.

### Why make this change?

This change helps track test coverage gaps in the codebase by explicitly marking components that need unit tests. These TODOs will serve as reminders to improve test coverage for these critical components in the discover feature.