### PR TITLE
Add badge indicator for unclicked Discover button

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeSandookPreferences.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeSandookPreferences.kt
@@ -1,0 +1,44 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.sandook.SandookPreferences
+
+class FakeSandookPreferences : SandookPreferences {
+
+    private val preferences = mutableMapOf<String, Any>()
+
+    override fun getLong(key: String): Long? {
+        return preferences[key] as? Long
+    }
+
+    override fun setLong(key: String, value: Long) {
+        preferences[key] = value
+    }
+
+    override fun getString(key: String): String? {
+        return preferences[key] as? String
+    }
+
+    override fun setString(key: String, value: String) {
+        preferences[key] = value
+    }
+
+    override fun getBoolean(key: String): Boolean? {
+        return preferences[key] as? Boolean
+    }
+
+    override fun setBoolean(key: String, value: Boolean) {
+        preferences[key] = value
+    }
+
+    override fun getDouble(key: String): Double? {
+        return preferences[key] as? Double
+    }
+
+    override fun setDouble(key: String, value: Double) {
+        preferences[key] = value
+    }
+
+    override fun deletePreference(key: String) {
+        preferences.remove(key)
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -13,6 +13,7 @@ import xyz.ksharma.core.test.fakes.FakeNswParkRideSandook
 import xyz.ksharma.core.test.fakes.FakeParkRideFacilityManager
 import xyz.ksharma.core.test.fakes.FakeParkRideService
 import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.fakes.FakeSandookPreferences
 import xyz.ksharma.core.test.fakes.FakeStopResultsManager
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
@@ -48,6 +49,8 @@ class SavedTripsViewModelTest {
 
     private val fakeFlag: Flag = FakeFlag()
 
+    private val fakeSandookPreferences = FakeSandookPreferences()
+
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -60,6 +63,7 @@ class SavedTripsViewModelTest {
             parkRideSandook = fakeNswParkRideSandook,
             stopResultsManager = fakeStopResultsManager,
             flag = fakeFlag,
+            preferences = fakeSandookPreferences,
         )
     }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -14,4 +14,5 @@ data class SavedTripsState(
     val observeParkRideStopIdSet: ImmutableSet<String> = persistentSetOf(),
     val parkRideUiState: ImmutableList<ParkRideUiState> = persistentListOf(),
     val isDiscoverAvailable: Boolean = false,
+    val displayDiscoverBadge: Boolean = false,
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -54,6 +54,7 @@ val viewModelsModule = module {
             parkRideSandook = get(),
             stopResultsManager = get(),
             flag = get(),
+            preferences = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DiscoverPreferences.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DiscoverPreferences.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import xyz.ksharma.krail.sandook.SandookPreferences
+
+fun SandookPreferences.hasDiscoverBeenClicked(): Boolean {
+    return getBoolean(SandookPreferences.KEY_DISCOVER_CLICKED_BEFORE) ?: false
+}
+
+fun SandookPreferences.markDiscoverAsClicked() {
+    setBoolean(SandookPreferences.KEY_DISCOVER_CLICKED_BEFORE, true)
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -85,6 +85,7 @@ fun SavedTripsScreen(
                 actions = {
                     if (savedTripsState.isDiscoverAvailable) {
                         RoundIconButton(
+                            showBadge = savedTripsState.displayDiscoverBadge,
                             onClick = onDiscoverButtonClick,
                         ) {
                             Image(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -40,6 +40,7 @@ import xyz.ksharma.krail.sandook.NSWParkRideFacilityDetail
 import xyz.ksharma.krail.sandook.NswParkRideSandook
 import xyz.ksharma.krail.sandook.NswParkRideSandook.Companion.SavedParkRideSource.SavedTrips
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SavedParkRide
 import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
@@ -62,6 +63,7 @@ class SavedTripsViewModel(
     private val parkRideSandook: NswParkRideSandook,
     private val stopResultsManager: StopResultsManager,
     private val flag: Flag,
+    private val preferences: SandookPreferences,
 ) : ViewModel() {
 
     private val nonPeakTimeCooldownSeconds: Long by lazy {
@@ -143,6 +145,8 @@ class SavedTripsViewModel(
 
             SavedTripUiEvent.AnalyticsDiscoverButtonClick -> {
                 analytics.track(AnalyticsEvent.DiscoverButtonClick)
+                preferences.markDiscoverAsClicked()
+                updateUiState { copy(displayDiscoverBadge = false) }
             }
         }
     }
@@ -511,7 +515,12 @@ class SavedTripsViewModel(
     }
 
     private fun updateDiscoverState() {
-        updateUiState { copy(isDiscoverAvailable = this@SavedTripsViewModel.isDiscoverAvailable) }
+        updateUiState {
+            copy(
+                isDiscoverAvailable = this@SavedTripsViewModel.isDiscoverAvailable,
+                displayDiscoverBadge = !preferences.hasDiscoverBeenClicked() && savedTrips.isNotEmpty(),
+            )
+        }
     }
 
     private fun updateUiState(block: SavedTripsState.() -> SavedTripsState) {

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -27,5 +27,6 @@ interface SandookPreferences {
 
         const val KEY_NSW_STOPS_VERSION = "KEY_NSW_STOPS_VERSION"
         const val KEY_HAS_SEEN_INTRO = "KEY_HAS_SEEN_INTRO"
+        const val KEY_DISCOVER_CLICKED_BEFORE = "KEY_DISCOVER_CLICKED_BEFORE"
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/RoundIconButton.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/RoundIconButton.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalContainerColor
 import xyz.ksharma.krail.taj.LocalContentColor
@@ -23,6 +22,7 @@ import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.tokens.BadgeTokens
 import xyz.ksharma.krail.taj.tokens.ButtonTokens.RoundButtonSize
 
 /**
@@ -65,9 +65,9 @@ fun RoundIconButton(
             if (showBadge) {
                 Box(
                     modifier = Modifier
-                        .size(10.dp)
+                        .size(BadgeTokens.BadgeSize)
                         .align(Alignment.TopEnd)
-                        .offset(x = (-4).dp, y = 2.dp)
+                        .offset(x = BadgeTokens.BadgeOffsetX, y = BadgeTokens.BadgeOffsetY)
                         .clip(CircleShape)
                         .background(KrailTheme.colors.badge)
                 )

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/RoundIconButton.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/RoundIconButton.kt
@@ -1,19 +1,28 @@
 package xyz.ksharma.krail.taj.components
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalContainerColor
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.tokens.ButtonTokens.RoundButtonSize
 
 /**
@@ -29,6 +38,7 @@ import xyz.ksharma.krail.taj.tokens.ButtonTokens.RoundButtonSize
 fun RoundIconButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showBadge: Boolean = false,
     color: Color? = null,
     onClickLabel: String? = null,
     content: @Composable () -> Unit = {},
@@ -39,17 +49,65 @@ fun RoundIconButton(
     ) {
         Box(
             modifier = modifier
-                .size(RoundButtonSize) // TODO - token "SearchButtonHeight"
-                .clip(CircleShape)
-                .background(color = color ?: LocalContainerColor.current)
-                .klickable(onClick = onClick),
-            contentAlignment = Alignment.Center,
+                .size(RoundButtonSize)
         ) {
-            content()
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(CircleShape)
+                    .background(color = color ?: LocalContainerColor.current)
+                    .klickable(onClick = onClick),
+                contentAlignment = Alignment.Center,
+            ) {
+                content()
+            }
+
+            if (showBadge) {
+                Box(
+                    modifier = Modifier
+                        .size(10.dp)
+                        .align(Alignment.TopEnd)
+                        .offset(x = (-4).dp, y = 2.dp)
+                        .clip(CircleShape)
+                        .background(KrailTheme.colors.badge)
+                )
+            }
         }
     }
 }
 
 // region Previews
+
+@Preview
+@Composable
+private fun PreviewRoundIconButton() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        RoundIconButton(
+            onClick = { }
+        ) {
+            Image(
+                imageVector = Icons.Default.Add,
+                contentDescription = "Add"
+            )
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun PreviewRoundIconButtonWithBadge() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        RoundIconButton(
+            showBadge = true,
+            onClick = { }
+        ) {
+            Image(
+                imageVector = Icons.Default.Add,
+                contentDescription = "Add"
+            )
+        }
+    }
+}
 
 // endregion

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -39,6 +39,8 @@ val barbie_pink_theme = Color(0xFFE0218A)
 
 val seed = Color(0xFFFFBA27)
 
+val md_theme_badge = Color(0xFFFF0000)
+
 @Immutable
 data class KrailColors(
     val label: Color,
@@ -52,6 +54,7 @@ data class KrailColors(
     val alert: Color,
     val softLabel: Color,
     val secondaryLabel: Color,
+    val badge: Color,
 )
 
 internal val KrailLightColors = KrailColors(
@@ -66,6 +69,7 @@ internal val KrailLightColors = KrailColors(
     alert = md_theme_light_alert,
     softLabel = md_theme_light_softLabel,
     secondaryLabel = md_theme_light_secondary_label,
+    badge = md_theme_badge,
 )
 
 internal val KrailDarkColors = KrailColors(
@@ -80,6 +84,7 @@ internal val KrailDarkColors = KrailColors(
     alert = md_theme_dark_alert,
     softLabel = md_theme_dark_softLabel,
     secondaryLabel = md_theme_dark_secondary_label,
+    badge = md_theme_badge,
 )
 
 internal val LocalKrailColors = staticCompositionLocalOf {
@@ -95,5 +100,6 @@ internal val LocalKrailColors = staticCompositionLocalOf {
         alert = Color.Unspecified,
         softLabel = Color.Unspecified,
         secondaryLabel = Color.Unspecified,
+        badge = Color.Unspecified,
     )
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/BadgeTokens.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/BadgeTokens.kt
@@ -1,0 +1,21 @@
+package xyz.ksharma.krail.taj.tokens
+
+import androidx.compose.ui.unit.dp
+
+internal object BadgeTokens {
+    /**
+     * The size of the badge.
+     */
+    val BadgeSize = 16.dp
+
+    /**
+     * The offset of the badge from the top right corner.
+     */
+    val BadgeOffsetX = (-4).dp
+
+    /**
+     * The offset of the badge from the top right corner.
+     * This is used to position the badge correctly on the button.
+     */
+    val BadgeOffsetY = 2.dp
+}


### PR DESCRIPTION
### TL;DR

Added a notification badge to the Discover button that appears until the user clicks it for the first time.

### What changed?

- Added a `displayDiscoverBadge` boolean to `SavedTripsState` to track badge visibility
- Created `DiscoverPreferences.kt` with functions to check and mark if the Discover button has been clicked
- Enhanced `RoundIconButton` component to support displaying a badge
- Added badge color to the theme's color palette
- Updated `SavedTripsViewModel` to manage badge state based on user interaction
- Badge is shown only when there are saved trips and the user hasn't clicked Discover before

### How to test?

1. Launch the app with saved trips but without having clicked the Discover button before
2. Verify the red notification badge appears on the Discover button
3. Click the Discover button and confirm the badge disappears
4. Restart the app and verify the badge doesn't reappear

### Why make this change?

This change improves user discovery of the Discover feature by adding a visual indicator that draws attention to it. The badge only appears until the user clicks the button for the first time, ensuring it doesn't become a persistent distraction after the user is aware of the feature.