### PR TITLE
Remove Kids category and add Unknown type to DiscoverCardType

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -328,9 +328,11 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         )
 
         enum class CardType(val type: String) {
-            KRAIL("krail"), TRAVEL("travel"), EVENTS("events"), FOOD("food"), SPORTS("sports"), KIDS(
-                "kids"
-            ),
+            KRAIL("krail"),
+            TRAVEL("travel"),
+            EVENTS("events"),
+            FOOD("food"),
+            SPORTS("sports"),
             UNKNOWN("unknown"),
         }
 

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
@@ -38,18 +38,18 @@ data class DiscoverState(
     )
 }
 
-enum class DiscoverCardType {
-    Krail, // general Krail related content
+enum class DiscoverCardType(val displayName: String) {
+    Krail("KRAIL"), // general Krail related content
 
-    Travel, // places to visit, travel tips etc.
+    Travel("Travel"), // places to visit, travel tips etc.
 
-    Events, // concerts, festivals etc.
+    Events("Events"), // concerts, festivals etc.
 
-    Food, // restaurants, cafes etc.
+    Food("Food"), // restaurants, cafes etc.
 
-    Sports, // football, cricket etc.
+    Sports("Sports"), // football, cricket etc.
 
-    Kids // pokemon, games etc..
+    Unknown("Unknown"); // fallback for unknown types
     ;
 }
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -334,7 +334,7 @@ val previewDiscoverCardList = listOf(
         title = "Share Only Card",
         description = "This is a sample description for the Discover Card. It can be used to display additional information.",
         imageList = persistentListOf("https://plus.unsplash.com/premium_photo-1751906599846-2e31345c8014"),
-        type = DiscoverCardType.Kids,
+        type = DiscoverCardType.Travel,
         buttons = persistentListOf(
             Button.Share(
                 shareUrl = "https://example.com/share",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapper.kt
@@ -10,9 +10,9 @@ internal fun DiscoverCardType.toAnalyticsCardType(): DiscoverCardClick.CardType 
         DiscoverCardType.Events -> DiscoverCardClick.CardType.EVENTS
         DiscoverCardType.Sports -> DiscoverCardClick.CardType.SPORTS
         DiscoverCardType.Krail -> DiscoverCardClick.CardType.KRAIL
-        DiscoverCardType.Kids -> DiscoverCardClick.CardType.KIDS
         DiscoverCardType.Travel -> DiscoverCardClick.CardType.TRAVEL
         DiscoverCardType.Food -> DiscoverCardClick.CardType.FOOD
+        DiscoverCardType.Unknown -> DiscoverCardClick.CardType.UNKNOWN
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -1,0 +1,77 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.taj.themeBackgroundColor
+import xyz.ksharma.krail.taj.themeColor
+
+@Composable
+fun DiscoverChip(
+    type: DiscoverCardType,
+    selected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+
+    val backgroundColor = if (selected) themeBackgroundColor()
+    else KrailTheme.colors.discoverChipBackground
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(50))
+            .background(
+                color = backgroundColor,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = type.displayName,
+            style = KrailTheme.typography.title,
+            color = getForegroundColor(
+                backgroundColor = backgroundColor,
+            ),
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        )
+    }
+}
+
+// region Previews
+
+@Preview
+@Composable
+private fun DiscoverChipPreview_Metro_Selected() {
+    PreviewTheme(themeStyle = KrailThemeStyle.BarbiePink, darkTheme = false) {
+        DiscoverChip(
+            type = DiscoverCardType.Travel,
+            selected = true,
+            modifier = Modifier.padding(8.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DiscoverChipPreview_Metro_Unselected() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        DiscoverChip(
+            type = DiscoverCardType.Travel,
+            selected = false,
+            modifier = Modifier.padding(8.dp)
+        )
+    }
+}
+
+// endregion

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
@@ -46,12 +46,17 @@ fun getForegroundColor(
     val lightForegroundColor = md_theme_dark_onSurface
     val darkForegroundColor = md_theme_light_onSurface
 
+    val superWhiteForegroundColor = Color(0xFFFFFFFF) // A very light color for high contrast
+    val superBlackForegroundColor = Color(0xFF000000) // A very dark color for high contrast
+
     // Return the color with a sufficient contrast ratio
     return if (lightForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
         lightForegroundColor
-    } else {
+    } else if (darkForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
         darkForegroundColor
-    }
+    } else if (superWhiteForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
+        superWhiteForegroundColor
+    } else superBlackForegroundColor
 }
 
 fun shouldUseDarkIcons(backgroundColor: Color): Boolean {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -13,8 +13,9 @@ val md_theme_light_onSurface = Color(0xFF010101)
 val md_theme_light_scrim = Color(0xFF000000)
 val md_theme_light_alert = Color(0xFFFFBA27)
 val md_theme_light_softLabel = Color(0xFF767676)
-
 val md_theme_light_secondary_label = Color(0xFF2E2E2E)
+val md_theme_light_discover_chip_background = Color(0xFFF5F5F5)
+
 
 // Dark Color tokens
 val md_theme_dark_error = Color(0xFFFFB4AB)
@@ -27,6 +28,7 @@ val md_theme_dark_scrim = Color(0xFF000000)
 val md_theme_dark_alert = Color(0xFFF4B400)
 val md_theme_dark_softLabel = Color(0xFFB0B0B0)
 val md_theme_dark_secondary_label = Color(0xFFE2E2E2)
+val md_theme_dark_discover_chip_background = Color(0xFF1C1C1E)
 
 val bus_theme = Color(0xFF00B5EF)
 val train_theme = Color(0xFFF6891F)
@@ -55,6 +57,7 @@ data class KrailColors(
     val softLabel: Color,
     val secondaryLabel: Color,
     val badge: Color,
+    val discoverChipBackground: Color,
 )
 
 internal val KrailLightColors = KrailColors(
@@ -70,6 +73,7 @@ internal val KrailLightColors = KrailColors(
     softLabel = md_theme_light_softLabel,
     secondaryLabel = md_theme_light_secondary_label,
     badge = md_theme_badge,
+    discoverChipBackground = md_theme_light_discover_chip_background,
 )
 
 internal val KrailDarkColors = KrailColors(
@@ -85,6 +89,7 @@ internal val KrailDarkColors = KrailColors(
     softLabel = md_theme_dark_softLabel,
     secondaryLabel = md_theme_dark_secondary_label,
     badge = md_theme_badge,
+    discoverChipBackground = md_theme_dark_discover_chip_background,
 )
 
 internal val LocalKrailColors = staticCompositionLocalOf {
@@ -101,5 +106,6 @@ internal val LocalKrailColors = staticCompositionLocalOf {
         softLabel = Color.Unspecified,
         secondaryLabel = Color.Unspecified,
         badge = Color.Unspecified,
+        discoverChipBackground = Color.Unspecified,
     )
 }


### PR DESCRIPTION
# Remove Kids Category from Discover Cards and Add Chip Component

### TL;DR

Removed the Kids category from DiscoverCardType, added an Unknown fallback type, and created a new DiscoverChip component for filtering content.

### What changed?

- Removed the `Kids` category from `DiscoverCardType` enum and added an `Unknown` type with fallback functionality
- Added a `displayName` property to `DiscoverCardType` for better UI presentation
- Created a new `DiscoverChip` component for filtering discover content
- Enhanced the `getForegroundColor` function with super high contrast options for better accessibility
- Added theme colors for discover chip backgrounds in both light and dark modes
- Updated analytics mapping to handle the new type structure

### How to test?

1. Verify that the `Kids` category no longer appears in the discover section
2. Check that the new `DiscoverChip` component renders correctly with proper styling
3. Test the `Unknown` type fallback functionality by trying to display a card with an unrecognized type
4. Verify that the enhanced contrast functionality works correctly in different theme settings

### Why make this change?

This change streamlines the content categories in the discover section by removing the Kids category and adding a more robust fallback mechanism. The new DiscoverChip component improves the user experience by providing a consistent way to filter content. The accessibility improvements ensure better readability across different background colors and theme settings.