### PR TITLE
Add DiscoverChipRow component for filtering discover cards

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.discover.state.DiscoverCardType
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
@@ -18,7 +20,7 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun DiscoverChipRow(
-    chipTypes: Set<DiscoverCardType>,
+    chipTypes: ImmutableList<DiscoverCardType>,
     selectedType: DiscoverCardType,
     onChipSelected: (DiscoverCardType) -> Unit,
     modifier: Modifier = Modifier,
@@ -29,7 +31,7 @@ fun DiscoverChipRow(
         contentPadding = PaddingValues(horizontal = 16.dp)
     ) {
         items(
-            items = chipTypes.toList(),
+            items = chipTypes,
             key = { type ->
                 type.displayName
             },
@@ -60,7 +62,7 @@ private fun DiscoverChipRowPreview() {
                 DiscoverCardType.Events,
                 DiscoverCardType.Food,
                 DiscoverCardType.Sports,
-            ),
+            ).toImmutableList(),
             selectedType = DiscoverCardType.Travel,
             onChipSelected = { }
         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
@@ -1,0 +1,70 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+
+@Composable
+fun DiscoverChipRow(
+    chipTypes: Set<DiscoverCardType>,
+    selectedType: DiscoverCardType,
+    onChipSelected: (DiscoverCardType) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp)
+    ) {
+        items(
+            items = chipTypes.toList(),
+            key = { type ->
+                type.displayName
+            },
+        ) { type ->
+            DiscoverChip(
+                type = type,
+                selected = type == selectedType,
+                modifier = Modifier.clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) {
+                    onChipSelected(type)
+                }
+            )
+        }
+    }
+}
+
+// region Previews
+
+@Preview
+@Composable
+private fun DiscoverChipRowPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        DiscoverChipRow(
+            chipTypes = setOf(
+                DiscoverCardType.Travel,
+                DiscoverCardType.Events,
+                DiscoverCardType.Food,
+                DiscoverCardType.Sports,
+            ),
+            selectedType = DiscoverCardType.Travel,
+            onChipSelected = { }
+        )
+    }
+}
+
+// endregion Previews


### PR DESCRIPTION
### TL;DR

Added a new `DiscoverChipRow` composable for the trip planner UI.

### What changed?

Created a new Kotlin file `DiscoverChipRow.kt` that implements a horizontally scrollable row of selectable chips for the discover section. The component:
- Displays a set of `DiscoverCardType` options as chips in a `LazyRow`
- Highlights the currently selected chip
- Handles selection through a callback
- Includes proper spacing and padding

### How to test?

1. Navigate to the discover section of the trip planner
2. Verify that the chip row displays correctly with proper spacing
3. Check that the selected chip is visually highlighted
4. Tap on different chips to ensure the selection changes appropriately
5. Verify the preview renders correctly in Android Studio

### Why make this change?

This component provides a consistent UI element for filtering content in the discover section, allowing users to easily switch between different categories (Travel, Events, Food, Sports, etc.) when browsing available options in the trip planner.