### PR TITLE
Add animated chip selection to Discover screen with improved theming

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -1,13 +1,21 @@
 package xyz.ksharma.krail.trip.planner.ui.discover
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.discover.state.DiscoverCardType
@@ -16,8 +24,8 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
-import xyz.ksharma.krail.taj.themeBackgroundColor
-import xyz.ksharma.krail.taj.themeColor
+import xyz.ksharma.krail.taj.themeContentColor
+import xyz.ksharma.krail.taj.themeSolidBackgroundColor
 
 @Composable
 fun DiscoverChip(
@@ -25,24 +33,44 @@ fun DiscoverChip(
     selected: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val selectedBackgroundColor = themeSolidBackgroundColor()
+    val unselectedBackgroundColor = KrailTheme.colors.discoverChipBackground
 
-    val backgroundColor = if (selected) themeBackgroundColor()
-    else KrailTheme.colors.discoverChipBackground
+    val textColor = if (selected) {
+        getForegroundColor(backgroundColor = selectedBackgroundColor)
+    } else {
+        KrailTheme.colors.label
+    }
+
+    val selectedAlpha by animateFloatAsState(
+        targetValue = if (selected) 1f else 0f,
+        animationSpec = tween(durationMillis = 200, easing = LinearEasing),
+        label = "selected_alpha"
+    )
+
+    val unselectedAlpha by animateFloatAsState(
+        targetValue = if (selected) 0f else 1f,
+        animationSpec = tween(durationMillis = 200, easing = LinearEasing),
+        label = "unselected_alpha"
+    )
 
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(50))
-            .background(
-                color = backgroundColor,
-            ),
+            .background(color = Color.Transparent)
+            .drawBehind {
+                val blendedColor =
+                    lerp(unselectedBackgroundColor, selectedBackgroundColor, selectedAlpha)
+                drawRect(color = blendedColor)
+            },
         contentAlignment = Alignment.Center,
     ) {
         Text(
             text = type.displayName,
-            style = KrailTheme.typography.title,
-            color = getForegroundColor(
-                backgroundColor = backgroundColor,
+            style = KrailTheme.typography.title.copy(
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
             ),
+            color = textColor,
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -8,10 +8,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -19,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.core.appinfo.LocalAppInfo
 import xyz.ksharma.krail.discover.state.Button
 import xyz.ksharma.krail.discover.state.DiscoverCardType
@@ -140,8 +145,18 @@ fun DiscoverScreen(
                         startY = 0f,
                         endY = Float.POSITIVE_INFINITY,
                     )
-                ).height(100.dp),
+                )
+                .navigationBarsPadding(),
         ) {
+            var selectedType by remember { mutableStateOf(DiscoverCardType.Krail) }
+            DiscoverChipRow(
+                chipTypes = DiscoverCardType.entries.toImmutableList(),
+                selectedType = selectedType,
+                modifier = Modifier.padding(vertical = 20.dp),
+                onChipSelected = { type ->
+                    selectedType = type
+                },
+            )
         }
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import kotlin.math.absoluteValue
 
 fun String.hexToComposeColor(): Color {
@@ -210,4 +211,44 @@ fun darkenColor(color: Int, factor: Float = 0.2f): Int {
 
     // Convert back to RGB and return the color as an Int
     return hsvToColor(hsv)
+}
+
+@Composable
+fun themeSolidBackgroundColor(): Color {
+    val themeColor by LocalThemeColor.current
+    return if (isSystemInDarkTheme()) {
+        // Blend the theme color with dark surface for solid color
+        blendColors(
+            foreground = themeColor.hexToComposeColor().copy(alpha = 0.45f),
+            background = KrailTheme.colors.surface
+        )
+    } else {
+        // Blend the theme color with light surface for solid color
+        blendColors(
+            foreground = themeColor.hexToComposeColor().copy(alpha = 0.15f),
+            background = KrailTheme.colors.surface
+        )
+    }
+}
+
+/**
+ * Blends two colors based on the alpha of the foreground color.
+ *
+ * This function takes a foreground color and a background color, and blends them
+ * according to the alpha value of the foreground color. The resulting color is
+ * a mix of both colors, with the foreground color's alpha determining how much
+ * of each color is present in the final result.
+ *
+ * @param foreground The foreground color to blend.
+ * @param background The background color to blend with.
+ * @return A new Color that is a blend of the foreground and background colors.
+ */
+private fun blendColors(foreground: Color, background: Color): Color {
+    val alpha = foreground.alpha
+    return Color(
+        red = foreground.red * alpha + background.red * (1 - alpha),
+        green = foreground.green * alpha + background.green * (1 - alpha),
+        blue = foreground.blue * alpha + background.blue * (1 - alpha),
+        alpha = 1f
+    )
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
@@ -46,17 +46,12 @@ fun getForegroundColor(
     val lightForegroundColor = md_theme_dark_onSurface
     val darkForegroundColor = md_theme_light_onSurface
 
-    val superWhiteForegroundColor = Color(0xFFFFFFFF) // A very light color for high contrast
-    val superBlackForegroundColor = Color(0xFF000000) // A very dark color for high contrast
-
     // Return the color with a sufficient contrast ratio
     return if (lightForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
         lightForegroundColor
-    } else if (darkForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
+    } else {
         darkForegroundColor
-    } else if (superWhiteForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
-        superWhiteForegroundColor
-    } else superBlackForegroundColor
+    }
 }
 
 fun shouldUseDarkIcons(backgroundColor: Color): Boolean {


### PR DESCRIPTION
### TL;DR

Enhanced the DiscoverChip component with smooth animations and improved the color system for better accessibility and resolved DiscoverChip color animation issues by implementing proper color blending.

### What changed?

- Added animation to `DiscoverChip` selection state transitions using `animateFloatAsState`
- Implemented a new drawing approach for `DiscoverChip` backgrounds using `drawBehind` to support smooth alpha transitions
- Added bold font weight for selected chips to improve visual hierarchy
- Created a new `themeSolidBackgroundColor()` function that properly blends theme colors with surface colors
- Simplified the foreground color selection logic in `getForegroundColor()`
- Added navigation bar padding to the DiscoverScreen bottom section
- Implemented a working chip selection system in `DiscoverScreen`. Dummy data is being displayed, will be using data from config in next PR. 

## Fix: 
- Replace `themeBackgroundColor()` with `themeSolidBackgroundColor()` in `DiscoverChip`
- Add `blendColors()` function to mathematically blend semi-transparent theme colors with surface colors
- Ensures `getForegroundColor()` calculates contrast ratios based on actual visual colors, not alpha-adjusted colors
- Eliminates white-on-white text issues in light mode animations

The fix resolves the color calculation issue in `DiscoverChip` animations. Here's what was wrong and how it was fixed:

### Problem
The `themeBackgroundColor()` function returns a semi-transparent color (alpha 0.15f in light mode, 0.45f in dark mode). When this transparent color is applied over a surface, the visual result is a blend of the theme color and the underlying surface color. However, the `getForegroundColor()` function was calculating contrast based on the alpha-adjusted color, not the final blended visual result, leading to incorrect text color selection.

### Solution

- Created `themeSolidBackgroundColor()` function that:
- Pre-blends colors: Uses `blendColors()` to mathematically combine the semi-transparent theme color with the surface color
- Returns opaque color: The result is a solid color (alpha = 1f) that matches the actual visual appearance
- Enables proper contrast calculation: `getForegroundColor()` can now calculate accurate contrast ratios