### PR TITLE
Enhance DiscoverChip with scale animation and configurable padding

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.discover.state.DiscoverCardType
@@ -37,6 +38,8 @@ fun DiscoverChip(
     type: DiscoverCardType,
     selected: Boolean,
     modifier: Modifier = Modifier,
+    horizontalPadding: Dp = DiscoverChipDefaults.ChipHorizontalPadding,
+    verticalPadding: Dp = DiscoverChipDefaults.ChipVerticalPadding,
 ) {
     val selectedBackgroundColor = themeColor()
     val unselectedBackgroundColor = themeBackgroundColor()
@@ -58,19 +61,25 @@ fun DiscoverChip(
         targetValue = if (selected) 1.1f else 1f,
         animationSpec = if (selected) {
             // When becoming selected: quick grow then settle
-            tween(durationMillis = 400, easing = androidx.compose.animation.core.FastOutSlowInEasing)
+            tween(
+                durationMillis = 400,
+                easing = androidx.compose.animation.core.FastOutSlowInEasing
+            )
         } else {
             // When becoming deselected: quick shrink
-            tween(durationMillis = 200, easing = androidx.compose.animation.core.FastOutLinearInEasing)
+            tween(
+                durationMillis = 200,
+                easing = androidx.compose.animation.core.FastOutLinearInEasing
+            )
         },
         label = "bubble_scale"
     )
 
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textStyle = KrailTheme.typography.title
+    val textStyle = KrailTheme.typography.labelSmall
 
-    val chipWidth = remember(type.displayName, textStyle, density) {
+    val chipWidth = remember(type.displayName, textStyle, density, horizontalPadding) {
         val boldTextWidth = textMeasurer.measure(
             text = type.displayName,
             style = textStyle.copy(fontWeight = FontWeight.Bold)
@@ -82,7 +91,7 @@ fun DiscoverChip(
         ).size.width
 
         with(density) {
-            (maxOf(boldTextWidth, normalTextWidth) / density.density).dp + 32.dp
+            (maxOf(boldTextWidth, normalTextWidth) / density.density).dp + (horizontalPadding * 4)
         }
     }
 
@@ -107,8 +116,9 @@ fun DiscoverChip(
             style = KrailTheme.typography.title.copy(
                 fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
             ),
+            maxLines = 1,
             color = textColor,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = horizontalPadding, vertical = verticalPadding),
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -48,8 +49,21 @@ fun DiscoverChip(
 
     val selectedAlpha by animateFloatAsState(
         targetValue = if (selected) 1f else 0f,
-        animationSpec = tween(durationMillis = 200, easing = LinearEasing),
+        animationSpec = tween(durationMillis = 300, easing = LinearEasing),
         label = "selected_alpha"
+    )
+
+    // Bubble scale animation
+    val scale by animateFloatAsState(
+        targetValue = if (selected) 1.1f else 1f,
+        animationSpec = if (selected) {
+            // When becoming selected: quick grow then settle
+            tween(durationMillis = 400, easing = androidx.compose.animation.core.FastOutSlowInEasing)
+        } else {
+            // When becoming deselected: quick shrink
+            tween(durationMillis = 200, easing = androidx.compose.animation.core.FastOutLinearInEasing)
+        },
+        label = "bubble_scale"
     )
 
     val textMeasurer = rememberTextMeasurer()
@@ -57,19 +71,16 @@ fun DiscoverChip(
     val textStyle = KrailTheme.typography.title
 
     val chipWidth = remember(type.displayName, textStyle, density) {
-        // Measure the text with bold font weight
         val boldTextWidth = textMeasurer.measure(
             text = type.displayName,
             style = textStyle.copy(fontWeight = FontWeight.Bold)
         ).size.width
 
-        // Measure the text with normal font weight
         val normalTextWidth = textMeasurer.measure(
             text = type.displayName,
             style = textStyle.copy(fontWeight = FontWeight.Normal)
         ).size.width
 
-        // Take the maximum of the two and add padding
         with(density) {
             (maxOf(boldTextWidth, normalTextWidth) / density.density).dp + 32.dp
         }
@@ -78,6 +89,10 @@ fun DiscoverChip(
     Box(
         modifier = modifier
             .width(chipWidth)
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
             .clip(RoundedCornerShape(50))
             .background(color = Color.Transparent)
             .drawBehind {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipDefaults.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipDefaults.kt
@@ -1,0 +1,11 @@
+
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import androidx.compose.ui.unit.dp
+
+internal object DiscoverChipDefaults {
+    val ChipHorizontalPadding = 16.dp
+    val ChipVerticalPadding = 8.dp
+    val RowSpacing = 16.dp // Space between chips in the LazyRow
+    val RowContentPadding = 16.dp // Padding at the start/end of the LazyRow
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
@@ -10,13 +10,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.discover.state.DiscoverCardType
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.discover.DiscoverChipDefaults.RowContentPadding
+import xyz.ksharma.krail.trip.planner.ui.discover.DiscoverChipDefaults.RowSpacing
 
 @Composable
 fun DiscoverChipRow(
@@ -27,8 +28,8 @@ fun DiscoverChipRow(
 ) {
     LazyRow(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp)
+        horizontalArrangement = Arrangement.spacedBy(RowSpacing),
+        contentPadding = PaddingValues(horizontal = RowContentPadding)
     ) {
         items(
             items = chipTypes,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -119,11 +119,7 @@ fun DiscoverScreen(
 
             Text(
                 text = "What's On, Sydney!", // todo -dynamically from config.
-                style = if (fontScale < 1.5f) {
-                    KrailTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Normal)
-                } else {
-                    KrailTheme.typography.titleLarge.copy(fontWeight = FontWeight.Normal)
-                },
+                style = KrailTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Normal),
                 modifier = Modifier
                     .padding(horizontal = 24.dp)
                     .padding(bottom = if (fontScale < 1.5f) 16.dp else 8.dp)


### PR DESCRIPTION
# Enhance DiscoverChip with bubble animation and improved layout

- Added scale animation to DiscoverChip when selected (grows to 1.1x with a smooth animation)
- Improved animation timing with different easing for selection/deselection
- Created DiscoverChipDefaults to centralize spacing and padding constants
- Made chip padding customizable with new parameters
- Ensured text stays in a single line with maxLines=1
- Adjusted typography to use labelSmall for better readability
- Refined width calculation to account for custom padding
- Updated animation duration from 200ms to 300ms for smoother transitions