### PR TITLE
Sort discover card types for consistent filter chip ordering

### DIFF
--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
@@ -2,19 +2,14 @@ package xyz.ksharma.krail.discover.state
 
 import androidx.compose.runtime.Stable
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toImmutableList
-import kotlinx.collections.immutable.toImmutableSet
 import xyz.ksharma.krail.social.state.SocialType
 
 @Stable
 data class DiscoverState(
     val discoverCardsList: ImmutableList<DiscoverUiModel> = persistentListOf(),
+    val sortedDiscoverCardTypes: ImmutableList<DiscoverCardType> = persistentListOf()
 ) {
-
-    val discoverFilterChipTypes: ImmutableList<DiscoverCardType>
-        get() = discoverCardsList.map { it.type }.toSet().toImmutableList()
 
     @Stable
     data class DiscoverUiModel(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.core.appinfo.LocalAppInfo
 import xyz.ksharma.krail.discover.state.Button
 import xyz.ksharma.krail.discover.state.DiscoverCardType
@@ -144,7 +146,7 @@ fun DiscoverScreen(
         ) {
             var selectedType by remember { mutableStateOf(DiscoverCardType.Travel) }
             DiscoverChipRow(
-                chipTypes = state.discoverFilterChipTypes,
+                chipTypes = state.sortedDiscoverCardTypes,
                 selectedType = selectedType,
                 modifier = Modifier.padding(vertical = 20.dp),
                 onChipSelected = { type ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.discover
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CoroutineDispatcher
@@ -26,8 +27,10 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
+import xyz.ksharma.krail.discover.state.DiscoverCardType
 import xyz.ksharma.krail.discover.state.DiscoverEvent
 import xyz.ksharma.krail.discover.state.DiscoverState
+import xyz.ksharma.krail.discover.state.DiscoverState.DiscoverUiModel
 import xyz.ksharma.krail.platform.ops.PlatformOps
 import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
 
@@ -132,14 +135,24 @@ class DiscoverViewModel(
                 updateUiState {
                     copy(
                         discoverCardsList = data.toImmutableList(),
+                        sortedDiscoverCardTypes = data.extractSortedDiscoverCardTypes(),
                     )
                 }
             }
     }
 
-    private fun List<DiscoverModel>.toDiscoverUiModelList(): List<DiscoverState.DiscoverUiModel> {
+    private fun List<DiscoverUiModel>.extractSortedDiscoverCardTypes(): ImmutableList<DiscoverCardType> {
+        val sortedTypes = this
+            .map { it.type }
+            .toSet()
+            .sortedBy { discoverCardType -> discoverCardType.sortOrder }
+            .toImmutableList()
+        return sortedTypes
+    }
+
+    private fun List<DiscoverModel>.toDiscoverUiModelList(): List<DiscoverUiModel> {
         return map { model ->
-            DiscoverState.DiscoverUiModel(
+            DiscoverUiModel(
                 title = model.title,
                 description = model.description,
                 imageList = model.imageList.toPersistentList(),


### PR DESCRIPTION
### TL;DR

Improved the discover card type filtering system by adding a sorted list of card types to the state and implementing proper sorting logic.

### What changed?

- Added a new `sortedDiscoverCardTypes` property to `DiscoverState` to replace the computed `discoverFilterChipTypes` property
- Implemented a new `extractSortedDiscoverCardTypes()` function that sorts discover card types based on their `sortOrder` property
- Updated the `DiscoverScreen` to use the new `sortedDiscoverCardTypes` property instead of the old computed property
- Refactored the code to improve readability and maintainability by extracting the card type sorting logic

### How to test?

1. Navigate to the Discover screen
2. Verify that the filter chips appear in the correct order based on their `sortOrder` property
3. Test that selecting different filter chips correctly filters the discover cards
4. Ensure that all discover card types are represented in the filter chips

### Why make this change?

The previous implementation calculated the filter chip types on-the-fly from the discover cards list, which didn't allow for custom sorting. This change enables proper sorting of discover card types in the UI, providing a more consistent and intuitive user experience. It also improves performance by pre-computing the sorted list rather than deriving it each time it's needed.