### PR TITLE
Enhance DiscoverCard UI with adaptive gradient backgrounds and improved layout

### DIFF
--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -46,7 +46,7 @@ import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.components.discoverCardHeight
+import xyz.ksharma.krail.taj.components.rememberCardHeight
 import xyz.ksharma.krail.taj.isLargeFontScale
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
@@ -65,6 +65,8 @@ fun DiscoverCard(
     onCtaClicked: (url: String, cardId: String, cardType: DiscoverCardType) -> Unit = { _, _, _ -> },
     onShareClick: (String) -> Unit = {},
 ) {
+    val discoverCardHeight = rememberCardHeight()
+
     Column(
         modifier = modifier
             .height(discoverCardHeight)
@@ -89,22 +91,22 @@ fun DiscoverCard(
                 modifier = Modifier
                     .width(maxCardWidth)
                     .height(imageHeight)
-                    .padding(horizontal = 8.dp, vertical = 8.dp)
-                    .clip(RoundedCornerShape(8.dp)),
+                    //.padding(horizontal = 8.dp, vertical = 8.dp)
+                    .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp)),
             )
         }
 
         Text(
             text = discoverModel.title,
-            modifier = Modifier.padding(horizontal = 16.dp).padding(top = 4.dp),
+            modifier = Modifier.padding(horizontal = 12.dp).padding(top = 12.dp),
             maxLines = 2,
             style = KrailTheme.typography.headlineSmall,
         )
 
         Text(
             text = discoverModel.description,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-            maxLines = if (isLargeFontScale() && discoverModel.disclaimer != null) 2 else 3,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            maxLines = if (isLargeFontScale() && discoverModel.disclaimer != null || !discoverModel.buttons.isNullOrEmpty()) 2 else 3,
             style = KrailTheme.typography.bodyMedium,
             color = KrailTheme.colors.secondaryLabel,
         )
@@ -112,7 +114,7 @@ fun DiscoverCard(
         discoverModel.disclaimer?.let { disclaimer ->
             Text(
                 text = disclaimer,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = 12.dp),
                 maxLines = 1,
                 style = KrailTheme.typography.labelSmall,
             )
@@ -133,6 +135,7 @@ fun DiscoverCard(
                     onCtaClicked(url, discoverModel.cardId, discoverModel.type)
                 },
                 onShareClick = onShareClick,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 20.dp)
             )
         }
     }
@@ -157,7 +160,7 @@ private fun DiscoverCardButtonRow(
     }
 
     Row(
-        modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 20.dp),
+        modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
         // Left button (always left-aligned)

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -2,6 +2,8 @@ package xyz.ksharma.krail.discover.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,11 +15,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_android_share
@@ -42,14 +49,18 @@ import xyz.ksharma.krail.discover.state.toButtonRowState
 import xyz.ksharma.krail.social.state.KrailSocialType
 import xyz.ksharma.krail.social.state.SocialType
 import xyz.ksharma.krail.social.ui.SocialConnectionRow
+import xyz.ksharma.krail.taj.backgroundColorOf
+import xyz.ksharma.krail.taj.brighten
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.rememberCardHeight
+import xyz.ksharma.krail.taj.darken
 import xyz.ksharma.krail.taj.isLargeFontScale
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
+import xyz.ksharma.krail.taj.themeColor
 import app.krail.taj.resources.Res as TajRes
 
 @Composable
@@ -67,11 +78,23 @@ fun DiscoverCard(
 ) {
     val discoverCardHeight = rememberCardHeight()
 
+    // Create a blended background that combines theme color with surface
+    val blendedBackground = createAdaptiveBackground()
+
     Column(
         modifier = modifier
             .height(discoverCardHeight)
-            .clip(RoundedCornerShape(16.dp))
-            .background(color = themeBackgroundColor()),
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        KrailTheme.colors.surface,           // Top: pure surface
+                        blendedBackground.copy(alpha = 0.3f), // Middle: subtle blend
+                        blendedBackground.copy(alpha = 0.6f)  // Bottom: stronger blend
+                    )
+                ),
+                shape = RoundedCornerShape(16.dp)
+            )
+            .clip(RoundedCornerShape(16.dp)),
     ) {
         BoxWithConstraints {
             val maxCardWidth = maxWidth
@@ -139,6 +162,39 @@ fun DiscoverCard(
             )
         }
     }
+}
+
+@Composable
+fun createAdaptiveBackground(): Color {
+    val themeColor = themeColor()
+    val surfaceColor = KrailTheme.colors.surface
+
+    return if (isSystemInDarkTheme()) {
+        // Dark mode: blend theme color with darkened surface (towards black)
+        blendColors(
+            foreground = themeColor.copy(alpha = 0.15f), // Reduced alpha for subtlety
+            background = surfaceColor.darken(0.65f)     // More darkening towards black
+        )
+    } else {
+        // Light mode: blend theme color with brightened surface (towards white)
+        blendColors(
+            foreground = themeColor.copy(alpha = 0.1f), // Reduced alpha for subtlety
+            background = surfaceColor.brighten(0.15f)    // More brightening towards white
+        )
+    }
+}
+
+/**
+ * Blends two colors based on the alpha of the foreground color.
+ */
+private fun blendColors(foreground: Color, background: Color): Color {
+    val alpha = foreground.alpha
+    return Color(
+        red = foreground.red * alpha + background.red * (1 - alpha),
+        green = foreground.green * alpha + background.green * (1 - alpha),
+        blue = foreground.blue * alpha + background.blue * (1 - alpha),
+        alpha = 1f
+    )
 }
 
 @Composable

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -68,7 +68,7 @@ fun DiscoverCard(
     Column(
         modifier = modifier
             .height(discoverCardHeight)
-            .clip(RoundedCornerShape(24.dp))
+            .clip(RoundedCornerShape(16.dp))
             .background(color = themeBackgroundColor()),
     ) {
         BoxWithConstraints {
@@ -89,8 +89,8 @@ fun DiscoverCard(
                 modifier = Modifier
                     .width(maxCardWidth)
                     .height(imageHeight)
-                    .padding(horizontal = 12.dp, vertical = 12.dp)
-                    .clip(RoundedCornerShape(16.dp)),
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
+                    .clip(RoundedCornerShape(8.dp)),
             )
         }
 

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -165,8 +165,8 @@ fun createAdaptiveBackground(): Color {
     return if (isSystemInDarkTheme()) {
         // Dark mode: blend theme color with darkened surface (towards black)
         blendColors(
-            foreground = themeColor.copy(alpha = 0.15f), // Reduced alpha for subtlety
-            background = surfaceColor.darken(0.45f)     // More darkening towards black
+            foreground = themeColor.copy(alpha = 0.1f), // Reduced alpha for subtlety
+            background = surfaceColor.darken(0.35f)     // More darkening towards black
         )
     } else {
         // Light mode: blend theme color with brightened surface (towards white)

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -2,7 +2,6 @@ package xyz.ksharma.krail.discover.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -15,16 +14,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_android_share
@@ -49,7 +44,6 @@ import xyz.ksharma.krail.discover.state.toButtonRowState
 import xyz.ksharma.krail.social.state.KrailSocialType
 import xyz.ksharma.krail.social.state.SocialType
 import xyz.ksharma.krail.social.ui.SocialConnectionRow
-import xyz.ksharma.krail.taj.backgroundColorOf
 import xyz.ksharma.krail.taj.brighten
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
@@ -59,7 +53,6 @@ import xyz.ksharma.krail.taj.components.rememberCardHeight
 import xyz.ksharma.krail.taj.darken
 import xyz.ksharma.krail.taj.isLargeFontScale
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
 import app.krail.taj.resources.Res as TajRes
 
@@ -173,7 +166,7 @@ fun createAdaptiveBackground(): Color {
         // Dark mode: blend theme color with darkened surface (towards black)
         blendColors(
             foreground = themeColor.copy(alpha = 0.15f), // Reduced alpha for subtlety
-            background = surfaceColor.darken(0.65f)     // More darkening towards black
+            background = surfaceColor.darken(0.45f)     // More darkening towards black
         )
     } else {
         // Light mode: blend theme color with brightened surface (towards white)
@@ -224,6 +217,7 @@ private fun DiscoverCardButtonRow(
             is DiscoverCardButtonRowState.LeftButtonType.Cta -> {
                 Button(
                     dimensions = ButtonDefaults.mediumButtonSize(),
+                    colors = ButtonDefaults.monochromeButtonColors(),
                     onClick = {
                         onCtaClicked(left.button.url)
                     },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -1,9 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.discover
 
-import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -14,10 +15,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
@@ -26,11 +25,11 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.discover.state.DiscoverCardType
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.darken
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
-import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
 
 @Composable
@@ -41,20 +40,13 @@ fun DiscoverChip(
     horizontalPadding: Dp = DiscoverChipDefaults.ChipHorizontalPadding,
     verticalPadding: Dp = DiscoverChipDefaults.ChipVerticalPadding,
 ) {
-    val selectedBackgroundColor = themeColor()
-    val unselectedBackgroundColor = themeBackgroundColor()
-
     val textColor = if (selected) {
-        getForegroundColor(backgroundColor = selectedBackgroundColor)
+        getForegroundColor(
+            backgroundColor = if (isSystemInDarkTheme()) themeColor().darken() else themeColor(),
+        )
     } else {
         KrailTheme.colors.label
     }
-
-    val selectedAlpha by animateFloatAsState(
-        targetValue = if (selected) 1f else 0f,
-        animationSpec = tween(durationMillis = 300, easing = LinearEasing),
-        label = "selected_alpha"
-    )
 
     // Bubble scale animation
     val scale by animateFloatAsState(
@@ -103,12 +95,15 @@ fun DiscoverChip(
                 scaleY = scale
             }
             .clip(RoundedCornerShape(50))
-            .background(color = Color.Transparent)
-            .drawBehind {
-                val blendedColor =
-                    lerp(unselectedBackgroundColor, selectedBackgroundColor, selectedAlpha)
-                drawRect(color = blendedColor)
-            },
+            .border(
+                width = 1.dp,
+                color = if (selected) Color.Transparent else themeColor(),
+                shape = RoundedCornerShape(50)
+            )
+            .background(
+                color = if (selected) if (isSystemInDarkTheme()) themeColor().darken() else themeColor() else KrailTheme.colors.discoverChipBackground,
+                shape = RoundedCornerShape(50)
+            ),
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -77,7 +77,7 @@ fun DiscoverChip(
 
     val textMeasurer = rememberTextMeasurer()
     val density = LocalDensity.current
-    val textStyle = KrailTheme.typography.labelSmall
+    val textStyle = KrailTheme.typography.bodyLarge
 
     val chipWidth = remember(type.displayName, textStyle, density, horizontalPadding) {
         val boldTextWidth = textMeasurer.measure(
@@ -113,7 +113,7 @@ fun DiscoverChip(
     ) {
         Text(
             text = type.displayName,
-            style = KrailTheme.typography.title.copy(
+            style = textStyle.copy(
                 fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
             ),
             maxLines = 1,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -135,8 +135,8 @@ fun DiscoverScreen(
                 .background(
                     brush = Brush.verticalGradient(
                         colors = listOf(
+                            KrailTheme.colors.surface.copy(alpha = 0.10f),
                             KrailTheme.colors.surface.copy(alpha = 0.95f),
-                            KrailTheme.colors.surface.copy(alpha = 0.85f),
                         ),
                         startY = 0f,
                         endY = Float.POSITIVE_INFINITY,

--- a/taj/build.gradle.kts
+++ b/taj/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)
                 implementation(compose.foundation)
-                implementation(compose.material3)
+                api(compose.material3)
                 implementation(compose.runtime)
                 implementation(compose.ui)
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
@@ -3,7 +3,7 @@ package xyz.ksharma.krail.taj
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
 
-const val LARGE_FONT_SCALE_THRESHOLD = 1.3f
+const val LARGE_FONT_SCALE_THRESHOLD = 1.7f
 
 @Composable
 fun isLargeFontScale(): Boolean {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -182,7 +182,7 @@ private fun Int.toHex(): String {
     return this.toString(16).padStart(2, '0').uppercase()
 }
 
-private fun Color.darken(factor: Float = 0.2f): Color {
+fun Color.darken(factor: Float = 0.2f): Color {
     val argb = this.toArgb()
     val darkArgb = darkenColor(argb, factor)
     return Color(darkArgb)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -273,7 +273,13 @@ object ButtonDefaults {
             mutableStateOf(hexContainerColor.hexToComposeColor())
         }
         val containerColor = customContainerColor ?: defaultContainerColor
-        val defaultContentColor: Color by remember { mutableStateOf(getForegroundColor(containerColor)) }
+        val defaultContentColor: Color by remember {
+            mutableStateOf(
+                getForegroundColor(
+                    containerColor
+                )
+            )
+        }
         val contentColor = customContentColor ?: defaultContentColor
 
         return ButtonColors(
@@ -281,6 +287,14 @@ object ButtonDefaults {
             contentColor = contentColor,
             disabledContainerColor = containerColor.copy(alpha = DisabledContentAlpha),
             disabledContentColor = contentColor.copy(alpha = DisabledContentAlpha),
+        )
+    }
+
+    @Composable
+    fun monochromeButtonColors(): ButtonColors {
+        return buttonColors(
+            customContainerColor = KrailTheme.colors.onSurface,
+            customContentColor = KrailTheme.colors.surface,
         )
     }
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -80,7 +80,7 @@ fun <T> DiscoverCardVerticalPager(
             val isCardSelected = pagerState.currentPage == page
             val pageOffset = pagerState.calculateCurrentOffsetForPage(page).absoluteValue
 
-            val scale = lerp(1f, 0.95f, pageOffset.coerceIn(0f, 1f))
+            val scale = lerp(1f, 0.90f, pageOffset.coerceIn(0f, 1f))
             val alpha = lerp(1f, 0.15f, pageOffset.coerceIn(0f, 1f))
 
             Box(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -14,13 +14,25 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import kotlin.math.absoluteValue
 
-val discoverCardHeight = 550.dp
+@Composable
+fun rememberCardHeight(): Dp {
+    val density = LocalDensity.current
+    if (density.fontScale <= 1.3f) {
+        return 500.dp
+    } else if (density.fontScale <= 1.7f) {
+        return 525.dp
+    } else {
+        return 550.dp
+    }
+}
 
 // todo - to be used only with a mobile , not for tablet.
 @Composable
@@ -35,6 +47,7 @@ fun <T> DiscoverCardVerticalPager(
         initialPage = initialPage,
         pageCount = { Int.MAX_VALUE }
     )
+    val discoverCardHeight = rememberCardHeight()
 
     BoxWithConstraints(
         modifier = modifier
@@ -95,19 +108,4 @@ fun lerp(start: Float, end: Float, fraction: Float): Float {
 
 fun PagerState.calculateCurrentOffsetForPage(page: Int): Float {
     return (currentPage - page) + currentPageOffsetFraction
-}
-
-@Preview
-@Composable
-private fun VerticalCardStackPreview() {
-    KrailTheme {
-/*
-        DiscoverCardVerticalPager(
-            items = discoverCardList,
-            content = { cardModel ->
-                DiscoverCard(discoverCardModel = cardModel)
-            }
-        )
-*/
-    }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -81,7 +81,7 @@ fun <T> DiscoverCardVerticalPager(
             val pageOffset = pagerState.calculateCurrentOffsetForPage(page).absoluteValue
 
             val scale = lerp(1f, 0.95f, pageOffset.coerceIn(0f, 1f))
-            val alpha = lerp(1f, 0.2f, pageOffset.coerceIn(0f, 1f))
+            val alpha = lerp(1f, 0.15f, pageOffset.coerceIn(0f, 1f))
 
             Box(
                 modifier = Modifier

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -77,7 +77,7 @@ fun <T> DiscoverCardVerticalPager(
                         scaleY = scale
                         this.alpha = alpha
                     }
-                    .zIndex(2f - pageOffset)
+                    .zIndex(1f - pageOffset)
                     .height(discoverCardHeight)
                     .width(maxCardWidth)
                     .align(Alignment.Center),

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
@@ -45,12 +45,18 @@ fun getForegroundColor(
     // Default to predefined light and dark theme colors
     val lightForegroundColor = md_theme_dark_onSurface
     val darkForegroundColor = md_theme_light_onSurface
+    val highContrastLightForegroundColor = Color(0xFF000000) // High contrast light color
+    val highContrastDarkForegroundColor = Color(0xFFFFFFFF) // High contrast dark color
 
     // Return the color with a sufficient contrast ratio
     return if (lightForegroundColor.contrastRatio(backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
         lightForegroundColor
-    } else {
+    } else if (darkForegroundColor.contrastRatio( backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
         darkForegroundColor
+    } else if(highContrastLightForegroundColor.contrastRatio( backgroundColor) >= DEFAULT_TEXT_SIZE_CONTRAST_AA) {
+       highContrastLightForegroundColor
+    } else {
+        highContrastDarkForegroundColor
     }
 }
 


### PR DESCRIPTION
# Enhanced Discover Card UI with Improved Accessibility

- Redesigned the `DiscoverCard` with a gradient background that adapts to light/dark themes
- Reduced corner radius from 24dp to 16dp for a more modern look
- Adjusted padding values throughout the card for better visual balance
- Implemented dynamic card height calculation based on font scale to better support accessibility
- Added `createAdaptiveBackground()` and `blendColors()` functions for theme-aware backgrounds
- Improved contrast ratios for text elements to ensure readability
- Added monochrome button style option with `monochromeButtonColors()`
- Refined the `DiscoverChip` component with better visual feedback for selected state
- Increased the large font scale threshold from 1.3f to 1.7f for better accessibility support
- Enhanced card animations with improved scaling and alpha transitions
- Exposed Material 3 as an API dependency rather than implementation