### PR TITLE
Add filtering functionality to Discover screen with card ID prefix standardization

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -108,7 +108,7 @@ object RemoteConfigDefaults {
                 second = """
                     [
                       {
-                        "cardId": "1",
+                        "cardId": "card_1",
                         "title": "CITY 2 SURF",
                         "description": "Join the iconic City 2 Surf event in Sydney! Experience the thrill of running from the city to Bondi Beach.",
                         "startDate": "2025-12-20",
@@ -126,7 +126,7 @@ object RemoteConfigDefaults {
                         ]
                       },
                       {
-                        "cardId": "2",
+                        "cardId": "card_2",
                         "title": "Park & Ride",
                         "description": "Your guide to Park & Ride facilities in NSW. Find the nearest facility and enjoy hassle-free travel.",
                         "disclaimer": "Image Credit: Unsplash",
@@ -137,7 +137,7 @@ object RemoteConfigDefaults {
                         "buttons": []
                       },
                       {
-                        "cardId": "3",
+                        "cardId": "card_3",
                         "title": "Follow KRAIL",
                         "description": "Stay updated with the latest from KRAIL.",
                         "imageList": [
@@ -151,7 +151,7 @@ object RemoteConfigDefaults {
                         ]
                       },
                       {
-                        "cardId": "4",
+                        "cardId": "card_4",
                         "title": "Opal Fare Changes 2025",
                         "description": "Opal fares are changing in 2025. Check out the latest updates and plan your travel accordingly.",
                         "imageList": [
@@ -172,8 +172,8 @@ object RemoteConfigDefaults {
                         ]
                       },
                       {
-                        "cardId": "5",
-                        "title": "Park & Ride",
+                        "cardId": "card_5",
+                        "title": "New Park & Ride",
                         "description": "Park & Ride is a convenient way to travel in NSW. Find out more about the facilities available.",
                         "imageList": [
                           "https://i.imgur.com/vMbFo2W.png"
@@ -187,7 +187,7 @@ object RemoteConfigDefaults {
                         ]
                       },
                       {
-                        "cardId": "6",
+                        "cardId": "card_6",
                         "title": "Cta + Share Card",
                         "description": "This is a sample description for the Discover Card. It can be used to display additional information.",
                         "imageList": [

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverEvent.kt
@@ -29,4 +29,6 @@ sealed interface DiscoverEvent {
     data class CardSeen(val cardId: String) : DiscoverEvent
 
     data object ResetAllSeenCards : DiscoverEvent
+
+    data class FilterChipClicked(val cardType: DiscoverCardType) : DiscoverEvent
 }

--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
@@ -8,7 +8,8 @@ import xyz.ksharma.krail.social.state.SocialType
 @Stable
 data class DiscoverState(
     val discoverCardsList: ImmutableList<DiscoverUiModel> = persistentListOf(),
-    val sortedDiscoverCardTypes: ImmutableList<DiscoverCardType> = persistentListOf()
+    val sortedDiscoverCardTypes: ImmutableList<DiscoverCardType> = persistentListOf(),
+    val selectedType: DiscoverCardType = DiscoverCardType.Unknown,
 ) {
 
     @Stable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverDestination.kt
@@ -59,6 +59,11 @@ internal fun NavGraphBuilder.discoverDestination(navController: NavHostControlle
             },
             resetAllSeenCards = {
                 viewModel.onEvent(event = DiscoverEvent.ResetAllSeenCards)
+            },
+            onChipSelected = { cardType ->
+                viewModel.onEvent(
+                    event = DiscoverEvent.FilterChipClicked(cardType = cardType)
+                )
             }
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -46,6 +46,7 @@ fun DiscoverScreen(
     onShareClick: (shareUrl: String, cardId: String, cardType: DiscoverCardType) -> Unit,
     onCardSeen: (cardId: String) -> Unit,
     resetAllSeenCards: () -> Unit,
+    onChipSelected: (DiscoverCardType) -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -144,14 +145,11 @@ fun DiscoverScreen(
                 )
                 .navigationBarsPadding(),
         ) {
-            var selectedType by remember { mutableStateOf(DiscoverCardType.Travel) }
             DiscoverChipRow(
                 chipTypes = state.sortedDiscoverCardTypes,
-                selectedType = selectedType,
+                selectedType = state.selectedType,
                 modifier = Modifier.padding(vertical = 20.dp),
-                onChipSelected = { type ->
-                    selectedType = type
-                },
+                onChipSelected = onChipSelected,
             )
         }
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -42,7 +42,12 @@ fun <T> DiscoverCardVerticalPager(
     keySelector: (T) -> String,
     content: @Composable (T, isCardSelected: Boolean) -> Unit,
 ) {
-    val initialPage = Int.MAX_VALUE / 2
+    if (pages.isEmpty()) return
+
+    // Calculate initial page to ensure first card (index 0) is shown
+    val baseInitialPage = Int.MAX_VALUE / 2
+    val initialPage = baseInitialPage - (baseInitialPage % pages.size)
+
     val pagerState = rememberPagerState(
         initialPage = initialPage,
         pageCount = { Int.MAX_VALUE }
@@ -53,22 +58,14 @@ fun <T> DiscoverCardVerticalPager(
         modifier = modifier
             .fillMaxSize()
     ) {
-        val maxCardWidth = maxWidth - 48.dp // 24.dp padding on each side
-
-        // Calculate padding to center the selected item
+        val maxCardWidth = maxWidth - 24.dp
         val screenHeight = maxHeight
         val topPadding = ((screenHeight - discoverCardHeight) / 2).coerceAtLeast(0.dp)
-
-        if (pages.isEmpty()) {
-            return@BoxWithConstraints
-        }
 
         VerticalPager(
             state = pagerState,
             pageSpacing = 20.dp,
-            pageSize = PageSize.Fixed(
-                pageSize = discoverCardHeight,
-            ),
+            pageSize = PageSize.Fixed(pageSize = discoverCardHeight),
             key = { page ->
                 val actualPage = page % pages.size
                 keySelector(pages[actualPage])


### PR DESCRIPTION
# Implement Card Filtering by Type in Discover Screen

This PR adds the ability to filter discover cards by type. Key changes include:

- Updated card IDs in RemoteConfigDefaults to use a consistent format with "card_" prefix
- Added a new FilterChipClicked event to handle chip selection in the Discover screen
- Modified DiscoverState to track the currently selected card type
- Refactored DiscoverViewModel to use a combine flow for filtering cards based on selected type
- Fixed the DiscoverCardVerticalPager to properly handle empty lists and page bounds
- Improved pager behavior to reset to first page when the list changes

The implementation now properly filters cards in the ViewModel rather than in the UI layer, ensuring consistent state management.