### PR TITLE
Enhance DiscoverCard UI with improved typography, padding, and dark mode contrast

### DIFF
--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_android_share
@@ -96,7 +97,6 @@ fun DiscoverCard(
 
             AsyncImage(
                 model = ImageRequest.Builder(context)
-                    .crossfade(true)
                     .data(discoverModel.imageList.firstOrNull())
                     .diskCachePolicy(CachePolicy.ENABLED)
                     .memoryCachePolicy(CachePolicy.DISABLED)
@@ -104,10 +104,11 @@ fun DiscoverCard(
                     .build(),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
+                placeholder = ColorPainter(blendedBackground),
                 modifier = Modifier
                     .width(maxCardWidth)
                     .height(imageHeight)
-                    //.padding(horizontal = 8.dp, vertical = 8.dp)
+                    .padding(horizontal = 8.dp, vertical = 8.dp)
                     .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp)),
             )
         }
@@ -116,14 +117,14 @@ fun DiscoverCard(
             text = discoverModel.title,
             modifier = Modifier.padding(horizontal = 12.dp).padding(top = 12.dp),
             maxLines = 2,
-            style = KrailTheme.typography.headlineSmall,
+            style = KrailTheme.typography.displayMedium,
         )
 
         Text(
             text = discoverModel.description,
             modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             maxLines = if (isLargeFontScale() && discoverModel.disclaimer != null || !discoverModel.buttons.isNullOrEmpty()) 2 else 3,
-            style = KrailTheme.typography.bodyMedium,
+            style = KrailTheme.typography.bodyLarge,
             color = KrailTheme.colors.secondaryLabel,
         )
 
@@ -166,7 +167,7 @@ fun createAdaptiveBackground(): Color {
         // Dark mode: blend theme color with darkened surface (towards black)
         blendColors(
             foreground = themeColor.copy(alpha = 0.1f), // Reduced alpha for subtlety
-            background = surfaceColor.darken(0.35f)     // More darkening towards black
+            background = surfaceColor.darken(0.25f)     // More darkening towards black
         )
     } else {
         // Light mode: blend theme color with brightened surface (towards white)

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -167,7 +167,7 @@ fun createAdaptiveBackground(): Color {
         // Dark mode: blend theme color with darkened surface (towards black)
         blendColors(
             foreground = themeColor.copy(alpha = 0.1f), // Reduced alpha for subtlety
-            background = surfaceColor.darken(0.25f)     // More darkening towards black
+            background = surfaceColor.darken(0.15f)     // More darkening towards black
         )
     } else {
         // Light mode: blend theme color with brightened surface (towards white)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.taj.components
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
@@ -83,7 +84,13 @@ fun <T> DiscoverCardVerticalPager(
                 val pageOffset = pagerState.calculateCurrentOffsetForPage(page).absoluteValue
 
                 val scale = lerp(1f, 0.90f, pageOffset.coerceIn(0f, 1f))
-                val alpha = lerp(1f, 0.15f, pageOffset.coerceIn(0f, 1f))
+
+                // if light mode then 0.1f for dark mode 0.25f
+                val alpha = if (isSystemInDarkTheme()) {
+                    lerp(1f, 0.25f, pageOffset.coerceIn(0f, 1f))
+                } else {
+                    lerp(1f, 0.1f, pageOffset.coerceIn(0f, 1f))
+                }
 
                 Box(
                     modifier = Modifier

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/BadgeTokens.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/BadgeTokens.kt
@@ -6,7 +6,7 @@ internal object BadgeTokens {
     /**
      * The size of the badge.
      */
-    val BadgeSize = 16.dp
+    val BadgeSize = 12.dp
 
     /**
      * The offset of the badge from the top right corner.


### PR DESCRIPTION
# UI Enhancements for Discover Card and Badge Components

- Enhanced `DiscoverCard` with improved typography using `displayMedium` for title and `bodyLarge` for description
- Added padding around images (8dp horizontal and vertical)
- Replaced crossfade animation with a `ColorPainter` placeholder for smoother loading
- Adjusted background darkening in dark mode (0.35f → 0.15f)
- Improved alpha values in `DiscoverCardVerticalPager` with different values for light mode (0.1f) and dark mode (0.25f)
- Reduced badge size from 16dp to 12dp in `BadgeTokens`