### PR TITLE
Add border to DiscoverCard and update Park & Ride image

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -107,6 +107,31 @@ object RemoteConfigDefaults {
                 first = FlagKeys.DISCOVER_SYDNEY.key,
                 second = """
                     [
+                     {
+                        "cardId": "card_ap_bakery_1",
+                        "title": "Secret Bakery Everyone’s Talking About",
+                        "description": "AP Quay by All Purpose Bakery is making waves with flaky croissants, snacks, and wine from 5pm in Circular Quay.",
+                        "imageList": [
+                          "https://i.imgur.com/EuUxtgY.png"
+                        ],
+                        "type": "Food",
+                        "buttons": [
+                          {
+                            "buttonType": "PartnerSocial",
+                            "socialPartnerName": "AP Bakery",
+                            "links": [
+                              {
+                                "type": "Instagram",
+                                "url": "https://www.instagram.com/a.p.bread/"
+                              }
+                            ]
+                          },
+                          {
+                            "buttonType": "Share",
+                            "shareUrl": "Check out AP Quay by All Purpose Bakery (https://www.instagram.com/a.p.bread/) — flaky croissants, bread snacks, and great wine in Circular Quay! Found it on the KRAIL app — your guide to the best food, travel, and events in Sydney. #KRAILApp https://krail.app"
+                          }
+                        ]
+                      },
                       {
                         "cardId": "card_1",
                         "title": "CITY 2 SURF",

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -131,7 +131,7 @@ object RemoteConfigDefaults {
                         "description": "Your guide to Park & Ride facilities in NSW. Find the nearest facility and enjoy hassle-free travel.",
                         "disclaimer": "Image Credit: Unsplash",
                         "imageList": [
-                          "https://i.imgur.com/LvuEwiP.png"
+                          "https://i.imgur.com/JMtCVR6.png"
                         ],
                         "type": "Events",
                         "buttons": []

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.discover.ui
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -53,6 +54,7 @@ import xyz.ksharma.krail.taj.components.rememberCardHeight
 import xyz.ksharma.krail.taj.darken
 import xyz.ksharma.krail.taj.isLargeFontScale
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
 import app.krail.taj.resources.Res as TajRes
 
@@ -86,6 +88,11 @@ fun DiscoverCard(
                     )
                 ),
                 shape = RoundedCornerShape(16.dp)
+            )
+            .border(
+                width = 1.dp,
+                color = themeBackgroundColor(),
+                shape = RoundedCornerShape(16.dp),
             )
             .clip(RoundedCornerShape(16.dp)),
     ) {

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,6 +37,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.jetbrains.compose.ui.tooling.preview.PreviewParameterProvider
 import xyz.ksharma.krail.core.appinfo.DevicePlatformType
 import xyz.ksharma.krail.core.appinfo.getAppPlatformType
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.discover.state.Button
 import xyz.ksharma.krail.discover.state.DiscoverCardButtonRowState
@@ -52,7 +54,7 @@ import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.rememberCardHeight
 import xyz.ksharma.krail.taj.darken
-import xyz.ksharma.krail.taj.isLargeFontScale
+import xyz.ksharma.krail.taj.getImageHeightRatio
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
@@ -98,7 +100,7 @@ fun DiscoverCard(
     ) {
         BoxWithConstraints {
             val maxCardWidth = maxWidth
-            val imageHeight = discoverCardHeight * if (isLargeFontScale()) 0.5f else 0.6f
+            val imageHeight = discoverCardHeight * getImageHeightRatio()
             val context = LocalPlatformContext.current
 
             AsyncImage(
@@ -123,14 +125,14 @@ fun DiscoverCard(
             text = discoverModel.title,
             modifier = Modifier.padding(horizontal = 12.dp).padding(top = 12.dp),
             maxLines = 2,
-            style = KrailTheme.typography.displayMedium,
+            style = KrailTheme.typography.titleLarge,
         )
 
         Text(
             text = discoverModel.description,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-            maxLines = if (isLargeFontScale() && discoverModel.disclaimer != null || !discoverModel.buttons.isNullOrEmpty()) 2 else 3,
-            style = KrailTheme.typography.bodyLarge,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+            maxLines = if (discoverModel.disclaimer != null) 2 else 3,
+            style = KrailTheme.typography.bodySmall,
             color = KrailTheme.colors.secondaryLabel,
         )
 
@@ -158,7 +160,7 @@ fun DiscoverCard(
                     onCtaClicked(url, discoverModel.cardId, discoverModel.type)
                 },
                 onShareClick = onShareClick,
-                modifier = Modifier.padding(horizontal = 12.dp, vertical = 20.dp)
+                modifier = Modifier.padding(horizontal = 12.dp).padding(bottom = 12.dp)
             )
         }
     }
@@ -213,11 +215,14 @@ private fun DiscoverCardButtonRow(
                     "${buttonsList.map { it::class.simpleName }}"
         )
         return
+    } else {
+        log("Buttons state: left=${state.left}, right=${state.right}")
     }
 
     Row(
         modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         // Left button (always left-aligned)
         when (val left = state.left) {
@@ -264,6 +269,8 @@ private fun DiscoverCardButtonRow(
         // Right button (always right-aligned)
         when (val rightButton = state.right) {
             is DiscoverCardButtonRowState.RightButtonType.Share -> {
+                log("Right button is Share: ${rightButton.button.shareUrl}")
+
                 RoundIconButton(
                     onClick = { onShareClick(rightButton.button.shareUrl) },
                     color = Color.Transparent,
@@ -274,14 +281,16 @@ private fun DiscoverCardButtonRow(
                         } else {
                             painterResource(TajRes.drawable.ic_android_share)
                         },
-                        contentDescription = "Invite Friends",
+                        contentDescription = "Share",
                         colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
                         modifier = Modifier.size(24.dp),
                     )
                 }
             }
 
-            null -> Unit
+            null -> {
+                log("No right button to display")
+            }
         }
     }
 }

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
@@ -3,7 +3,6 @@ package xyz.ksharma.krail.social.ui
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -24,7 +23,7 @@ fun SocialConnectionRow(
     onClick: (KrailSocialType) -> Unit,
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         socialLinks.forEach { socialType ->
@@ -51,7 +50,7 @@ fun SocialConnectionRow(
     onClick: (PartnerSocialLink) -> Unit,
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         partnerSocialLinks.forEach { socialType ->

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/A11yExt.kt
@@ -3,11 +3,16 @@ package xyz.ksharma.krail.taj
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
 
-const val LARGE_FONT_SCALE_THRESHOLD = 1.7f
+const val XL_FONT_SCALE_THRESHOLD = 1.7f
+const val L_FONT_SCALE_THRESHOLD = 1.3f
 
 @Composable
-fun isLargeFontScale(): Boolean {
+fun getImageHeightRatio(): Float {
     val density = LocalDensity.current
     val fontScale = density.fontScale
-    return fontScale >= LARGE_FONT_SCALE_THRESHOLD
+    return when {
+        fontScale >= XL_FONT_SCALE_THRESHOLD -> 0.45f // Extra large fonts need more text space
+        fontScale >= L_FONT_SCALE_THRESHOLD -> 0.5f  // Large fonts need some text space
+        else -> 0.6f // Normal fonts can use standard image size
+    }
 }


### PR DESCRIPTION
### TL;DR

Updated the Park & Ride image in remote config and added a border to DiscoverCard component.

### What changed?

- Changed the Park & Ride image URL in RemoteConfigDefaults from `https://i.imgur.com/LvuEwiP.png` to `https://i.imgur.com/JMtCVR6.png`
- Added a 1dp border to the DiscoverCard component that uses the theme background color with rounded corners (16dp)

### How to test?

1. Check that the Park & Ride card in the Discover section displays the new image
2. Verify that all DiscoverCards now have a visible border that matches the theme background color
3. Test in both light and dark themes to ensure the border is visible and properly styled

### Why make this change?

The border addition improves the visual distinction of cards against different backgrounds, enhancing the UI's clarity. The image update likely provides a better or more current representation of the Park & Ride facilities.