### PR TITLE
Add lenient JSON parsing to DiscoverSydneyManager

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -106,7 +106,7 @@ object RemoteConfigDefaults {
             Pair(
                 first = FlagKeys.DISCOVER_SYDNEY.key,
                 second = """
-                   []
+                    []
                 """.trimIndent(),
             ),
             Pair(

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -26,6 +26,11 @@ internal class RealDiscoverSydneyManager(
     private var cachedFlagValue: FlagValue? = null
     private var cachedParsedCards: List<DiscoverModel>? = null
 
+    private val json = Json {
+        ignoreUnknownKeys = true // Ignore unknown keys in JSON
+        isLenient = true // Allow lenient parsing
+    }
+
     /**
      * Fetches Discover cards for the UI.
      * - Caches the parsed JSON card list to avoid repeated parsing.
@@ -69,8 +74,8 @@ internal class RealDiscoverSydneyManager(
         return withContext(defaultDispatcher) {
             when (flagValue) {
                 is FlagValue.JsonValue -> {
-                    val jsonArray = Json.parseToJsonElement(flagValue.value).jsonArray
-                    jsonArray.map { Json.decodeFromJsonElement<DiscoverModel>(it) }
+                    val jsonArray = json.parseToJsonElement(flagValue.value).jsonArray
+                    jsonArray.map { json.decodeFromJsonElement<DiscoverModel>(it) }
                 }
 
                 else -> {
@@ -80,8 +85,8 @@ internal class RealDiscoverSydneyManager(
                     if (defaultJson == null) {
                         emptyList()
                     } else {
-                        val jsonArray = Json.parseToJsonElement(defaultJson).jsonArray
-                        jsonArray.map { Json.decodeFromJsonElement<DiscoverModel>(it) }
+                        val jsonArray = json.parseToJsonElement(defaultJson).jsonArray
+                        jsonArray.map { json.decodeFromJsonElement<DiscoverModel>(it) }
                     }
                 }
             }


### PR DESCRIPTION
### TL;DR

Added lenient JSON parsing for Discover Sydney cards to improve error handling.

### What changed?

- Created a custom JSON parser configuration in `RealDiscoverSydneyManager` that ignores unknown keys and allows lenient parsing
- Updated all JSON parsing operations to use this custom configuration instead of the default `Json` parser
- Fixed indentation in the `RemoteConfigDefaults.kt` file for the Discover Sydney flag key

### How to test?

1. Verify that Discover Sydney cards load correctly with the new JSON parser
2. Test with malformed JSON data to ensure the lenient parsing handles it gracefully
3. Confirm that JSON with unknown keys doesn't cause parsing failures

### Why make this change?

The previous implementation used the default JSON parser which would fail when encountering unknown keys or malformed JSON. This change makes the parsing more robust by ignoring unknown keys and allowing lenient parsing, which helps prevent crashes when the remote configuration contains unexpected data formats or when the API response structure changes slightly.