### PR TITLE
Fix SavedTripsViewModel discover state logic and bump version codes

### DIFF
--- a/discover/network/api/build.gradle.kts
+++ b/discover/network/api/build.gradle.kts
@@ -43,9 +43,6 @@ kotlin {
                 implementation(libs.test.kotlinxCoroutineTest)
             }
         }
-        all {
-            languageSettings.enableLanguageFeature("PropertyParamAnnotationDefaultTargetMode")
-        }
     }
 }
 

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -15,7 +15,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
 
             androidAppExtension().apply {
                 defaultConfig {
-                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 113
+                    versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 114
                     versionName = "1.7.5"
                 }
             }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.5</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Fixed discover badge display logic and improved logging in SavedTripsViewModel. Incremented version numbers for release.

### What changed?

- Fixed the discover badge display logic in `SavedTripsViewModel` to only show when trips are available
- Added a small delay in `updateDiscoverState()` to ensure saved trips are initialized before checking discover availability
- Improved logging in `SavedTripsViewModel` with more descriptive prefixes
- Incremented Android version code from 113 to 114
- Incremented iOS build number from 8 to 9

## Removed warning 

Following warning was being displayed when running UT, removed the property from build.gradle.

```
Task :discover:network:api:compileReleaseKotlinAndroid
w: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+PropertyParamAnnotationDefaultTargetMode

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!
```

The discover badge was showing incorrectly in some cases due to timing issues with saved trips initialization. This change ensures the badge only appears when appropriate and improves the reliability of the discover feature's availability state. The version number updates prepare for the next release.
