### PR TITLE
Update Android compile and target SDK to 36

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
@@ -41,7 +41,7 @@ fun Project.configureAndroid() {
 
 object AndroidVersion {
     // https://developer.android.com/build/releases/gradle-plugin#api-level-support
-    const val COMPILE_SDK = 35
+    const val COMPILE_SDK = 36
     const val MIN_SDK = 26 // Oreo 8.0
-    const val TARGET_SDK = 35
+    const val TARGET_SDK = 36
 }


### PR DESCRIPTION
### TL;DR

Update Android SDK versions from 35 to 36

`androidx.core:core-ktx:1.17.0` requires 36

### What changed?

- Updated `COMPILE_SDK` from 35 to 36
- Updated `TARGET_SDK` from 35 to 36
- Kept `MIN_SDK` at 26 (Oreo 8.0)

### How to test?

1. Build the project to ensure it compiles successfully with the new SDK versions
2. Run the app on a device or emulator to verify functionality
3. Check that the app targets Android 14 (API 36) correctly

### Why make this change?

Keeping up with the latest Android SDK versions ensures the app can leverage new platform features and optimizations. This update prepares the codebase for compatibility with the newest Android release while maintaining backward compatibility with Android 8.0 and above.