### PR TITLE
UI: Add shadow effects to DiscoverCardVerticalPager cards

### DIFF
--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -81,6 +82,15 @@ fun DiscoverCard(
     Column(
         modifier = modifier
             .height(discoverCardHeight)
+            .dropShadow(
+                RoundedCornerShape(16.dp),
+                dropShadow = DropShadow(
+                    radius = 16.dp,
+                    color = Color.Black,
+                    spread = 8.dp,
+                    alpha = 0.18f
+                )
+            )
             .background(
                 brush = Brush.verticalGradient(
                     colors = listOf(

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -19,11 +19,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.draw.innerShadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_android_share
@@ -82,15 +83,6 @@ fun DiscoverCard(
     Column(
         modifier = modifier
             .height(discoverCardHeight)
-            .dropShadow(
-                RoundedCornerShape(16.dp),
-                dropShadow = DropShadow(
-                    radius = 16.dp,
-                    color = Color.Black,
-                    spread = 8.dp,
-                    alpha = 0.18f
-                )
-            )
             .background(
                 brush = Brush.verticalGradient(
                     colors = listOf(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.taj.components
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -14,6 +16,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.dropShadow
@@ -23,10 +26,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.themeColor
 import kotlin.math.absoluteValue
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.runtime.getValue
 
 @Composable
 fun rememberCardHeight(): Dp {
@@ -95,19 +97,27 @@ fun <T> DiscoverCardVerticalPager(
                     lerp(1f, 0.1f, pageOffset.coerceIn(0f, 1f))
                 }
 
-                val shadowAlpha = lerp(0.25f, 0f, pageOffset.coerceIn(0f, 1f))
+                // region Shadow for card
+                val maxShadowAlpha = 0.25f
+                val targetShadowAlpha = if (isCardSelected) {
+                    lerp(maxShadowAlpha, 0f, pageOffset.coerceIn(0f, 1f))
+                } else {
+                    0f
+                }
+                val animatedShadowAlpha by animateFloatAsState(targetValue = targetShadowAlpha)
+                // endregion Shadow for card
 
                 Box(
                     modifier = Modifier
                         .height(discoverCardHeight)
                         .width(maxCardWidth)
                         .dropShadow(
-                            shape = RoundedCornerShape((16.dp * scale).coerceIn(1.dp, 16.dp)),
+                            shape = RoundedCornerShape((8.dp * scale).coerceIn(1.dp, 8.dp)),
                             shadow = Shadow(
                                 radius = (8.dp * scale).coerceIn(1.dp, 8.dp),
                                 color = themeColor(),
                                 spread = (4.dp * scale).coerceIn(1.dp, 4.dp),
-                                alpha = shadowAlpha,
+                                alpha = animatedShadowAlpha,
                             )
                         )
                         .graphicsLayer {
@@ -115,6 +125,7 @@ fun <T> DiscoverCardVerticalPager(
                             scaleY = scale
                             this.alpha = alpha
                         }
+                        .background(color = KrailTheme.colors.surface, shape = RoundedCornerShape(16.dp))
                         .zIndex(1f - pageOffset)
                         .align(Alignment.Center),
                     contentAlignment = Alignment.Center,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -95,8 +95,7 @@ fun <T> DiscoverCardVerticalPager(
                     lerp(1f, 0.1f, pageOffset.coerceIn(0f, 1f))
                 }
 
-                val shadowTargetAlpha = if (isCardSelected) 0.35f else 0f
-                val shadowAnimatedAlpha by animateFloatAsState(targetValue = shadowTargetAlpha)
+                val shadowAlpha = lerp(0.35f, 0f, pageOffset.coerceIn(0f, 1f))
 
                 Box(
                     modifier = Modifier
@@ -108,7 +107,7 @@ fun <T> DiscoverCardVerticalPager(
                                 radius = 8.dp,
                                 color = themeColor(),
                                 spread = 4.dp,
-                                alpha = shadowAnimatedAlpha
+                                alpha = shadowAlpha,
                             )
                         )
                         .graphicsLayer {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -11,19 +11,22 @@ import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import org.jetbrains.compose.ui.tooling.preview.Preview
-import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.themeColor
 import kotlin.math.absoluteValue
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.runtime.getValue
 
 @Composable
 fun rememberCardHeight(): Dp {
@@ -92,16 +95,28 @@ fun <T> DiscoverCardVerticalPager(
                     lerp(1f, 0.1f, pageOffset.coerceIn(0f, 1f))
                 }
 
+                val shadowTargetAlpha = if (isCardSelected) 0.35f else 0f
+                val shadowAnimatedAlpha by animateFloatAsState(targetValue = shadowTargetAlpha)
+
                 Box(
                     modifier = Modifier
+                        .height(discoverCardHeight)
+                        .width(maxCardWidth)
+                        .dropShadow(
+                            shape = RoundedCornerShape(16.dp),
+                            shadow = Shadow(
+                                radius = 8.dp,
+                                color = themeColor(),
+                                spread = 4.dp,
+                                alpha = shadowAnimatedAlpha
+                            )
+                        )
                         .graphicsLayer {
                             scaleX = scale
                             scaleY = scale
                             this.alpha = alpha
                         }
                         .zIndex(1f - pageOffset)
-                        .height(discoverCardHeight)
-                        .width(maxCardWidth)
                         .align(Alignment.Center),
                     contentAlignment = Alignment.Center,
                 ) {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -95,18 +95,18 @@ fun <T> DiscoverCardVerticalPager(
                     lerp(1f, 0.1f, pageOffset.coerceIn(0f, 1f))
                 }
 
-                val shadowAlpha = lerp(0.35f, 0f, pageOffset.coerceIn(0f, 1f))
+                val shadowAlpha = lerp(0.25f, 0f, pageOffset.coerceIn(0f, 1f))
 
                 Box(
                     modifier = Modifier
                         .height(discoverCardHeight)
                         .width(maxCardWidth)
                         .dropShadow(
-                            shape = RoundedCornerShape(16.dp),
+                            shape = RoundedCornerShape((16.dp * scale).coerceIn(1.dp, 16.dp)),
                             shadow = Shadow(
-                                radius = 8.dp,
+                                radius = (8.dp * scale).coerceIn(1.dp, 8.dp),
                                 color = themeColor(),
-                                spread = 4.dp,
+                                spread = (4.dp * scale).coerceIn(1.dp, 4.dp),
                                 alpha = shadowAlpha,
                             )
                         )


### PR DESCRIPTION
# Enhanced Discover Card with Dynamic Shadows

- Added drop shadow effect to discover cards in the vertical pager
- Implemented dynamic shadow animation based on card selection state
- Shadow alpha animates smoothly between selected and non-selected states
- Added constraints to shadow and shape sizes that scale proportionally with card size
- Applied surface color background to cards with rounded corners
- Shadow color matches theme color for consistent visual design

The shadow effect enhances visual hierarchy by giving selected cards more prominence while maintaining a clean interface when cards are not in focus.

## Screenshots

| Old (Border) | New (Shadows) |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/e500334c-c9b1-4bcc-8380-f18336591e4f"></video> | <video src="https://github.com/user-attachments/assets/2437f1e0-9918-47d6-ae41-ef4b1f181404"></video> |