### PR TITLE
Add HTTP timeout configuration and SLF4J Android logging dependency

### DIFF
--- a/core/log/build.gradle.kts
+++ b/core/log/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
         androidMain {
             dependencies {
                 api(libs.di.koinAndroid)
+                implementation(libs.log.slf4j.android)
             }
         }
 

--- a/core/network/src/androidMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/androidMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.core.network
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -43,6 +44,11 @@ actual fun baseHttpClient(
                     level = LogLevel.NONE
                 }
             }
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = DEFAULT_TIMEOUTS.requestTimeoutMillis
+            connectTimeoutMillis = DEFAULT_TIMEOUTS.connectTimeoutMillis
+            socketTimeoutMillis = DEFAULT_TIMEOUTS.socketTimeoutMillis
         }
     }
 }

--- a/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/HttpTimeouts.kt
+++ b/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/HttpTimeouts.kt
@@ -1,0 +1,14 @@
+package xyz.ksharma.krail.core.network
+
+import io.ktor.client.plugins.HttpTimeoutConfig
+import kotlin.time.Duration.Companion.seconds
+
+val REQUEST_TIMEOUT = 30.seconds.inWholeMilliseconds
+val CONNECT_TIMEOUT = 15.seconds.inWholeMilliseconds
+val SOCKET_TIMEOUT = 30.seconds.inWholeMilliseconds
+
+val DEFAULT_TIMEOUTS = HttpTimeoutConfig(
+    requestTimeoutMillis = REQUEST_TIMEOUT,
+    connectTimeoutMillis = CONNECT_TIMEOUT,
+    socketTimeoutMillis = SOCKET_TIMEOUT
+)

--- a/core/network/src/iosMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/iosMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.core.network
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -43,6 +44,11 @@ actual fun baseHttpClient(
                     level = LogLevel.NONE
                 }
             }
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = DEFAULT_TIMEOUTS.requestTimeoutMillis
+            connectTimeoutMillis = DEFAULT_TIMEOUTS.connectTimeoutMillis
+            socketTimeoutMillis = DEFAULT_TIMEOUTS.socketTimeoutMillis
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ androidx-lifecycle = "2.9.2"
 kotlinxCoroutines = "1.10.2"
 buildkonfigGradlePlugin = "0.17.1"
 kermit = "2.0.6"
+slf4jAndroid = "1.7.36"
 sqlDelight = "2.1.0"
 koin = "4.1.0"
 firebaseGitLive = "2.2.0"
@@ -49,6 +50,7 @@ material-adaptive = { module = "org.jetbrains.compose.material3.adaptive:adaptiv
 navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 
+# Logging
 log-kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 
 lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
@@ -68,6 +70,7 @@ ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "kto
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
+log-slf4j-android = { module = "org.slf4j:slf4j-android", version.ref = "slf4jAndroid" }
 
 #Test
 test-composeUiTestManifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
### TL;DR

Added HTTP timeout configuration to network clients and SLF4J Android logging dependency.

### What changed?

- Created a new `HttpTimeouts.kt` file with default timeout configurations:
  - Request timeout: 30 seconds
  - Connect timeout: 15 seconds
  - Socket timeout: 30 seconds
- Added `HttpTimeout` plugin to both Android and iOS HTTP clients
- Added SLF4J Android logging dependency to the core log module

### How to test?

- Verify that network requests properly timeout after the specified durations
- Test network requests under poor connectivity conditions to ensure timeouts work as expected
- Check that logging works correctly on Android devices

### Why make this change?

Adding explicit timeout configurations helps prevent network requests from hanging indefinitely, improving app reliability and user experience during poor network conditions. The SLF4J Android logging dependency enhances logging capabilities on Android devices, providing better diagnostic information.