### PR TITLE
Make AppInfoProvider synchronous by removing suspend modifier

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -56,7 +56,7 @@ class SplashViewModel(
         }
     }
 
-    private suspend fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {
+    private fun trackAppStartEvent() = with(appInfoProvider.getAppInfo()) {
         log("AppInfo: $this, krailTheme: ${_uiState.value.themeStyle.id}")
         analytics.track(
             AnalyticsEvent.AppStart(

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -71,18 +71,15 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
 
     override fun toString() =
         "AndroidAppInfo(type=$devicePlatformType, isDebug=$isDebug, appVersion=$appVersion, osVersion=$osVersion, " +
-            "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
-            "deviceManufacturer=$deviceManufacturer, locale=$locale, batteryLevel=$batteryLevel, " +
-            "timeZone=$timeZone)"
+                "fontSize=$fontSize, isDarkTheme=$isDarkTheme, deviceModel=$deviceModel, " +
+                "deviceManufacturer=$deviceManufacturer, locale=$locale, batteryLevel=$batteryLevel, " +
+                "timeZone=$timeZone)"
 }
 
 class AndroidAppInfoProvider(
     private val context: Context,
-    private val defaultDispatcher: CoroutineDispatcher,
 ) : AppInfoProvider {
-    override suspend fun getAppInfo(): AppInfo = withContext(defaultDispatcher) {
-        AndroidAppInfo(context)
-    }
+    override fun getAppInfo(): AppInfo = AndroidAppInfo(context)
 }
 
 actual fun getAppPlatformType() = DevicePlatformType.ANDROID

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/di/AppInfoModule.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/di/AppInfoModule.android.kt
@@ -4,13 +4,11 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appinfo.AndroidAppInfoProvider
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
-import xyz.ksharma.krail.core.di.DispatchersComponent
 
 actual val appInfoModule = module {
     single<AppInfoProvider> {
         AndroidAppInfoProvider(
             context = androidContext(),
-            defaultDispatcher = DispatchersComponent().defaultDispatcher,
         )
     }
 }

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -83,5 +83,5 @@ enum class DevicePlatformType {
 }
 
 interface AppInfoProvider {
-    suspend fun getAppInfo(): AppInfo
+    fun getAppInfo(): AppInfo
 }

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -77,7 +77,7 @@ class IOSAppInfo : AppInfo {
 }
 
 class IosAppInfoProvider : AppInfoProvider {
-    override suspend fun getAppInfo(): AppInfo {
+    override fun getAppInfo(): AppInfo {
         return IOSAppInfo()
     }
 }

--- a/core/network/src/androidMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/androidMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -9,15 +9,12 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.log.log as krailLog
 
 actual fun baseHttpClient(
     appInfoProvider: AppInfoProvider,
-    coroutineScope: CoroutineScope,
 ): HttpClient {
     return HttpClient(OkHttp) {
         expectSuccess = true
@@ -31,18 +28,16 @@ actual fun baseHttpClient(
             )
         }
         install(Logging) {
-            coroutineScope.launch {
-                if (appInfoProvider.getAppInfo().isDebug) {
-                    level = LogLevel.BODY
-                    logger = object : Logger {
-                        override fun log(message: String) {
-                            krailLog(message)
-                        }
+            if (appInfoProvider.getAppInfo().isDebug) {
+                level = LogLevel.BODY
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        krailLog(message)
                     }
-                    sanitizeHeader { header -> header == HttpHeaders.Authorization }
-                } else {
-                    level = LogLevel.NONE
                 }
+                sanitizeHeader { header -> header == HttpHeaders.Authorization }
+            } else {
+                level = LogLevel.NONE
             }
         }
         install(HttpTimeout) {

--- a/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -6,5 +6,4 @@ import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 
 expect fun baseHttpClient(
     appInfoProvider: AppInfoProvider,
-    coroutineScope: CoroutineScope,
 ): HttpClient

--- a/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/xyz/ksharma/krail/core/network/NetworkModule.kt
@@ -1,16 +1,12 @@
 package xyz.ksharma.krail.core.network
 
 import io.ktor.client.HttpClient
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import org.koin.dsl.module
 
 val coreNetworkModule = module {
     single<HttpClient> {
         baseHttpClient(
             appInfoProvider = get(),
-            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         )
     }
 }

--- a/core/network/src/iosMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/iosMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -9,15 +9,12 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.log.log as krailLog
 
 actual fun baseHttpClient(
     appInfoProvider: AppInfoProvider,
-    coroutineScope: CoroutineScope,
 ): HttpClient {
     return HttpClient(Darwin) {
         expectSuccess = true
@@ -31,18 +28,16 @@ actual fun baseHttpClient(
             )
         }
         install(Logging) {
-            coroutineScope.launch {
-                if (appInfoProvider.getAppInfo().isDebug) {
-                    level = LogLevel.BODY
-                    logger = object : Logger {
-                        override fun log(message: String) {
-                            krailLog(message)
-                        }
+            if (appInfoProvider.getAppInfo().isDebug) {
+                level = LogLevel.BODY
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        krailLog(message)
                     }
-                    sanitizeHeader { header -> header == HttpHeaders.Authorization }
-                } else {
-                    level = LogLevel.NONE
                 }
+                sanitizeHeader { header -> header == HttpHeaders.Authorization }
+            } else {
+                level = LogLevel.NONE
             }
         }
         install(HttpTimeout) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -46,7 +46,7 @@ class SettingsViewModel(
         }
     }
 
-    private suspend fun fetchAppVersion() {
+    private fun fetchAppVersion() {
         val appVersion = appInfoProvider.getAppInfo().appVersion
         _uiState.value = _uiState.value.copy(appVersion = appVersion)
     }


### PR DESCRIPTION
# Make AppInfoProvider.getAppInfo() synchronous

This PR removes the suspend modifier from `AppInfoProvider.getAppInfo()` method, making it synchronous since app info can be retrieved without blocking operations. This change simplifies the code by:

1. Removing unnecessary coroutine scope and dispatcher dependencies from HttpClient
2. Eliminating withContext calls in the Android implementation
3. Simplifying logging setup in network clients
4. Allowing direct calls to getAppInfo() in ViewModels without suspend functions

As app info is remembered at KRAILAppComposable level, this change improves code efficiency without affecting functionality.