### PR TITLE
Add workflow_dispatch trigger to Google Play distribution workflow

### DIFF
--- a/.github/workflows/distribute-google-play.yml
+++ b/.github/workflows/distribute-google-play.yml
@@ -6,6 +6,17 @@ on:
       artifact-name:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      artifact-name:
+        description: 'Distribute KRAIL App to Google Play Store internal test tack.'
+        required: true
+        type: string
+      track:
+        description: 'Play Store - Internal track'
+        required: true
+        default: 'internal'
+        type: string
 
 jobs:
   distribute:
@@ -15,7 +26,7 @@ jobs:
       - name: Download Release AAB artifact
         uses: actions/download-artifact@v5
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ github.event.inputs.artifact-name || inputs.artifact-name }}
           path: aab
 
       - name: Deploy to Play Store (Internal)
@@ -24,7 +35,7 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: xyz.ksharma.krail
           releaseFiles: aab/*.aab
-          track: internal
+          track: ${{ github.event.inputs.track || 'internal' }}
 
       - name: Create Github Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
### TL;DR

Added manual trigger capability to the Google Play distribution workflow.

### What changed?

- Added `workflow_dispatch` trigger to allow manual execution of the Google Play distribution workflow
- Added input parameters for artifact name and track when manually triggered
- Updated the artifact name and track references to use either the manual input values or the original workflow call inputs
- The track parameter now defaults to 'internal' but can be overridden when manually triggered

### How to test?

1. Navigate to the Actions tab in GitHub
2. Select the "Distribute to Google Play" workflow
3. Click "Run workflow"
4. Enter the required artifact name and optionally change the track
5. Verify the workflow executes correctly and distributes to the specified track

### Why make this change?

This change provides flexibility to manually trigger the Google Play distribution process without needing to call it from another workflow. This is useful for situations where you need to redistribute an existing build or when the automated process fails and needs to be manually rerun.