### PR TITLE
Add track parameter to Google Play distribution workflow

### DIFF
--- a/.github/workflows/distribute-google-play.yml
+++ b/.github/workflows/distribute-google-play.yml
@@ -6,6 +6,9 @@ on:
       artifact-name:
         required: true
         type: string
+      track:
+        required: true
+        type: string
 
 jobs:
   distribute:


### PR DESCRIPTION
### TL;DR

Added a required `track` parameter to the Google Play distribution workflow.

### What changed?

Added a new required input parameter called `track` of type string to the GitHub workflow for Google Play distribution. This parameter will allow specifying which track (e.g., production, beta, alpha, internal) to use when distributing the app.

### How to test?

1. Trigger the `distribute-google-play` workflow with both the existing `artifact-name` parameter and the new `track` parameter
2. Verify that the workflow requires the `track` parameter and fails if it's not provided
3. Confirm that the app is distributed to the specified track in Google Play Console
