### PR TITLE
Update GitHub release workflow path and increment iOS build number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
     # Only create a release for prod branch pushes
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/prod/')
     needs: distribute-google-play
-    uses: ./.github/workflows/release-github.yml
+    uses: ./.github/workflows/create-github-release.yml
     with:
       tag_name: v${{ needs.android.outputs.version_name }}
     secrets: inherit

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.6</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Updated GitHub workflow reference and incremented iOS build number.

### What changed?

- Changed the GitHub workflow reference in `build.yml` from `./.github/workflows/release-github.yml` to `./.github/workflows/create-github-release.yml`
- Incremented the iOS app build number from `1` to `2` in the `Info.plist` file while keeping the version string at `1.7.6`

### How to test?

1. Verify that the GitHub workflow runs correctly when pushing to a prod branch
2. Confirm that the iOS app builds with the updated build number
3. Ensure the GitHub release is created properly with the correct tag name

### Why make this change?

The workflow file was likely renamed to better reflect its purpose (creating GitHub releases), and the iOS build number needed to be incremented for a new release while maintaining the same version number.