### PR TITLE
Remove automatic Google Play distribution and GitHub release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,20 +46,3 @@ jobs:
     with:
       variant: release
     secrets: inherit
-
-  distribute-google-play:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/prod/')
-    needs: build-android-release
-    uses: ./.github/workflows/distribute-google-play.yml
-    with:
-      artifact-name: composeApp-release-aab-${{ github.run_id }}
-    secrets: inherit
-
-  create-github-release:
-    # Only create a release for prod branch pushes
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/prod/')
-    needs: distribute-google-play
-    uses: ./.github/workflows/create-github-release.yml
-    with:
-      tag_name: v${{ needs.android.outputs.version_name }}
-    secrets: inherit

--- a/.github/workflows/distribute-google-play-manual.yml
+++ b/.github/workflows/distribute-google-play-manual.yml
@@ -1,7 +1,7 @@
 name: Manual Build & Distribute Google Play
 
 on:
-  workflow_dispatch:
+  workflow_dispatch: # Manual trigger for building and distributing Android release
     inputs:
       track:
         description: 'Play Store track (e.g., internal, closed)'


### PR DESCRIPTION
# Remove automatic Google Play distribution and GitHub release from build workflow

This PR removes the automatic Google Play distribution and GitHub release creation steps from the main build workflow. These steps were previously triggered automatically on pushes to prod branches.

The manual distribution workflow remains available through workflow_dispatch, with an improved description clarifying its purpose as "Manual trigger for building and distributing Android release".