### PR TITLE
UI: Add large font scale support for Discover screen and increment iOS build number

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/A11yExt.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/A11yExt.kt
@@ -8,3 +8,10 @@ fun isFontScaleLessThanThreshold(fontScaleThreshold: Float = 1.8f): Boolean {
     val density = LocalDensity.current
     return density.fontScale < fontScaleThreshold
 }
+
+@Composable
+fun isLargeFontScale(): Boolean {
+    val density = LocalDensity.current
+    val fontScale = density.fontScale
+    return fontScale > 1.4f
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -42,6 +43,7 @@ import xyz.ksharma.krail.taj.components.DiscoverCardVerticalPager
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.isLargeFontScale
 
 @Composable
 fun DiscoverScreen(
@@ -103,40 +105,79 @@ fun DiscoverScreenCompact(
         return
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().systemBarsPadding()) {
 
-        DiscoverCardVerticalPager(
-            pages = state.discoverCardsList,
-            modifier = modifier.fillMaxSize(),
-            keySelector = { it.cardId },
-            content = { cardModel, isCardSelected ->
+        if (isLargeFontScale()) {
+            LazyColumn(
+                contentPadding = PaddingValues(bottom = 200.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = modifier.fillMaxSize()
+            ) {
+                item {
+                    DiscoverTitleBar(onBackClick, resetAllSeenCards)
+                }
 
-                if (isCardSelected) {
+                stickyHeader {
+                    DiscoverFooterChipsRow(state, onChipSelected)
+                }
+
+                items(
+                    count = state.discoverCardsList.size,
+                    key = { index -> state.discoverCardsList[index].cardId }
+                ) { index ->
+                    val cardModel = state.discoverCardsList[index]
+
                     LaunchedEffect(cardModel.cardId) {
                         onCardSeen(cardModel.cardId)
                     }
+
+                    DiscoverCard(
+                        discoverModel = cardModel,
+                        onAppSocialLinkClicked = onAppSocialLinkClicked,
+                        onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
+                        onCtaClicked = onCtaClicked,
+                        onShareClick = {
+                            onShareClick(cardModel.cardId, cardModel.type)
+                        },
+                        modifier = Modifier.animateItem(),
+                    )
                 }
-
-                DiscoverCard(
-                    discoverModel = cardModel,
-                    onAppSocialLinkClicked = onAppSocialLinkClicked,
-                    onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
-                    onCtaClicked = onCtaClicked,
-                    onShareClick = {
-                        onShareClick(
-                            cardModel.cardId,
-                            cardModel.type,
-                        )
-                    }
-                )
             }
-        )
+        } else {
+            DiscoverCardVerticalPager(
+                pages = state.discoverCardsList,
+                modifier = modifier.fillMaxSize(),
+                keySelector = { it.cardId },
+                content = { cardModel, isCardSelected ->
 
-        // Header with title bar
-        DiscoverTitleBar(onBackClick, resetAllSeenCards)
+                    if (isCardSelected) {
+                        LaunchedEffect(cardModel.cardId) {
+                            onCardSeen(cardModel.cardId)
+                        }
+                    }
 
-        // Footer with chips
-        DiscoverFooterChipsRow(state, onChipSelected)
+                    DiscoverCard(
+                        discoverModel = cardModel,
+                        onAppSocialLinkClicked = onAppSocialLinkClicked,
+                        onPartnerSocialLinkClicked = onPartnerSocialLinkClicked,
+                        onCtaClicked = onCtaClicked,
+                        onShareClick = {
+                            onShareClick(
+                                cardModel.cardId,
+                                cardModel.type,
+                            )
+                        }
+                    )
+                }
+            )
+
+            // Header with title bar
+            DiscoverTitleBar(onBackClick, resetAllSeenCards)
+
+            // Footer with chips
+            DiscoverFooterChipsRow(state, onChipSelected)
+        }
     }
 }
 
@@ -153,17 +194,13 @@ fun DiscoverScreenTablet(
     resetAllSeenCards: () -> Unit,
     onChipSelected: (DiscoverCardType) -> Unit,
 ) {
-    val density = LocalDensity.current
-    val fontScale = density.fontScale
-    val useLargeFontLayout = fontScale > 1.4f
-
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(KrailTheme.colors.surface),
     ) {
         Column {
-            if (useLargeFontLayout) {
+            if (isLargeFontScale()) {
                 // Large font: centered lazy column
                 LazyColumn(
                     contentPadding = PaddingValues(top = 120.dp, bottom = 200.dp),

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.7.6</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>7</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Improved accessibility support for large font scales in the Discover screen.

### What changed?

- Added a new `isLargeFontScale()` composable function that checks if the font scale is greater than 1.4f
- Modified the DiscoverScreenCompact to use a LazyColumn layout when large font scale is detected, instead of the vertical pager
- Added systemBarsPadding to the DiscoverScreenCompact for better spacing
- Refactored the DiscoverScreenTablet to use the new isLargeFontScale() function
- Incremented the iOS app build number from 3 to 7

### How to test?

1. Enable large font sizes in device accessibility settings
2. Open the Discover screen in both compact and tablet modes
3. Verify that the layout adapts appropriately with large text
4. Confirm that all content is readable and properly spaced
5. Test navigation and interaction with the new layout

### Why make this change?

This change improves the app's accessibility for users with visual impairments who rely on larger font sizes. The previous vertical pager layout wasn't optimal for large text, so this implementation provides a more usable alternative with a scrollable list when large font scales are detected.