### PR TITLE
UI: Fix TextButton clip order for proper background rendering

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -46,7 +46,7 @@ fun Button(
     colors: ButtonColors = ButtonDefaults.buttonColors(),
     dimensions: ButtonDimensions = ButtonDefaults.largeButtonSize(),
     enabled: Boolean = true,
-    content: @Composable () -> Unit, // RowScope and place
+    content: @Composable () -> Unit,
 ) {
     val contentAlphaProvider =
         rememberSaveable(enabled) { if (enabled) EnabledContentAlpha else DisabledContentAlpha }
@@ -146,11 +146,12 @@ fun TextButton(
         Box(
             modifier = modifier
                 .heightIn(dimensions.height)
-                .clip(dimensions.shape)
                 .background(
                     color = Color.Transparent,
                     shape = dimensions.shape,
-                ).klickable(
+                )
+                .clip(dimensions.shape)
+                .klickable(
                     enabled = enabled,
                     onClick = onClick,
                 )


### PR DESCRIPTION
### TL;DR

Reordered modifiers in TextButton to fix touch target issues.

### What changed?

Reordered the modifier chain in the TextButton component by moving the `.clip(dimensions.shape)` modifier after the `.background()` modifier instead of before it. This ensures that the touch target respects the clipped shape.

### How to test?

1. Run the app and navigate to a screen with TextButtons
2. Tap on the edges of the buttons to verify that touch events are properly constrained to the button's visual shape
3. Confirm that the button only responds to clicks within its visible boundaries

### Why make this change?

The previous implementation had the clip modifier before the background, which meant the touch target area could extend beyond the visible button shape. By applying the clip modifier after the background, we ensure that both the visual appearance and the interactive area of the button are consistently defined by the same shape.