### PR TITLE
UI: Add InfoTile component 

### DIFF
--- a/taj/src/commonMain/composeResources/drawable/ic_close.xml
+++ b/taj/src/commonMain/composeResources/drawable/ic_close.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="12dp"
-    android:height="12dp"
-    android:viewportWidth="12"
-    android:viewportHeight="12">
-  <path
-      android:pathData="M9.5,3.205L8.795,2.5L6,5.295L3.205,2.5L2.5,3.205L5.295,6L2.5,8.795L3.205,9.5L6,6.705L8.795,9.5L9.5,8.795L6.705,6L9.5,3.205Z"
-      android:fillColor="#ffffff"/>
-</vector>

--- a/taj/src/commonMain/composeResources/drawable/ic_close.xml
+++ b/taj/src/commonMain/composeResources/drawable/ic_close.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportWidth="12"
+    android:viewportHeight="12">
+  <path
+      android:pathData="M9.5,3.205L8.795,2.5L6,5.295L3.205,2.5L2.5,3.205L5.295,6L2.5,8.795L3.205,9.5L6,6.705L8.795,9.5L9.5,8.795L6.705,6L9.5,3.205Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -19,6 +20,15 @@ import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 
+@Stable
+data class InfoTileState(
+    val title: String,
+    val description: String,
+    val dismissCtaText: String = "Dismiss",
+    val primaryCta: InfoTileCta? = null,
+)
+
+@Stable
 data class InfoTileCta(
     val text: String,
     val url: String,
@@ -26,61 +36,53 @@ data class InfoTileCta(
 
 @Composable
 fun InfoTile(
-    title: String,
-    description: String,
-    dismissText: String = "Dismiss",
+    infoTileState: InfoTileState,
     modifier: Modifier = Modifier,
-    infoTileCta: InfoTileCta? = null,
     backgroundColor: Color = themeBackgroundColor(),
     onCtaClicked: (url: String) -> Unit,
     onDismissClick: (() -> Unit) = {},
 ) {
-    Row(
-        modifier = modifier.fillMaxWidth()
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
             .background(color = backgroundColor, shape = RoundedCornerShape(16.dp))
             .padding(vertical = 12.dp, horizontal = 16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(
-            modifier = Modifier.weight(1f),
+        Text(
+            text = infoTileState.title,
+            style = KrailTheme.typography.title,
+        )
+
+        Text(
+            text = infoTileState.description,
+            style = KrailTheme.typography.bodyMedium,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
         ) {
-            Text(
-                text = title,
-                style = KrailTheme.typography.title,
-            )
-
-            Text(
-                text = description,
-                style = KrailTheme.typography.bodyMedium,
-                modifier = Modifier.padding(top = 4.dp),
-            )
-
-            Row(
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            TextButton(
+                onClick = onDismissClick,
+                dimensions = ButtonDefaults.mediumButtonSize(),
+                modifier = Modifier.padding(end = 12.dp),
             ) {
-                TextButton(
-                    onClick = onDismissClick,
-                    dimensions = ButtonDefaults.mediumButtonSize(),
-                    modifier = Modifier.padding(end = 12.dp),
-                ) {
-                    Text(text = dismissText)
-                }
+                Text(text = infoTileState.dismissCtaText)
+            }
 
-                infoTileCta?.let { cta ->
-                    Button(
-                        dimensions = ButtonDefaults.mediumButtonSize(),
-                        onClick = { onCtaClicked(cta.url) },
-                    ) {
-                        Text(text = cta.text)
-                    }
+            infoTileState.primaryCta?.let { cta ->
+                Button(
+                    dimensions = ButtonDefaults.mediumButtonSize(),
+                    onClick = { onCtaClicked(cta.url) },
+                ) {
+                    Text(text = cta.text)
                 }
             }
         }
     }
 }
-
 
 // region Previews
 
@@ -93,11 +95,13 @@ private fun InfoTileLightPreview() {
     //  In future, colors should be calculated and set in tokens rather than being calculated on fly.
     PreviewTheme(themeStyle = KrailThemeStyle.PurpleDrip, darkTheme = false) {
         InfoTile(
-            title = "Service update",
-            description = "Planned maintenance may cause minor delays this weekend.",
-            infoTileCta = InfoTileCta(
-                text = "Learn more",
-                url = "https://example.com/maintenance"
+            infoTileState = InfoTileState(
+                title = "Service update",
+                description = "Planned maintenance may cause minor delays this weekend.",
+                primaryCta = InfoTileCta(
+                    text = "Learn more",
+                    url = "https://example.com/maintenance",
+                ),
             ),
             onCtaClicked = {},
             onDismissClick = {},
@@ -111,9 +115,10 @@ private fun InfoTileLightPreview() {
 private fun InfoTileDarkPreview() {
     PreviewTheme(themeStyle = KrailThemeStyle.Train, darkTheme = true) {
         InfoTile(
-            title = "Network issue resolved",
-            description = "All lines are now operating on their regular schedules.",
-            infoTileCta = null,
+            infoTileState = InfoTileState(
+                title = "Network issue resolved",
+                description = "All lines are now operating on their regular schedules.",
+            ),
             onCtaClicked = {},
             onDismissClick = {},
         )

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
@@ -1,0 +1,122 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.themeBackgroundColor
+
+data class InfoTileCta(
+    val text: String,
+    val url: String,
+)
+
+@Composable
+fun InfoTile(
+    title: String,
+    description: String,
+    dismissText: String = "Dismiss",
+    modifier: Modifier = Modifier,
+    infoTileCta: InfoTileCta? = null,
+    backgroundColor: Color = themeBackgroundColor(),
+    onCtaClicked: (url: String) -> Unit,
+    onDismissClick: (() -> Unit) = {},
+) {
+    Row(
+        modifier = modifier.fillMaxWidth()
+            .background(color = backgroundColor, shape = RoundedCornerShape(16.dp))
+            .padding(vertical = 12.dp, horizontal = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = title,
+                style = KrailTheme.typography.title,
+            )
+
+            Text(
+                text = description,
+                style = KrailTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            ) {
+                TextButton(
+                    onClick = onDismissClick,
+                    dimensions = ButtonDefaults.mediumButtonSize(),
+                    modifier = Modifier.padding(end = 12.dp),
+                ) {
+                    Text(text = dismissText)
+                }
+
+                infoTileCta?.let { cta ->
+                    Button(
+                        dimensions = ButtonDefaults.mediumButtonSize(),
+                        onClick = { onCtaClicked(cta.url) },
+                    ) {
+                        Text(text = cta.text)
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+// region Previews
+
+@Preview(name = "InfoTile Light")
+@Composable
+private fun InfoTileLightPreview() {
+    // TODO: the text color in preview is not visible properly as background colors are calculates as
+    //  alpha and are not concrete colors in DS: Taj
+    //  Should be rendered fine though.
+    //  In future, colors should be calculated and set in tokens rather than being calculated on fly.
+    PreviewTheme(themeStyle = KrailThemeStyle.PurpleDrip, darkTheme = false) {
+        InfoTile(
+            title = "Service update",
+            description = "Planned maintenance may cause minor delays this weekend.",
+            infoTileCta = InfoTileCta(
+                text = "Learn more",
+                url = "https://example.com/maintenance"
+            ),
+            onCtaClicked = {},
+            onDismissClick = {},
+            modifier = Modifier.systemBarsPadding(),
+        )
+    }
+}
+
+@Preview(name = "InfoTile Dark")
+@Composable
+private fun InfoTileDarkPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train, darkTheme = true) {
+        InfoTile(
+            title = "Network issue resolved",
+            description = "All lines are now operating on their regular schedules.",
+            infoTileCta = null,
+            onCtaClicked = {},
+            onDismissClick = {},
+        )
+    }
+}
+// endregion


### PR DESCRIPTION
# Add InfoTile component

This PR adds a new InfoTile component that can be used to display informational messages with optional CTAs.

- Adds `InfoTileState` and `InfoTileCta` data classes to manage the component state
- Implements the `InfoTile` composable with support for:
  - Title and description text
  - Customizable dismiss button
  - Optional primary CTA with URL handling
  - Configurable background color
- Includes light and dark theme previews
- Fixes the order of clip and background modifiers in TextButton for proper rendering