### PR TITLE
Add appBuildNumber to AppInfo and increase Android MIN_SDK to 28

### DIFF
--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -5,8 +5,6 @@ import android.content.Context.BATTERY_SERVICE
 import android.content.res.Configuration
 import android.os.BatteryManager
 import android.os.Build
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 
 class AndroidAppInfo(private val context: Context) : AppInfo {
 
@@ -16,11 +14,16 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
         get() =
             context.applicationInfo.flags and android.content.pm.ApplicationInfo.FLAG_DEBUGGABLE != 0
 
+    private val packageInfo by lazy {
+        context.packageManager.getPackageInfo(context.packageName, 0)
+    }
+
     override val appVersion: String
-        get() {
-            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            return packageInfo.versionName ?: "Unknown"
-        }
+        get() = packageInfo.versionName ?: "Unknown"
+
+    override val appBuildNumber: String
+        get() = packageInfo.longVersionCode.toString()
+
     override val osVersion: String
         get() = Build.VERSION.SDK_INT.toString()
 

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -15,9 +15,22 @@ interface AppInfo {
     val isDebug: Boolean
 
     /**
-     * App version.
+     * Semantic version name (e.g. "1.7.6"). Used for comparisons.
      */
     val appVersion: String
+
+    /**
+     * Build number / version code (Android: versionCode/longVersionCode, iOS: CFBundleVersion).
+     */
+    val appBuildNumber: String
+
+    /**
+     * UI friendly display (debug: "1.7.6 (123)", release: "1.7.6").
+     */
+    val appVersionDisplay: String
+        get() = if (isDebug && appBuildNumber.isNotBlank())
+            "$appVersion ($appBuildNumber)"
+        else appVersion
 
     /**
      * OS version.

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -16,20 +16,17 @@ import kotlin.math.absoluteValue
 class IOSAppInfo : AppInfo {
 
     override val devicePlatformType: DevicePlatformType = DevicePlatformType.IOS
+    private val info = NSBundle.mainBundle.infoDictionary
 
     @OptIn(ExperimentalNativeApi::class)
     override val isDebug: Boolean
         get() = Platform.isDebugBinary
 
     override val appVersion: String
-        get() {
-            val shortVersion =
-                NSBundle.mainBundle.infoDictionary?.get("CFBundleShortVersionString") as? String
-                    ?: "Unknown"
-            val buildVersion =
-                NSBundle.mainBundle.infoDictionary?.get("CFBundleVersion") as? String ?: "Unknown"
-            return "$shortVersion ${if (isDebug) "($buildVersion)" else ""}"
-        }
+        get() = info?.get("CFBundleShortVersionString") as? String ?: "Unknown"
+
+    override val appBuildNumber: String
+        get() = info?.get("CFBundleVersion") as? String ?: "Unknown"
 
     override val osVersion: String
         get() = UIDevice.currentDevice.systemVersion

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Android.kt
@@ -42,6 +42,6 @@ fun Project.configureAndroid() {
 object AndroidVersion {
     // https://developer.android.com/build/releases/gradle-plugin#api-level-support
     const val COMPILE_SDK = 36
-    const val MIN_SDK = 26 // Oreo 8.0
+    const val MIN_SDK = 28 // Android 9.0 (Pie)
     const val TARGET_SDK = 36
 }


### PR DESCRIPTION
### TL;DR

Added app build number information to AppInfo and updated version display formatting across platforms.

### What changed?

- Added `appBuildNumber` property to the `AppInfo` interface to expose build number/version code
- Added `appVersionDisplay` property that formats version information differently for debug vs release builds
- Refactored Android implementation to use lazy loading for package info
- Fixed iOS implementation to separate version name from build number
- Increased minimum Android SDK from 26 (Oreo 8.0) to 28 (Pie 9.0)

### How to test?

1. Run the app in both debug and release configurations
2. Verify that version information displays correctly:
   - Debug builds should show: "1.7.6 (123)" format
   - Release builds should show: "1.7.6" format
3. Test on both Android and iOS platforms to ensure consistent behavior

### Why make this change?

This change provides a more consistent way to access and display version information across platforms. It separates the semantic version from the build number, allowing for more flexible version display in the UI while maintaining the ability to use each component separately when needed.