### PR TITLE
Add app version checking functionality with update notifications

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -115,6 +115,7 @@ kotlin {
             implementation(projects.core.analytics)
             implementation(projects.core.appInfo)
             implementation(projects.core.appStart)
+            implementation(projects.core.appVersion)
             implementation(projects.core.coroutinesExt)
             implementation(projects.core.di)
             implementation(projects.core.festival)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -9,6 +9,7 @@ import org.koin.dsl.module
 import xyz.ksharma.krail.core.analytics.di.analyticsModule
 import xyz.ksharma.krail.core.appinfo.di.appInfoModule
 import xyz.ksharma.krail.core.appstart.di.appStartModule
+import xyz.ksharma.krail.core.appversion.di.appVersionModule
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.core.di.coroutineDispatchersModule
 import xyz.ksharma.krail.core.festival.di.festivalModule
@@ -33,6 +34,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             sandookModule,
             splashModule,
             appInfoModule,
+            appVersionModule,
             analyticsModule,
             remoteConfigModule,
             gtfsModule,
@@ -55,6 +57,7 @@ val splashModule = module {
             ioDispatcher = get(named(IODispatcher)),
             appStart = get(),
             preferences = get(),
+            appVersionManager = get(),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appinfo.AppVersionManager
 import xyz.ksharma.krail.core.appstart.AppStart
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
@@ -30,6 +31,7 @@ class SplashViewModel(
     private val ioDispatcher: CoroutineDispatcher,
     private val appStart: AppStart,
     private val preferences: SandookPreferences,
+    private val appVersionManager: AppVersionManager,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SplashState> = MutableStateFlow(SplashState())
@@ -41,6 +43,7 @@ class SplashViewModel(
             coroutineScope {
                 loadKrailThemeStyle()
                 displayIntroScreen()
+                appVersionManager.checkForUpdates()
                 appStart.start()
                 trackAppStartEvent()
             }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
-import xyz.ksharma.krail.core.appinfo.AppVersionManager
+import xyz.ksharma.krail.core.appversion.AppVersionManager
 import xyz.ksharma.krail.core.appstart.AppStart
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError

--- a/core/app-version/build.gradle.kts
+++ b/core/app-version/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    alias(libs.plugins.krail.android.library)
+    alias(libs.plugins.krail.kotlin.multiplatform)
+    alias(libs.plugins.krail.compose.multiplatform)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.compose.compiler)
+}
+
+android {
+    namespace = "xyz.ksharma.krail.core.appversion"
+}
+
+kotlin {
+    applyDefaultHierarchyTemplate()
+
+    androidTarget()
+
+    iosArm64()
+    iosSimulatorArm64()
+
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(JavaVersion.VERSION_17.majorVersion))
+        }
+    }
+
+    sourceSets {
+        androidMain {
+            dependencies {
+                api(libs.di.koinAndroid)
+            }
+        }
+
+        commonMain {
+            dependencies {
+                implementation(projects.core.appInfo)
+                implementation(projects.core.di)
+                implementation(projects.core.log)
+                implementation(projects.core.remoteConfig)
+
+                implementation(libs.kotlinx.serialization.json)
+
+                implementation(compose.runtime)
+                api(libs.di.koinComposeViewmodel)
+            }
+        }
+    }
+}

--- a/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManager.kt
+++ b/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManager.kt
@@ -1,0 +1,117 @@
+package xyz.ksharma.krail.core.appinfo
+
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.remote_config.flag.Flag
+import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
+import xyz.ksharma.krail.core.remote_config.flag.asString
+
+interface AppVersionManager {
+
+    /**
+     * Checks the current app version against the latest available version.
+     * Returns an [AppVersionUpdateState] indicating whether the app is up to date,
+     * if an update is required, or if a forced update is necessary.
+     */
+    suspend fun checkForUpdates(): AppVersionUpdateState
+
+    /**
+     * Retrieves the current version of the app.
+     */
+    fun getCurrentVersion(): String
+}
+
+internal class RealAppVersionManager(
+    private val appInfoProvider: AppInfoProvider,
+    private val flag: Flag,
+) : AppVersionManager {
+
+    private val minimumSupportedAppVersion: String by lazy {
+        flag.getFlagValue(FlagKeys.MIN_SUPPORTED_APP_VERSION.key).asString()
+    }
+
+    private val latestAppVersion: String by lazy {
+
+        when (appInfoProvider.getAppInfo().devicePlatformType) {
+            DevicePlatformType.ANDROID -> {
+                log("Fetching latest app version for Android: ")
+                flag.getFlagValue(FlagKeys.LATEST_APP_VERSION_ANDROID.key)
+                    .asString()
+            }
+
+            DevicePlatformType.IOS -> {
+                log("Fetching latest app version for iOS: ")
+                flag.getFlagValue(FlagKeys.LATEST_APP_VERSION_IOS.key)
+                    .asString()
+            }
+
+            DevicePlatformType.UNKNOWN -> {
+                log("Fetching latest app version for unknown platform: ")
+                // If the platform is unknown, we can't determine the latest version
+                ""
+            }
+        }
+    }
+
+    override suspend fun checkForUpdates(): AppVersionUpdateState {
+        log("Checking app version updates...")
+        val current = getCurrentVersion()
+        log("Current app version: $current")
+        if (current.isBlank()) return AppVersionUpdateState.UpToDate
+
+        log("Checking app version: current=$current, minimumSupported=$minimumSupportedAppVersion, latest=$latestAppVersion")
+
+        val x = when {
+            compareVersions(current, minimumSupportedAppVersion) < 0 ->
+                AppVersionUpdateState.ForcedUpdateRequired
+
+            compareVersions(current, latestAppVersion) < 0 ->
+                AppVersionUpdateState.UpdateRequired
+
+            else -> AppVersionUpdateState.UpToDate
+        }
+        log("App version update state: $x")
+        return x
+    }
+
+    override fun getCurrentVersion(): String = appInfoProvider.getAppInfo().appVersion
+
+    private fun compareVersions(currentVersion: String, other: String): Int {
+        val av = parse(currentVersion)
+        val bv = parse(other)
+        val max = maxOf(av.size, bv.size)
+        for (i in 0 until max) {
+            val ai = av.getOrElse(i) { 0 }
+            val bi = bv.getOrElse(i) { 0 }
+            if (ai != bi) return ai - bi
+        }
+        return 0
+    }
+
+    private fun parse(v: String): List<Int> =
+        v.split('.')
+            .map { seg ->
+                seg.filter { it.isDigit() }
+                    .takeIf { it.isNotEmpty() }
+                    ?.toIntOrNull() ?: 0
+            }
+}
+
+
+sealed interface AppVersionUpdateState {
+
+    /**
+     * Indicates that the app is up to date and no updates are available.
+     */
+    data object UpToDate : AppVersionUpdateState
+
+    /**
+     * Indicates that an update is available, but it is optional for the user to update the app.
+     */
+    data object UpdateRequired : AppVersionUpdateState
+
+    /**
+     * Indicates that an update is available and it is mandatory for the user to update the app.
+     * The user must update the app to continue using it.
+     */
+    data object ForcedUpdateRequired : AppVersionUpdateState
+}

--- a/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManager.kt
+++ b/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManager.kt
@@ -1,5 +1,7 @@
-package xyz.ksharma.krail.core.appinfo
+package xyz.ksharma.krail.core.appversion
 
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys

--- a/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/di/AppVersionModuie.kt
+++ b/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/di/AppVersionModuie.kt
@@ -1,0 +1,9 @@
+package xyz.ksharma.krail.core.appversion.di
+
+import org.koin.dsl.module
+import xyz.ksharma.krail.core.appinfo.AppVersionManager
+import xyz.ksharma.krail.core.appinfo.RealAppVersionManager
+
+val appVersionModule = module {
+    single<AppVersionManager> { RealAppVersionManager(get(), get()) }
+}

--- a/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/di/AppVersionModule.kt
+++ b/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/di/AppVersionModule.kt
@@ -1,8 +1,8 @@
 package xyz.ksharma.krail.core.appversion.di
 
 import org.koin.dsl.module
-import xyz.ksharma.krail.core.appinfo.AppVersionManager
-import xyz.ksharma.krail.core.appinfo.RealAppVersionManager
+import xyz.ksharma.krail.core.appversion.AppVersionManager
+import xyz.ksharma.krail.core.appversion.RealAppVersionManager
 
 val appVersionModule = module {
     single<AppVersionManager> { RealAppVersionManager(get(), get()) }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -113,6 +113,18 @@ object RemoteConfigDefaults {
                 first = FlagKeys.DISCOVER_AVAILABLE.key,
                 second = true,
             ),
+            Pair(
+                first = FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+                second = "1.6.1",
+            ),
+            Pair(
+                first = FlagKeys.LATEST_APP_VERSION_IOS.key,
+                second = "",
+            ),
+            Pair(
+                first = FlagKeys.LATEST_APP_VERSION_ANDROID.key,
+                second = "",
+            )
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/flag/FlagKeys.kt
@@ -19,4 +19,10 @@ enum class FlagKeys(val key: String) {
     DISCOVER_SYDNEY("discover_sydney"),
 
     DISCOVER_AVAILABLE("is_discover_available"),
+
+    MIN_SUPPORTED_APP_VERSION("min_supported_app_version"),
+
+    LATEST_APP_VERSION_ANDROID("latest_app_version_android"),
+
+    LATEST_APP_VERSION_IOS("latest_app_version_ios"),
 }

--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -42,6 +42,8 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(projects.core.analytics)
+                implementation(projects.core.appInfo)
+                implementation(projects.core.appVersion)
                 implementation(projects.core.dateTime)
                 implementation(projects.core.festival)
                 implementation(projects.core.log)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/appversion/AppVersionManagerTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/appversion/AppVersionManagerTest.kt
@@ -1,0 +1,191 @@
+package xyz.ksharma.core.test.appversion
+
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.core.test.fakes.FakeAppInfo
+import xyz.ksharma.core.test.fakes.FakeAppInfoProvider
+import xyz.ksharma.core.test.fakes.FakeFlag
+import xyz.ksharma.krail.core.appinfo.AppVersionUpdateState
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+import xyz.ksharma.krail.core.appinfo.RealAppVersionManager
+import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
+import xyz.ksharma.krail.core.remote_config.flag.FlagValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppVersionManagerTest {
+
+    private val fakeFlag = FakeFlag()
+    private val fakeAppInfoProvider = FakeAppInfoProvider()
+    private val appVersionManager = RealAppVersionManager(fakeAppInfoProvider, fakeFlag)
+
+    @Test
+    fun `getCurrentVersion returns app version from AppInfoProvider`() {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(appVersion = "2.1.0")
+
+        // When
+        val result = appVersionManager.getCurrentVersion()
+
+        // Then
+        assertEquals("2.1.0", result)
+    }
+
+    @Test
+    fun `checkForUpdates returns UpToDate when current version equals latest`() = runTest {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(appVersion = "1.5.0")
+        fakeFlag.setFlagValue(
+            FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+            FlagValue.StringValue("1.0.0"),
+        )
+        fakeFlag.setFlagValue(
+            FlagKeys.LATEST_APP_VERSION_ANDROID.key,
+            FlagValue.StringValue("1.5.0")
+        )
+
+        // When
+        val result = appVersionManager.checkForUpdates()
+
+        // Then
+        assertEquals(AppVersionUpdateState.UpToDate, result)
+    }
+
+    @Test
+    fun `checkForUpdates returns UpdateRequired when current version is less than latest`() =
+        runTest {
+            // Given
+            fakeAppInfoProvider.mockAppInfo = FakeAppInfo(appVersion = "1.4.0",)
+            fakeFlag.setFlagValue(
+                FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+                FlagValue.StringValue("1.0.0")
+            )
+            fakeFlag.setFlagValue(
+                FlagKeys.LATEST_APP_VERSION_ANDROID.key,
+                FlagValue.StringValue("1.5.0")
+            )
+
+            // When
+            val result = appVersionManager.checkForUpdates()
+
+            // Then
+            assertEquals(AppVersionUpdateState.UpdateRequired, result)
+        }
+
+    @Test
+    fun `checkForUpdates returns ForcedUpdateRequired when current version is less than minimum supported`() =
+        runTest {
+            // Given
+            fakeAppInfoProvider.mockAppInfo = FakeAppInfo(
+                appVersion = "0.9.0",
+                
+            )
+            fakeFlag.setFlagValue(
+                FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+                FlagValue.StringValue("1.0.0")
+            )
+            fakeFlag.setFlagValue(
+                FlagKeys.LATEST_APP_VERSION_ANDROID.key,
+                FlagValue.StringValue("1.5.0")
+            )
+
+            // When
+            val result = appVersionManager.checkForUpdates()
+
+            // Then
+            assertEquals(AppVersionUpdateState.ForcedUpdateRequired, result)
+        }
+
+    @Test
+    fun `checkForUpdates uses iOS version flag for iOS platform`() = runTest {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(
+            appVersion = "1.4.0",
+            devicePlatformType = DevicePlatformType.IOS,
+        )
+        fakeFlag.setFlagValue(
+            FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+            FlagValue.StringValue("1.0.0")
+        )
+        fakeFlag.setFlagValue(FlagKeys.LATEST_APP_VERSION_IOS.key, FlagValue.StringValue("1.5.0"))
+
+        // When
+        val result = appVersionManager.checkForUpdates()
+
+        // Then
+        assertEquals(AppVersionUpdateState.UpdateRequired, result)
+    }
+
+    @Test
+    fun `checkForUpdates returns UpToDate when current version is blank`() = runTest {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(appVersion = "")
+
+        // When
+        val result = appVersionManager.checkForUpdates()
+
+        // Then
+        assertEquals(AppVersionUpdateState.UpToDate, result)
+    }
+
+    @Test
+    fun `checkForUpdates returns UpToDate for unknown platform`() = runTest {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(
+            appVersion = "1.0.0",
+            devicePlatformType = DevicePlatformType.UNKNOWN
+        )
+        fakeFlag.setFlagValue(
+            FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+            FlagValue.StringValue("0.9.0")
+        )
+
+        // When
+        val result = appVersionManager.checkForUpdates()
+
+        // Then
+        assertEquals(AppVersionUpdateState.UpToDate, result)
+    }
+
+    @Test
+    fun `version comparison works correctly for complex versions`() = runTest {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(
+            appVersion = "1.2.3",
+            
+        )
+        fakeFlag.setFlagValue(
+            FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+            FlagValue.StringValue("1.2.2")
+        )
+        fakeFlag.setFlagValue(
+            FlagKeys.LATEST_APP_VERSION_ANDROID.key,
+            FlagValue.StringValue("1.2.4")
+        )
+
+        // When
+        val result = appVersionManager.checkForUpdates()
+
+        // Then
+        assertEquals(AppVersionUpdateState.UpdateRequired, result)
+    }
+
+    @Test
+    fun `checkForUpdates returns UpdateRequired when current version 1_9_0 is less than latest 2_0_0`() = runTest {
+        // Given
+        fakeAppInfoProvider.mockAppInfo = FakeAppInfo(appVersion = "1.9.0")
+        fakeFlag.setFlagValue(
+            FlagKeys.MIN_SUPPORTED_APP_VERSION.key,
+            FlagValue.StringValue("1.0.0")
+        )
+        fakeFlag.setFlagValue(
+            FlagKeys.LATEST_APP_VERSION_ANDROID.key,
+            FlagValue.StringValue("2.0.0")
+        )
+
+        // When
+        val result = appVersionManager.checkForUpdates()
+
+        // Then
+        assertEquals(AppVersionUpdateState.UpdateRequired, result)
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/appversion/AppVersionManagerTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/appversion/AppVersionManagerTest.kt
@@ -4,9 +4,9 @@ import kotlinx.coroutines.test.runTest
 import xyz.ksharma.core.test.fakes.FakeAppInfo
 import xyz.ksharma.core.test.fakes.FakeAppInfoProvider
 import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.krail.core.appinfo.AppVersionUpdateState
+import xyz.ksharma.krail.core.appversion.AppVersionUpdateState
 import xyz.ksharma.krail.core.appinfo.DevicePlatformType
-import xyz.ksharma.krail.core.appinfo.RealAppVersionManager
+import xyz.ksharma.krail.core.appversion.RealAppVersionManager
 import xyz.ksharma.krail.core.remote_config.flag.FlagKeys
 import xyz.ksharma.krail.core.remote_config.flag.FlagValue
 import kotlin.test.Test

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppInfo.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppInfo.kt
@@ -1,0 +1,20 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.core.appinfo.AppInfo
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+
+class FakeAppInfo(
+    override val devicePlatformType: DevicePlatformType = DevicePlatformType.ANDROID,
+    override val isDebug: Boolean = false,
+    override val appVersion: String = "1.0.0",
+    override val appBuildNumber: String = "123",
+    override val osVersion: String = "30",
+    override val fontSize: String = "1.0",
+    override val isDarkTheme: Boolean = false,
+    override val deviceModel: String = "Pixel 4",
+    override val deviceManufacturer: String = "Google",
+    override val locale: String = "en_AU",
+    override val batteryLevel: Int = 80,
+    override val timeZone: String = "Australia/Sydney",
+    override val appStoreUrl: String = "https://play.google.com/store/apps/details?id=xyz.ksharma.krail"
+) : AppInfo

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppInfoProvider.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppInfoProvider.kt
@@ -1,0 +1,15 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.core.appinfo.AppInfo
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+
+class FakeAppInfoProvider : AppInfoProvider {
+
+    var mockAppInfo: AppInfo = FakeAppInfo(
+        appVersion = "1.0.0",
+        devicePlatformType = DevicePlatformType.ANDROID
+    )
+
+    override fun getAppInfo(): AppInfo = mockAppInfo
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppVersionManager.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppVersionManager.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.core.appinfo.AppVersionManager
+import xyz.ksharma.krail.core.appinfo.AppVersionUpdateState
+
+class FakeAppVersionManager: AppVersionManager {
+
+    var versionUpdateState: AppVersionUpdateState = AppVersionUpdateState.UpToDate
+    var mockCurrentVersion: String = "1.0.0"
+
+    override suspend fun checkForUpdates(): AppVersionUpdateState {
+        return versionUpdateState
+    }
+
+    override fun getCurrentVersion(): String {
+        return mockCurrentVersion
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppVersionManager.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppVersionManager.kt
@@ -1,7 +1,7 @@
 package xyz.ksharma.core.test.fakes
 
-import xyz.ksharma.krail.core.appinfo.AppVersionManager
-import xyz.ksharma.krail.core.appinfo.AppVersionUpdateState
+import xyz.ksharma.krail.core.appversion.AppVersionManager
+import xyz.ksharma.krail.core.appversion.AppVersionUpdateState
 
 class FakeAppVersionManager: AppVersionManager {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(":taj") // Design System
 include(":core:analytics")
 include(":core:app-info")
 include(":core:app-start")
+include(":core:app-version")
 include(":core:coroutines-ext")
 include(":core:date-time")
 include(":core:di")


### PR DESCRIPTION
### TL;DR

Added app version management to check for updates and enforce minimum version requirements.

### What changed?

- Created a new `app-version` module with `AppVersionManager` interface and implementation
- Added version comparison logic to determine if an app is up-to-date, needs an update, or requires a forced update
- Integrated version checking into the splash screen flow
- Added remote config flags for minimum supported app version and latest versions for Android and iOS

### How to test?

1. Run the app and verify it checks for updates during startup
2. Test with different version configurations in remote config:
    - Set `min_supported_app_version` higher than current to trigger forced update
    - Set platform-specific latest version higher than current to trigger update required
    - Set both equal to or lower than current to verify up-to-date state

### Why make this change?

This change enables the app to notify users when updates are available and enforce minimum version requirements for compatibility and security reasons. The version management system helps ensure users are running supported versions of the app and can be prompted to update when necessary.