### PR TITLE
Enable Gradle configuration cache with override for Android builds

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -76,9 +76,9 @@ jobs:
         run: |
           set -e
           if [[ "${{ inputs.variant }}" == "debug" ]]; then
-            ./gradlew :composeApp:assembleDebug test -PversionCode="${VERSION_CODE}" --rerun-tasks --stacktrace
+            ./gradlew :composeApp:assembleDebug test -PversionCode="${VERSION_CODE}" --rerun-tasks --stacktrace --no-configuration-cache
           elif [[ "${{ inputs.variant }}" == "release" ]]; then
-            ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${VERSION_CODE}"
+            ./gradlew :composeApp:assembleRelease :composeApp:bundleRelease -PversionCode="${VERSION_CODE}" --no-configuration-cache
           fi
 
       - name: Upload Debug APK

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.caching=true
 kotlin.native.ignoreDisabledTargets=true
 # https://kotlinlang.org/docs/native-improving-compilation-time.html
 kotlin.native.cacheKind=none
+# https://docs.gradle.org/9.0.0/userguide/configuration_cache_enabling.html
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
### TL;DR

Enable Gradle configuration cache for faster build times while disabling it for CI builds.

https://docs.gradle.org/9.0.0/userguide/configuration_cache_enabling.html

### What changed?

- Added configuration cache settings in `gradle.properties`:
  - Enabled configuration cache with `org.gradle.configuration-cache=true`
  - Enabled parallel configuration cache with `org.gradle.configuration-cache.parallel=true`
- Modified the Android build workflow to explicitly disable configuration cache for CI builds by adding `--no-configuration-cache` flag to Gradle commands for both debug and release variants

### How to test?

1. Run a local build and verify that the configuration cache is being used (you should see configuration cache messages in the Gradle output)
2. Verify that subsequent builds are faster due to the configuration cache
3. Run the CI workflow and confirm that builds complete successfully with the configuration cache disabled

### Why make this change?

Configuration cache improves build performance by storing the result of the configuration phase and reusing it for subsequent builds. This significantly reduces build time for local development. However, it's disabled in CI to ensure consistent and reliable builds in the pipeline, as configuration cache can sometimes cause issues in CI environments.