### PR TITLE
Add forced upgrade screen and improve splash navigation flow

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
@@ -44,7 +44,7 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 fun SplashScreen(
     logoColor: Color?,
     backgroundColor: Color?,
-    onSplashComplete: () -> Unit,
+    onSplashAnimationComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -55,7 +55,7 @@ fun SplashScreen(
     ) {
         AnimatedKrailLogo(logoColor = logoColor ?: KrailTheme.colors.onSurface)
 
-        val splashComplete by rememberUpdatedState(onSplashComplete)
+        val splashComplete by rememberUpdatedState(onSplashAnimationComplete)
         LaunchedEffect(key1 = Unit) {
             delay(1200)
             splashComplete()
@@ -196,7 +196,7 @@ private fun PreviewLogo() {
 private fun PreviewSplashScreen() {
     KrailTheme {
         SplashScreen(
-            onSplashComplete = {},
+            onSplashAnimationComplete = {},
             logoColor = KrailTheme.colors.onSurface,
             backgroundColor = Color(0xFF009B77),
         )

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashState.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashState.kt
@@ -2,8 +2,10 @@ package xyz.ksharma.krail.splash
 
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.trip.planner.ui.navigation.KrailRoute
 
 data class SplashState(
     val hasSeenIntro: Boolean = true,
     val themeStyle: KrailThemeStyle = DEFAULT_THEME_STYLE,
+    val navigationDestination: KrailRoute? = null
 )

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashUiEvent.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashUiEvent.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.splash
+
+sealed interface SplashUiEvent {
+    data object SplashAnimationComplete : SplashUiEvent
+}

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/upgrade/ForceUpgradeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/upgrade/ForceUpgradeScreen.kt
@@ -1,0 +1,16 @@
+package xyz.ksharma.krail.upgrade
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import xyz.ksharma.krail.taj.components.Text
+
+@Composable
+fun ForceUpgradeScreen() {
+    Box(modifier = Modifier.fillMaxSize().statusBarsPadding()) {
+        Text("Force Upgrade Required")
+        // Button tp redirect to Play Store or App Store
+    }
+}

--- a/core/coroutines-ext/src/commonMain/kotlin/xyz/ksharma/krail/coroutines/ext/ExceptionHandler.kt
+++ b/core/coroutines-ext/src/commonMain/kotlin/xyz/ksharma/krail/coroutines/ext/ExceptionHandler.kt
@@ -8,12 +8,21 @@ import xyz.ksharma.krail.core.log.logError
 
 inline fun <reified T> CoroutineScope.launchWithExceptionHandler(
     dispatcher: CoroutineDispatcher,
+    noinline errorBlock: () -> Unit = {},
     crossinline block: suspend CoroutineScope.() -> Unit,
-) = launch(context = dispatcher + coroutineExceptionHandler(message = T::class.simpleName)) {
+) = launch(
+    context = dispatcher + coroutineExceptionHandler(
+        message = T::class.simpleName,
+        errorBlock = errorBlock,
+    )
+) {
     block()
 }
 
-fun coroutineExceptionHandler(message: String? = null) =
-    CoroutineExceptionHandler { _, throwable ->
-        logError(message = message ?: throwable.message ?: "", throwable = throwable)
-    }
+fun coroutineExceptionHandler(
+    message: String? = null,
+    errorBlock: () -> Unit = {},
+) = CoroutineExceptionHandler { _, throwable ->
+    logError(message = message ?: throwable.message ?: "", throwable = throwable)
+    errorBlock()
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerDestinations.kt
@@ -62,11 +62,13 @@ internal sealed class SearchStopFieldType(val key: String) {
     }
 }
 
+interface KrailRoute
+
 @Serializable
 internal data object TripPlannerNavRoute
 
 @Serializable
-data object SavedTripsRoute
+data object SavedTripsRoute: KrailRoute
 
 @Serializable
 internal data class TimeTableRoute(
@@ -97,7 +99,10 @@ data object SettingsRoute
 data object OurStoryRoute
 
 @Serializable
-data object IntroRoute
+data object IntroRoute: KrailRoute
+
+@Serializable
+data object ForcedUpgradeRoute: KrailRoute
 
 @Serializable
 data class DateTimeSelectorRoute(


### PR DESCRIPTION
### TL;DR

Implemented a forced app upgrade flow with improved splash screen navigation logic.

### What changed?

- Added a new `ForceUpgradeScreen` component to handle mandatory app updates
- Created a `SplashUiEvent` sealed interface to handle splash screen events
- Modified the splash screen navigation flow to check app version before proceeding
- Added `navigationDestination` to `SplashState` to control navigation after splash animation
- Renamed `onSplashComplete` to `onSplashAnimationComplete` for clarity
- Enhanced `coroutineExceptionHandler` to support custom error handling
- Created a `KrailRoute` interface for route type safety

### How to test?

1. Run the app and verify the splash screen appears and animates correctly
2. Test with different app version scenarios:
   - Up-to-date app should navigate to saved trips or intro screen
   - App requiring forced update should navigate to the upgrade screen
3. Verify error handling by simulating failures during the splash animation completion

### Why make this change?

This change improves the app's ability to handle version management by forcing users to update when critical updates are available. It also enhances the splash screen navigation logic by separating the animation completion from the actual navigation decision, allowing for version checks and other initialization tasks to complete before determining the appropriate destination.