### PR TITLE
Use appVersionDisplay instead of appVersion in SettingsViewModel

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
@@ -47,8 +48,11 @@ class SettingsViewModel(
     }
 
     private fun fetchAppVersion() {
-        val appVersion = appInfoProvider.getAppInfo().appVersion
-        _uiState.value = _uiState.value.copy(appVersion = appVersion)
+        updateUiState {
+            copy(
+                appVersion = appInfoProvider.getAppInfo().appVersionDisplay,
+            )
+        }
     }
 
     fun onReferFriendClick() {
@@ -66,5 +70,9 @@ class SettingsViewModel(
 
     fun onOurStoryClick() {
         analytics.track(AnalyticsEvent.OurStoryClick)
+    }
+
+    private fun updateUiState(block: SettingsState.() -> SettingsState) {
+        _uiState.update(block)
     }
 }


### PR DESCRIPTION
### TL;DR

Updated app version display in Settings screen

### What changed?

- Replaced direct mutation of `_uiState.value` with a new `updateUiState` helper method that uses `update` from Kotlin flows
- Changed from using `appVersion` to `appVersionDisplay` from the app info provider
- Added a private helper method `updateUiState` to encapsulate state updates

### How to test?

1. Open the app and navigate to the Settings screen
2. Verify that the app version is displayed correctly
3. Confirm that the displayed version matches the expected format from `appVersionDisplay`

### Why make this change?

This change improves state management by using the more idiomatic `update` function from Kotlin flows instead of directly replacing the state value. It also switches to using `appVersionDisplay` which likely provides a more user-friendly version format than the raw `appVersion`.