### PR TITLE
Replace hardcoded yellow hex with magic_yellow constant in IntroState

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/intro/IntroState.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Stable
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.magic_yellow
+import xyz.ksharma.krail.taj.toHex
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 data class IntroState(
@@ -33,6 +35,7 @@ data class IntroState(
     }
 
     companion object {
+
         fun default(): IntroState = IntroState(
             pages = persistentListOf(
                 IntroPage(
@@ -40,7 +43,7 @@ data class IntroState(
                     colorsList = persistentListOf(
                         KrailThemeStyle.Metro.hexColorCode,
                         KrailThemeStyle.Bus.hexColorCode,
-                        "#FFC800", // Yellow
+                        magic_yellow.toHex(),
                         KrailThemeStyle.Metro.hexColorCode,
                     ),
                     title = "Save Your Trips",
@@ -54,7 +57,7 @@ data class IntroState(
                     id = 1,
                     colorsList = persistentListOf(
                         TransportMode.Ferry().colorCode,
-                        "#FFC800", // Yellow
+                        magic_yellow.toHex(),
                         TransportMode.Ferry().colorCode,
                     ),
                     title = "Live Updates",
@@ -68,7 +71,7 @@ data class IntroState(
                     id = 2,
                     colorsList = persistentListOf(
                         KrailThemeStyle.Bus.hexColorCode,
-                        "#FFC800", // Yellow
+                        magic_yellow.toHex(),
                         KrailThemeStyle.Bus.hexColorCode,
                     ),
                     title = "Park & Ride",
@@ -111,7 +114,7 @@ data class IntroState(
                     id = 5,
                     colorsList = persistentListOf(
                         KrailThemeStyle.PurpleDrip.hexColorCode,
-                        "#FFC800", // Yellow
+                        magic_yellow.toHex(),
                         KrailThemeStyle.PurpleDrip.hexColorCode,
                     ),
                     title = "Plan Your Trip",
@@ -125,7 +128,7 @@ data class IntroState(
                     id = 6,
                     colorsList = persistentListOf(
                         KrailThemeStyle.BarbiePink.hexColorCode,
-                        "#FFC800", // Yellow
+                        magic_yellow.toHex(),
                         KrailThemeStyle.BarbiePink.hexColorCode,
                     ),
                     title = "Invite Your Friends",


### PR DESCRIPTION
### TL;DR

Replaced hardcoded yellow color hex values with the `magic_yellow` constant in the `IntroState` class.

### What changed?

- Imported `magic_yellow` color constant and `toHex()` extension function
- Replaced all instances of the hardcoded yellow color value `"#FFC800"` with `magic_yellow.toHex()`
- This change affects multiple intro pages in the trip planner feature

### How to test?

1. Open the trip planner feature
2. Navigate through the intro pages
3. Verify that the yellow elements in the UI appear correctly
4. Confirm that the visual appearance hasn't changed from the previous implementation

### Why make this change?

This change improves code maintainability by using a centralized color constant instead of hardcoded hex values. If the yellow color needs to be updated in the future, it can be changed in a single location rather than finding and replacing all instances of the hex code throughout the codebase.