### PR TITLE
Reduce opacity of CookieShapeBox border and update default colors

### DIFF
--- a/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppUpgradeScreen.kt
+++ b/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppUpgradeScreen.kt
@@ -138,7 +138,9 @@ fun AppUpgradeScreen(
                     backgroundColor = KrailTheme.colors.surface,
                     cookieShadow = cookieShapeShadow(),
                     outlineBrush = Brush.linearGradient(
-                        colors = magicBorderColors(),
+                        colors = magicBorderColors().map {
+                            it.copy(alpha = 0.8f) // Slightly faded for subtlety
+                        },
                     ),
                     modifier = Modifier
                         .fillMaxWidth()

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CookieShapeBox.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CookieShapeBox.kt
@@ -21,8 +21,6 @@ import xyz.ksharma.krail.taj.magicBorderColors
 import xyz.ksharma.krail.taj.shapes.CookieShape
 import xyz.ksharma.krail.taj.shapes.buildCookiePath
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.themeBackgroundColor
-import xyz.ksharma.krail.taj.themeColor
 
 /**
  * A box with a cookie-shaped background and optional multi-color stroke.
@@ -40,8 +38,8 @@ import xyz.ksharma.krail.taj.themeColor
 @Composable
 fun CookieShapeBox(
     modifier: Modifier = Modifier,
-    backgroundColor: Color = themeBackgroundColor(),
-    strokeColor: Color = themeColor(),
+    backgroundColor: Color = KrailTheme.colors.surface,
+    strokeColor: Color = Color.Transparent,
     outlineBrush: Brush? = null,
     cookieShadow: Shadow? = null,
     content: @Composable () -> Unit = {},
@@ -84,12 +82,12 @@ fun CookieShapeBox(
 @Composable
 fun CookieShapeCanvas(
     modifier: Modifier = Modifier,
-    fill: Color = themeBackgroundColor(),
-    stroke: Color = themeColor()
+    backgroundColor: Color = KrailTheme.colors.surface,
+    stroke: Color = Color.Transparent,
 ) {
     Canvas(modifier.size(SIZE)) {
         val path = buildCookiePath(size, bumps = BUMPS, depthFraction = 0.13f, smooth = true)
-        drawPath(path, fill)
+        drawPath(path, backgroundColor)
         drawPath(path, stroke, style = Stroke(width = size.minDimension * 0.018f))
     }
 }


### PR DESCRIPTION
### TL;DR

Improved CookieShapeBox component with better default values and added subtle transparency to border colors in the AppUpgradeScreen.

### What changed?

- Updated `CookieShapeBox` component to use more appropriate default values:
    - Changed default `backgroundColor` to use `KrailTheme.colors.surface` directly
    - Changed default `strokeColor` to `Color.Transparent` instead of theme color
    - Renamed `fill` parameter to `backgroundColor` in `CookieShapeCanvas` for consistency
- Modified the magic border colors in `AppUpgradeScreen` to have 80% opacity (alpha = 0.8f) for a more subtle appearance
- Removed unused imports (`themeBackgroundColor` and `themeColor`) from CookieShapeBox.kt

### How to test?

1. Navigate to the AppUpgradeScreen and verify the border colors appear slightly more subtle
2. Check that any components using CookieShapeBox still render correctly with the updated defaults
3. Verify that the renamed parameter in CookieShapeCanvas doesn't break any existing implementations

### Why make this change?

This change improves the visual design consistency by:

- Making the magic border colors slightly more subtle for a refined look
- Establishing better defaults for the CookieShapeBox component that align with our design system
- Ensuring parameter naming is consistent between related functions