### PR TITLE
Restore app version check functionality in SplashViewModel and add update info tile

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -15,8 +15,10 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.appstart.AppStart
 import xyz.ksharma.krail.core.appversion.AppVersionManager
+import xyz.ksharma.krail.core.appversion.AppVersionUpdateState
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.coroutines.ext.safeResult
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
@@ -24,6 +26,8 @@ import xyz.ksharma.krail.sandook.SandookPreferences.Companion.KEY_HAS_SEEN_INTRO
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.trip.planner.ui.navigation.AppUpgradeRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 
 class SplashViewModel(
     private val sandook: Sandook,
@@ -100,8 +104,7 @@ class SplashViewModel(
     }
 
     private fun onSplashAnimationComplete() {
-        updateUiState { copy(navigationDestination = AppUpgradeRoute) }
-/*        viewModelScope.launchWithExceptionHandler<SplashViewModel>(
+       viewModelScope.launchWithExceptionHandler<SplashViewModel>(
             dispatcher = ioDispatcher,
             errorBlock = {
                 logError("Error during splash animation completion, navigating to saved trips.")
@@ -110,7 +113,7 @@ class SplashViewModel(
             when (appVersionManager.checkForUpdates()) {
                 AppVersionUpdateState.ForcedUpdateRequired -> {
                     log("Forced update required, navigating to update screen.")
-                    updateUiState { copy(navigationDestination = ForcedUpgradeRoute) }
+                    updateUiState { copy(navigationDestination = AppUpgradeRoute) }
                 }
 
                 AppVersionUpdateState.UpToDate, AppVersionUpdateState.UpdateRequired -> {
@@ -124,7 +127,7 @@ class SplashViewModel(
                     }
                 }
             }
-        }*/
+        }
     }
 
     private fun updateUiState(block: SplashState.() -> SplashState) {

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppVersionManager.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeAppVersionManager.kt
@@ -3,10 +3,11 @@ package xyz.ksharma.core.test.fakes
 import xyz.ksharma.krail.core.appversion.AppVersionManager
 import xyz.ksharma.krail.core.appversion.AppVersionUpdateState
 
-class FakeAppVersionManager: AppVersionManager {
+class FakeAppVersionManager : AppVersionManager {
 
     var versionUpdateState: AppVersionUpdateState = AppVersionUpdateState.UpToDate
     var mockCurrentVersion: String = "1.0.0"
+    var mockUpdateCopy: AppVersionManager.AppVersionUpdateCopy? = null
 
     override suspend fun checkForUpdates(): AppVersionUpdateState {
         return versionUpdateState
@@ -14,5 +15,9 @@ class FakeAppVersionManager: AppVersionManager {
 
     override fun getCurrentVersion(): String {
         return mockCurrentVersion
+    }
+
+    override suspend fun getUpdateCopy(): AppVersionManager.AppVersionUpdateCopy? {
+        return mockUpdateCopy
     }
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeAppInfoProvider
+import xyz.ksharma.core.test.fakes.FakeAppVersionManager
 import xyz.ksharma.core.test.fakes.FakeFlag
 import xyz.ksharma.core.test.fakes.FakeNswParkRideSandook
 import xyz.ksharma.core.test.fakes.FakeParkRideFacilityManager
@@ -17,6 +19,7 @@ import xyz.ksharma.core.test.fakes.FakeSandookPreferences
 import xyz.ksharma.core.test.fakes.FakeStopResultsManager
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.appversion.AppVersionManager
 import xyz.ksharma.krail.core.remote_config.flag.Flag
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.park.ride.network.service.ParkRideService
@@ -51,6 +54,10 @@ class SavedTripsViewModelTest {
 
     private val fakeSandookPreferences = FakeSandookPreferences()
 
+    private val fakeAppVersionManager = FakeAppVersionManager()
+
+    private val fakeAppInfoProvider = FakeAppInfoProvider()
+
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
@@ -64,6 +71,8 @@ class SavedTripsViewModelTest {
             stopResultsManager = fakeStopResultsManager,
             flag = fakeFlag,
             preferences = fakeSandookPreferences,
+            appVersionManager = fakeAppVersionManager,
+            appInfoProvider = fakeAppInfoProvider,
         )
     }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -5,6 +5,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
+import xyz.ksharma.krail.taj.components.InfoTileState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 @Stable
@@ -15,4 +16,5 @@ data class SavedTripsState(
     val parkRideUiState: ImmutableList<ParkRideUiState> = persistentListOf(),
     val isDiscoverAvailable: Boolean = false,
     val displayDiscoverBadge: Boolean = false,
+    val infoTiles: ImmutableSet<InfoTileState>? = null,
 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -16,5 +16,5 @@ data class SavedTripsState(
     val parkRideUiState: ImmutableList<ParkRideUiState> = persistentListOf(),
     val isDiscoverAvailable: Boolean = false,
     val displayDiscoverBadge: Boolean = false,
-    val infoTiles: ImmutableSet<InfoTileState>? = null,
+    val infoTiles: ImmutableList<InfoTileState>? = null,
 )

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.core.appInfo)
+                implementation(projects.core.appVersion)
                 implementation(projects.core.analytics)
                 implementation(projects.core.coroutinesExt)
                 implementation(projects.core.dateTime)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -55,6 +55,8 @@ val viewModelsModule = module {
             stopResultsManager = get(),
             flag = get(),
             preferences = get(),
+            appVersionManager = get(),
+            appInfoProvider = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -183,7 +183,7 @@ private fun LazyListScope.infoTiles(infoTiles: ImmutableList<InfoTileState>) {
             onCtaClicked = {},
             onDismissClick = {},
             modifier = Modifier
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -182,6 +182,8 @@ private fun LazyListScope.infoTiles(infoTiles: ImmutableList<InfoTileState>) {
             infoTileState = tileState,
             onCtaClicked = {},
             onDismissClick = {},
+            modifier = Modifier
+                .padding(horizontal = 16.dp),
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -26,12 +26,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_settings
 import krail.feature.trip_planner.ui.generated.resources.ic_sydney
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalTextStyle
+import xyz.ksharma.krail.taj.components.InfoTile
+import xyz.ksharma.krail.taj.components.InfoTileState
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
@@ -124,6 +127,11 @@ fun SavedTripsScreen(
                     }
 
                     savedTripsState.savedTrips.isEmpty() -> {
+
+                        savedTripsState.infoTiles?.let{ infoTiles ->
+                            infoTiles(infoTiles)
+                        }
+
                         item(key = "empty_state") {
                             ErrorMessage(
                                 emoji = "🌟",
@@ -137,6 +145,11 @@ fun SavedTripsScreen(
                     }
 
                     savedTripsState.savedTrips.isNotEmpty() -> {
+
+                        savedTripsState.infoTiles?.let{ infoTiles ->
+                            infoTiles(infoTiles)
+                        }
+
                         SavedTripsContent(
                             savedTripsState = savedTripsState,
                             onEvent = onEvent,
@@ -156,6 +169,19 @@ fun SavedTripsScreen(
             toButtonClick = toButtonClick,
             onReverseButtonClick = onReverseButtonClick,
             onSearchButtonClick = { onSearchButtonClick() },
+        )
+    }
+}
+
+private fun LazyListScope.infoTiles(infoTiles: ImmutableList<InfoTileState>) {
+    items(
+        items = infoTiles,
+        key = { item -> item.hashCode() },
+    ) { tileState ->
+        InfoTile(
+            infoTileState = tileState,
+            onCtaClicked = {},
+            onDismissClick = {},
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -557,7 +557,10 @@ class SavedTripsViewModel(
                 )
             )
             copy(
-                infoTiles = persistentListOf(infoTiles, updateTile).flatMapTo(InfoTileState)
+                infoTiles = (infoTiles ?: persistentListOf())
+                    .plus(updateTile)
+                    .toSet()
+                    .toImmutableList()
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -557,7 +557,7 @@ class SavedTripsViewModel(
                 )
             )
             copy(
-                infoTiles = (infoTiles?.plus(updateTile))?.toImmutableSet()
+                infoTiles = persistentListOf(infoTiles, updateTile).flatMapTo(InfoTileState)
             )
         }
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
@@ -1,11 +1,5 @@
 package xyz.ksharma.krail.taj.components
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -17,19 +11,24 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import xyz.ksharma.krail.taj.magicBorderColors
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.SHADOW_ALPHA
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.borderWidth
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.horizontalPadding
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.shadowRadius
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.shadowSpread
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.shape
+import xyz.ksharma.krail.taj.components.InfoTileDefaults.verticalPadding
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
-import xyz.ksharma.krail.taj.themeColor
 
 @Stable
 data class InfoTileState(
@@ -45,39 +44,46 @@ data class InfoTileCta(
     val url: String,
 )
 
+object InfoTileDefaults {
+    val shape: RoundedCornerShape = RoundedCornerShape(size = 12.dp)
+    val horizontalPadding = 12.dp
+    val verticalPadding = 16.dp
+    val borderWidth = 1.dp
+
+    // region Shadow
+    val shadowRadius = 12.dp
+    val shadowSpread = 2.dp
+    const val SHADOW_ALPHA = 1f
+    // endregion
+}
+
 @Composable
 fun InfoTile(
     infoTileState: InfoTileState,
     modifier: Modifier = Modifier,
-    backgroundColor: Color = themeBackgroundColor(),
     onCtaClicked: (url: String) -> Unit,
     onDismissClick: (() -> Unit) = {},
 ) {
-    val infiniteTransition = rememberInfiniteTransition()
-    val gradientOffset by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 3000, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        )
-    )
-
     Column(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                width = 2.dp,
-                brush = Brush.linearGradient(
-                    colors = listOf(
-                        themeColor(),
-                        KrailTheme.colors.magicYellow,
-                        themeColor(),
-                    ),
-                ),
-                shape = RoundedCornerShape(12.dp)
+                width = borderWidth,
+                color = themeBackgroundColor(),
+                shape = shape,
             )
-            .padding(vertical = 16.dp, horizontal = 12.dp),
+            .dropShadow(
+                shape = shape,
+                shadow = Shadow(
+                    radius = shadowRadius,
+                    color = themeBackgroundColor(),
+                    spread = shadowSpread,
+                    alpha = SHADOW_ALPHA,
+                )
+            )
+            .background(color = KrailTheme.colors.surface, shape = shape)
+            .padding(vertical = verticalPadding, horizontal = horizontalPadding)
+            .semantics(mergeDescendants = true) {},
     ) {
         Text(
             text = infoTileState.title,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
@@ -1,6 +1,13 @@
 package xyz.ksharma.krail.taj.components
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,15 +17,19 @@ import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.taj.magicBorderColors
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
+import xyz.ksharma.krail.taj.themeColor
 
 @Stable
 data class InfoTileState(
@@ -42,11 +53,31 @@ fun InfoTile(
     onCtaClicked: (url: String) -> Unit,
     onDismissClick: (() -> Unit) = {},
 ) {
+    val infiniteTransition = rememberInfiniteTransition()
+    val gradientOffset by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 3000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        )
+    )
+
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = backgroundColor, shape = RoundedCornerShape(16.dp))
-            .padding(vertical = 12.dp, horizontal = 16.dp),
+            .border(
+                width = 2.dp,
+                brush = Brush.linearGradient(
+                    colors = listOf(
+                        themeColor(),
+                        KrailTheme.colors.magicYellow,
+                        themeColor(),
+                    ),
+                ),
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(vertical = 16.dp, horizontal = 12.dp),
     ) {
         Text(
             text = infoTileState.title,
@@ -56,13 +87,13 @@ fun InfoTile(
         Text(
             text = infoTileState.description,
             style = KrailTheme.typography.bodyMedium,
-            modifier = Modifier.padding(top = 4.dp),
+            modifier = Modifier.padding(top = 8.dp),
         )
 
         Row(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
         ) {
             TextButton(
                 onClick = onDismissClick,


### PR DESCRIPTION
# Implement App Version Update Notification in Saved Trips Screen

This PR enables app version update notifications in the Saved Trips screen by:

1. Restoring the app version check logic in `SplashViewModel` that was previously commented out
2. Enhancing `AppVersionManager` with new methods:
    - `isOptionalUpdateAvailable()` and `isForcedUpdateRequired()` for checking update status
    - `getUpdateCopy()` to retrieve appropriate messaging for update notifications
    - Added `AppVersionUpdateCopy` data class to store title, description, and CTA text
3. Updating the Saved Trips screen to:
    - Display update notifications as info tiles
    - Add version check logic in `SavedTripsViewModel`
    - Inject `AppVersionManager` and `AppInfoProvider` dependencies
4. Improving the `InfoTile` component with:
    - Better styling with borders and drop shadows
    - Standardized padding and spacing
    - Added `InfoTileDefaults` object for consistent styling properties