### PR TITLE
Refactor InfoTileState to InfoTileData with type-based priority system

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
 
+import xyz.ksharma.krail.taj.components.InfoTileData
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 sealed interface SavedTripUiEvent {
@@ -25,4 +26,8 @@ sealed interface SavedTripUiEvent {
     data class ParkRideCardClick(
         val parkRideState: ParkRideUiState, val isExpanded: Boolean
     ) : SavedTripUiEvent
+
+    data class DismissInfoTile(val infoTile: InfoTileData) : SavedTripUiEvent
+
+    data class InfoTileCtaClick(val infoTile: String) : SavedTripUiEvent
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -5,7 +5,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
-import xyz.ksharma.krail.taj.components.InfoTileState
+import xyz.ksharma.krail.taj.components.InfoTileData
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 @Stable
@@ -16,5 +16,5 @@ data class SavedTripsState(
     val parkRideUiState: ImmutableList<ParkRideUiState> = persistentListOf(),
     val isDiscoverAvailable: Boolean = false,
     val displayDiscoverBadge: Boolean = false,
-    val infoTiles: ImmutableList<InfoTileState>? = null,
+    val infoTiles: ImmutableList<InfoTileData>? = null,
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -34,7 +34,7 @@ import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.InfoTile
-import xyz.ksharma.krail.taj.components.InfoTileState
+import xyz.ksharma.krail.taj.components.InfoTileData
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
@@ -173,13 +173,13 @@ fun SavedTripsScreen(
     }
 }
 
-private fun LazyListScope.infoTiles(infoTiles: ImmutableList<InfoTileState>) {
+private fun LazyListScope.infoTiles(infoTiles: ImmutableList<InfoTileData>) {
     items(
         items = infoTiles,
         key = { item -> item.hashCode() },
     ) { tileState ->
         InfoTile(
-            infoTileState = tileState,
+            infoTileData = tileState,
             onCtaClicked = {},
             onDismissClick = {},
             modifier = Modifier

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
@@ -31,12 +31,32 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 
 @Stable
-data class InfoTileState(
+data class InfoTileData(
     val title: String,
+
     val description: String,
+
+    /**
+     * Type of Tile which determines its priority in the list of Tiles.
+     */
+    val type: InfoTileType,
+
     val dismissCtaText: String = "Dismiss",
+
+    /**
+     * ISO-8601 formatted date string representing the end date of the info tile.
+     * E.g., "2023-12-31" for December 31, 2023.
+     */
+    val endDate: String? = null,
+
     val primaryCta: InfoTileCta? = null,
-)
+) {
+    enum class InfoTileType(val priority: Int) {
+        INFO(priority = 1),
+        APP_UPDATE(priority = 2), //  higher priority than info, but lower than alert
+        CRITICAL_ALERT(9999), // highest priority, should be shown at top of list
+    }
+}
 
 @Stable
 data class InfoTileCta(
@@ -46,7 +66,7 @@ data class InfoTileCta(
 
 object InfoTileDefaults {
     val shape: RoundedCornerShape = RoundedCornerShape(size = 12.dp)
-    val horizontalPadding = 12.dp
+    val horizontalPadding = 16.dp
     val verticalPadding = 16.dp
     val borderWidth = 1.dp
 
@@ -59,7 +79,7 @@ object InfoTileDefaults {
 
 @Composable
 fun InfoTile(
-    infoTileState: InfoTileState,
+    infoTileData: InfoTileData,
     modifier: Modifier = Modifier,
     onCtaClicked: (url: String) -> Unit,
     onDismissClick: (() -> Unit) = {},
@@ -86,12 +106,12 @@ fun InfoTile(
             .semantics(mergeDescendants = true) {},
     ) {
         Text(
-            text = infoTileState.title,
+            text = infoTileData.title,
             style = KrailTheme.typography.title,
         )
 
         Text(
-            text = infoTileState.description,
+            text = infoTileData.description,
             style = KrailTheme.typography.bodyMedium,
             modifier = Modifier.padding(top = 8.dp),
         )
@@ -106,10 +126,10 @@ fun InfoTile(
                 dimensions = ButtonDefaults.mediumButtonSize(),
                 modifier = Modifier.padding(end = 12.dp),
             ) {
-                Text(text = infoTileState.dismissCtaText)
+                Text(text = infoTileData.dismissCtaText)
             }
 
-            infoTileState.primaryCta?.let { cta ->
+            infoTileData.primaryCta?.let { cta ->
                 Button(
                     dimensions = ButtonDefaults.mediumButtonSize(),
                     onClick = { onCtaClicked(cta.url) },
@@ -132,13 +152,14 @@ private fun InfoTileLightPreview() {
     //  In future, colors should be calculated and set in tokens rather than being calculated on fly.
     PreviewTheme(themeStyle = KrailThemeStyle.PurpleDrip, darkTheme = false) {
         InfoTile(
-            infoTileState = InfoTileState(
+            infoTileData = InfoTileData(
                 title = "Service update",
                 description = "Planned maintenance may cause minor delays this weekend.",
                 primaryCta = InfoTileCta(
                     text = "Learn more",
                     url = "https://example.com/maintenance",
                 ),
+                type = InfoTileData.InfoTileType.INFO,
             ),
             onCtaClicked = {},
             onDismissClick = {},
@@ -152,9 +173,10 @@ private fun InfoTileLightPreview() {
 private fun InfoTileDarkPreview() {
     PreviewTheme(themeStyle = KrailThemeStyle.Train, darkTheme = true) {
         InfoTile(
-            infoTileState = InfoTileState(
+            infoTileData = InfoTileData(
                 title = "Network issue resolved",
                 description = "All lines are now operating on their regular schedules.",
+                type = InfoTileData.InfoTileType.INFO,
             ),
             onCtaClicked = {},
             onDismissClick = {},


### PR DESCRIPTION
### TL;DR

Updated the InfoTile component to support prioritization and improved the handling of info tiles in the SavedTrips screen.

### What changed?

- Renamed `InfoTileState` to `InfoTileData` with enhanced properties:
    - Added `type` enum property to categorize tiles (INFO, APP_UPDATE, CRITICAL_ALERT)
    - Added priority system for sorting tiles
    - Added optional `endDate` field for expiration dates
- Added new UI events in `SavedTripUiEvent` for dismissing tiles and handling CTA clicks
- Modified the SavedTripsViewModel to sort info tiles by priority and limit display to 2 tiles
- Increased horizontal padding in InfoTile from 12dp to 16dp for better visual appearance
- Updated all references to use the new `InfoTileData` class

### How to test?

1. Navigate to the SavedTrips screen
2. Verify that info tiles appear in the correct priority order
3. Confirm that at most 2 tiles are displayed at once
4. Test that the dismiss and CTA click functionality works correctly
5. Check that the updated padding looks correct in the UI

### Why make this change?

This change improves the user experience by prioritizing important notifications and preventing information overload. The type-based prioritization ensures critical alerts are shown first, followed by app updates and general information. The limit of 2 tiles prevents the UI from becoming cluttered while still delivering important information to users.