### PR TITLE
Implement InfoTile CTA click handling with PlatformOps integration

### DIFF
--- a/core/test/build.gradle.kts
+++ b/core/test/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
                 implementation(projects.feature.tripPlanner.ui)
                 implementation(projects.feature.tripPlanner.state)
                 implementation(projects.feature.tripPlanner.network)
+                implementation(projects.platform.ops)
                 implementation(projects.taj)
 
                 implementation(libs.test.junit)

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakePlatformOps.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakePlatformOps.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.core.test.fakes
+
+import xyz.ksharma.krail.platform.ops.PlatformOps
+
+class FakePlatformOps : PlatformOps {
+    var lastSharedText: String? = null
+    var lastShareTitle: String? = null
+    var lastOpenedUrl: String? = null
+
+    override fun sharePlainText(text: String, title: String) {
+        lastSharedText = text
+        lastShareTitle = title
+    }
+
+    override fun openUrl(url: String) {
+        lastOpenedUrl = url
+    }
+}

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -14,6 +14,7 @@ import xyz.ksharma.core.test.fakes.FakeFlag
 import xyz.ksharma.core.test.fakes.FakeNswParkRideSandook
 import xyz.ksharma.core.test.fakes.FakeParkRideFacilityManager
 import xyz.ksharma.core.test.fakes.FakeParkRideService
+import xyz.ksharma.core.test.fakes.FakePlatformOps
 import xyz.ksharma.core.test.fakes.FakeSandook
 import xyz.ksharma.core.test.fakes.FakeSandookPreferences
 import xyz.ksharma.core.test.fakes.FakeStopResultsManager
@@ -57,6 +58,7 @@ class SavedTripsViewModelTest {
     private val fakeAppVersionManager = FakeAppVersionManager()
 
     private val fakeAppInfoProvider = FakeAppInfoProvider()
+    private val fakePlatformOps = FakePlatformOps()
 
     @BeforeTest
     fun setUp() {
@@ -73,6 +75,7 @@ class SavedTripsViewModelTest {
             preferences = fakeSandookPreferences,
             appVersionManager = fakeAppVersionManager,
             appInfoProvider = fakeAppInfoProvider,
+            platformOps = fakePlatformOps,
         )
     }
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -26,6 +26,8 @@ import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.park.ride.network.service.ParkRideService
 import xyz.ksharma.krail.sandook.NswParkRideSandook
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.taj.components.InfoTileCta
+import xyz.ksharma.krail.taj.components.InfoTileData
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -33,6 +35,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -267,4 +270,25 @@ class SavedTripsViewModelTest {
             val eventName = AnalyticsEvent.ToFieldClickEvent.name
             assertTrue(fakeAnalytics.isEventTracked(eventName))
         }
+
+    @Test
+    fun `GIVEN InfoTileCtaClick event WHEN triggered THEN platformOps openUrl is called with correct url`() = runTest {
+        // GIVEN an info tile with a primary CTA URL
+        val testUrl = "https://example.com"
+        val infoTile = InfoTileData(
+            title = "Test",
+            description = "Test Desc",
+            type = InfoTileData.InfoTileType.APP_UPDATE,
+            primaryCta = InfoTileCta(
+                text = "Go",
+                url = testUrl
+            )
+        )
+
+        // WHEN the InfoTileCtaClick event is triggered
+        viewModel.onEvent(SavedTripUiEvent.InfoTileCtaClick(infoTile))
+
+        // THEN verify platformOps.openUrl was called with the correct URL
+        assertEquals(testUrl, fakePlatformOps.lastOpenedUrl)
+    }
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
 
 import xyz.ksharma.krail.taj.components.InfoTileData
+import xyz.ksharma.krail.taj.components.InfoTileState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 sealed interface SavedTripUiEvent {
@@ -29,5 +30,5 @@ sealed interface SavedTripUiEvent {
 
     data class DismissInfoTile(val infoTile: InfoTileData) : SavedTripUiEvent
 
-    data class InfoTileCtaClick(val infoTile: String) : SavedTripUiEvent
+    data class InfoTileCtaClick(val infoTile: InfoTileData) : SavedTripUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -57,6 +57,7 @@ val viewModelsModule = module {
             preferences = get(),
             appVersionManager = get(),
             appInfoProvider = get(),
+            platformOps = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -128,8 +128,13 @@ fun SavedTripsScreen(
 
                     savedTripsState.savedTrips.isEmpty() -> {
 
-                        savedTripsState.infoTiles?.let{ infoTiles ->
-                            infoTiles(infoTiles)
+                        savedTripsState.infoTiles?.let { infoTiles ->
+                            infoTiles(
+                                infoTiles = infoTiles,
+                                onCtaClicked = { tileData ->
+                                    onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
+                                },
+                            )
                         }
 
                         item(key = "empty_state") {
@@ -145,9 +150,13 @@ fun SavedTripsScreen(
                     }
 
                     savedTripsState.savedTrips.isNotEmpty() -> {
-
-                        savedTripsState.infoTiles?.let{ infoTiles ->
-                            infoTiles(infoTiles)
+                        savedTripsState.infoTiles?.let { infoTiles ->
+                            infoTiles(
+                                infoTiles = infoTiles,
+                                onCtaClicked = { tileData ->
+                                    onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
+                                },
+                            )
                         }
 
                         SavedTripsContent(
@@ -173,14 +182,17 @@ fun SavedTripsScreen(
     }
 }
 
-private fun LazyListScope.infoTiles(infoTiles: ImmutableList<InfoTileData>) {
+private fun LazyListScope.infoTiles(
+    infoTiles: ImmutableList<InfoTileData>,
+    onCtaClicked: (InfoTileData) -> Unit,
+) {
     items(
         items = infoTiles,
         key = { item -> item.hashCode() },
-    ) { tileState ->
+    ) { tileData ->
         InfoTile(
-            infoTileData = tileState,
-            onCtaClicked = {},
+            infoTileData = tileData,
+            onCtaClicked = onCtaClicked,
             onDismissClick = {},
             modifier = Modifier
                 .padding(horizontal = 16.dp, vertical = 12.dp),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -39,6 +39,7 @@ import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
 import xyz.ksharma.krail.park.ride.network.service.ParkRideService
+import xyz.ksharma.krail.platform.ops.PlatformOps
 import xyz.ksharma.krail.sandook.NSWParkRideFacilityDetail
 import xyz.ksharma.krail.sandook.NswParkRideSandook
 import xyz.ksharma.krail.sandook.NswParkRideSandook.Companion.SavedParkRideSource.SavedTrips
@@ -72,6 +73,7 @@ class SavedTripsViewModel(
     private val preferences: SandookPreferences,
     private val appVersionManager: AppVersionManager,
     private val appInfoProvider: AppInfoProvider,
+    private val platformOps: PlatformOps,
 ) : ViewModel() {
 
     private val nonPeakTimeCooldownSeconds: Long by lazy {
@@ -160,8 +162,15 @@ class SavedTripsViewModel(
 
             is SavedTripUiEvent.DismissInfoTile -> {} //onDismissInfoTile(event.infoTileState)
 
-            is SavedTripUiEvent.InfoTileCtaClick -> {} // onInfoTileCtaClick(event.infoTileState)
+            is SavedTripUiEvent.InfoTileCtaClick -> onInfoTileCtaClick(event.infoTile)
         }
+    }
+
+    private fun onInfoTileCtaClick(infoTile: InfoTileData) {
+        infoTile.primaryCta?.url?.let { url ->
+            platformOps.openUrl(url)
+        }
+        // TODO - track analytics.
     }
 
     private fun onParkRideCardClick(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/InfoTile.kt
@@ -94,7 +94,7 @@ fun InfoTile(
     infoTileData: InfoTileData,
     infoTileState: InfoTileState = InfoTileState.COLLAPSED,
     modifier: Modifier = Modifier,
-    onCtaClicked: (url: String) -> Unit,
+    onCtaClicked: (InfoTileData) -> Unit,
     onDismissClick: (() -> Unit) = {},
 ) {
     var state by rememberSaveable { mutableStateOf(infoTileState) }
@@ -161,7 +161,7 @@ fun InfoTile(
                 infoTileData.primaryCta?.let { cta ->
                     Button(
                         dimensions = ButtonDefaults.mediumButtonSize(),
-                        onClick = { onCtaClicked(cta.url) },
+                        onClick = { onCtaClicked(infoTileData) },
                     ) {
                         Text(text = cta.text)
                     }


### PR DESCRIPTION
### TL;DR

Added functionality to handle InfoTile CTA clicks in the SavedTripsScreen by opening URLs through PlatformOps.

### What changed?

- Created a new `FakePlatformOps` class for testing purposes
- Updated `SavedTripUiEvent.InfoTileCtaClick` to pass the entire `InfoTileData` instead of just a string
- Implemented the `onInfoTileCtaClick` method in `SavedTripsViewModel` to open URLs using `PlatformOps`
- Modified the `InfoTile` component to pass the entire `InfoTileData` to the `onCtaClicked` callback
- Connected the InfoTile CTA clicks in the SavedTripsScreen to the appropriate event handler

### How to test?

1. Navigate to the SavedTripsScreen
2. Verify that InfoTiles are displayed correctly
3. Click on a CTA button in an InfoTile
4. Confirm that the URL associated with the CTA opens correctly

### Why make this change?

This change enables users to interact with call-to-action buttons in InfoTiles on the SavedTripsScreen. Previously, clicking these buttons had no effect. Now, when a user clicks a CTA button, the associated URL will open, providing a more interactive and useful experience.