### PR TITLE
Add slide-out animation for dismissing info tiles

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,5 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -19,8 +22,11 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -197,13 +203,25 @@ private fun LazyListScope.infoTiles(
         items = infoTiles,
         key = { item -> item.key },
     ) { tileData ->
-        InfoTile(
-            infoTileData = tileData,
-            onCtaClick = onCtaClick,
-            onDismissClick = onDismissClick,
-            modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-        )
+        var visible by remember { mutableStateOf(true) }
+        AnimatedVisibility(
+            visible = visible,
+            exit = slideOutHorizontally(
+                targetOffsetX = { it }, // slide fully to the right
+                animationSpec = tween(300)
+            ),
+        ) {
+            InfoTile(
+                infoTileData = tileData,
+                onCtaClick = onCtaClick,
+                onDismissClick = {
+                    visible = false
+                    onDismissClick
+                },
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
### TL;DR

Added animation when dismissing info tiles in the Saved Trips screen and reset dismissed info tiles on app launch.

### What changed?

- Added slide-out animation when dismissing info tiles in the `SavedTripsScreen`
- Implemented `AnimatedVisibility` with a horizontal slide-out effect
- Added local state tracking for tile visibility
- Reset dismissed info tiles by setting an empty string to `KEY_DISMISSED_INFO_TILES` preference when the view model initializes

### How to test?

1. Navigate to the Saved Trips screen
2. Locate an info tile and tap the dismiss button
3. Verify that the tile slides out horizontally before disappearing
4. Restart the app and verify that previously dismissed info tiles reappear

## Visuals

https://github.com/user-attachments/assets/f66386d3-f06a-45c9-983d-f9d6269cd201


### Why make this change?

This change improves the user experience by providing visual feedback when dismissing info tiles, making the interaction feel more polished and intuitive. The reset of dismissed info tiles ensures users will see important information after app updates.