### PR TITLE
Fix InfoTile dismissal functionality and remove debug logs

### DIFF
--- a/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
+++ b/discover/state/src/commonMain/kotlin/xyz/ksharma/krail/discover/state/DiscoverState.kt
@@ -93,10 +93,8 @@ data class DiscoverCardButtonRowState(
 }
 
 fun List<Button>.toButtonRowState(): DiscoverCardButtonRowState? {
-    println("toButtonRowState - Input: ${this.map { it::class.simpleName }}")
 
     if (!isValidButtonCombo()) {
-        println("toButtonRowState - FAILED validation")
         return null
     }
 
@@ -108,16 +106,17 @@ fun List<Button>.toButtonRowState(): DiscoverCardButtonRowState? {
             is Button.Cta -> {
                 left = DiscoverCardButtonRowState.LeftButtonType.Cta(button)
             }
+
             is Button.Social -> {
                 left = DiscoverCardButtonRowState.LeftButtonType.Social(button)
             }
+
             is Button.Share -> {
                 right = DiscoverCardButtonRowState.RightButtonType.Share(button)
             }
         }
     }
 
-    println("toButtonRowState - Result: left=${left}, right=${right}")
     return DiscoverCardButtonRowState(left, right)
 }
 
@@ -125,7 +124,6 @@ fun List<Button>.isValidButtonCombo(): Boolean {
     val types = this.map { it::class }
 
     // This logs: [PartnerSocial, Share]
-    println("Button validation - Input buttons: ${this.map { it::class.simpleName }}")
 
     val leftTypes = listOf(
         Button.Cta::class,
@@ -151,6 +149,5 @@ fun List<Button>.isValidButtonCombo(): Boolean {
     }
 
     // The validation should pass and return true
-    println("Button validation - PASSED: Valid button combination")
     return true
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -50,7 +50,7 @@ fun SavedTripCard(
         modifier = modifier
             .cardBackground()
             .klickable(onClick = onCardClick)
-            .padding(vertical = 16.dp, horizontal = 12.dp),
+            .padding(vertical = 16.dp, horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         primaryTransportMode?.let {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -216,7 +216,7 @@ private fun LazyListScope.infoTiles(
                 onCtaClick = onCtaClick,
                 onDismissClick = {
                     visible = false
-                    onDismissClick
+                    onDismissClick(tileData)
                 },
                 modifier = Modifier
                     .padding(horizontal = 16.dp, vertical = 12.dp),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -552,18 +552,18 @@ class SavedTripsViewModel(
     private suspend fun updateInfoTilesUiState() {
         log("Updating info tiles in UI state")
         val activeTiles = infoTileManager.getInfoTiles()
+        log("Active info tiles: ${activeTiles.map { it.key }}")
         updateUiState {
             copy(infoTiles = activeTiles.toImmutableList())
         }
     }
 
     private fun onDismissInfoTile(infoTileData: InfoTileData) {
-        log("Dismissing info tile: ${infoTileData.key}")
-        infoTileManager.markInfoTileDismissed(infoTileData)
-        updateUiState {
-            copy(
-                infoTiles = infoTiles?.filter { it.key != infoTileData.key }?.toImmutableList()
-            )
+        log("onDismissInfoTile: ${infoTileData.key}")
+        viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+            log("Dismissing info tile: ${infoTileData.key}")
+            infoTileManager.markInfoTileDismissed(infoTileData)
+            updateInfoTilesUiState()
         }
     }
 

--- a/info-tile/network/api/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/api/db/InfolTilePreferences.kt
+++ b/info-tile/network/api/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/api/db/InfolTilePreferences.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.info.tile.network.api.db
 
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SandookPreferences.Companion.KEY_DISMISSED_INFO_TILES
 
@@ -17,6 +18,7 @@ fun SandookPreferences.isInfoTileDismissed(key: String): Boolean {
         ?.split(",")
         ?.filter { it.isNotBlank() }
         ?.toSet() ?: emptySet()
+    log("Checking if info tile key '$key' is dismissed. Dismissed keys: ${dismissed.joinToString(",")}")
     return key in dismissed
 }
 
@@ -35,4 +37,11 @@ fun SandookPreferences.markInfoTileAsDismissed(key: String) {
         ?.toMutableSet() ?: mutableSetOf()
     dismissed.add(key)
     setString(KEY_DISMISSED_INFO_TILES, dismissed.joinToString(","))
+    log(
+        "Marked info tile key '$key' as dismissed. Updated dismissed keys: ${
+            dismissed.joinToString(
+                ","
+            )
+        }"
+    )
 }

--- a/info-tile/network/real/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/real/RealInfoTileManager.kt
+++ b/info-tile/network/real/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/real/RealInfoTileManager.kt
@@ -47,6 +47,7 @@ class RealInfoTileManager(
     }
 
     override fun markInfoTileDismissed(infoTileData: InfoTileData) {
+        log("Marking info tile key '${infoTileData.key}' as dismissed.")
         preferences.markInfoTileAsDismissed(infoTileData.key)
     }
 
@@ -68,7 +69,7 @@ class RealInfoTileManager(
         filter { isKeyNotInDismissedTiles(it.key) }
 
     private fun isKeyNotInDismissedTiles(key: String): Boolean {
-        log("Checking if info tile key '$key' is not in dismissed tiles.")
+        log("Checking if info tile key '$key' is not in dismissed tiles. : ${preferences.isInfoTileDismissed(key)}")
         return !preferences.isInfoTileDismissed(key)
     }
 

--- a/info-tile/state/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/state/InfoTileState.kt
+++ b/info-tile/state/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/state/InfoTileState.kt
@@ -1,8 +1,10 @@
 package xyz.ksharma.krail.info.tile.state
 
 import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
 
 @Stable
+@Serializable
 data class InfoTileData(
     /**
      * Unique key to identify the info tile, will be used to track when user dismisses the tile.
@@ -36,6 +38,7 @@ data class InfoTileData(
 }
 
 @Stable
+@Serializable
 data class InfoTileCta(
     val text: String,
     val url: String,


### PR DESCRIPTION
### TL;DR

Fixed info tile dismissal functionality and removed debug logging statements.

### What changed?

- Fixed the info tile dismissal functionality by properly invoking the `onDismissClick` callback with the tile data parameter
- Moved the info tile dismissal logic to run on the IO dispatcher within a coroutine
- Added proper logging for info tile dismissal operations
- Added `@Serializable` annotation to `InfoTileData` and `InfoTileCta` classes
- Removed unnecessary debug print statements from button validation logic
- Adjusted horizontal padding in `SavedTripCard` from 12dp to 16dp for better visual consistency

### How to test?

1. Navigate to the Saved Trips screen
2. Verify that info tiles appear correctly
3. Dismiss an info tile and confirm it disappears properly
4. Restart the app and verify the dismissed tile remains hidden
5. Check that the SavedTripCard has consistent 16dp padding on all sides

### Why make this change?

The info tile dismissal functionality was broken as the callback wasn't being properly invoked with the tile data. Additionally, the dismissal operation wasn't running on the appropriate dispatcher, which could cause UI freezes. This change ensures proper persistence of dismissed tiles and improves the overall user experience by fixing these issues and providing consistent UI padding.