### PR TITLE
Adjust vertical padding for info tiles from 12dp to 8dp

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -219,7 +219,7 @@ private fun LazyListScope.infoTiles(
                     onDismissClick(tileData)
                 },
                 modifier = Modifier
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
             )
         }
     }


### PR DESCRIPTION
### TL;DR

Adjusted vertical padding in the SavedTripsScreen info tiles from 12dp to 8dp.

### What changed?

Modified the vertical padding in the `SavedTripsScreen.kt` file from 12dp to 8dp for info tiles in the lazy list. This change affects the spacing around content in the saved trips view.

### How to test?

1. Navigate to the Saved Trips screen
2. Verify that the info tiles have the correct vertical spacing (8dp)
3. Confirm that the UI looks visually balanced with the reduced padding

## Visuals

https://github.com/user-attachments/assets/0bb97bf1-ae80-467b-9b13-c465ba14da98

