### PR TITLE
Update InfoTileType priority values to reorder display sequence

### DIFF
--- a/info-tile/state/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/state/InfoTileState.kt
+++ b/info-tile/state/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/state/InfoTileState.kt
@@ -31,9 +31,9 @@ data class InfoTileData(
     val primaryCta: InfoTileCta? = null,
 ) {
     enum class InfoTileType(val priority: Int) {
-        INFO(priority = 1),
-        APP_UPDATE(priority = 2), //  higher priority than info, but lower than alert
-        CRITICAL_ALERT(9999), // highest priority, should be shown at top of list
+        CRITICAL_ALERT(1), // highest priority, should be shown at top of list
+        INFO(priority = 100), // higher priority than app update
+        APP_UPDATE(priority = 200), // lower priority than info, should be shown at bottom of list
     }
 }
 


### PR DESCRIPTION
### TL;DR

Updated the priority values for InfoTileType enum to better reflect display order requirements.

### What changed?

- Changed CRITICAL_ALERT priority from 9999 to 1
- Changed INFO priority from 1 to 100
- Changed APP_UPDATE priority from 2 to 200
- Updated comments to accurately reflect the new priority ordering

### How to test?

1. Verify that InfoTiles are displayed in the correct order with CRITICAL_ALERT at the top, followed by INFO, and APP_UPDATE at the bottom
2. Check that any sorting logic using these priority values works as expected with the new values

### Why make this change?

The previous priority values didn't clearly communicate the intended display order. This change establishes a more intuitive numbering system where lower numbers indicate higher priority (CRITICAL_ALERT = 1), and provides more spacing between values to allow for potential future priority levels to be inserted between existing ones if needed.