### PR TITLE
Add analytics to info tiles

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -363,4 +363,24 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     )
 
     // endregion
+
+    // region InfoTiles
+
+    data class InfoTileInteraction(
+        val key: String,
+        val expand: Boolean? = null,
+        val dismiss: Boolean? = null,
+        val ctaUrl: String? = null,
+    ) : AnalyticsEvent(
+        name = "info_tile_interaction",
+        properties = mutableMapOf<String, Any>(
+            "key" to key,
+        ).apply {
+            dismiss?.let { put("dismiss", dismiss) }
+            ctaUrl?.let { put("cta_click", ctaUrl) }
+            expand?.let { put("expand", expand) }
+        }
+    )
+
+    // endregion
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -127,7 +127,39 @@ object RemoteConfigDefaults {
             ),
             Pair(
                 first = FlagKeys.INFO_TILES.key,
-                second = "[]",
+                second = """
+                    [
+                      {
+                        "key": "update_2024",
+                        "title": "App Update Available",
+                        "description": "A new version of the app is available. Update now for new features.",
+                        "type": "APP_UPDATE",
+                        "dismissCtaText": "Dismiss",
+                        "primaryCta": {
+                          "text": "Update",
+                          "url": "https://example.com/app"
+                        }
+                      },
+                      {
+                        "key": "info_001",
+                        "title": "Welcome!",
+                        "description": "Thanks for installing our app.",
+                        "type": "INFO",
+                        "dismissCtaText": "Dismiss",
+                        "endDate": "2025-09-01",
+                        "primaryCta": {
+                          "text": "Learn More",
+                          "url": "https://example.com/welcome"
+                        }
+                      },
+                      {
+                        "key": "critical_01",
+                        "title": "Security Alert",
+                        "description": "Please update your app immediately.",
+                        "type": "CRITICAL_ALERT"
+                      }
+                    ]
+                """.trimIndent(),
             )
         )
     }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -30,4 +30,6 @@ sealed interface SavedTripUiEvent {
     data class DismissInfoTile(val infoTile: InfoTileData) : SavedTripUiEvent
 
     data class InfoTileCtaClick(val infoTile: InfoTileData) : SavedTripUiEvent
+
+    data class InfoTileExpand(val key: String): SavedTripUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -143,6 +143,9 @@ fun SavedTripsScreen(
                                 onDismissClick = { tileData ->
                                     onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
                                 },
+                                onTileExpand = {
+                                    onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
+                                },
                             )
                         }
 
@@ -167,6 +170,9 @@ fun SavedTripsScreen(
                                 },
                                 onDismissClick = { tileData ->
                                     onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
+                                },
+                                onTileExpand = {
+                                    onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
                                 },
                             )
                         }
@@ -198,6 +204,7 @@ private fun LazyListScope.infoTiles(
     infoTiles: ImmutableList<InfoTileData>,
     onCtaClick: (InfoTileData) -> Unit,
     onDismissClick: (InfoTileData) -> Unit,
+    onTileExpand: (InfoTileData) -> Unit,
 ) {
     items(
         items = infoTiles,
@@ -218,6 +225,7 @@ private fun LazyListScope.infoTiles(
                     visible = false
                     onDismissClick(tileData)
                 },
+                onTileExpand = onTileExpand,
                 modifier = Modifier
                     .padding(horizontal = 16.dp, vertical = 8.dp),
             )

--- a/info-tile/ui/src/commonMain/kotlin/xyz/ksharma/krail/info/tiles/ui/InfoTile.kt
+++ b/info-tile/ui/src/commonMain/kotlin/xyz/ksharma/krail/info/tiles/ui/InfoTile.kt
@@ -63,6 +63,8 @@ fun InfoTile(
     modifier: Modifier = Modifier,
     onCtaClick: (InfoTileData) -> Unit,
     onDismissClick: (InfoTileData) -> Unit,
+    // required for analytics only
+    onTileExpand: (InfoTileData) -> Unit = {},
 ) {
     var state by rememberSaveable { mutableStateOf(infoTileState) }
 
@@ -84,7 +86,11 @@ fun InfoTile(
             .klickable(
                 onClick = {
                     state = when (state) {
-                        InfoTileState.COLLAPSED -> InfoTileState.EXPANDED
+                        InfoTileState.COLLAPSED -> {
+                            onTileExpand(infoTileData)
+                            InfoTileState.EXPANDED
+                        }
+
                         InfoTileState.EXPANDED -> InfoTileState.COLLAPSED
                     }
                 },


### PR DESCRIPTION
### TL;DR

Added analytics tracking for info tile interactions and implemented expandable info tiles with sample configurations.

### What changed?

- Added a new `InfoTileInteraction` analytics event to track user interactions with info tiles
- Created sample info tile configurations in `RemoteConfigDefaults` with different types (APP_UPDATE, INFO, CRITICAL_ALERT)
- Added a new `InfoTileExpand` UI event to handle tile expansion
- Implemented analytics tracking for info tile interactions (expand, dismiss, CTA clicks)
- Updated the `InfoTile` component to support expansion tracking
- Modified `SavedTripsScreen` and `SavedTripsViewModel` to handle and track info tile interactions

### How to test?

1. Navigate to the Saved Trips screen
2. Interact with info tiles by:
   - Expanding/collapsing tiles
   - Clicking on CTAs
   - Dismissing tiles
3. Verify analytics events are being tracked correctly in your analytics dashboard
4. Check that the sample info tiles display correctly with their respective configurations

### Why make this change?

This change enables tracking user interactions with info tiles to better understand engagement and effectiveness. The analytics data will help optimize the content and presentation of info tiles. Additionally, the sample configurations provide a foundation for different types of notifications (updates, information, alerts) that can be displayed to users.


### Visuals

<img width="1333" height="209" alt="Screenshot 2025-08-31 at 7 31 28 pm" src="https://github.com/user-attachments/assets/7e8e4f2e-27c7-404e-93bd-d11899ece956" />


