### PR TITLE
Remove default info tiles from remote config

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remote_config/RemoteConfigDefaults.kt
@@ -127,39 +127,7 @@ object RemoteConfigDefaults {
             ),
             Pair(
                 first = FlagKeys.INFO_TILES.key,
-                second = """
-                    [
-                      {
-                        "key": "update_2024",
-                        "title": "App Update Available",
-                        "description": "A new version of the app is available. Update now for new features.",
-                        "type": "APP_UPDATE",
-                        "dismissCtaText": "Dismiss",
-                        "primaryCta": {
-                          "text": "Update",
-                          "url": "https://example.com/app"
-                        }
-                      },
-                      {
-                        "key": "info_001",
-                        "title": "Welcome!",
-                        "description": "Thanks for installing our app.",
-                        "type": "INFO",
-                        "dismissCtaText": "Dismiss",
-                        "endDate": "2025-09-01",
-                        "primaryCta": {
-                          "text": "Learn More",
-                          "url": "https://example.com/welcome"
-                        }
-                      },
-                      {
-                        "key": "critical_01",
-                        "title": "Security Alert",
-                        "description": "Please update your app immediately.",
-                        "type": "CRITICAL_ALERT"
-                      }
-                    ]
-                """.trimIndent(),
+                second = "[]",
             )
         )
     }


### PR DESCRIPTION
### TL;DR

Removed default info tiles from remote config defaults.

### What changed?

Changed the default value for `FlagKeys.INFO_TILES.key` from a JSON array containing three sample info tiles to an empty array (`[]`). The previous default included sample tiles for app updates, welcome messages, and security alerts.

### How to test?

1. Verify that when remote config is initialized with defaults, no info tiles appear in the app
2. Confirm that info tiles can still be added through the remote config service when needed
3. Check that existing remote config implementations aren't affected by this change

### Why make this change?

The default info tiles were likely sample/placeholder content that shouldn't appear in production environments. Removing them prevents unintended tiles from showing up in the app when using default configurations, requiring explicit configuration for any info tiles to be displayed.