### PR TITLE
Improve accessibility for large font sizes in transport mode components

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -41,6 +41,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.toAdaptiveDecorativeIconSize
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -283,10 +284,10 @@ private fun StopsRow(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
-    FlowRow(
+    Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         val buttonContainerColor by remember {
             mutableStateOf(line.transportMode.colorCode.hexToComposeColor())
@@ -456,7 +457,22 @@ private fun PreviewLegViewLightRail() {
 @Preview
 @Composable
 private fun PreviewStopsRow() {
-    KrailTheme {
+    PreviewTheme {
+        StopsRow(
+            stops = "3 stops",
+            line = TransportModeLine(
+                transportMode = TransportMode.Bus(),
+                lineName = "700",
+            ),
+            onClick = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewStopsRow_LargeFont() {
+    PreviewTheme(fontScale = 2.0f) {
         StopsRow(
             stops = "3 stops",
             line = TransportModeLine(
@@ -490,7 +506,7 @@ private fun PreviewRouteSummary() {
             routeText = "towards AVC via XYZ Rd",
             modifier = Modifier.background(KrailTheme.colors.surface),
             badgeText = "700",
-            badgeColor = "00B5EF".hexToComposeColor(),
+            badgeColor = Color.Red,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -35,7 +35,7 @@ fun TransportModeBadge(
     ) {
         Box(
             modifier = modifier
-                .requiredHeightIn(with(density) { 28.toDp() })
+                //.requiredHeightIn(with(density) { 28.toDp() })
                 .clip(shape = RoundedCornerShape(percent = 20))
                 .background(color = backgroundColor),
             contentAlignment = Alignment.Center,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeChip.kt
@@ -84,7 +84,6 @@ fun TransportModeChip(
             TransportModeIcon(
                 transportMode = transportMode,
                 displayBorder = true,
-                adaptiveSize = true,
             )
 
             Text(text = transportMode.name, color = textColor)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
@@ -20,8 +21,8 @@ import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.toAdaptiveDecorativeIconSize
-import xyz.ksharma.krail.taj.toAdaptiveSize
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
@@ -30,7 +31,6 @@ fun TransportModeIcon(
     transportMode: TransportMode,
     modifier: Modifier = Modifier,
     borderColor: Color = Color.White,
-    adaptiveSize: Boolean = false,
     displayBorder: Boolean = false,
     size: TransportModeIconSize = TransportModeIconSize.Medium,
 ) {
@@ -43,13 +43,8 @@ fun TransportModeIcon(
     ) {
         Box(
             modifier = modifier
-                .size(
-                    if (adaptiveSize) {
-                        size.dpSize.toAdaptiveSize()
-                    } else {
-                        size.dpSize.toAdaptiveDecorativeIconSize()
-                    }
-                )
+                .size(size.dpSize.toAdaptiveDecorativeIconSize())
+                .heightIn(min = size.dpSize)
                 .clip(CircleShape)
                 .background(
                     color = transportMode.colorCode.hexToComposeColor(),
@@ -101,6 +96,21 @@ private fun TrainPreview() {
         )
     }
 }
+
+@Preview(group = previewGroupName)
+@Composable
+private fun TrainPreviewLarge() {
+    PreviewTheme(
+        fontScale = 2.0f,
+        backgroundColor = Color.Transparent,
+    ) {
+        TransportModeIcon(
+            transportMode = TransportMode.Train(),
+            displayBorder = false,
+        )
+    }
+}
+
 
 @Preview(group = previewGroupName)
 @Composable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeInfo.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeInfo.kt
@@ -5,8 +5,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalContentAlpha
-import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 @Composable
@@ -32,9 +33,20 @@ fun TransportModeInfo(
 
 // region Previews
 
+@Preview
 @Composable
 private fun TransportModeInfoPreview() {
-    KrailTheme {
+    PreviewTheme {
+        TransportModeInfo(
+            transportMode = TransportMode.Bus(),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TransportModeInfoPreview_LargeFont() {
+    PreviewTheme(fontScale = 2.0f) {
         TransportModeInfo(
             transportMode = TransportMode.Bus(),
         )

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/DpExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/DpExt.kt
@@ -23,7 +23,7 @@ fun Dp.toAdaptiveSize(): Dp {
 fun Dp.toAdaptiveDecorativeIconSize(): Dp {
     val density = LocalDensity.current
     return if (density.fontScale > 1.5f) {
-        this.times(density.fontScale * 0.7f)
+        this.times(density.fontScale * 0.8f)
     } else {
         this.times(density.fontScale)
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/PreviewTheme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/PreviewTheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import xyz.ksharma.krail.taj.LocalThemeColor
@@ -18,6 +19,7 @@ fun PreviewTheme(
     modifier: Modifier = Modifier,
     darkTheme: Boolean = false,
     fontScale: Float = 1.0f, // temporary measure until font scale support is added to compose multiplatform
+    backgroundColor: Color = KrailTheme.colors.surface,
     content: @Composable () -> Unit,
 ) {
     KrailTheme(darkTheme = darkTheme) {
@@ -27,7 +29,7 @@ fun PreviewTheme(
             LocalThemeColor provides color,
             LocalDensity provides Density(density = density.density, fontScale = fontScale)
         ) {
-            Column(modifier = modifier.systemBarsPadding().background(KrailTheme.colors.surface)) {
+            Column(modifier = modifier.systemBarsPadding().background(backgroundColor)) {
                 content()
             }
         }


### PR DESCRIPTION
### TL;DR

Improved accessibility for large font sizes in the trip planner UI components.

### What changed?

- Replaced `FlowRow` with `Row` in `StopsRow` component to better handle text alignment
- Removed fixed height constraint in `TransportModeBadge` to allow content to expand with larger font sizes
- Removed `adaptiveSize` parameter from `TransportModeIcon` and improved its sizing logic
- Added `heightIn` modifier to `TransportModeIcon` to ensure minimum size
- Adjusted the scaling factor in `toAdaptiveDecorativeIconSize()` from 0.7f to 0.8f for better proportions
- Added large font size previews to test accessibility
- Updated `PreviewTheme` to accept a background color parameter
- Fixed a color in `PreviewRouteSummary` (changed from hex color to Color.Red)

### How to test?

1. Run the app with different font scale settings (particularly 2.0x)
2. Verify that all transport mode icons, badges, and text remain properly aligned and visible
3. Check that components expand appropriately to accommodate larger text
4. Review the new preview functions with large font sizes

### Why make this change?

These changes improve accessibility for users with visual impairments who rely on larger font sizes. The previous implementation had fixed heights and layout constraints that caused text clipping and misalignment when font sizes were increased. This update ensures that UI components adapt properly to different font scales while maintaining visual consistency.