### PR TITLE
Refine JourneyCard layout with platform-dependent transport mode display

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -392,7 +392,7 @@ fun DefaultJourneyCardContent(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            if (displayAdaptiveTransportModeList(transportModeLineList)) {
+            if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
                 Text(
                     text = timeToDeparture,
                     style = KrailTheme.typography.titleMedium,
@@ -427,12 +427,12 @@ fun DefaultJourneyCardContent(
                     text = text,
                     textAlign = TextAlign.Center,
                     style = KrailTheme.typography.labelLarge,
-                    modifier = Modifier,
+                    modifier = Modifier.padding(start = 4.dp),
                 )
             }
         }
 
-        if (displayAdaptiveTransportModeList(transportModeLineList)) {
+        if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
             // Always show badges/icons on a new line for large font scale; let FlowRow wrap
             TransportModesRow(
                 transportModeLineList = transportModeLineList,
@@ -492,8 +492,9 @@ fun DefaultJourneyCardContent(
 
 @Composable
 private fun displayAdaptiveTransportModeList(
-    transportModeLineList: ImmutableList<TransportModeLine>
-): Boolean = isLargeFontScale() || transportModeLineList.size > 2
+    transportModeLineList: ImmutableList<TransportModeLine>,
+    platformText: String?,
+): Boolean = isLargeFontScale() || transportModeLineList.size > 2 && platformText != null
 
 @Composable
 private fun TransportModesRow(


### PR DESCRIPTION
### TL;DR

Updated the journey card layout to improve display of transport modes based on platform availability.

### What changed?

- Modified the `displayAdaptiveTransportModeList` function to consider platform text availability when determining layout
- Added padding to text elements in the journey card for better spacing
- Updated the conditional logic for displaying transport modes in a separate row

### How to test?

1. Open the trip planner and view journey cards with various combinations of:
   - Different numbers of transport modes
   - With and without platform text
   - At different font scale settings
2. Verify that transport modes display correctly in all scenarios
3. Check that the layout adapts appropriately based on the presence of platform text

### Why make this change?

This change improves the journey card UI by making the transport mode display more contextual. Now, the decision to show transport modes in a separate row depends not only on font scale and number of transport modes, but also on whether platform text is available. This creates a more balanced and informative layout that better utilizes the available space.

## Visuals

<img width="337" height="747" alt="ptext" src="https://github.com/user-attachments/assets/6d1ab0b8-9ce9-44fb-a491-69d7883f1752" />

