### PR TITLE
Add fare calculator logic

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/FareCalculator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/FareCalculator.kt
@@ -1,0 +1,96 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+
+enum class UserType { ADULT, CHILD, CONCESSION, SENIOR }
+data class FareResult(
+    val totalFare: Double
+)
+
+fun calculateFare(
+    userType: UserType,
+    mode: TransportMode,
+    distanceKm: Double,
+    isPeak: Boolean,
+    isFridayOrWeekendOrHoliday: Boolean,
+    includesAirport: Boolean = false,
+    faresSoFarToday: Double = 0.0,
+    faresSoFarThisWeek: Double = 0.0,
+): FareResult {
+    val fare = when (userType) {
+        UserType.ADULT -> when (mode) {
+            is TransportMode.Train, is TransportMode.Metro -> when {
+                distanceKm <= 10 -> if (isPeak) 4.20 else 2.94
+                distanceKm <= 20 -> if (isPeak) 5.22 else 3.65
+                distanceKm <= 35 -> if (isPeak) 6.01 else 4.20
+                distanceKm <= 65 -> if (isPeak) 8.03 else 5.62
+                else -> if (isPeak) 10.33 else 7.23
+            }
+            is TransportMode.Bus, is TransportMode.LightRail -> when {
+                distanceKm <= 3 -> if (isPeak) 3.20 else 2.24
+                distanceKm <= 8 -> if (isPeak) 4.36 else 3.05
+                else -> if (isPeak) 5.60 else 3.92
+            }
+            is TransportMode.Ferry -> if (distanceKm <= 9) 7.13 else 8.92
+            is TransportMode.Coach -> 0.0 // Not covered by Opal
+        }
+        UserType.CHILD, UserType.CONCESSION -> when (mode) {
+            is TransportMode.Train, is TransportMode.Metro -> when {
+                distanceKm <= 10 -> if (isPeak) 2.10 else 1.47
+                distanceKm <= 20 -> if (isPeak) 2.61 else 1.82
+                distanceKm <= 35 -> if (isPeak) 3.00 else 2.10
+                distanceKm <= 65 -> if (isPeak) 4.01 else 2.80
+                else -> if (isPeak) 5.16 else 3.61
+            }
+            is TransportMode.Bus, is TransportMode.LightRail -> when {
+                distanceKm <= 3 -> if (isPeak) 1.60 else 1.12
+                distanceKm <= 8 -> if (isPeak) 2.18 else 1.52
+                else -> if (isPeak) 2.80 else 1.96
+            }
+            is TransportMode.Ferry -> if (distanceKm <= 9) 3.56 else 4.46
+            is TransportMode.Coach -> 0.0
+        }
+        UserType.SENIOR -> when (mode) {
+            is TransportMode.Train, is TransportMode.Metro -> when {
+                distanceKm <= 10 -> if (isPeak) 2.10 else 1.47
+                distanceKm <= 20 -> if (isPeak) 2.50 else 1.82
+                distanceKm <= 35 -> if (isPeak) 2.50 else 2.10
+                distanceKm <= 65 -> 2.50
+                else -> 2.50
+            }
+            is TransportMode.Bus, is TransportMode.LightRail -> when {
+                distanceKm <= 3 -> if (isPeak) 1.60 else 1.12
+                distanceKm <= 8 -> if (isPeak) 2.18 else 1.52
+                else -> if (isPeak) 2.50 else 1.96
+            }
+            is TransportMode.Ferry -> 2.50 // Daily cap applies
+            is TransportMode.Coach -> 0.0
+        }
+    }
+
+    val airportFee = when (userType) {
+        UserType.ADULT -> if (includesAirport) 17.34 else 0.0
+        UserType.CHILD, UserType.CONCESSION, UserType.SENIOR -> if (includesAirport) 15.50 else 0.0
+    }
+
+    val dailyCap = when (userType) {
+        UserType.ADULT -> if (isFridayOrWeekendOrHoliday) 9.35 else 18.70
+        UserType.CHILD, UserType.CONCESSION -> if (isFridayOrWeekendOrHoliday) 4.65 else 9.35
+        UserType.SENIOR -> 2.50
+    }
+    val weeklyCap = when (userType) {
+        UserType.ADULT -> 50.0
+        UserType.CHILD, UserType.CONCESSION -> 25.0
+        UserType.SENIOR -> 17.50
+    }
+
+    val cappedFare = minOf(
+        fare,
+        dailyCap - faresSoFarToday,
+        weeklyCap - faresSoFarThisWeek
+    ).coerceAtLeast(0.0)
+
+    val totalFare = cappedFare + airportFee
+
+    return FareResult(totalFare = totalFare)
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/FareCalculatorTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/FareCalculatorTest.kt
@@ -1,0 +1,516 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
+
+class FareCalculatorTest {
+    // region ADULT tests
+    @Test
+    fun testAdultTrainPeak_0_10km() =
+        assertEquals(
+            4.20,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 8.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainOffPeak_0_10km() =
+        assertEquals(
+            2.94,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 8.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainPeak_10_20km() =
+        assertEquals(
+            5.22,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 15.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainOffPeak_10_20km() =
+        assertEquals(
+            3.65,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 15.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainPeak_20_35km() =
+        assertEquals(
+            6.01,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 25.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainOffPeak_20_35km() =
+        assertEquals(
+            4.20,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 25.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainPeak_35_65km() =
+        assertEquals(
+            8.03,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 50.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainOffPeak_35_65km() =
+        assertEquals(
+            5.62,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 50.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainPeak_65plus() =
+        assertEquals(
+            10.33,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 70.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultTrainOffPeak_65plus() =
+        assertEquals(
+            7.23,
+            calculateFare(UserType.ADULT, TransportMode.Train(), 70.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultBusPeak_0_3km() =
+        assertEquals(
+            3.20,
+            calculateFare(UserType.ADULT, TransportMode.Bus(), 2.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultBusOffPeak_0_3km() =
+        assertEquals(
+            2.24,
+            calculateFare(UserType.ADULT, TransportMode.Bus(), 2.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultBusPeak_3_8km() =
+        assertEquals(
+            4.36,
+            calculateFare(UserType.ADULT, TransportMode.Bus(), 5.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultBusOffPeak_3_8km() =
+        assertEquals(
+            3.05,
+            calculateFare(UserType.ADULT, TransportMode.Bus(), 5.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultBusPeak_8plus() =
+        assertEquals(
+            5.60,
+            calculateFare(UserType.ADULT, TransportMode.Bus(), 10.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultBusOffPeak_8plus() =
+        assertEquals(
+            3.92,
+            calculateFare(UserType.ADULT, TransportMode.Bus(), 10.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultFerryShort() =
+        assertEquals(
+            7.13,
+            calculateFare(UserType.ADULT, TransportMode.Ferry(), 5.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultFerryLong() =
+        assertEquals(
+            8.92,
+            calculateFare(UserType.ADULT, TransportMode.Ferry(), 15.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultMetroPeak() =
+        assertEquals(
+            4.20,
+            calculateFare(UserType.ADULT, TransportMode.Metro(), 8.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testAdultWithAirportFee() =
+        assertEquals(
+            4.20 + 17.34,
+            calculateFare(
+                UserType.ADULT,
+                TransportMode.Train(),
+                8.0,
+                true,
+                false,
+                includesAirport = true
+            ).totalFare,
+            0.01
+        )
+
+    // endregion
+
+    // region CHILD tests
+    @Test
+    fun testChildTrainPeak_0_10km() =
+        assertEquals(
+            2.10,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 8.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainOffPeak_0_10km() =
+        assertEquals(
+            1.47,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 8.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainPeak_10_20km() =
+        assertEquals(
+            2.61,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 15.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainOffPeak_10_20km() =
+        assertEquals(
+            1.82,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 15.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainPeak_20_35km() =
+        assertEquals(
+            3.00,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 25.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainOffPeak_20_35km() =
+        assertEquals(
+            2.10,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 25.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainPeak_35_65km() =
+        assertEquals(
+            4.01,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 50.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainOffPeak_35_65km() =
+        assertEquals(
+            2.80,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 50.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainPeak_65plus() =
+        assertEquals(
+            5.16,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 70.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildTrainOffPeak_65plus() =
+        assertEquals(
+            3.61,
+            calculateFare(UserType.CHILD, TransportMode.Train(), 70.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildBusPeak_0_3km() =
+        assertEquals(
+            1.60,
+            calculateFare(UserType.CHILD, TransportMode.Bus(), 2.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildBusOffPeak_0_3km() =
+        assertEquals(
+            1.12,
+            calculateFare(UserType.CHILD, TransportMode.Bus(), 2.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildBusPeak_3_8km() =
+        assertEquals(
+            2.18,
+            calculateFare(UserType.CHILD, TransportMode.Bus(), 5.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildBusOffPeak_3_8km() =
+        assertEquals(
+            1.52,
+            calculateFare(UserType.CHILD, TransportMode.Bus(), 5.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildBusPeak_8plus() =
+        assertEquals(
+            2.80,
+            calculateFare(UserType.CHILD, TransportMode.Bus(), 10.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildBusOffPeak_8plus() =
+        assertEquals(
+            1.96,
+            calculateFare(UserType.CHILD, TransportMode.Bus(), 10.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildFerryShort() =
+        assertEquals(
+            3.56,
+            calculateFare(UserType.CHILD, TransportMode.Ferry(), 5.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildFerryLong() =
+        assertEquals(
+            4.46,
+            calculateFare(UserType.CHILD, TransportMode.Ferry(), 15.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildMetroPeak() =
+        assertEquals(
+            2.10,
+            calculateFare(UserType.CHILD, TransportMode.Metro(), 8.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testChildWithAirportFee() =
+        assertEquals(
+            2.10 + 15.50,
+            calculateFare(
+                UserType.CHILD,
+                TransportMode.Train(),
+                8.0,
+                true,
+                false,
+                includesAirport = true
+            ).totalFare,
+            0.01
+        )
+    // endregion
+
+    // region SENIOR tests
+    @Test
+    fun testSeniorTrainPeak_0_10km() =
+        assertEquals(
+            2.10,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 8.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainOffPeak_0_10km() =
+        assertEquals(
+            1.47,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 8.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainPeak_10_20km() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 15.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainOffPeak_10_20km() =
+        assertEquals(
+            1.82,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 15.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainPeak_20_35km() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 25.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainOffPeak_20_35km() =
+        assertEquals(
+            2.10,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 25.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainPeak_35_65km() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 50.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainOffPeak_35_65km() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 50.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainPeak_65plus() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 70.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorTrainOffPeak_65plus() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Train(), 70.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorBusPeak_0_3km() =
+        assertEquals(
+            1.60,
+            calculateFare(UserType.SENIOR, TransportMode.Bus(), 2.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorBusOffPeak_0_3km() =
+        assertEquals(
+            1.12,
+            calculateFare(UserType.SENIOR, TransportMode.Bus(), 2.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorBusPeak_3_8km() =
+        assertEquals(
+            2.18,
+            calculateFare(UserType.SENIOR, TransportMode.Bus(), 5.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorBusOffPeak_3_8km() =
+        assertEquals(
+            1.52,
+            calculateFare(UserType.SENIOR, TransportMode.Bus(), 5.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorBusPeak_8plus() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Bus(), 10.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorBusOffPeak_8plus() =
+        assertEquals(
+            1.96,
+            calculateFare(UserType.SENIOR, TransportMode.Bus(), 10.0, false, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorFerryShort() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Ferry(), 5.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorFerryLong() =
+        assertEquals(
+            2.50,
+            calculateFare(UserType.SENIOR, TransportMode.Ferry(), 15.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorMetroPeak() =
+        assertEquals(
+            2.10,
+            calculateFare(UserType.SENIOR, TransportMode.Metro(), 8.0, true, false).totalFare,
+            0.01
+        )
+
+    @Test
+    fun testSeniorWithAirportFee() =
+        assertEquals(
+            2.10 + 15.50,
+            calculateFare(
+                UserType.SENIOR,
+                TransportMode.Train(),
+                8.0,
+                true,
+                false,
+                includesAirport = true
+            ).totalFare,
+            0.01
+        )
+
+    // endregion
+}


### PR DESCRIPTION
### TL;DR

Added fare calculation functionality for public transport trips based on user type, distance, and time of travel.

### What changed?

- Created a new `FareCalculator.kt` file with:
  - `UserType` enum (ADULT, CHILD, CONCESSION, SENIOR)
  - `FareResult` data class to hold calculation results
  - `calculateFare()` function that determines fares based on:
    - User type (adult, child, concession, senior)
    - Transport mode (train, metro, bus, light rail, ferry)
    - Distance traveled
    - Peak/off-peak times
    - Day of week (weekday vs weekend/holiday)
    - Airport station usage
    - Daily and weekly fare caps

- Added comprehensive unit tests in `FareCalculatorTest.kt` covering:
  - All user types
  - All transport modes
  - Various distance bands
  - Peak and off-peak scenarios
  - Airport fee calculations

### How to test?

1. Run the unit tests in `FareCalculatorTest.kt` to verify fare calculations
2. Test with different combinations of:
   - User types (adult, child, concession, senior)
   - Transport modes (train, metro, bus, light rail, ferry)
   - Distances (short, medium, long trips)
   - Peak and off-peak times
   - Weekday vs weekend travel
   - Airport station inclusion

### Why make this change?

This implementation provides accurate fare calculations for the trip planner feature, allowing users to see the cost of their journey based on their eligibility type, distance traveled, and time of travel. The fare structure follows the Opal card pricing system with appropriate daily and weekly caps.