### PR TITLE
Set 100% content alpha for TransportModeBadge text

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -13,11 +13,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens
 
 @Composable
 fun TransportModeBadge(
@@ -28,6 +30,8 @@ fun TransportModeBadge(
     CompositionLocalProvider(
         LocalTextColor provides Color.White,
         LocalTextStyle provides KrailTheme.typography.titleMedium,
+        // Alpha should always be 100%
+        LocalContentAlpha provides ContentAlphaTokens.EnabledContentAlpha,
     ) {
         Box(
             modifier = modifier


### PR DESCRIPTION
# Fix Transport Mode Badge Alpha

This PR fixes an issue with the Transport Mode Badge by ensuring consistent visibility:

- Sets ContentAlpha to always be 100% for transport mode badges
- Adds `LocalContentAlpha provides ContentAlphaTokens.EnabledContentAlpha` to the CompositionLocalProvider
- Prevents any alpha-related visual inconsistencies in the badge display

This change ensures that transport mode badges maintain full opacity regardless of their context in the UI.