### PR TITLE
Replace gradient border with solid colors for journey cards

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -131,7 +131,8 @@ fun JourneyCard(
                         Modifier.border(
                             width = 2.dp,
                             shape = RoundedCornerShape(12.dp),
-                            color = KrailTheme.colors.onSurface,
+                            color = if (isPastJourney) KrailTheme.colors.pastJourney
+                            else KrailTheme.colors.futureJourney,
                         )
                     } else {
                         Modifier
@@ -543,8 +544,7 @@ private fun ResponsiveJourneyInfoRow(
         // Try 3: Split clock up (Row1: dest + clock) (Row2: walk start, deviation end)
         val firstRowSplitFits = (destW + clockW) <= maxW
         val secondRowSplitFits = walkW <= secondRowSpace
-        val splitClockUp =
-            !oneRowFits && !twoRowDefaultFits && firstRowSplitFits && secondRowSplitFits
+        val splitClockUp = !oneRowFits && !twoRowDefaultFits && firstRowSplitFits && secondRowSplitFits
 
         val layoutHeight = when {
             oneRowFits -> maxOf(destH, clockH, walkH, devH)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -29,10 +29,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
@@ -129,11 +131,7 @@ fun JourneyCard(
                         Modifier.border(
                             width = 2.dp,
                             shape = RoundedCornerShape(12.dp),
-                            brush = if (!isPastJourney) {
-                                Brush.linearGradient(colors = borderColors)
-                            } else {
-                                Brush.linearGradient(listOf(pastJourneyColor, pastJourneyColor))
-                            },
+                            color = KrailTheme.colors.onSurface,
                         )
                     } else {
                         Modifier
@@ -545,7 +543,8 @@ private fun ResponsiveJourneyInfoRow(
         // Try 3: Split clock up (Row1: dest + clock) (Row2: walk start, deviation end)
         val firstRowSplitFits = (destW + clockW) <= maxW
         val secondRowSplitFits = walkW <= secondRowSpace
-        val splitClockUp = !oneRowFits && !twoRowDefaultFits && firstRowSplitFits && secondRowSplitFits
+        val splitClockUp =
+            !oneRowFits && !twoRowDefaultFits && firstRowSplitFits && secondRowSplitFits
 
         val layoutHeight = when {
             oneRowFits -> maxOf(destH, clockH, walkH, devH)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -16,13 +16,18 @@ val md_theme_light_softLabel = Color(0xFF767676)
 val md_theme_light_secondary_label = Color(0xFF2E2E2E)
 val md_theme_light_discover_chip_background = Color(0xFFF5F5F5)
 val md_theme_light_discover_card_background = Color(0xFFF5F5F5)
-
 // Light theme (Deviations colors)
 val md_theme_light_onTime = Color(0xFF31DB39)
 val md_theme_light_early = Color(0xFFFFC60F)
 val md_theme_light_late = Color(0xFFF12525)
+// Future and past journey colors
+val md_theme_light_future_journey= Color(0xFF3A3A3A)
+val md_theme_light_past_journey = Color(0xFFBBBBBB)
 
-// Dark Color tokens
+
+/**
+ * KRAIL Dark theme color tokens
+ */
 val md_theme_dark_error = Color(0xFFFFB4AB)
 val md_theme_dark_errorContainer = Color(0xFF93000A)
 val md_theme_dark_onError = Color(0xFF690005)
@@ -40,7 +45,12 @@ val md_theme_dark_discover_card_background = Color(0xFF292929)
 val md_theme_dark_onTime = Color(0xFF31DB39)
 val md_theme_dark_early = Color(0xFFFFC60F)
 val md_theme_dark_late = Color(0xFFFF2B2B)
+// Future and past journey colors
+val md_theme_dark_future_journey= Color(0xFFEEEEEE)
+val md_theme_dark_past_journey = Color(0xFF8F8F8F)
 
+
+// Transport mode theme colors
 val bus_theme = Color(0xFF00B5EF)
 val train_theme = Color(0xFFF6891F)
 val metro_theme = Color(0xFF009B77)
@@ -77,6 +87,9 @@ data class KrailColors(
     val deviationOnTime: Color,
     val deviationEarly: Color,
     val deviationLate: Color,
+    // JourneyCard colors
+    val pastJourney: Color,
+    val futureJourney: Color,
 )
 
 internal val KrailLightColors = KrailColors(
@@ -98,6 +111,8 @@ internal val KrailLightColors = KrailColors(
     deviationOnTime = md_theme_light_onTime,
     deviationEarly = md_theme_light_early,
     deviationLate = md_theme_light_late,
+    pastJourney = md_theme_light_past_journey,
+    futureJourney = md_theme_light_future_journey,
 )
 
 internal val KrailDarkColors = KrailColors(
@@ -119,6 +134,8 @@ internal val KrailDarkColors = KrailColors(
     deviationOnTime = md_theme_dark_onTime,
     deviationEarly = md_theme_dark_early,
     deviationLate = md_theme_dark_late,
+    pastJourney = md_theme_dark_past_journey,
+    futureJourney = md_theme_dark_future_journey,
 )
 
 internal val LocalKrailColors = staticCompositionLocalOf {
@@ -141,5 +158,7 @@ internal val LocalKrailColors = staticCompositionLocalOf {
         deviationOnTime = Color.Unspecified,
         deviationEarly = Color.Unspecified,
         deviationLate = Color.Unspecified,
+        pastJourney = Color.Unspecified,
+        futureJourney = Color.Unspecified,
     )
 }


### PR DESCRIPTION
# Simplify Journey Card Border Colors

This PR replaces the gradient border with solid colors for journey cards. It adds dedicated design tokens for past and future journey colors in both light and dark themes.

Key changes:
- Replace gradient border with solid color borders in JourneyCard
- Add new color tokens for past and future journeys
- Remove unnecessary weight modifier in RouteSummary component