### PR TITLE
Make displayText nullable and improve train/metro destination formatting

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -111,7 +111,7 @@ data class TimeTableState(
                 val transportModeLine: TransportModeLine,
 
                 // transportation.description -> "Burwood to Liverpool",
-                val displayText: String, // "towards X via X"
+                val displayText: String?, // "towards X via X"
 
                 // leg.stopSequence.size  (leg.duration seconds)
                 val totalDuration: String, // 12 min"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -54,7 +54,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 
 @Composable
 fun LegView(
-    routeText: String, // AVC via XYZ
+    routeText: String?, // AVC via XYZ
     transportModeLine: TransportModeLine,
     stops: ImmutableList<TimeTableState.JourneyCardInfo.Stop>,
     modifier: Modifier = Modifier,
@@ -208,7 +208,7 @@ fun LegView(
 
 @Composable
 private fun RouteSummary(
-    routeText: String,
+    routeText: String?,
     badgeText: String,
     badgeColor: Color,
     modifier: Modifier = Modifier,
@@ -223,12 +223,14 @@ private fun RouteSummary(
             modifier = Modifier.padding(end = 10.dp)
         )
 
-        Text(
-            text = routeText,
-            style = KrailTheme.typography.labelLarge.copy(fontWeight = FontWeight.Normal), // token todo
-            modifier = Modifier
-                .align(Alignment.CenterVertically),
-        )
+        routeText?.let {
+            Text(
+                text = routeText,
+                style = KrailTheme.typography.labelLarge.copy(fontWeight = FontWeight.Normal), // token todo
+                modifier = Modifier
+                    .align(Alignment.CenterVertically),
+            )
+        }
     }
 }
 
@@ -250,8 +252,12 @@ private fun StopInfo(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            val textStyle = if (isProminent) KrailTheme.typography.titleSmall else KrailTheme.typography.bodySmall
-            val iconTint = if (isProminent) KrailTheme.colors.onSurface else KrailTheme.colors.onSurface.copy(alpha = 0.75f)
+            val textStyle =
+                if (isProminent) KrailTheme.typography.titleSmall else KrailTheme.typography.bodySmall
+            val iconTint =
+                if (isProminent) KrailTheme.colors.onSurface else KrailTheme.colors.onSurface.copy(
+                    alpha = 0.75f
+                )
 
             val annotated = remember(name, isWheelchairAccessible) {
                 buildAnnotatedString {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -119,9 +119,9 @@ private fun List<TripResponse.Leg>.logTransportModes() = forEachIndexed { index,
     log("Origin #$index: ${leg.origin?.disassembledName}")
     log(
         "TransportMode #$index: ${leg.transportation?.product?.productClass}, " +
-            "name: ${leg.transportation?.product?.name}, " +
-            "stops: ${leg.stopSequence?.size}, " +
-            "duration: ${leg.duration}",
+                "name: ${leg.transportation?.product?.name}, " +
+                "stops: ${leg.stopSequence?.size}, " +
+                "duration: ${leg.duration}",
     )
 }
 
@@ -151,12 +151,12 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
             ?.let { TransportMode.toTransportModeType(productClass = it) }
     val lineName = transportation?.disassembledName
 
-    val displayText =
-        if (transportation?.product?.productClass?.toInt() == TransportMode.Train().productClass) {
-            transportation?.destination?.name
-        } else {
-            transportation?.description
-        }
+    val productClass = transportation?.product?.productClass?.toInt()
+    val displayText = when (productClass) {
+        TransportMode.Train().productClass, TransportMode.Metro().productClass ->
+            "towards ${transportation?.destination?.name}"
+        else -> transportation?.description
+    }
     val numberOfStops = stopSequence?.size
     val displayDuration = duration?.seconds?.toFormattedDurationTimeString()
     val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
@@ -192,8 +192,8 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
             } else {
                 logError(
                     "Something is null - NOT adding Transport LEG: " +
-                        "TransportMode: $transportMode, lineName: $lineName, displayText: $displayText, " +
-                        "numberOfStops: $numberOfStops, stops: $stops, displayDuration: $displayDuration",
+                            "TransportMode: $transportMode, lineName: $lineName, displayText: $displayText, " +
+                            "numberOfStops: $numberOfStops, stops: $stops, displayDuration: $displayDuration",
                 )
                 null
             }
@@ -238,7 +238,7 @@ private fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInf
     // For first leg there is no arrival time, so using departure time.
     val time =
         departureTimeEstimated ?: departureTimePlanned ?: arrivalTimeEstimated
-            ?: arrivalTimePlanned
+        ?: arrivalTimePlanned
     return if (stopName != null && time != null) {
         TimeTableState.JourneyCardInfo.Stop(
             name = stopName,
@@ -271,6 +271,7 @@ private fun TripResponse.Leg?.getDepartureDeviation(): TimeTableState.JourneyCar
             val unit = if (abs == 1L) "min" else "mins"
             TimeTableState.JourneyCardInfo.DepartureDeviation.Late("$abs $unit late")
         }
+
         else -> {
             val abs = mins.absoluteValue
             val unit = if (abs == 1L) "min" else "mins"

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Made `displayText` nullable in TimeTableState and updated the UI to handle null values. Also improved the display text formatting for train and metro transport modes.

### What changed?

- Changed `displayText` in `TimeTableState.JourneyCardInfo.Leg` from `String` to `String?` to handle cases where there might not be a display text
- Updated `LegView` and `RouteSummary` components to handle nullable `routeText`
- Modified the display text formatting logic in `TripResponseMapper`:
  - For trains and metros, now shows "towards [destination]" format
  - For other transport modes, continues to use the transportation description
- Incremented iOS build number from 3 to 4

### How to test?

1. Navigate to the trip planner
2. Search for a journey that includes train or metro transport modes
3. Verify that the leg information displays "towards [destination]" for trains and metros
4. Verify that the UI handles cases where display text might be null

### Why make this change?

This change improves the user experience by providing more consistent and meaningful route descriptions. By making the display text nullable, we're also making the code more robust to handle cases where description information might be missing from the API response.