### PR TITLE
MAJOR UI: Replace JourneyCard border with divider

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -1,10 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
 import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -52,6 +50,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.AlertButton
 import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.SeparatorIcon
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -113,33 +112,12 @@ fun JourneyCard(
         KrailTheme.colors.onSurface
     }
 
-    val horizontalCardPadding by animateDpAsState(
-        targetValue = if (cardState == JourneyCardState.DEFAULT) 12.dp else 0.dp,
-        label = "cardPadding",
-    )
-
     CompositionLocalProvider(LocalContentAlpha provides if (isPastJourney) 0.5f else 1f) {
         Column(
             modifier = modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
                 .background(color = KrailTheme.colors.surface)
-                .then(
-                    if (cardState == JourneyCardState.DEFAULT) {
-                        Modifier.border(
-                            width = 2.dp,
-                            shape = RoundedCornerShape(12.dp),
-                            color = if (isPastJourney) KrailTheme.colors.pastJourney
-                            else KrailTheme.colors.futureJourney,
-                        )
-                    } else {
-                        Modifier
-                    },
-                )
-                .padding(
-                    vertical = 8.dp,
-                    horizontal = horizontalCardPadding,
-                )
                 .animateContentSize(),
         ) {
             when (cardState) {
@@ -180,6 +158,8 @@ fun JourneyCard(
                     ),
                 )
             }
+
+            Divider(modifier = Modifier.padding(top = 16.dp, start = 4.dp, end = 4.dp))
         }
     }
 }
@@ -543,7 +523,8 @@ private fun ResponsiveJourneyInfoRow(
         // Try 3: Split clock up (Row1: dest + clock) (Row2: walk start, deviation end)
         val firstRowSplitFits = (destW + clockW) <= maxW
         val secondRowSplitFits = walkW <= secondRowSpace
-        val splitClockUp = !oneRowFits && !twoRowDefaultFits && firstRowSplitFits && secondRowSplitFits
+        val splitClockUp =
+            !oneRowFits && !twoRowDefaultFits && firstRowSplitFits && secondRowSplitFits
 
         val layoutHeight = when {
             oneRowFits -> maxOf(destH, clockH, walkH, devH)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -55,6 +55,7 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
@@ -193,7 +194,7 @@ fun TimeTableScreen(
                 FlowRow(
                     modifier = Modifier
                         .fillParentMaxWidth()
-                        .padding(horizontal = 10.dp)
+                        .padding(horizontal = 12.dp)
                         .padding(top = 8.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Redesigned the JourneyCard component by removing the border and adding a divider at the bottom.

### What changed?

- Removed the animated border from JourneyCard and replaced it with a simple divider at the bottom
- Removed unnecessary padding and animation logic related to the border
- Removed unused imports (animateDpAsState, border)
- Added a Divider component at the bottom of the JourneyCard with appropriate padding
- Adjusted padding in TimeTableScreen's FlowRow from 10dp to 12dp for consistency

### How to test?

1. Navigate to the Trip Planner feature
2. Verify that journey cards now display with a divider at the bottom instead of a border
3. Check that the cards still properly distinguish between past and future journeys
4. Confirm that the animation when expanding/collapsing cards still works correctly

### Why make this change?

This change simplifies the visual design of the JourneyCard component while maintaining clear separation between cards. Using a divider instead of a border creates a cleaner, more modern look that aligns better with material design principles while reducing animation complexity.