### PR TITLE
Refactor JourneyCard to extract header component

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -115,78 +115,19 @@ fun JourneyCard(
                 .animateContentSize(),
         ) {
 
-            Column(
-                modifier = Modifier
-                    .clickable(
-                        role = Role.Button,
-                        onClick = onClick,
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                    )
-                    .padding(bottom = 4.dp),
-            ) {
-                Row(
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
-                        Text(
-                            text = timeToDeparture,
-                            style = KrailTheme.typography.titleMedium,
-                            color = firstLegTransportModeColor,
-                            modifier = Modifier
-                                .padding(end = 8.dp),
-                        )
-                    } else {
-                        FlowRow(
-                            horizontalArrangement = Arrangement.Start,
-                            modifier = Modifier.weight(1f).padding(end = 8.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                        ) {
-                            Text(
-                                text = timeToDeparture,
-                                style = KrailTheme.typography.titleMedium,
-                                color = firstLegTransportModeColor,
-                                modifier = Modifier
-                                    .padding(end = 8.dp),
-                            )
-                            TransportModesRow(
-                                transportModeLineList = transportModeLineList,
-                                showBadge = { it.transportMode is TransportMode.Bus },
-                            )
-                        }
-                    }
-
-                    platformText?.let { text ->
-                        Text(
-                            text = text,
-                            textAlign = TextAlign.Center,
-                            style = KrailTheme.typography.titleMedium,
-                            color = firstLegTransportModeColor,
-                            modifier = Modifier.padding(start = 4.dp),
-                        )
-                    }
-                }
-
-                if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
-                    // Always show badges/icons on a new line for large font scale; let FlowRow wrap
-                    TransportModesRow(
-                        transportModeLineList = transportModeLineList,
-                        showBadge = { it.transportMode is TransportMode.Bus },
-                        modifier = Modifier.padding(top = 4.dp),
-                    )
-                }
-            }
+            JourneyCardHeader(
+                transportModeLineList = transportModeLineList,
+                platformText = platformText,
+                timeToDeparture = timeToDeparture,
+                firstLegTransportModeColor = firstLegTransportModeColor,
+                onClick = onClick,
+            )
 
             when (cardState) {
                 JourneyCardState.DEFAULT -> DefaultJourneyCardContent(
-                    timeToDeparture = timeToDeparture,
                     originTime = originTime,
                     destinationTime = destinationTime,
                     totalTravelTime = totalTravelTime,
-                    firstLegTransportModeColor = firstLegTransportModeColor,
-                    transportModeLineList = transportModeLineList,
-                    platformText = platformText,
                     totalWalkTime = totalWalkTime,
                     departureDeviation = departureDeviation,
                     modifier = Modifier
@@ -200,9 +141,6 @@ fun JourneyCard(
                 )
 
                 JourneyCardState.EXPANDED -> ExpandedJourneyCardContent(
-                    timeToDeparture = timeToDeparture,
-                    firstLegTransportModeColor = firstLegTransportModeColor,
-                    platformText = platformText,
                     totalTravelTime = totalTravelTime,
                     legList = legList,
                     totalUniqueServiceAlerts = totalUniqueServiceAlerts,
@@ -217,7 +155,80 @@ fun JourneyCard(
                 )
             }
 
-            Divider(modifier = Modifier.padding(top = 16.dp, start = 4.dp, end = 4.dp))
+            Divider(modifier = Modifier.padding(top = 16.dp))
+        }
+    }
+}
+
+@Composable
+private fun JourneyCardHeader(
+    transportModeLineList: ImmutableList<TransportModeLine>,
+    platformText: String?,
+    timeToDeparture: String,
+    firstLegTransportModeColor: Color,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .clickable(
+                role = Role.Button,
+                onClick = onClick,
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            )
+            .padding(bottom = 4.dp),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
+                Text(
+                    text = timeToDeparture,
+                    style = KrailTheme.typography.titleMedium,
+                    color = firstLegTransportModeColor,
+                    modifier = Modifier
+                        .padding(end = 8.dp),
+                )
+            } else {
+                FlowRow(
+                    horizontalArrangement = Arrangement.Start,
+                    modifier = Modifier.weight(1f).padding(end = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        text = timeToDeparture,
+                        style = KrailTheme.typography.titleMedium,
+                        color = firstLegTransportModeColor,
+                        modifier = Modifier
+                            .padding(end = 8.dp),
+                    )
+                    TransportModesRow(
+                        transportModeLineList = transportModeLineList,
+                        showBadge = { it.transportMode is TransportMode.Bus },
+                    )
+                }
+            }
+
+            platformText?.let { text ->
+                Text(
+                    text = text,
+                    textAlign = TextAlign.Center,
+                    style = KrailTheme.typography.titleMedium,
+                    color = firstLegTransportModeColor,
+                    modifier = Modifier.padding(start = 4.dp),
+                )
+            }
+        }
+
+        if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
+            // Always show badges/icons on a new line for large font scale; let FlowRow wrap
+            TransportModesRow(
+                transportModeLineList = transportModeLineList,
+                showBadge = { it.transportMode is TransportMode.Bus },
+                modifier = Modifier.padding(top = 4.dp),
+            )
         }
     }
 }
@@ -261,9 +272,6 @@ private fun DepartureDeviationIndicator(
 
 @Composable
 fun ExpandedJourneyCardContent(
-    timeToDeparture: String,
-    firstLegTransportModeColor: Color,
-    platformText: String?,
     totalTravelTime: String,
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
     totalUniqueServiceAlerts: Int,
@@ -389,13 +397,9 @@ fun getPaddingValue(lastLeg: TimeTableState.JourneyCardInfo.Leg): Dp {
 
 @Composable
 fun DefaultJourneyCardContent(
-    timeToDeparture: String,
     originTime: String,
     destinationTime: String,
     totalTravelTime: String,
-    firstLegTransportModeColor: Color,
-    transportModeLineList: ImmutableList<TransportModeLine>,
-    platformText: String?,
     totalWalkTime: String?,
     modifier: Modifier = Modifier,
     departureDeviation: TimeTableState.JourneyCardInfo.DepartureDeviation? = null,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -114,6 +114,70 @@ fun JourneyCard(
                 .background(color = KrailTheme.colors.surface)
                 .animateContentSize(),
         ) {
+
+            Column(
+                modifier = Modifier
+                    .clickable(
+                        role = Role.Button,
+                        onClick = onClick,
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    )
+                    .padding(bottom = 4.dp),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
+                        Text(
+                            text = timeToDeparture,
+                            style = KrailTheme.typography.titleMedium,
+                            color = firstLegTransportModeColor,
+                            modifier = Modifier
+                                .padding(end = 8.dp),
+                        )
+                    } else {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.Start,
+                            modifier = Modifier.weight(1f).padding(end = 8.dp),
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                text = timeToDeparture,
+                                style = KrailTheme.typography.titleMedium,
+                                color = firstLegTransportModeColor,
+                                modifier = Modifier
+                                    .padding(end = 8.dp),
+                            )
+                            TransportModesRow(
+                                transportModeLineList = transportModeLineList,
+                                showBadge = { it.transportMode is TransportMode.Bus },
+                            )
+                        }
+                    }
+
+                    platformText?.let { text ->
+                        Text(
+                            text = text,
+                            textAlign = TextAlign.Center,
+                            style = KrailTheme.typography.titleMedium,
+                            color = firstLegTransportModeColor,
+                            modifier = Modifier.padding(start = 4.dp),
+                        )
+                    }
+                }
+
+                if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
+                    // Always show badges/icons on a new line for large font scale; let FlowRow wrap
+                    TransportModesRow(
+                        transportModeLineList = transportModeLineList,
+                        showBadge = { it.transportMode is TransportMode.Bus },
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+            }
+
             when (cardState) {
                 JourneyCardState.DEFAULT -> DefaultJourneyCardContent(
                     timeToDeparture = timeToDeparture,
@@ -208,27 +272,6 @@ fun ExpandedJourneyCardContent(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier) {
-        FlowRow(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalArrangement = if (platformText != null) Arrangement.SpaceBetween else Arrangement.Start,
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Text(
-                text = timeToDeparture,
-                style = KrailTheme.typography.titleMedium,
-                color = firstLegTransportModeColor,
-            )
-
-            platformText?.let { text ->
-                Text(
-                    text = text,
-                    style = KrailTheme.typography.titleMedium,
-                    color = firstLegTransportModeColor,
-                    modifier = Modifier,
-                )
-            }
-        }
         FlowRow(
             modifier = Modifier
                 .fillMaxWidth()
@@ -358,58 +401,6 @@ fun DefaultJourneyCardContent(
     departureDeviation: TimeTableState.JourneyCardInfo.DepartureDeviation? = null,
 ) {
     Column(modifier = modifier) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
-                Text(
-                    text = timeToDeparture,
-                    style = KrailTheme.typography.titleMedium,
-                    color = firstLegTransportModeColor,
-                    modifier = Modifier
-                        .padding(end = 8.dp),
-                )
-            } else {
-                FlowRow(
-                    horizontalArrangement = Arrangement.Start,
-                    modifier = Modifier.weight(1f).padding(end = 8.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        text = timeToDeparture,
-                        style = KrailTheme.typography.titleMedium,
-                        color = firstLegTransportModeColor,
-                        modifier = Modifier
-                            .padding(end = 8.dp),
-                    )
-                    TransportModesRow(
-                        transportModeLineList = transportModeLineList,
-                        showBadge = { it.transportMode is TransportMode.Bus },
-                    )
-                }
-            }
-
-            platformText?.let { text ->
-                Text(
-                    text = text,
-                    textAlign = TextAlign.Center,
-                    style = KrailTheme.typography.titleMedium,
-                    color = firstLegTransportModeColor,
-                    modifier = Modifier.padding(start = 4.dp),
-                )
-            }
-        }
-
-        if (displayAdaptiveTransportModeList(transportModeLineList, platformText)) {
-            // Always show badges/icons on a new line for large font scale; let FlowRow wrap
-            TransportModesRow(
-                transportModeLineList = transportModeLineList,
-                showBadge = { it.transportMode is TransportMode.Bus },
-                modifier = Modifier.padding(top = 4.dp),
-            )
-        }
-
         // Origin time + deviation
         Row(
             verticalAlignment = Alignment.CenterVertically,

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
# Refactor JourneyCard to improve animation and component separation

- Created a new `JourneyCardHeader` composable to extract the header functionality from both card states
- Moved common header elements (time to departure, transport mode lines, platform text) to the shared header
- Removed duplicate header code from `DefaultJourneyCardContent` and `ExpandedJourneyCardContent`
- Fixed padding on the divider for consistency
- Incremented iOS build number from 5 to 6

This refactoring improves the animation between card states by keeping the header consistent and separate from the content that changes during expansion.