### PR TITLE
Add StopSelectionManager to persist stop selection across navigation

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeStopResultsManager.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeStopResultsManager.kt
@@ -4,10 +4,15 @@ import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 class FakeStopResultsManager : StopResultsManager {
     // Add a flag to control whether fetchStopResults should throw an exception
     var shouldThrowError = false
+
+    // Track selected stops
+    private var _selectedFromStop: StopItem? = null
+    private var _selectedToStop: StopItem? = null
 
     private val testStopResults = listOf(
         SearchStopState.StopResult(
@@ -32,6 +37,12 @@ class FakeStopResultsManager : StopResultsManager {
         )
     )
 
+    override val selectedFromStop: StopItem?
+        get() = _selectedFromStop
+
+    override val selectedToStop: StopItem?
+        get() = _selectedToStop
+
     override suspend fun fetchStopResults(query: String): List<SearchStopState.StopResult> {
         // Throw an exception if shouldThrowError is true
         if (shouldThrowError) {
@@ -53,5 +64,31 @@ class FakeStopResultsManager : StopResultsManager {
 
     override fun fetchLocalStopName(stopId: String): String? {
         return testStopResults.firstOrNull { it.stopId == stopId }?.stopName
+    }
+
+    override fun setSelectedFromStop(stopItem: StopItem?) {
+        _selectedFromStop = stopItem
+    }
+
+    override fun setSelectedToStop(stopItem: StopItem?) {
+        _selectedToStop = stopItem
+    }
+
+    override fun reverseSelectedStops() {
+        val tempFrom = _selectedFromStop
+        _selectedFromStop = _selectedToStop
+        _selectedToStop = tempFrom
+    }
+
+    override fun clearSelectedStops() {
+        _selectedFromStop = null
+        _selectedToStop = null
+    }
+
+    // Helper methods for testing
+    fun reset() {
+        _selectedFromStop = null
+        _selectedToStop = null
+        shouldThrowError = false
     }
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -212,7 +212,7 @@ class SavedTripsViewModelTest {
     fun `GIVEN a trip WHEN AnalyticsReverseSavedTrip event is triggered THEN track ReverseStopClickEvent should be called`() =
         runTest {
             // WHEN the AnalyticsReverseSavedTrip event is triggered
-            viewModel.onEvent(SavedTripUiEvent.AnalyticsReverseSavedTrip)
+            viewModel.onEvent(SavedTripUiEvent.ReverseStopClick)
 
             // THEN verify that track is called with ReverseStopClickEvent
             val fakeAnalytics: FakeAnalytics = fakeAnalytics as FakeAnalytics

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -587,4 +587,252 @@ class SavedTripsViewModelTest {
     }
 
     // endregion Park and Ride Tests
+
+    // region Selected Stop Events Tests
+
+    @Test
+    fun `GIVEN FromStopChanged event with valid JSON WHEN triggered THEN fromStop is updated in UI state`() =
+        runTest {
+            // GIVEN a valid StopItem JSON
+            val stopItem = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Central Station",
+                stopId = "10101"
+            )
+            val stopJson = stopItem.toJsonString()
+
+            viewModel.uiState.test {
+                skipItems(1) // Skip initial state
+
+                // WHEN FromStopChanged event is triggered
+                viewModel.onEvent(SavedTripUiEvent.FromStopChanged(stopJson))
+
+                // THEN fromStop should be updated in UI state
+                val item = awaitItem()
+                assertEquals(stopItem.stopId, item.fromStop?.stopId)
+                assertEquals(stopItem.stopName, item.fromStop?.stopName)
+
+                // AND stopResultsManager should have the selected stop
+                assertEquals(stopItem, fakeStopResultsManager.selectedFromStop)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN ToStopChanged event with valid JSON WHEN triggered THEN toStop is updated in UI state`() =
+        runTest {
+            // GIVEN a valid StopItem JSON
+            val stopItem = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Town Hall",
+                stopId = "10102"
+            )
+            val stopJson = stopItem.toJsonString()
+
+            viewModel.uiState.test {
+                skipItems(1) // Skip initial state
+
+                // WHEN ToStopChanged event is triggered
+                viewModel.onEvent(SavedTripUiEvent.ToStopChanged(stopJson))
+
+                // THEN toStop should be updated in UI state
+                val item = awaitItem()
+                assertEquals(stopItem.stopId, item.toStop?.stopId)
+                assertEquals(stopItem.stopName, item.toStop?.stopName)
+
+                // AND stopResultsManager should have the selected stop
+                assertEquals(stopItem, fakeStopResultsManager.selectedToStop)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN FromStopChanged event with invalid JSON WHEN triggered THEN fromStop remains unchanged`() =
+        runTest {
+            // GIVEN invalid JSON
+            val invalidJson = "invalid json string"
+
+            viewModel.uiState.test {
+                val initialState = awaitItem()
+
+                // WHEN FromStopChanged event is triggered with invalid JSON
+                viewModel.onEvent(SavedTripUiEvent.FromStopChanged(invalidJson))
+
+                // THEN fromStop should remain unchanged (null in this case)
+                expectNoEvents() // No state update should occur
+                assertEquals(null, fakeStopResultsManager.selectedFromStop)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN ToStopChanged event with invalid JSON WHEN triggered THEN toStop remains unchanged`() =
+        runTest {
+            // GIVEN invalid JSON
+            val invalidJson = "invalid json string"
+
+            viewModel.uiState.test {
+                val initialState = awaitItem()
+
+                // WHEN ToStopChanged event is triggered with invalid JSON
+                viewModel.onEvent(SavedTripUiEvent.ToStopChanged(invalidJson))
+
+                // THEN toStop should remain unchanged (null in this case)
+                expectNoEvents() // No state update should occur
+                assertEquals(null, fakeStopResultsManager.selectedToStop)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN both from and to stops selected WHEN ReverseStopClick event is triggered THEN stops are swapped`() =
+        runTest {
+            // GIVEN both from and to stops are selected
+            val fromStop = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Central Station",
+                stopId = "10101"
+            )
+            val toStop = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Town Hall",
+                stopId = "10102"
+            )
+
+            // Set initial stops
+            fakeStopResultsManager.setSelectedFromStop(fromStop)
+            fakeStopResultsManager.setSelectedToStop(toStop)
+
+            viewModel.uiState.test {
+                skipItems(1) // Skip initial state that loads the selected stops
+
+                // WHEN ReverseStopClick event is triggered
+                viewModel.onEvent(SavedTripUiEvent.ReverseStopClick)
+
+                // THEN stops should be swapped in UI state
+                val item = awaitItem()
+                assertEquals(toStop.stopId, item.fromStop?.stopId)
+                assertEquals(toStop.stopName, item.fromStop?.stopName)
+                assertEquals(fromStop.stopId, item.toStop?.stopId)
+                assertEquals(fromStop.stopName, item.toStop?.stopName)
+
+                // AND in the stopResultsManager
+                assertEquals(toStop, fakeStopResultsManager.selectedFromStop)
+                assertEquals(fromStop, fakeStopResultsManager.selectedToStop)
+
+                // AND analytics event should be tracked
+                val fakeAnalytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+                assertTrue(fakeAnalytics.isEventTracked(AnalyticsEvent.ReverseStopClickEvent.name))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN only from stop selected WHEN ReverseStopClick event is triggered THEN from becomes to and to becomes null`() =
+        runTest {
+            // GIVEN only from stop is selected
+            val fromStop = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Central Station",
+                stopId = "10101"
+            )
+
+            fakeStopResultsManager.setSelectedFromStop(fromStop)
+            fakeStopResultsManager.setSelectedToStop(null)
+
+            viewModel.uiState.test {
+                skipItems(1) // Skip initial state
+
+                // WHEN ReverseStopClick event is triggered
+                viewModel.onEvent(SavedTripUiEvent.ReverseStopClick)
+
+                // THEN from should become null and to should become the original from
+                val item = awaitItem()
+                assertEquals(null, item.fromStop)
+                assertEquals(fromStop.stopId, item.toStop?.stopId)
+                assertEquals(fromStop.stopName, item.toStop?.stopName)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN no stops selected WHEN ReverseStopClick event is triggered THEN both remain null`() =
+        runTest {
+            // GIVEN no stops are selected
+            fakeStopResultsManager.setSelectedFromStop(null)
+            fakeStopResultsManager.setSelectedToStop(null)
+
+            viewModel.uiState.test {
+                skipItems(1) // Skip initial state
+
+                // WHEN ReverseStopClick event is triggered
+                viewModel.onEvent(SavedTripUiEvent.ReverseStopClick)
+
+                // THEN both should remain null
+                val item = awaitItem()
+                assertEquals(null, item.fromStop)
+                assertEquals(null, item.toStop)
+
+                // AND analytics event should still be tracked
+                val fakeAnalytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+                assertTrue(fakeAnalytics.isEventTracked(AnalyticsEvent.ReverseStopClickEvent.name))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN stops are selected WHEN multiple events are triggered in sequence THEN UI state updates correctly`() =
+        runTest {
+            // GIVEN initial stops
+            val centralStation = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Central Station",
+                stopId = "10101"
+            )
+            val townHall = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Town Hall",
+                stopId = "10102"
+            )
+            val airport = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem(
+                stopName = "Sydney Airport",
+                stopId = "10104"
+            )
+
+            viewModel.uiState.test {
+                skipItems(1) // Skip initial state
+
+                // WHEN setting from stop
+                viewModel.onEvent(SavedTripUiEvent.FromStopChanged(centralStation.toJsonString()))
+                awaitItem().run {
+                    assertEquals(centralStation, fromStop)
+                    assertEquals(null, toStop)
+                }
+
+                // WHEN setting to stop
+                viewModel.onEvent(SavedTripUiEvent.ToStopChanged(townHall.toJsonString()))
+                awaitItem().run {
+                    assertEquals(centralStation, fromStop)
+                    assertEquals(townHall, toStop)
+                }
+
+                // WHEN reversing stops
+                viewModel.onEvent(SavedTripUiEvent.ReverseStopClick)
+                awaitItem().run {
+                    assertEquals(townHall, fromStop)
+                    assertEquals(centralStation, toStop)
+                }
+
+                // WHEN changing from stop again
+                viewModel.onEvent(SavedTripUiEvent.FromStopChanged(airport.toJsonString()))
+                awaitItem().run {
+                    assertEquals(airport, fromStop)
+                    assertEquals(centralStation, toStop)
+                }
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion Selected Stop Events Tests
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -140,7 +140,6 @@ class SearchStopViewModelTest {
                 SearchStopUiEvent.StopSelected(
                     StopItem(
                         stopName = "name",
-                        persistentSetOf(TransportMode.Train()),
                         stopId = "stopID",
                     )
                 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -13,7 +13,7 @@ sealed interface SavedTripUiEvent {
     data class AnalyticsLoadTimeTableClick(val fromStopId: String, val toStopId: String) :
         SavedTripUiEvent
 
-    data object AnalyticsReverseSavedTrip : SavedTripUiEvent
+    data object ReverseStopClick : SavedTripUiEvent
 
     data object AnalyticsSettingsButtonClick : SavedTripUiEvent
 
@@ -32,4 +32,8 @@ sealed interface SavedTripUiEvent {
     data class InfoTileCtaClick(val infoTile: InfoTileData) : SavedTripUiEvent
 
     data class InfoTileExpand(val key: String): SavedTripUiEvent
+
+    // JSON-based events for navigation compatibility
+    data class FromStopChanged(val fromJson: String) : SavedTripUiEvent
+    data class ToStopChanged(val toJson: String) : SavedTripUiEvent
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import xyz.ksharma.krail.info.tile.state.InfoTileData
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 @Stable
@@ -17,4 +18,7 @@ data class SavedTripsState(
     val isDiscoverAvailable: Boolean = false,
     val displayDiscoverBadge: Boolean = false,
     val infoTiles: ImmutableList<InfoTileData>? = null,
+    // Stop selection state managed by ViewModel
+    val fromStop: StopItem? = null,
+    val toStop: StopItem? = null,
 )

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/StopSelectionManager.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/StopSelectionManager.kt
@@ -1,0 +1,38 @@
+package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Singleton manager for stop selection state that survives navigation lifecycle.
+ * This ensures selected stops persist when navigating between screens.
+ */
+class StopSelectionManager {
+
+    private val _fromStop = MutableStateFlow<StopItem?>(null)
+    val fromStop: StateFlow<StopItem?> = _fromStop.asStateFlow()
+
+    private val _toStop = MutableStateFlow<StopItem?>(null)
+    val toStop: StateFlow<StopItem?> = _toStop.asStateFlow()
+
+    fun setFromStop(stop: StopItem?) {
+        _fromStop.value = stop
+    }
+
+    fun setToStop(stop: StopItem?) {
+        _toStop.value = stop
+    }
+
+    fun reverseStops() {
+        val tempFrom = _fromStop.value
+        _fromStop.value = _toStop.value
+        _toStop.value = tempFrom
+    }
+
+    fun clearStops() {
+        _fromStop.value = null
+        _toStop.value = null
+    }
+}

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/model/StopItem.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/model/StopItem.kt
@@ -1,9 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.state.searchstop.model
 
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.serialization.json.Json
-import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 /**
  * Represents a Stop item in the search results when searching for stops.
@@ -12,7 +9,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 @kotlinx.serialization.Serializable
 data class StopItem(
     val stopName: String,
-    val transportModes: ImmutableSet<TransportMode> = persistentSetOf(),
     val stopId: String,
 ) {
     fun toJsonString() = Json.encodeToString(serializer(), this)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -18,6 +18,7 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
 import xyz.ksharma.krail.trip.planner.ui.settings.story.OurStoryViewModel
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopSelectionManager
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -58,8 +58,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 fun SavedTripsScreen(
     savedTripsState: SavedTripsState,
     modifier: Modifier = Modifier,
-    fromStopItem: StopItem? = null,
-    toStopItem: StopItem? = null,
     fromButtonClick: () -> Unit = {},
     toButtonClick: () -> Unit = {},
     onReverseButtonClick: () -> Unit = {},
@@ -69,19 +67,6 @@ fun SavedTripsScreen(
     onDiscoverButtonClick: () -> Unit = {},
     onEvent: (SavedTripUiEvent) -> Unit = {},
 ) {
-    // TODO -  handle colors of status bar
-    /*    DisposableEffect(themeContentColor) {
-            context.getActivityOrNull()?.let { activity ->
-                (activity as ComponentActivity).enableEdgeToEdge(
-                    navigationBarStyle = SystemBarStyle.auto(
-                        lightScrim = themeContentColor.hexToComposeColor().toArgb(),
-                        darkScrim = themeContentColor.hexToComposeColor().toArgb(),
-                    ),
-                )
-            }
-            onDispose {}
-        }*/
-
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -190,8 +175,8 @@ fun SavedTripsScreen(
 
         SearchStopRow(
             modifier = Modifier.align(Alignment.BottomCenter),
-            fromStopItem = fromStopItem,
-            toStopItem = toStopItem,
+            fromStopItem = savedTripsState.fromStop,
+            toStopItem = savedTripsState.toStop,
             fromButtonClick = fromButtonClick,
             toButtonClick = toButtonClick,
             onReverseButtonClick = onReverseButtonClick,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -14,14 +14,50 @@ import xyz.ksharma.krail.sandook.SelectProductClassesForStop
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeSortOrder
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 class RealStopResultsManager(
     private val sandook: Sandook,
     private val flag: Flag,
 ) : StopResultsManager {
 
+    // Store selected stops with private setters
+    override var selectedFromStop: StopItem? = null
+        private set
+
+    override var selectedToStop: StopItem? = null
+        private set
+
     private val highPriorityStopIdList: List<String> by lazy {
         flag.getFlagValue(FlagKeys.HIGH_PRIORITY_STOP_IDS.key).toStopsIdList()
+    }
+
+    // Methods to update selected stops
+    override fun setSelectedFromStop(stopItem: StopItem?) {
+        if (stopItem != null) {
+            selectedFromStop = stopItem
+        }
+        log("StopResultsManager - setSelectedFromStop: $stopItem")
+    }
+
+    override fun setSelectedToStop(stopItem: StopItem?) {
+        if(stopItem != null) {
+            selectedToStop = stopItem
+        }
+        log("StopResultsManager - setSelectedToStop: $stopItem")
+    }
+
+    override fun reverseSelectedStops() {
+        val temp = selectedFromStop
+        selectedFromStop = selectedToStop
+        selectedToStop = temp
+        log("StopResultsManager - reverseSelectedStops: from=$selectedFromStop, to=$selectedToStop")
+    }
+
+    override fun clearSelectedStops() {
+        selectedFromStop = null
+        selectedToStop = null
+        log("StopResultsManager - clearSelectedStops")
     }
 
     override suspend fun fetchStopResults(query: String): List<SearchStopState.StopResult> {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManager.kt
@@ -1,8 +1,13 @@
 package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 interface StopResultsManager {
+
+    val selectedFromStop: StopItem?
+
+    val selectedToStop: StopItem?
 
     suspend fun fetchStopResults(query: String): List<SearchStopState.StopResult>
 
@@ -15,4 +20,13 @@ interface StopResultsManager {
      * @return The name of the stop if found, or null if not found.
      */
     fun fetchLocalStopName(stopId: String): String?
+
+    // Selected stop management methods
+    fun setSelectedFromStop(stopItem: StopItem?)
+
+    fun setSelectedToStop(stopItem: StopItem?)
+
+    fun reverseSelectedStops()
+
+    fun clearSelectedStops()
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableDestination.kt
@@ -64,10 +64,7 @@ internal fun NavGraphBuilder.timeTableDestination(navController: NavHostControll
                     )
                 )
 
-                navController.navigate(
-                    route = SavedTripsRoute,
-                    navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
-                )
+                navController.navigateUp()
             },
             onAlertClick = { journeyId ->
                 log("AlertClicked for journeyId: $journeyId")


### PR DESCRIPTION
### TL;DR

Implemented persistent stop selection across navigation in the trip planner feature.

### What changed?

- Created a `StopSelectionManager` to maintain stop selection state across navigation
- Refactored `SavedTripsViewModel` to use the manager for stop state persistence
- Renamed `AnalyticsReverseSavedTrip` to `ReverseStopClick` for clarity
- Added JSON-based events (`FromStopChanged`, `ToStopChanged`) for navigation compatibility
- Updated `SavedTripsState` to include `fromStop` and `toStop` properties
- Simplified `StopItem` by removing unnecessary transport modes
- Modified `SavedTripsDestination` to handle stop selection through the ViewModel
- Improved navigation flow when returning from the time table screen

### How to test?

1. Select origin and destination stops in the trip planner
2. Navigate to other screens and back to verify stops remain selected
3. Test the reverse button functionality to ensure it properly swaps origin/destination
4. Navigate to the time table and back to verify stop selection persists
5. Test JSON-based stop selection through navigation arguments

### Why make this change?

The previous implementation lost stop selection state during navigation, requiring users to reselect stops when returning to the trip planner screen. This change improves user experience by maintaining stop selection across the navigation flow, allowing for a more seamless journey planning experience.