### PR TITLE
Add recent search stops functionality to Sandook database

### DIFF
--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -18,6 +18,8 @@ internal class RealSandook(
 
     private val nswParkRideQueries = sandook.nswParkRideQueries
 
+    private val recentSearchStopsQueries = sandook.recentSearchStopsQueries
+
     // region Theme
     override fun insertOrReplaceTheme(productClass: Long) {
         query.insertOrReplaceProductClass(productClass)
@@ -149,4 +151,28 @@ internal class RealSandook(
     }
 
     // endregion NswStops
+
+    // region RecentSearchStops
+    override fun insertOrReplaceRecentSearchStop(stopId: String) {
+        recentSearchStopsQueries.insertOrReplaceRecentSearchStop(stopId)
+        // Automatically cleanup old entries to maintain max 5 items
+        recentSearchStopsQueries.cleanupOldRecentSearchStops()
+    }
+
+    override fun selectRecentSearchStops(): List<SelectRecentSearchStops> {
+        return recentSearchStopsQueries.selectRecentSearchStops().executeAsList()
+    }
+
+    override fun clearRecentSearchStops() {
+        recentSearchStopsQueries.clearRecentSearchStops()
+    }
+
+    override fun cleanupOrphanedRecentSearchStops() {
+        recentSearchStopsQueries.cleanupOrphanedRecentSearchStops()
+    }
+
+    override fun cleanupOldRecentSearchStops() {
+        recentSearchStopsQueries.cleanupOldRecentSearchStops()
+    }
+    // endregion
 }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -64,4 +64,17 @@ interface Sandook {
         stopName: String,
         excludeProductClassList: List<Int>,
     ): List<SelectProductClassesForStop>
+    // endregion
+
+    // region RecentSearchStops
+    fun insertOrReplaceRecentSearchStop(stopId: String)
+
+    fun selectRecentSearchStops(): List<SelectRecentSearchStops>
+
+    fun clearRecentSearchStops()
+
+    fun cleanupOrphanedRecentSearchStops()
+
+    fun cleanupOldRecentSearchStops()
+    // endregion
 }

--- a/sandook/src/commonMain/sqldelight/migrations/6.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/6.sqm
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS RecentSearchStops (
+    stopId TEXT NOT NULL PRIMARY KEY,
+    timestamp TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (stopId) REFERENCES NswStops(stopId)
+);

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/RecentSearchStops.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/RecentSearchStops.sq
@@ -1,0 +1,40 @@
+-- Create RecentSearchStops Table --
+-- Only store stopId and timestamp, fetch details from NswStops when needed
+CREATE TABLE IF NOT EXISTS RecentSearchStops (
+    stopId TEXT NOT NULL PRIMARY KEY,
+    timestamp TEXT DEFAULT (datetime('now')),
+    FOREIGN KEY (stopId) REFERENCES NswStops(stopId)
+);
+
+insertOrReplaceRecentSearchStop:
+INSERT OR REPLACE INTO RecentSearchStops(stopId, timestamp)
+VALUES (?, datetime('now'));
+
+-- Join with NswStops to get current stop details and filter out non-existent stops
+-- Limited to 5 most recent items
+selectRecentSearchStops:
+SELECT rss.stopId, rss.timestamp, ns.stopName,
+       COALESCE(GROUP_CONCAT(nspc.productClass), '') AS productClasses
+FROM RecentSearchStops rss
+INNER JOIN NswStops ns ON rss.stopId = ns.stopId
+LEFT JOIN NswStopProductClass nspc ON ns.stopId = nspc.stopId
+GROUP BY rss.stopId, rss.timestamp, ns.stopName
+ORDER BY rss.timestamp DESC
+LIMIT 5;
+
+-- Clean up old entries to keep only the 5 most recent
+cleanupOldRecentSearchStops:
+DELETE FROM RecentSearchStops
+WHERE stopId NOT IN (
+    SELECT stopId FROM RecentSearchStops
+    ORDER BY timestamp DESC
+    LIMIT 5
+);
+
+clearRecentSearchStops:
+DELETE FROM RecentSearchStops;
+
+-- Optional: Clean up orphaned entries (stops that no longer exist)
+cleanupOrphanedRecentSearchStops:
+DELETE FROM RecentSearchStops
+WHERE stopId NOT IN (SELECT stopId FROM NswStops);

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
@@ -8,6 +8,7 @@ import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter2
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter3
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter4
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter5
+import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter6
 
 class IosSandookDriverFactory : SandookDriverFactory {
     override fun createDriver(): SqlDriver {
@@ -24,5 +25,6 @@ class IosSandookDriverFactory : SandookDriverFactory {
         AfterVersion(3) { SandookMigrationAfter3.migrate(it) },
         AfterVersion(4) { SandookMigrationAfter4.migrate(it) },
         AfterVersion(5) { SandookMigrationAfter5.migrate(it) },
+        AfterVersion(6) { SandookMigrationAfter6.migrate(it) },
     )
 }

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter6.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter6.kt
@@ -1,0 +1,22 @@
+package xyz.ksharma.krail.sandook.migrations
+
+import app.cash.sqldelight.db.SqlDriver
+import xyz.ksharma.krail.core.log.log
+
+internal object SandookMigrationAfter6 : SandookMigration {
+
+    override fun migrate(sqlDriver: SqlDriver) {
+        log("Upgrading database from version 6 to 7")
+        sqlDriver.execute(
+            identifier = null,
+            sql = """
+                CREATE TABLE IF NOT EXISTS RecentSearchStops (
+                    stopId TEXT NOT NULL PRIMARY KEY,
+                    timestamp TEXT DEFAULT (datetime('now')),
+                    FOREIGN KEY (stopId) REFERENCES NswStops(stopId)
+                );
+            """.trimIndent(),
+            parameters = 0,
+        )
+    }
+}


### PR DESCRIPTION
### TL;DR

Added recent search stops functionality to the database layer.

### What changed?

- Created a new `RecentSearchStops` table to track recently searched stops
- Added SQLDelight queries for managing recent searches (insert, select, cleanup)
- Implemented corresponding methods in `RealSandook` and `Sandook` interface
- Added migration script (version 6) for the new table
- Implemented automatic cleanup to maintain a maximum of 5 recent searches
- Added foreign key constraint to ensure data integrity with the NswStops table

### How to test?

1. Search for different stops in the app
2. Verify that up to 5 recent searches are stored and displayed
3. Confirm that older searches are automatically removed when new ones are added
4. Test that clearing recent searches works as expected
5. Verify that orphaned entries (stops that no longer exist) are properly cleaned up

### Why make this change?

This feature improves user experience by allowing quick access to previously searched stops, reducing the need for users to repeatedly search for frequently used locations. The implementation maintains a small, manageable list of recent searches while ensuring data integrity with the existing stops database.