### PR TITLE
Prevent timetable loading when origin and destination stops are identical

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsDestination.kt
@@ -87,7 +87,7 @@ internal fun NavGraphBuilder.savedTripsDestination(navController: NavHostControl
                 val fromStopItem = savedTripState.fromStop
                 val toStopItem = savedTripState.toStop
 
-                if (fromStopItem != null && toStopItem != null) {
+                if (fromStopItem != null && toStopItem != null && fromStopItem.stopId != toStopItem.stopId) {
                     viewModel.onEvent(
                         SavedTripUiEvent.AnalyticsLoadTimeTableClick(
                             fromStopId = fromStopItem.stopId,


### PR DESCRIPTION
### TL;DR

Added validation to prevent loading timetables when origin and destination stops are the same.

### 