### PR TITLE
Add isRecentSearch flag to StopSelectedEvent analytics tracking

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -42,9 +42,15 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // region SearchStop
 
-    data class StopSelectedEvent(val stopId: String) : AnalyticsEvent(
+    data class StopSelectedEvent(
+        val stopId: String,
+        val isRecentSearch: Boolean = false,
+    ) : AnalyticsEvent(
         name = "stop_selected",
-        properties = mapOf("stopId" to stopId),
+        properties = mapOf(
+            "stopId" to stopId,
+            "isRecentSearch" to isRecentSearch,
+        ),
     )
 
     data class SearchStopQuery(

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -136,11 +136,12 @@ class SearchStopViewModelTest {
 
             // WHEN
             viewModel.onEvent(
-                SearchStopUiEvent.StopSelected(
+                SearchStopUiEvent.TrackStopSelected(
                     StopItem(
                         stopName = "name",
                         stopId = "stopID",
-                    )
+                    ),
+                    isRecentSearch = false
                 )
             )
 
@@ -150,6 +151,31 @@ class SearchStopViewModelTest {
             val event = fakeAnalytics.getTrackedEvent("stop_selected")
             assertIs<AnalyticsEvent.StopSelectedEvent>(event)
             assertEquals("stopID", event.stopId)
+            assertEquals(false, event.isRecentSearch)
+        }
+
+    @Test
+    fun `GIVEN recent stop item WHEN StopSelected with isRecentSearch true is triggered THEN analytics event is tracked with correct flag`() =
+        runTest {
+
+            // WHEN
+            viewModel.onEvent(
+                SearchStopUiEvent.TrackStopSelected(
+                    StopItem(
+                        stopName = "Recent Stop",
+                        stopId = "recentStopID",
+                    ),
+                    isRecentSearch = true
+                )
+            )
+
+            // THEN
+            assertTrue(fakeAnalytics is FakeAnalytics)
+            assertTrue(fakeAnalytics.isEventTracked("stop_selected"))
+            val event = fakeAnalytics.getTrackedEvent("stop_selected")
+            assertIs<AnalyticsEvent.StopSelectedEvent>(event)
+            assertEquals("recentStopID", event.stopId)
+            assertEquals(true, event.isRecentSearch)
         }
 
     // region RecentSearchStops

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
@@ -4,6 +4,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 sealed interface SearchStopUiEvent {
     data class SearchTextChanged(val query: String) : SearchStopUiEvent
-    data class StopSelected(val stopItem: StopItem) : SearchStopUiEvent
+    data class TrackStopSelected(val stopItem: StopItem, val isRecentSearch: Boolean = false) : SearchStopUiEvent
     data object ClearRecentSearchStops : SearchStopUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopDestination.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import org.koin.compose.viewmodel.koinViewModel
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopRoute
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 
@@ -19,8 +20,7 @@ fun NavGraphBuilder.searchStopDestination(navController: NavHostController) {
         SearchStopScreen(
             searchStopState = searchStopState,
             onStopSelect = { stopItem ->
-                // log(("onStopSelected: fieldTypeKey=${route.fieldType.key} and stopItem: $stopItem")
-                viewModel.onEvent(SearchStopUiEvent.StopSelected(stopItem))
+                log("onStopSelected: fieldTypeKey=${route.fieldType.key} and stopItem: $stopItem")
 
                 navController.previousBackStackEntry?.savedStateHandle?.set(
                     route.fieldType.key,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -89,11 +89,6 @@ fun SearchStopScreen(
     val keyboard = LocalSoftwareKeyboardController.current
     val focusRequester = remember { FocusRequester() }
     var backClicked by rememberSaveable { mutableStateOf(false) }
-    var selectedStop: StopItem? by remember { mutableStateOf(null) }
-
-    LaunchedEffect(selectedStop) {
-        selectedStop?.let { onStopSelect(it) }
-    }
 
     LaunchedEffect(backClicked) {
         if (backClicked) {
@@ -291,7 +286,8 @@ fun SearchStopScreen(
                         onClick = { stopItem ->
                             keyboard?.hide()
                             focusRequester.freeFocus()
-                            selectedStop = stopItem
+                            onStopSelect(stopItem)
+                            onEvent(SearchStopUiEvent.TrackStopSelected(stopItem = stopItem))
                         },
                         modifier = Modifier
                             .fillMaxWidth(),
@@ -342,7 +338,13 @@ fun SearchStopScreen(
                         onClick = { stopItem ->
                             keyboard?.hide()
                             focusRequester.freeFocus()
-                            selectedStop = stopItem
+                            onStopSelect(stopItem)
+                            onEvent(
+                                SearchStopUiEvent.TrackStopSelected(
+                                    stopItem = stopItem,
+                                    isRecentSearch = true,
+                                )
+                            )
                         },
                         modifier = Modifier
                             .fillMaxWidth(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -39,8 +39,13 @@ class SearchStopViewModel(
         when (event) {
             is SearchStopUiEvent.SearchTextChanged -> onSearchTextChanged(event.query)
 
-            is SearchStopUiEvent.StopSelected -> {
-                analytics.track(AnalyticsEvent.StopSelectedEvent(stopId = event.stopItem.stopId))
+            is SearchStopUiEvent.TrackStopSelected -> {
+                analytics.track(
+                    AnalyticsEvent.StopSelectedEvent(
+                        stopId = event.stopItem.stopId,
+                        isRecentSearch = event.isRecentSearch
+                    )
+                )
             }
 
             is SearchStopUiEvent.ClearRecentSearchStops -> {


### PR DESCRIPTION
### TL;DR

Added tracking for recent search selections in stop selection analytics events.

### What changed?

- Enhanced `StopSelectedEvent` in `AnalyticsEvent.kt` to include an `isRecentSearch` boolean flag
- Renamed `StopSelected` UI event to `TrackStopSelected` and added the `isRecentSearch` parameter
- Updated the stop selection flow in `SearchStopScreen` to track analytics separately from navigation
- Added distinct tracking for regular stops vs. recent search stops with appropriate flags

### How to test?

1. Open the app and navigate to the trip planner
2. Select a stop from the recent searches section
3. Verify in analytics that the event is tracked with `isRecentSearch = true`
4. Select a stop from the regular search results
5. Verify in analytics that the event is tracked with `isRecentSearch = false`

### Why make this change?

This change allows us to differentiate between users selecting stops from recent searches versus regular search results in our analytics data. Understanding this user behavior helps improve the search experience and evaluate the effectiveness of the recent searches feature.