### PR TITLE
Lint: Add documentation for Detekt linting and code analysis

### DIFF
--- a/docs/lint.md
+++ b/docs/lint.md
@@ -1,0 +1,55 @@
+# Lint & Code Analysis
+
+This file provides instructions for running linting and code analysis tools used in this project.
+
+## Detekt
+
+This project uses [Detekt](https://detekt.dev/) for static code analysis of Kotlin code.
+
+### Run Detekt
+
+The following commands can be used to run Detekt:
+
+```bash
+# All modules
+./gradlew detekt
+
+# Specific module
+./gradlew :core:analytics:detekt
+```
+
+### Generate/Update Baseline
+
+To generate or update the Detekt baseline, use the following commands:
+
+```bash
+# All modules
+./gradlew detektBaseline
+
+# Specific module
+./gradlew :core:analytics:detektBaseline
+```
+
+### Available Tasks
+
+To see all available Detekt tasks, you can run:
+
+```bash
+# List all detekt tasks
+./gradlew tasks --group="verification" | grep detekt
+```
+
+### Baseline Files
+
+- Global: `/config/baseline.xml`
+- Module-specific: `[module]/baseline.xml`
+
+### Common Commands
+
+```bash
+# Check code quality
+./gradlew detekt
+
+# Suppress existing issues (create baseline)
+./gradlew detektBaseline
+```


### PR DESCRIPTION
### TL;DR

Added documentation for Detekt static code analysis setup and usage.

### What changed?

Created a new documentation file `docs/lint.md` that provides comprehensive instructions for using Detekt in the project:
- Basic commands for running Detekt across all modules or specific ones
- Instructions for generating and updating baseline files
- How to list available Detekt tasks
- Information about baseline file locations
- Common commands for checking code quality and suppressing issues

### How to test?

1. Review the new documentation file at `docs/lint.md`
2. Try running the documented commands to verify they work as described:
   ```bash
   ./gradlew detekt
   ./gradlew tasks --group="verification" | grep detekt
   ```

### Why make this change?

To provide clear documentation for developers on how to use the Detekt static code analysis tool within the project. This helps maintain code quality by ensuring team members understand how to run linting checks and manage baseline configurations.