### PR TITLE
UI: Reduce vertical padding in ThemeSelectionRadioButton from 24dp to 16dp

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
@@ -108,7 +108,7 @@ fun ThemeSelectionRadioButton(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 24.dp)
+            .padding(horizontal = 12.dp, vertical = 16.dp)
             .scalingKlickable { onClick(themeStyle) },
         verticalAlignment = Alignment.CenterVertically,
     ) {


### PR DESCRIPTION
### TL;DR

Reduced vertical padding in the ThemeSelectionRadioButton component from 24dp to 16dp.

### What changed?

Modified the vertical padding in the ThemeSelectionRadioButton component from 24dp to 16dp while keeping the horizontal padding at 12dp. This change affects the Row component that wraps the radio button content.
