### PR TITLE
Refactor: Make ThemeSelectionRadioGroup controlled component with external state management

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioGroup.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioGroup.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -53,15 +54,21 @@ import kotlin.math.roundToInt
 
 @Composable
 fun ThemeSelectionRadioGroup(
+    selectedTheme: ThemeMode,
+    onThemeSelect: (ThemeMode) -> Unit,
     glowColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    val themeController = LocalThemeController.current
-    val currentMode = themeController.currentMode
-
-    var targetIndex by remember { mutableStateOf(ThemeMode.entries.indexOfFirst { it == currentMode }) }
+    var targetIndex by remember {
+        mutableStateOf(ThemeMode.entries.indexOfFirst { it == selectedTheme })
+    }
     var dragOffset by remember { mutableFloatStateOf(0f) }
     var isDragging by remember { mutableStateOf(false) }
+
+    // Update targetIndex when selectedTheme changes from outside
+    LaunchedEffect(selectedTheme) {
+        targetIndex = ThemeMode.entries.indexOfFirst { it == selectedTheme }
+    }
 
     // Store measured text widths
     val textWidths = remember { mutableStateMapOf<Int, Float>() }
@@ -116,7 +123,7 @@ fun ThemeSelectionRadioGroup(
                         val tappedIndex = (offset.x / optionWidth).toInt()
                             .coerceIn(0, ThemeMode.entries.lastIndex)
                         targetIndex = tappedIndex
-                        themeController.setThemeMode(ThemeMode.entries[tappedIndex])
+                        onThemeSelect(ThemeMode.entries[tappedIndex])
                     }
                 },
         )
@@ -139,7 +146,7 @@ fun ThemeSelectionRadioGroup(
                             val snappedIndex = (dragOffset / optionWidth).roundToInt()
                                 .coerceIn(0, ThemeMode.entries.lastIndex)
                             targetIndex = snappedIndex
-                            themeController.setThemeMode(ThemeMode.entries[snappedIndex])
+                            onThemeSelect(ThemeMode.entries[snappedIndex])
                         },
                     ) { change, dragAmount ->
                         change.consume()
@@ -340,6 +347,11 @@ private fun ThemeSelectionRadioGroupPreview() {
                 contentAlignment = Alignment.Center,
             ) {
                 ThemeSelectionRadioGroup(
+                    selectedTheme = currentMode,
+                    onThemeSelect = { newMode ->
+                        currentMode = newMode
+                        dummyThemeController.setThemeMode(newMode)
+                    },
                     glowColor = KrailTheme.colors.onSurface,
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -5,9 +5,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -16,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -31,15 +28,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import app.krail.taj.resources.ic_dark_mode
-import app.krail.taj.resources.ic_light_mode
 import kotlinx.coroutines.delay
-import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.components.Button
-import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -48,7 +40,6 @@ import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.LocalThemeController
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
-import app.krail.taj.resources.Res as TajRes
 
 @Composable
 fun ThemeSelectionScreen(
@@ -73,33 +64,11 @@ fun ThemeSelectionScreen(
             label = "buttonBackgroundColor",
             animationSpec = tween(durationMillis = 300, easing = LinearEasing),
         )
-        val themeController = LocalThemeController.current
-        val systemInDarkTheme = isSystemInDarkTheme()
 
         Column {
             TitleBar(
                 onNavActionClick = onBackClick,
                 title = {},
-                actions = {
-                    RoundIconButton(
-                        onClick = {
-                            themeController.toggleDarkMode(systemInDarkTheme)
-                        },
-                    ) {
-                        Image(
-                            painter = painterResource(
-                                resource = if ((themeController.isAppDarkMode())) {
-                                    TajRes.drawable.ic_light_mode
-                                } else {
-                                    TajRes.drawable.ic_dark_mode
-                                },
-                            ),
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                            modifier = Modifier.size(24.dp),
-                        )
-                    }
-                },
                 modifier = Modifier.fillMaxWidth(),
             )
 
@@ -149,9 +118,15 @@ fun ThemeSelectionScreen(
                 .navigationBarsPadding()
                 .padding(bottom = 10.dp),
         ) {
+            val themeController = LocalThemeController.current
+
             ThemeSelectionRadioGroup(
+                selectedTheme = themeController.currentMode,
                 glowColor = buttonBackgroundColor,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                onThemeSelect = { newTheme ->
+                    themeController.setThemeMode(newTheme)
+                },
             )
 
             Button(


### PR DESCRIPTION
### TL;DR

Refactored `ThemeSelectionRadioGroup` to follow unidirectional data flow pattern by adding explicit props for selected theme and theme selection callback.

### What changed?

- Modified `ThemeSelectionRadioGroup` to accept `selectedTheme` and `onThemeSelected` parameters instead of directly accessing the theme controller
- Added a `LaunchedEffect` to update the internal state when the selected theme changes from outside
- Updated the `ThemeSelectionScreen` to properly pass the current theme and handle theme changes
- Removed the manual theme toggle button from the title bar in `ThemeSelectionScreen`
- Updated the preview to demonstrate the new component API

### How to test?

1. Navigate to the Theme Selection screen
2. Verify that the radio group correctly shows the current theme
3. Select different themes and confirm they apply correctly
4. Test that theme changes from outside the component (if applicable) are properly reflected in the UI

### Why make this change?

This change improves the component architecture by:
- Following unidirectional data flow principles
- Making the component more reusable by removing direct dependencies on the theme controller
- Allowing for better testability since the component now accepts explicit inputs and outputs
- Ensuring the UI stays in sync with the application state through proper state management