### PR TITLE
Feature: Add theme mode persistence and apply on app startup

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
@@ -21,6 +21,7 @@ import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.appversion.AppUpgradeScreen
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.splash.SplashScreen
+import xyz.ksharma.krail.splash.SplashState
 import xyz.ksharma.krail.splash.SplashUiEvent
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.taj.LocalTextColor
@@ -73,14 +74,14 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
             composable<SplashScreen> {
                 val viewModel: SplashViewModel = koinViewModel<SplashViewModel>()
                 val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
-                val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+                val splashState: SplashState by viewModel.uiState.collectAsStateWithLifecycle()
 
                 // Set theme in CompositionLocal
-                themeId = uiState.themeStyle.id
-                themeColorHexCode.value = uiState.themeStyle.hexColorCode
+                themeId = splashState.themeStyle.id
+                themeColorHexCode.value = splashState.themeStyle.hexColorCode
 
-                LaunchedEffect(uiState.navigationDestination) {
-                    uiState.navigationDestination?.let { destination ->
+                LaunchedEffect(splashState.navigationDestination) {
+                    splashState.navigationDestination?.let { destination ->
                         log("Splash complete Navigating to destination: $destination")
                         navController.navigate(
                             route = destination,
@@ -95,6 +96,7 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
                 }
 
                 SplashScreen(
+                    splashState = splashState,
                     logoColor = if (themeId != null && themeColorHexCode.value != unspecifiedColor) {
                         themeColorHexCode.value.hexToComposeColor()
                     } else {

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -39,14 +40,25 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.LocalThemeController
 
 @Composable
 fun SplashScreen(
+    splashState: SplashState,
     logoColor: Color?,
     backgroundColor: Color?,
     onSplashAnimationComplete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val themeController = LocalThemeController.current
+    SideEffect {
+        splashState.themeMode?.let { themeMode ->
+            if (themeController.currentMode != themeMode) {
+                themeController.setThemeMode(themeMode)
+            }
+        }
+    }
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -196,6 +208,7 @@ private fun PreviewLogo() {
 private fun PreviewSplashScreen() {
     KrailTheme {
         SplashScreen(
+            splashState = SplashState(),
             onSplashAnimationComplete = {},
             logoColor = KrailTheme.colors.onSurface,
             backgroundColor = Color(0xFF009B77),

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashState.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashState.kt
@@ -2,10 +2,12 @@ package xyz.ksharma.krail.splash
 
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.ThemeMode
 import xyz.ksharma.krail.trip.planner.ui.navigation.KrailRoute
 
 data class SplashState(
     val hasSeenIntro: Boolean = true,
     val themeStyle: KrailThemeStyle = DEFAULT_THEME_STYLE,
+    val themeMode: ThemeMode? = null,
     val navigationDestination: KrailRoute? = null,
 )

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashViewModel.kt
@@ -23,8 +23,10 @@ import xyz.ksharma.krail.coroutines.ext.safeResult
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SandookPreferences.Companion.KEY_HAS_SEEN_INTRO
+import xyz.ksharma.krail.sandook.SandookPreferences.Companion.KEY_THEME_MODE
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.toThemeMode
 import xyz.ksharma.krail.trip.planner.ui.navigation.AppUpgradeRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
@@ -47,6 +49,7 @@ class SplashViewModel(
         .onStart {
             coroutineScope {
                 loadKrailThemeStyle()
+                loadThemeMode()
                 displayIntroScreen()
                 appStart.start()
                 trackAppStartEvent()
@@ -101,6 +104,14 @@ class SplashViewModel(
         logError("Error loading KRAIL theme style: $it", it)
     }.onSuccess {
         log("Krail theme style loaded: $it")
+    }
+
+    private fun loadThemeMode() {
+        val savedThemeModeCode = preferences.getLong(KEY_THEME_MODE)
+        val savedThemeMode = savedThemeModeCode.toThemeMode()
+        updateUiState {
+            copy(themeMode = savedThemeMode)
+        }
     }
 
     private fun onSplashAnimationComplete() {

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/ThemeSelectionViewModelTest.kt
@@ -10,11 +10,14 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.core.test.fakes.FakeAnalytics
 import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.fakes.FakeSandookPreferences
 import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.ThemeMode
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionEvent
 import xyz.ksharma.krail.trip.planner.ui.themeselection.ThemeSelectionViewModel
 import kotlin.test.AfterTest
@@ -34,6 +37,7 @@ class ThemeSelectionViewModelTest {
     private lateinit var viewModel: ThemeSelectionViewModel
 
     private val testDispatcher = StandardTestDispatcher()
+    private val fakePreferences = FakeSandookPreferences()
 
     @BeforeTest
     fun setUp() {
@@ -41,7 +45,8 @@ class ThemeSelectionViewModelTest {
         viewModel = ThemeSelectionViewModel(
             sandook = fakeSandook,
             analytics = fakeAnalytics,
-            ioDispatcher = testDispatcher
+            ioDispatcher = testDispatcher,
+            preferences = fakePreferences,
         )
     }
 
@@ -156,5 +161,23 @@ class ThemeSelectionViewModelTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    @Test
+    fun `GIVEN different theme modes WHEN ThemeModeSelected is triggered multiple times THEN preferences updates with latest theme mode code`() =
+        runTest {
+            // WHEN - Set to dark mode first
+            viewModel.onEvent(ThemeSelectionEvent.ThemeModeSelected(ThemeMode.DARK.code))
+            advanceUntilIdle()
+
+            // THEN
+            assertEquals(ThemeMode.DARK.code, fakePreferences.getLong(SandookPreferences.KEY_THEME_MODE))
+
+            // WHEN - Change to system mode
+            viewModel.onEvent(ThemeSelectionEvent.ThemeModeSelected(ThemeMode.SYSTEM.code))
+            advanceUntilIdle()
+
+            // THEN
+            assertEquals(ThemeMode.SYSTEM.code, fakePreferences.getLong(SandookPreferences.KEY_THEME_MODE))
         }
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/ThemeSelectionEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/usualride/ThemeSelectionEvent.kt
@@ -2,4 +2,5 @@ package xyz.ksharma.krail.trip.planner.ui.state.usualride
 
 sealed interface ThemeSelectionEvent {
     data class ThemeSelected(val themeId: Int) : ThemeSelectionEvent
+    data class ThemeModeSelected(val themeMode: Long) : ThemeSelectionEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -76,6 +76,7 @@ val viewModelsModule = module {
             sandook = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
+            preferences = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
@@ -57,6 +57,9 @@ internal fun NavGraphBuilder.themeSelectionDestination(navController: NavHostCon
                 viewModel.onEvent(ThemeSelectionEvent.ThemeSelected(themeId))
             },
             onBackClick = { navController.popBackStack() },
+            onThemeModeSelect = { code ->
+                viewModel.onEvent(ThemeSelectionEvent.ThemeModeSelected(code))
+            },
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -44,6 +44,7 @@ import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
 @Composable
 fun ThemeSelectionScreen(
     onThemeSelected: (Int) -> Unit,
+    onThemeModeSelect: (Long) -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     selectedThemeStyle: KrailThemeStyle = KrailThemeStyle.Train,
@@ -126,6 +127,7 @@ fun ThemeSelectionScreen(
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
                 onThemeSelect = { newTheme ->
                     themeController.setThemeMode(newTheme)
+                    onThemeModeSelect(newTheme.code)
                 },
             )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -15,6 +15,7 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionEvent
@@ -24,6 +25,7 @@ class ThemeSelectionViewModel(
     private val sandook: Sandook,
     private val analytics: Analytics,
     private val ioDispatcher: CoroutineDispatcher,
+    private val preferences: SandookPreferences,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<ThemeSelectionState> =
@@ -40,7 +42,12 @@ class ThemeSelectionViewModel(
     fun onEvent(event: ThemeSelectionEvent) {
         when (event) {
             is ThemeSelectionEvent.ThemeSelected -> onThemeSelected(event.themeId)
+            is ThemeSelectionEvent.ThemeModeSelected -> onThemeModeSelected(event.themeMode)
         }
+    }
+
+    private fun onThemeModeSelected(themeMode: Long) {
+        preferences.setLong(SandookPreferences.KEY_THEME_MODE, themeMode)
     }
 
     private fun onThemeSelected(productClass: Int) {

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -28,7 +28,7 @@ interface SandookPreferences {
         const val KEY_NSW_STOPS_VERSION = "KEY_NSW_STOPS_VERSION"
         const val KEY_HAS_SEEN_INTRO = "KEY_HAS_SEEN_INTRO"
         const val KEY_DISCOVER_CLICKED_BEFORE = "KEY_DISCOVER_CLICKED_BEFORE"
-
         const val KEY_DISMISSED_INFO_TILES = "KEY_DISMISSED_INFO_TILES"
+        const val KEY_THEME_MODE = "KEY_THEME_MODE"
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeManager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeManager.kt
@@ -7,11 +7,14 @@ import androidx.compose.runtime.staticCompositionLocalOf
 /**
  * Theme mode options for the app
  */
-enum class ThemeMode(val displayName: String) {
-    LIGHT("Light"),
-    DARK("Dark"),
-    SYSTEM("System"),
+enum class ThemeMode(val displayName: String, val code: Long) {
+    LIGHT(displayName = "Light", code = 1),
+    DARK(displayName = "Dark", code = 2),
+    SYSTEM(displayName = "System", code = 9),
 }
+
+fun Long?.toThemeMode(): ThemeMode =
+    ThemeMode.entries.firstOrNull { it.code == this } ?: ThemeMode.SYSTEM
 
 /**
  * Theme controller that provides current theme mode and allows changing it


### PR DESCRIPTION
### TL;DR

Added theme mode persistence across app restarts by saving and loading the user's theme preference.

### What changed?

- Added theme mode persistence by storing the selected theme mode in `SandookPreferences`
- Modified `SplashState` to include the theme mode
- Updated `SplashScreen` to apply the saved theme mode during app startup
- Enhanced `ThemeSelectionScreen` to save theme mode selections
- Added a new `ThemeModeSelected` event to handle theme mode changes
- Extended `ThemeMode` enum to include code values for storage

### How to test?

1. Change the theme mode (Light/Dark/System) in the theme selection screen
2. Close and restart the app
3. Verify that the previously selected theme mode is correctly applied on startup

### Why make this change?

Previously, the app would reset to the default theme mode on restart, providing a poor user experience. This change ensures that user preferences for theme mode are preserved across app sessions, creating a more consistent and personalized experience.