### PR TITLE
Feature: Add theme controller with system/light/dark mode support

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -2,7 +2,11 @@ package xyz.ksharma.krail
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.request.crossfade
@@ -11,12 +15,26 @@ import xyz.ksharma.krail.core.appinfo.AppInfo
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.appinfo.LocalAppInfo
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.LocalThemeController
+import xyz.ksharma.krail.taj.theme.ThemeController
+import xyz.ksharma.krail.taj.theme.ThemeMode
 
 @Composable
 fun KrailApp() {
     val appInfo = rememberAppInfo()
 
-    CompositionLocalProvider(LocalAppInfo provides appInfo) {
+    var currentThemeMode by remember { mutableStateOf(ThemeMode.SYSTEM) }
+    val themeController = remember(currentThemeMode) {
+        ThemeController(
+            currentMode = currentThemeMode,
+            setThemeMode = { newMode -> currentThemeMode = newMode },
+        )
+    }
+
+    CompositionLocalProvider(
+        LocalAppInfo provides appInfo,
+        LocalThemeController provides themeController,
+    ) {
         SetupCoilImageLoader()
 
         KrailTheme {

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/DiscoverCard.kt
@@ -3,7 +3,6 @@ package xyz.ksharma.krail.discover.ui
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -55,6 +54,7 @@ import xyz.ksharma.krail.taj.components.rememberCardHeight
 import xyz.ksharma.krail.taj.darken
 import xyz.ksharma.krail.taj.getImageHeightRatio
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
 import app.krail.taj.resources.Res as TajRes
@@ -167,7 +167,7 @@ fun createAdaptiveBackground(): Color {
     val themeColor = themeColor()
     val surfaceColor = KrailTheme.colors.surface
 
-    return if (isSystemInDarkTheme()) {
+    return if (isAppInDarkMode()) {
         // Dark mode: blend theme color with darkened surface (towards black)
         blendColors(
             foreground = themeColor.copy(alpha = 0.1f), // Reduced alpha for subtlety

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ColorExt.kt
@@ -1,10 +1,10 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 /**
@@ -17,7 +17,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
  */
 @Composable
 internal fun transportModeBackgroundColor(transportMode: TransportMode): Color {
-    return if (isSystemInDarkTheme()) {
+    return if (isAppInDarkMode()) {
         transportMode.colorCode.hexToComposeColor().copy(alpha = 0.45f)
     } else {
         transportMode.colorCode.hexToComposeColor().copy(alpha = 0.15f)
@@ -26,7 +26,7 @@ internal fun transportModeBackgroundColor(transportMode: TransportMode): Color {
 
 @Composable
 internal fun themeBackgroundColor(theme: KrailThemeStyle): Color {
-    return if (isSystemInDarkTheme()) {
+    return if (isAppInDarkMode()) {
         theme.hexColorCode.hexToComposeColor().copy(alpha = 0.45f)
     } else {
         theme.hexColorCode.hexToComposeColor().copy(alpha = 0.15f)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +32,7 @@ import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.cardBackground
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
@@ -86,7 +86,7 @@ fun SavedTripCard(
                 painter = painterResource(Res.drawable.ic_star_filled),
                 contentDescription = "Save Trip",
                 colorFilter = ColorFilter.tint(
-                    if (isSystemInDarkTheme().not()) {
+                    if (isAppInDarkMode().not()) {
                         primaryTransportMode?.colorCode
                             ?.hexToComposeColor() ?: themeColor()
                     } else {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -30,6 +29,7 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
 
 @Composable
@@ -42,7 +42,7 @@ fun DiscoverChip(
 ) {
     val textColor = if (selected) {
         getForegroundColor(
-            backgroundColor = if (isSystemInDarkTheme()) themeColor().darken() else themeColor(),
+            backgroundColor = if (isAppInDarkMode()) themeColor().darken() else themeColor(),
         )
     } else {
         KrailTheme.colors.label
@@ -101,7 +101,7 @@ fun DiscoverChip(
                 shape = RoundedCornerShape(50),
             )
             .background(
-                color = if (selected) if (isSystemInDarkTheme()) themeColor().darken() else themeColor() else KrailTheme.colors.discoverChipBackground,
+                color = if (selected) if (isAppInDarkMode()) themeColor().darken() else themeColor() else KrailTheme.colors.discoverChipBackground,
                 shape = RoundedCornerShape(50),
             ),
         contentAlignment = Alignment.Center,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -101,7 +101,11 @@ fun DiscoverChip(
                 shape = RoundedCornerShape(50),
             )
             .background(
-                color = if (selected) if (isAppInDarkMode()) themeColor().darken() else themeColor() else KrailTheme.colors.discoverChipBackground,
+                color = if (selected) {
+                    if (isAppInDarkMode()) themeColor().darken() else themeColor()
+                } else {
+                    KrailTheme.colors.discoverChipBackground
+                },
                 shape = RoundedCornerShape(50),
             ),
         contentAlignment = Alignment.Center,

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -1,12 +1,12 @@
 package xyz.ksharma.krail.taj
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import kotlin.math.absoluteValue
 
 fun String.hexToComposeColor(): Color {
@@ -64,7 +64,7 @@ fun themeColor(): Color {
 @Composable
 fun themeBackgroundColor(): Color {
     val themeColor by LocalThemeColor.current
-    return if (isSystemInDarkTheme()) {
+    return if (isAppInDarkMode()) {
         themeColor.hexToComposeColor().copy(alpha = 0.45f)
     } else {
         themeColor.hexToComposeColor().copy(alpha = 0.15f)
@@ -191,7 +191,7 @@ fun Color.darken(factor: Float = 0.2f): Color {
 
 @Composable
 fun backgroundColorOf(color: Color): Color {
-    return if (isSystemInDarkTheme()) {
+    return if (isAppInDarkMode()) {
         color.darken()
     } else {
         color.brighten()
@@ -217,7 +217,7 @@ fun darkenColor(color: Int, factor: Float = 0.2f): Int {
 @Composable
 fun themeSolidBackgroundColor(): Color {
     val themeColor by LocalThemeColor.current
-    return if (isSystemInDarkTheme()) {
+    return if (isAppInDarkMode()) {
         // Blend the theme color with dark surface for solid color
         blendColors(
             foreground = themeColor.hexToComposeColor().copy(alpha = 0.45f),

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/DiscoverCardVerticalPager.kt
@@ -2,7 +2,6 @@ package xyz.ksharma.krail.taj.components
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
@@ -26,8 +25,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
-import kotlin.compareTo
 import kotlin.math.absoluteValue
 
 @Composable
@@ -91,14 +90,14 @@ fun <T> DiscoverCardVerticalPager(
                 val scale = lerp(1f, 0.90f, pageOffset.coerceIn(0f, 1f))
 
                 // if light mode then 0.1f for dark mode 0.25f
-                val alpha = if (isSystemInDarkTheme()) {
+                val alpha = if (isAppInDarkMode()) {
                     lerp(1f, 0.25f, pageOffset.coerceIn(0f, 1f))
                 } else {
                     lerp(1f, 0.1f, pageOffset.coerceIn(0f, 1f))
                 }
 
                 // region Shadow for card
-                val maxShadowAlpha = if (isSystemInDarkTheme()) 0.15f else 0.1f
+                val maxShadowAlpha = if (isAppInDarkMode()) 0.15f else 0.1f
                 val targetShadowAlpha = if (isCardSelected) maxShadowAlpha else 0f
                 val animatedShadowAlpha by animateFloatAsState(
                     targetValue = targetShadowAlpha,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
@@ -21,10 +21,10 @@ fun KrailTheme(
         )
     }
 
-    val targetColors = if (isAppInDarkMode()) KrailDarkColors else KrailLightColors
+    val targetColors = if (themeController.isAppDarkMode()) KrailDarkColors else KrailLightColors
     val animatedColors = createLightDarkModeAnimatedColors(
         targetColors = targetColors,
-        isDarkMode = isAppInDarkMode(),
+        isDarkMode = themeController.isAppDarkMode(),
     )
 
     CompositionLocalProvider(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
@@ -21,10 +21,10 @@ fun KrailTheme(
         )
     }
 
-    val targetColors = if (themeController.isAppDarkMode()) KrailDarkColors else KrailLightColors
+    val targetColors = if (isAppInDarkMode()) KrailDarkColors else KrailLightColors
     val animatedColors = createLightDarkModeAnimatedColors(
         targetColors = targetColors,
-        isDarkMode = themeController.isAppDarkMode(),
+        isDarkMode = isAppInDarkMode(),
     )
 
     CompositionLocalProvider(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeManager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeManager.kt
@@ -31,9 +31,12 @@ data class ThemeController(
         }
         setThemeMode(if (isDarkMode) ThemeMode.LIGHT else ThemeMode.DARK)
     }
+}
 
-    @Composable
-    fun isAppDarkMode(): Boolean = when (currentMode) {
+@Composable
+fun isAppInDarkMode(): Boolean {
+    val themeController = LocalThemeController.current
+    return when (themeController.currentMode) {
         ThemeMode.DARK -> true
         ThemeMode.LIGHT -> false
         ThemeMode.SYSTEM -> isSystemInDarkTheme()

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeManager.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeManager.kt
@@ -31,6 +31,15 @@ data class ThemeController(
         }
         setThemeMode(if (isDarkMode) ThemeMode.LIGHT else ThemeMode.DARK)
     }
+
+    @Composable
+    fun isAppDarkMode(systemInDarkTheme: Boolean = isSystemInDarkTheme()): Boolean {
+        return when (currentMode) {
+            ThemeMode.DARK -> true
+            ThemeMode.LIGHT -> false
+            ThemeMode.SYSTEM -> systemInDarkTheme
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
# Add Theme Controller for App-Wide Dark Mode Management

This PR replaces direct usage of `isSystemInDarkTheme()` with a custom `isAppInDarkMode()` function that respects user theme preferences. The implementation:

1. Adds a `ThemeController` class that manages theme mode (LIGHT, DARK, SYSTEM)
2. Creates a `LocalThemeController` composition local to provide theme settings app-wide
3. Initializes the theme controller in `KrailApp.kt` before the `KrailTheme` is used
4. Replaces all instances of `isSystemInDarkTheme()` with `isAppInDarkMode()` across the codebase

This change allows the app to respect user theme preferences rather than always following the system setting.