### PR TITLE
Feature: Implement persistent theme management with platform-specific UI adaptations

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -101,6 +101,7 @@ kotlin {
             dependencies {
                 implementation(compose.preview)
                 implementation(libs.activity.compose)
+                implementation(libs.androidx.appcompat)
                 implementation(compose.foundation)
                 implementation(libs.core.ktx)
                 implementation(libs.kotlinx.serialization.json)

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -1,12 +1,12 @@
 package xyz.ksharma.krail
 
 import android.os.Bundle
+import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -1,15 +1,20 @@
 package xyz.ksharma.krail
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        // Enable edge-to-edge and allow status bar content color changes
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
         setContent {
             KrailApp()
         }

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/MainActivity.kt
@@ -1,9 +1,9 @@
 package xyz.ksharma.krail
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 
 class MainActivity : AppCompatActivity() {

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
@@ -1,0 +1,46 @@
+package xyz.ksharma.krail.theme
+
+import android.app.UiModeManager
+import android.content.Context
+import android.os.Build
+import androidx.appcompat.app.AppCompatDelegate
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.taj.theme.ThemeMode
+
+/**
+ * Android implementation of ThemeManager that handles system UI updates
+ * when theme mode changes to ensure status bar and navigation bar
+ * colors are updated correctly.
+ */
+class AndroidThemeManagerImpl(val context: Context, val coroutineScope: CoroutineScope) :
+    ThemeManager, KoinComponent {
+
+    var job: Job? = null
+
+    override fun applyThemeMode(themeMode: ThemeMode) {
+        job?.cancel()
+        job = coroutineScope.launch {
+            delay(1500)
+
+            log("Applying theme mode: $themeMode")
+            val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+            val nightMode = when (themeMode) {
+                ThemeMode.LIGHT -> UiModeManager.MODE_NIGHT_NO
+                ThemeMode.DARK -> UiModeManager.MODE_NIGHT_YES
+                ThemeMode.SYSTEM -> UiModeManager.MODE_NIGHT_AUTO
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                uiModeManager.setApplicationNightMode(nightMode)
+            } else {
+                AppCompatDelegate.setDefaultNightMode(nightMode)
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
@@ -4,10 +4,7 @@ import android.app.UiModeManager
 import android.content.Context
 import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import org.koin.core.component.KoinComponent
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.theme.ThemeMode
 
@@ -18,23 +15,17 @@ import xyz.ksharma.krail.taj.theme.ThemeMode
  */
 class AndroidThemeManagerImpl(
     val context: Context,
-    val coroutineScope: CoroutineScope,
 ) : ThemeManager {
 
-    var job: Job? = null
-
     override fun applyThemeMode(themeMode: ThemeMode) {
-        job?.cancel()
-        job = coroutineScope.launch {
-            log("Applying theme mode: $themeMode")
-            val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-            val nightMode = themeMode.toNightMode()
+        log("Applying theme mode: $themeMode")
+        val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+        val nightMode = themeMode.toNightMode()
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                uiModeManager.setApplicationNightMode(nightMode)
-            } else {
-                AppCompatDelegate.setDefaultNightMode(nightMode)
-            }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            uiModeManager.setApplicationNightMode(nightMode)
+        } else {
+            AppCompatDelegate.setDefaultNightMode(nightMode)
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
@@ -4,7 +4,6 @@ import android.app.UiModeManager
 import android.content.Context
 import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
-import kotlinx.coroutines.Job
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.theme.ThemeMode
 

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
@@ -6,8 +6,6 @@ import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import xyz.ksharma.krail.core.log.log
@@ -18,23 +16,19 @@ import xyz.ksharma.krail.taj.theme.ThemeMode
  * when theme mode changes to ensure status bar and navigation bar
  * colors are updated correctly.
  */
-class AndroidThemeManagerImpl(val context: Context, val coroutineScope: CoroutineScope) :
-    ThemeManager, KoinComponent {
+class AndroidThemeManagerImpl(
+    val context: Context,
+    val coroutineScope: CoroutineScope,
+) : ThemeManager {
 
     var job: Job? = null
 
     override fun applyThemeMode(themeMode: ThemeMode) {
         job?.cancel()
         job = coroutineScope.launch {
-            delay(1500)
-
             log("Applying theme mode: $themeMode")
             val uiModeManager = context.getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
-            val nightMode = when (themeMode) {
-                ThemeMode.LIGHT -> UiModeManager.MODE_NIGHT_NO
-                ThemeMode.DARK -> UiModeManager.MODE_NIGHT_YES
-                ThemeMode.SYSTEM -> UiModeManager.MODE_NIGHT_AUTO
-            }
+            val nightMode = themeMode.toNightMode()
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                 uiModeManager.setApplicationNightMode(nightMode)
@@ -42,5 +36,11 @@ class AndroidThemeManagerImpl(val context: Context, val coroutineScope: Coroutin
                 AppCompatDelegate.setDefaultNightMode(nightMode)
             }
         }
+    }
+
+    private fun ThemeMode.toNightMode() = when (this) {
+        ThemeMode.LIGHT -> UiModeManager.MODE_NIGHT_NO
+        ThemeMode.DARK -> UiModeManager.MODE_NIGHT_YES
+        ThemeMode.SYSTEM -> UiModeManager.MODE_NIGHT_AUTO
     }
 }

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.android.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.theme.di
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+import xyz.ksharma.krail.theme.AndroidThemeManagerImpl
+import xyz.ksharma.krail.theme.ThemeManager
+
+actual val themeManagerModule = module {
+    single<ThemeManager> {
+        AndroidThemeManagerImpl(
+            context = androidContext(),
+            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.android.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.android.kt
@@ -1,8 +1,5 @@
 package xyz.ksharma.krail.theme.di
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 import xyz.ksharma.krail.theme.AndroidThemeManagerImpl
@@ -12,7 +9,6 @@ actual val themeManagerModule = module {
     single<ThemeManager> {
         AndroidThemeManagerImpl(
             context = androidContext(),
-            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
         )
     }
 }

--- a/composeApp/src/androidMain/res/values/themes.xml
+++ b/composeApp/src/androidMain/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.Krail" parent="android:Theme.Material.NoActionBar">
+    <style name="Theme.Krail" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="android:windowBackground">@color/background_color</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
     </style>

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -2,11 +2,7 @@ package xyz.ksharma.krail
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.request.crossfade
@@ -14,30 +10,14 @@ import org.koin.compose.koinInject
 import xyz.ksharma.krail.core.appinfo.AppInfo
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.appinfo.LocalAppInfo
-import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.LocalThemeController
-import xyz.ksharma.krail.taj.theme.ThemeController
-import xyz.ksharma.krail.taj.theme.ThemeMode
-import xyz.ksharma.krail.theme.ThemeManager
+import xyz.ksharma.krail.theme.rememberAppThemeController
 
 @Composable
 fun KrailApp() {
     val appInfo = rememberAppInfo()
-    val themeManager: ThemeManager = koinInject()
-
-    var currentThemeMode by remember { mutableStateOf(ThemeMode.SYSTEM) }
-    val themeController = remember(currentThemeMode) {
-        ThemeController(
-            currentMode = currentThemeMode,
-            setThemeMode = { newThemeMode ->
-                log("Theme mode changed to $newThemeMode")
-                currentThemeMode = newThemeMode
-                // Apply theme changes to platform-specific system UI
-                themeManager.applyThemeMode(newThemeMode)
-            },
-        )
-    }
+    val themeController = rememberAppThemeController()
 
     CompositionLocalProvider(
         LocalAppInfo provides appInfo,

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -14,20 +14,28 @@ import org.koin.compose.koinInject
 import xyz.ksharma.krail.core.appinfo.AppInfo
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.appinfo.LocalAppInfo
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.LocalThemeController
 import xyz.ksharma.krail.taj.theme.ThemeController
 import xyz.ksharma.krail.taj.theme.ThemeMode
+import xyz.ksharma.krail.theme.ThemeManager
 
 @Composable
 fun KrailApp() {
     val appInfo = rememberAppInfo()
+    val themeManager: ThemeManager = koinInject()
 
     var currentThemeMode by remember { mutableStateOf(ThemeMode.SYSTEM) }
     val themeController = remember(currentThemeMode) {
         ThemeController(
             currentMode = currentThemeMode,
-            setThemeMode = { newMode -> currentThemeMode = newMode },
+            setThemeMode = { newMode ->
+                log("Theme mode changed to $newMode")
+                currentThemeMode = newMode
+                // Apply theme changes to platform-specific system UI
+                themeManager.applyThemeMode(newMode)
+            },
         )
     }
 
@@ -37,7 +45,7 @@ fun KrailApp() {
     ) {
         SetupCoilImageLoader()
 
-        KrailTheme {
+        KrailTheme(themeController = themeController) {
             KrailNavHost()
         }
     }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -30,11 +30,11 @@ fun KrailApp() {
     val themeController = remember(currentThemeMode) {
         ThemeController(
             currentMode = currentThemeMode,
-            setThemeMode = { newMode ->
-                log("Theme mode changed to $newMode")
-                currentThemeMode = newMode
+            setThemeMode = { newThemeMode ->
+                log("Theme mode changed to $newThemeMode")
+                currentThemeMode = newThemeMode
                 // Apply theme changes to platform-specific system UI
-                themeManager.applyThemeMode(newMode)
+                themeManager.applyThemeMode(newThemeMode)
             },
         )
     }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -1,3 +1,4 @@
+
 package xyz.ksharma.krail.di
 
 import org.koin.core.context.startKoin
@@ -21,6 +22,7 @@ import xyz.ksharma.krail.io.gtfs.di.gtfsModule
 import xyz.ksharma.krail.park.ride.network.di.parkRideNetworkModule
 import xyz.ksharma.krail.platform.ops.di.opsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
+import xyz.ksharma.krail.theme.di.themeManagerModule
 import xyz.ksharma.krail.splash.SplashViewModel
 import xyz.ksharma.krail.trip.planner.network.api.di.tripPlannerNetworkModule
 import xyz.ksharma.krail.trip.planner.ui.di.viewModelsModule
@@ -33,6 +35,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             coreNetworkModule,
             viewModelsModule,
             sandookModule,
+            themeManagerModule,
             splashModule,
             appInfoModule,
             appVersionModule,

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -22,8 +22,8 @@ import xyz.ksharma.krail.io.gtfs.di.gtfsModule
 import xyz.ksharma.krail.park.ride.network.di.parkRideNetworkModule
 import xyz.ksharma.krail.platform.ops.di.opsModule
 import xyz.ksharma.krail.sandook.di.sandookModule
-import xyz.ksharma.krail.theme.di.themeManagerModule
 import xyz.ksharma.krail.splash.SplashViewModel
+import xyz.ksharma.krail.theme.di.themeManagerModule
 import xyz.ksharma.krail.trip.planner.network.api.di.tripPlannerNetworkModule
 import xyz.ksharma.krail.trip.planner.ui.di.viewModelsModule
 

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/theme/AppThemeManager.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/theme/AppThemeManager.kt
@@ -1,0 +1,66 @@
+package xyz.ksharma.krail.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import org.koin.compose.koinInject
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.sandook.SandookPreferences
+import xyz.ksharma.krail.taj.theme.ThemeController
+import xyz.ksharma.krail.taj.theme.toThemeMode
+
+/**
+ * Composable that creates and manages the app's [ThemeController] with persistence.
+ *
+ * This handles:
+ * - Reading saved theme preference on app startup
+ * - Creating [ThemeController] with proper initialization
+ * - Saving theme changes to preferences automatically
+ * - Applying platform-specific theme changes
+ */
+@Composable
+fun rememberAppThemeController(): ThemeController {
+    val themeManager: ThemeManager = koinInject()
+
+    /**
+     * Inject [SandookPreferences] to read persisted theme mode on app startup.
+     * This is critical for maintaining theme consistency across app sessions:
+     *
+     * 1. App Startup: Without this, the app would always default to SYSTEM theme mode
+     *    regardless of user's previous selection (Light/Dark mode).
+     *
+     * 2. Activity Recreation: When the app is recreated (device rotation, memory pressure,
+     *    coming back from background), the [ThemeController] needs to restore the user's
+     *    selected theme mode from persistent storage.
+     *
+     * 3. Theme Selection Flow: When user selects a theme in ThemeSelectionScreen,
+     *    the selection is saved to preferences. On next app launch or recreation,
+     *    this saved preference must be read to maintain the selected theme.
+     *
+     * Without preferences injection here, users would experience theme resets to SYSTEM
+     * mode every time the app starts, losing their personalized theme choice.
+     */
+    val preferences: SandookPreferences = koinInject()
+
+    val initialThemeMode = remember {
+        preferences.getLong(SandookPreferences.KEY_THEME_MODE).toThemeMode()
+    }
+
+    var currentThemeMode by remember { mutableStateOf(initialThemeMode) }
+
+    return remember(currentThemeMode) {
+        ThemeController(
+            currentMode = currentThemeMode,
+            setThemeMode = { newThemeMode ->
+                log("Theme mode changed to $newThemeMode")
+                currentThemeMode = newThemeMode
+                // Save to preferences immediately when theme changes
+                preferences.setLong(SandookPreferences.KEY_THEME_MODE, newThemeMode.code)
+                // Apply theme changes to platform-specific system UI
+                themeManager.applyThemeMode(newThemeMode)
+            },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/theme/ThemeManager.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/theme/ThemeManager.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.theme
+
+import xyz.ksharma.krail.taj.theme.ThemeMode
+
+/**
+ * Platform-specific theme manager interface
+ * Inject [ThemeManager] to get platform-specific implementation
+ */
+interface ThemeManager {
+    fun applyThemeMode(themeMode: ThemeMode)
+}

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.kt
@@ -1,0 +1,5 @@
+package xyz.ksharma.krail.theme.di
+
+import org.koin.core.module.Module
+
+expect val themeManagerModule: Module

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/theme/IOSThemeManagerImpl.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/theme/IOSThemeManagerImpl.kt
@@ -1,0 +1,14 @@
+package xyz.ksharma.krail.theme
+
+import xyz.ksharma.krail.taj.theme.ThemeMode
+
+/**
+ * iOS implementation of ThemeManager
+ * iOS handles theme changes automatically, so this is a no-op
+ */
+class IOSThemeManagerImpl : ThemeManager {
+    override fun applyThemeMode(themeMode: ThemeMode) {
+        // iOS handles theme changes automatically through the system
+        // No action needed here
+    }
+}

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.ios.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/theme/di/ThemeManagerModule.ios.kt
@@ -1,0 +1,11 @@
+package xyz.ksharma.krail.theme.di
+
+import org.koin.dsl.module
+import xyz.ksharma.krail.theme.IOSThemeManagerImpl
+import xyz.ksharma.krail.theme.ThemeManager
+
+actual val themeManagerModule = module {
+    single<ThemeManager> {
+        IOSThemeManagerImpl()
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -43,7 +43,6 @@ import xyz.ksharma.krail.taj.components.DiscoverCardVerticalPager
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.theme.ThemeMode
 import xyz.ksharma.krail.trip.planner.ui.components.isLargeFontScale
 
 @Composable
@@ -378,7 +377,7 @@ private fun BoxScope.DiscoverTitleBar(
 )
 @Composable
 private fun DiscoverScreenTabletLightPreview() {
-    KrailTheme() {
+    KrailTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(4).toImmutableList(),
@@ -410,7 +409,7 @@ private fun DiscoverScreenTabletLightPreview() {
 )
 @Composable
 private fun DiscoverScreenTabletDarkPreview() {
-    KrailTheme() {
+    KrailTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(4).toImmutableList(),
@@ -442,7 +441,7 @@ private fun DiscoverScreenTabletDarkPreview() {
 )
 @Composable
 private fun DiscoverScreenCompactLightPreview() {
-    KrailTheme() {
+    KrailTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(3).toImmutableList(),
@@ -473,7 +472,7 @@ private fun DiscoverScreenCompactLightPreview() {
 )
 @Composable
 private fun DiscoverScreenCompactDarkPreview() {
-    KrailTheme() {
+    KrailTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(3).toImmutableList(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -378,7 +378,7 @@ private fun BoxScope.DiscoverTitleBar(
 )
 @Composable
 private fun DiscoverScreenTabletLightPreview() {
-    KrailTheme(themeMode = ThemeMode.DARK) {
+    KrailTheme() {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(4).toImmutableList(),
@@ -410,7 +410,7 @@ private fun DiscoverScreenTabletLightPreview() {
 )
 @Composable
 private fun DiscoverScreenTabletDarkPreview() {
-    KrailTheme(themeMode = ThemeMode.DARK) {
+    KrailTheme() {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(4).toImmutableList(),
@@ -442,7 +442,7 @@ private fun DiscoverScreenTabletDarkPreview() {
 )
 @Composable
 private fun DiscoverScreenCompactLightPreview() {
-    KrailTheme(themeMode = ThemeMode.LIGHT) {
+    KrailTheme() {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(3).toImmutableList(),
@@ -473,7 +473,7 @@ private fun DiscoverScreenCompactLightPreview() {
 )
 @Composable
 private fun DiscoverScreenCompactDarkPreview() {
-    KrailTheme(themeMode = ThemeMode.DARK) {
+    KrailTheme() {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(3).toImmutableList(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioGroup.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioGroup.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -59,7 +60,7 @@ fun ThemeSelectionRadioGroup(
     glowColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    var targetIndex by remember {
+    var targetIndex by rememberSaveable {
         mutableStateOf(ThemeMode.entries.indexOfFirst { it == selectedTheme })
     }
     var dragOffset by remember { mutableFloatStateOf(0f) }
@@ -330,11 +331,11 @@ private fun ThemeSelectionRadioGroupPreview() {
     val dummyThemeController = remember {
         ThemeController(
             currentMode = currentMode,
-            setThemeMode = { newMode -> currentMode = newMode },
+            setThemeMode = { },
         )
     }
 
-    KrailTheme(themeMode = currentMode) {
+    KrailTheme(dummyThemeController) {
         CompositionLocalProvider(
             LocalThemeController provides dummyThemeController,
         ) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,8 +35,10 @@ ui-tooling = "1.9.2"
 detekt = "1.23.8"
 detektCompose = "0.4.27"
 coil3 = "3.3.0"
+appcompat = "1.7.1"
 
 [libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildkonfigGradlePlugin" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.10.0</string>
 	<key>CFBundleVersion</key>
-	<string>3</string>
+	<string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/PreviewTheme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/PreviewTheme.kt
@@ -22,7 +22,12 @@ fun PreviewTheme(
     backgroundColor: Color = KrailTheme.colors.surface,
     content: @Composable () -> Unit,
 ) {
-    KrailTheme() {
+    KrailTheme(
+        themeController = ThemeController(
+            currentMode = if (darkTheme) ThemeMode.DARK else ThemeMode.LIGHT,
+            setThemeMode = {},
+        ),
+    ) {
         val color = remember { mutableStateOf(themeStyle.hexColorCode) }
         val density = LocalDensity.current
         CompositionLocalProvider(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/PreviewTheme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/PreviewTheme.kt
@@ -22,7 +22,7 @@ fun PreviewTheme(
     backgroundColor: Color = KrailTheme.colors.surface,
     content: @Composable () -> Unit,
 ) {
-    KrailTheme(themeMode = if (darkTheme) ThemeMode.DARK else ThemeMode.LIGHT) {
+    KrailTheme() {
         val color = remember { mutableStateOf(themeStyle.hexColorCode) }
         val density = LocalDensity.current
         CompositionLocalProvider(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
@@ -10,17 +10,12 @@ import xyz.ksharma.krail.taj.animations.createLightDarkModeAnimatedColors
 
 @Composable
 fun KrailTheme(
-    themeMode: ThemeMode = ThemeMode.SYSTEM,
+    themeController: ThemeController = ThemeController(
+        currentMode = ThemeMode.SYSTEM,
+        setThemeMode = {},
+    ),
     content: @Composable () -> Unit,
 ) {
-    var currentThemeMode by remember { mutableStateOf(themeMode) }
-    val themeController = remember(currentThemeMode) {
-        ThemeController(
-            currentMode = currentThemeMode,
-            setThemeMode = { newMode -> currentThemeMode = newMode },
-        )
-    }
-
     val targetColors = if (themeController.isAppDarkMode()) KrailDarkColors else KrailLightColors
     val animatedColors = createLightDarkModeAnimatedColors(
         targetColors = targetColors,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
@@ -2,14 +2,11 @@ package xyz.ksharma.krail.taj.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import xyz.ksharma.krail.taj.animations.createLightDarkModeAnimatedColors
 
 @Composable
 fun KrailTheme(
+    // default value is only set for usage in Previews, in prod code, this is be passed from KrailApp
     themeController: ThemeController = ThemeController(
         currentMode = ThemeMode.SYSTEM,
         setThemeMode = {},


### PR DESCRIPTION
# Implement Theme Persistence and System Integration

This PR adds proper theme persistence and system integration for the app's dark/light mode functionality:

- Creates a platform-specific `ThemeManager` interface with implementations for Android and iOS
- Implements `AndroidThemeManagerImpl` that properly applies theme changes to the Android system UI
- Replaces `MainActivity` to use `AppCompatActivity` for better theme compatibility
- Adds `rememberAppThemeController` to handle theme persistence using `SandookPreferences`
- Centralizes theme state management through `LocalThemeController` composition local
- Replaces direct `isSystemInDarkTheme()` calls with `isAppInDarkMode()` to respect user theme selection
- Updates theme-related components to work with the new theme system
- Ensures theme selection persists across app restarts and activity recreations

The implementation properly handles edge-to-edge display and status bar theming on Android while providing a no-op implementation for iOS where the system handles theme changes automatically.