### PR TITLE
Feature: Add PreviewTheme component for simplified UI previews

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/splash/SplashScreen.kt
@@ -41,6 +41,7 @@ import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.LocalThemeController
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun SplashScreen(
@@ -196,17 +197,15 @@ private fun AnimatedLetter(
 @Preview
 @Composable
 private fun PreviewLogo() {
-    KrailTheme {
-        Column(modifier = Modifier.background(color = KrailTheme.colors.surface)) {
-            AnimatedKrailLogo(logoColor = Color(0xFFF6891F))
-        }
+    PreviewTheme {
+        AnimatedKrailLogo(logoColor = Color(0xFFF6891F))
     }
 }
 
 @Preview
 @Composable
 private fun PreviewSplashScreen() {
-    KrailTheme {
+    PreviewTheme {
         SplashScreen(
             splashState = SplashState(),
             onSplashAnimationComplete = {},

--- a/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/PreviewDiscoverContent.kt
+++ b/discover/ui/src/commonMain/kotlin/xyz/ksharma/krail/discover/ui/PreviewDiscoverContent.kt
@@ -2,17 +2,14 @@ package xyz.ksharma.krail.discover.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import coil3.ColorImage
 import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.AsyncImagePreviewHandler
 import coil3.compose.LocalAsyncImagePreviewHandler
-import xyz.ksharma.krail.taj.LocalThemeColor
-import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @OptIn(ExperimentalCoilApi::class)
 @Composable
@@ -24,12 +21,8 @@ fun PreviewDiscoverContent(
     val previewHandler = AsyncImagePreviewHandler {
         ColorImage(color = imageColor.toArgb())
     }
-    val themeColorHexCode = rememberSaveable {
-        mutableStateOf(krailThemeStyle.hexColorCode)
-    }
-    KrailTheme {
+    PreviewTheme(themeStyle = krailThemeStyle) {
         CompositionLocalProvider(
-            LocalThemeColor provides themeColorHexCode,
             LocalAsyncImagePreviewHandler provides previewHandler,
         ) {
             content()

--- a/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkAndRideIcon.kt
+++ b/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkAndRideIcon.kt
@@ -7,10 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +25,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun ParkAndRideIcon() {
@@ -61,7 +59,7 @@ fun ParkAndRideIcon() {
 @Preview
 @Composable
 private fun ParkAndRideIconPreview() {
-    KrailTheme {
+    PreviewTheme {
         ParkAndRideIcon()
     }
 }
@@ -69,13 +67,7 @@ private fun ParkAndRideIconPreview() {
 @Preview
 @Composable
 private fun ParkAndRideIconThemedPreview() {
-    KrailTheme {
-        val themeColorHexCode =
-            rememberSaveable { mutableStateOf(KrailThemeStyle.Metro.hexColorCode) }
-        CompositionLocalProvider(
-            LocalThemeColor provides themeColorHexCode,
-        ) {
-            ParkAndRideIcon()
-        }
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        ParkAndRideIcon()
     }
 }

--- a/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkRideFacilityInfo.kt
+++ b/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkRideFacilityInfo.kt
@@ -28,10 +28,10 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 data class ParkRideFacilityInfo(
     val facilityName: String,
@@ -157,113 +157,93 @@ fun ParkRideInfoText(
 @Preview
 @Composable
 private fun ParkRideInfoCardPreview_SingleStop() {
-    KrailTheme {
-        Column(
-            modifier = Modifier.background(
-                color = KrailThemeStyle.Metro.hexColorCode.hexToComposeColor(),
-            ),
-        ) {
-            ParkRideInfoCard(
-                parkRideInfo = mapOf(
-                    "211" to listOf(
-                        ParkRideFacilityInfo(
-                            facilityName = "Tallawong P1",
-                            availableSpots = "100",
-                            fullPercentage = "50%",
-                        ),
-                    ).toImmutableList(),
-                ).toImmutableMap(),
-                onNavigateToMapsClick = { _ -> },
-            )
-        }
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        ParkRideInfoCard(
+            parkRideInfo = mapOf(
+                "211" to listOf(
+                    ParkRideFacilityInfo(
+                        facilityName = "Tallawong P1",
+                        availableSpots = "100",
+                        fullPercentage = "50%",
+                    ),
+                ).toImmutableList(),
+            ).toImmutableMap(),
+            onNavigateToMapsClick = { _ -> },
+        )
     }
 }
 
 @Preview
 @Composable
 private fun ParkRideInfoCardPreview_SingleStopMultipleFacilities() {
-    KrailTheme {
-        Column(
-            modifier = Modifier.background(
-                color = KrailThemeStyle.Metro.hexColorCode.hexToComposeColor(),
-            ),
-        ) {
-            ParkRideInfoCard(
-                parkRideInfo = mapOf(
-                    "999" to listOf(
-                        ParkRideFacilityInfo(
-                            facilityName = "Alpha P1",
-                            availableSpots = "10",
-                            fullPercentage = "10%",
-                        ),
-                        ParkRideFacilityInfo(
-                            facilityName = "Alpha P2",
-                            availableSpots = "20",
-                            fullPercentage = "20%",
-                        ),
-                    ).toImmutableList(),
-                ).toImmutableMap(),
-                onNavigateToMapsClick = { _ -> },
-            )
-        }
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        ParkRideInfoCard(
+            parkRideInfo = mapOf(
+                "999" to listOf(
+                    ParkRideFacilityInfo(
+                        facilityName = "Alpha P1",
+                        availableSpots = "10",
+                        fullPercentage = "10%",
+                    ),
+                    ParkRideFacilityInfo(
+                        facilityName = "Alpha P2",
+                        availableSpots = "20",
+                        fullPercentage = "20%",
+                    ),
+                ).toImmutableList(),
+            ).toImmutableMap(),
+            onNavigateToMapsClick = { _ -> },
+        )
     }
 }
 
 @Preview
 @Composable
 private fun ParkRideInfoCardPreview_MultipleStops() {
-    KrailTheme {
-        Column(
-            modifier = Modifier.background(
-                color = KrailThemeStyle.Metro.hexColorCode.hexToComposeColor(),
-            ),
-        ) {
-            ParkRideInfoCard(
-                parkRideInfo = mapOf(
-                    "211" to listOf(
-                        ParkRideFacilityInfo(
-                            facilityName = "Tallawong P1",
-                            availableSpots = "100",
-                            fullPercentage = "50%",
-                        ),
-                        ParkRideFacilityInfo(
-                            facilityName = "Tallawong P2",
-                            availableSpots = "200",
-                            fullPercentage = "75%",
-                        ),
-                    ).toImmutableList(),
-                    "212" to listOf(
-                        ParkRideFacilityInfo(
-                            facilityName = "Hornsby P1",
-                            availableSpots = "100",
-                            fullPercentage = "50%",
-                        ),
-                        ParkRideFacilityInfo(
-                            facilityName = "Hornsby P2",
-                            availableSpots = "200",
-                            fullPercentage = "75%",
-                        ),
-                    ).toImmutableList(),
-                ).toImmutableMap(),
-                onNavigateToMapsClick = { _ -> },
-            )
-        }
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        ParkRideInfoCard(
+            parkRideInfo = mapOf(
+                "211" to listOf(
+                    ParkRideFacilityInfo(
+                        facilityName = "Tallawong P1",
+                        availableSpots = "100",
+                        fullPercentage = "50%",
+                    ),
+                    ParkRideFacilityInfo(
+                        facilityName = "Tallawong P2",
+                        availableSpots = "200",
+                        fullPercentage = "75%",
+                    ),
+                ).toImmutableList(),
+                "212" to listOf(
+                    ParkRideFacilityInfo(
+                        facilityName = "Hornsby P1",
+                        availableSpots = "100",
+                        fullPercentage = "50%",
+                    ),
+                    ParkRideFacilityInfo(
+                        facilityName = "Hornsby P2",
+                        availableSpots = "200",
+                        fullPercentage = "75%",
+                    ),
+                ).toImmutableList(),
+            ).toImmutableMap(),
+            onNavigateToMapsClick = { _ -> },
+        )
     }
 }
 
 @Preview
 @Composable
 private fun ParkRideFacilityItemPreview() {
-    KrailTheme {
-        Column(modifier = Modifier.background(color = Color.White)) {
-            ParkRideFacilityItem(
-                parkRideFacilityInfo = ParkRideFacilityInfo(
-                    facilityName = "Tallawong P1",
-                    availableSpots = "100",
-                    fullPercentage = "50%",
-                ),
-            )
-        }
+    PreviewTheme {
+        ParkRideFacilityItem(
+            parkRideFacilityInfo = ParkRideFacilityInfo(
+                facilityName = "Tallawong P1",
+                availableSpots = "100",
+                fullPercentage = "50%",
+            ),
+        )
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/CollapsibleAlert.kt
@@ -31,6 +31,7 @@ import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.toAdaptiveSize
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
@@ -144,7 +145,7 @@ fun CollapsibleAlert(
 @Preview
 @Composable
 private fun PreviewCollapsibleAlertCollapsed() {
-    KrailTheme {
+    PreviewTheme {
         val color = remember { mutableStateOf(TransportMode.Ferry().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides color) {
             CollapsibleAlert(
@@ -163,7 +164,7 @@ private fun PreviewCollapsibleAlertCollapsed() {
 @Preview
 @Composable
 private fun PreviewCollapsibleAlertExpanded() {
-    KrailTheme {
+    PreviewTheme {
         val color = remember { mutableStateOf(TransportMode.Ferry().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides color) {
             CollapsibleAlert(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
@@ -19,9 +19,11 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
 @Composable
@@ -30,8 +32,6 @@ fun ServiceAlertScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit = {},
 ) {
-//    DefaultSystemBarColors()
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -74,10 +74,10 @@ fun ServiceAlertScreen(
     }
 }
 
-// @Preview
+@Preview
 @Composable
 private fun PreviewServiceAlertScreen() {
-    KrailTheme {
+    PreviewTheme {
         ServiceAlertScreen(
             serviceAlerts = persistentSetOf(
                 ServiceAlert(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ErrorMessage.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ErrorMessage.kt
@@ -14,12 +14,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextButton
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 
 @Composable
@@ -83,12 +85,12 @@ data class ActionData(
 )
 
 // region Preview
-
+@Preview
 @Composable
 private fun PreviewErrorMessage() {
     val themeColor = remember { mutableStateOf(TransportMode.Ferry().colorCode) }
     CompositionLocalProvider(LocalThemeColor provides themeColor) {
-        KrailTheme {
+        PreviewTheme {
             ErrorMessage(
                 title = "Eh! That's not looking right mate.",
                 message = "Let's try again.",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -345,7 +345,7 @@ private fun StopsRow(
 @Preview
 @Composable
 private fun PreviewLegView() {
-    KrailTheme {
+    PreviewTheme {
         LegView(
             routeText = "towards AVC via XYZ Rd",
             transportModeLine = TransportModeLine(
@@ -377,7 +377,7 @@ private fun PreviewLegView() {
 @Preview
 @Composable
 private fun PreviewLegViewTwoStops() {
-    KrailTheme {
+    PreviewTheme {
         LegView(
             routeText = "towards AVC via XYZ",
             transportModeLine = TransportModeLine(
@@ -404,7 +404,7 @@ private fun PreviewLegViewTwoStops() {
 @Preview
 @Composable
 private fun PreviewLegViewMetro() {
-    KrailTheme {
+    PreviewTheme {
         LegView(
             routeText = "towards AVC via XYZ",
             transportModeLine = TransportModeLine(
@@ -431,7 +431,7 @@ private fun PreviewLegViewMetro() {
 @Preview
 @Composable
 private fun PreviewLegViewFerry() {
-    KrailTheme {
+    PreviewTheme {
         LegView(
             routeText = "towards AVC via XYZ",
             transportModeLine = TransportModeLine(
@@ -458,7 +458,7 @@ private fun PreviewLegViewFerry() {
 @Preview
 @Composable
 private fun PreviewLegViewLightRail() {
-    KrailTheme {
+    PreviewTheme {
         LegView(
             routeText = "towards AVC via XYZ",
             transportModeLine = TransportModeLine(
@@ -515,7 +515,7 @@ private fun PreviewStopsRow_LargeFont() {
 @Preview
 @Composable
 private fun PreviewProminentStopInfo() {
-    KrailTheme {
+    PreviewTheme {
         StopInfo(
             time = "12:00",
             name = "XYZ Station, Platform 1",
@@ -529,7 +529,7 @@ private fun PreviewProminentStopInfo() {
 @Preview
 @Composable
 private fun PreviewRouteSummary() {
-    KrailTheme {
+    PreviewTheme {
         RouteSummary(
             routeText = "towards AVC via XYZ Rd",
             modifier = Modifier.background(KrailTheme.colors.surface),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -12,8 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,12 +23,13 @@ import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.cardBackground
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
@@ -103,33 +101,27 @@ fun SavedTripCard(
 @Preview
 @Composable
 private fun SavedTripCardPreview() {
-    KrailTheme {
-        val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
-        CompositionLocalProvider(LocalThemeColor provides themeColor) {
-            SavedTripCard(
-                trip = Trip(
-                    fromStopId = "1",
-                    fromStopName = "Edmondson Park Station",
-                    toStopId = "2",
-                    toStopName = "Harris Park Station",
-                ),
-                primaryTransportMode = TransportMode.Train(),
-                onCardClick = {},
-                onStarClick = {},
-                modifier = Modifier.background(color = KrailTheme.colors.surface),
-            )
-        }
+    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
+        SavedTripCard(
+            trip = Trip(
+                fromStopId = "1",
+                fromStopName = "Edmondson Park Station",
+                toStopId = "2",
+                toStopName = "Harris Park Station",
+            ),
+            primaryTransportMode = TransportMode.Train(),
+            onCardClick = {},
+            onStarClick = {},
+        )
     }
 }
 
 @Preview
 @Composable
 private fun SavedTripCardListPreview() {
-    KrailTheme {
+    PreviewTheme {
         Column(
-            modifier = Modifier
-                .background(color = KrailTheme.colors.surface)
-                .padding(16.dp),
+            modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             SavedTripCard(
@@ -171,11 +163,11 @@ private fun SavedTripCardListPreview() {
             SavedTripCard(
                 trip = Trip(
                     fromStopId = "1",
-                    fromStopName = "Manly Wharf",
+                    fromStopName = "Central Station",
                     toStopId = "2",
-                    toStopName = "Circular Quay Wharf",
+                    toStopName = "Town Hall Station",
                 ),
-                primaryTransportMode = null,
+                primaryTransportMode = TransportMode.Metro(),
                 onCardClick = {},
                 onStarClick = {},
             )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -43,7 +43,7 @@ import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.TextFieldButton
 import xyz.ksharma.krail.taj.components.ThemeTextFieldPlaceholderText
 import xyz.ksharma.krail.taj.hexToComposeColor
-import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
@@ -194,7 +194,7 @@ fun SearchStopRow(
 
 @Composable
 private fun SearchStopColumnPreview() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Train().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopRow(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopSearchListItem.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopSearchListItem.kt
@@ -1,6 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,8 +14,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.state.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
@@ -60,9 +61,10 @@ fun StopSearchListItem(
 
 // region Preview
 
+@Preview
 @Composable
 private fun StopSearchListItemPreview() {
-    KrailTheme {
+    PreviewTheme {
         StopSearchListItem(
             stopId = "123",
             stopName = "Stop Name",
@@ -71,14 +73,14 @@ private fun StopSearchListItemPreview() {
                 TransportMode.LightRail(),
             ),
             textColor = KrailTheme.colors.onSurface,
-            modifier = Modifier.background(color = KrailTheme.colors.surface),
         )
     }
 }
 
+@Preview
 @Composable
 private fun StopSearchListItemLongNamePreview() {
-    KrailTheme {
+    PreviewTheme {
         StopSearchListItem(
             stopId = "123",
             stopName = "This is a very long stop name that should wrap to the next line",
@@ -87,7 +89,6 @@ private fun StopSearchListItemLongNamePreview() {
                 TransportMode.Ferry(),
             ),
             textColor = KrailTheme.colors.onSurface,
-            modifier = Modifier.background(color = KrailTheme.colors.surface),
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -19,6 +19,7 @@ import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens
 
 @Composable
@@ -55,7 +56,7 @@ fun TransportModeBadge(
 @Preview
 @Composable
 private fun TransportModeBadgeBusPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeBadge(
             badgeText = "700",
             backgroundColor = "00B5EF".hexToComposeColor(),
@@ -63,9 +64,10 @@ private fun TransportModeBadgeBusPreview() {
     }
 }
 
+@Preview
 @Composable
 private fun TransportModeBadgeTrainPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeBadge(
             badgeText = "T1",
             backgroundColor = "#F6891F".hexToComposeColor(),
@@ -73,9 +75,10 @@ private fun TransportModeBadgeTrainPreview() {
     }
 }
 
+@Preview
 @Composable
 private fun TransportModeBadgeFerryPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeBadge(
             badgeText = "F1",
             backgroundColor = "#5AB031".hexToComposeColor(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeIcon.kt
@@ -89,7 +89,7 @@ private const val previewWithBackground = "Transport Mode Icons With Background"
 @Preview(group = previewGroupName)
 @Composable
 private fun TrainPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Train(),
             displayBorder = false,
@@ -114,7 +114,7 @@ private fun TrainPreviewLarge() {
 @Preview(group = previewGroupName)
 @Composable
 private fun BusPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Bus(),
             displayBorder = false,
@@ -125,7 +125,7 @@ private fun BusPreview() {
 @Preview(group = previewGroupName)
 @Composable
 private fun MetroPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Metro(),
             displayBorder = false,
@@ -136,7 +136,7 @@ private fun MetroPreview() {
 @Preview(group = previewGroupName)
 @Composable
 private fun LightRailPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.LightRail(),
             displayBorder = false,
@@ -147,7 +147,7 @@ private fun LightRailPreview() {
 @Preview(group = previewGroupName)
 @Composable
 private fun FerryPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Ferry(),
             displayBorder = false,
@@ -158,7 +158,7 @@ private fun FerryPreview() {
 @Preview(group = previewWithBackground)
 @Composable
 private fun TrainWithBackgroundPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Train(),
             displayBorder = true,
@@ -169,7 +169,7 @@ private fun TrainWithBackgroundPreview() {
 @Preview(group = previewWithBackground)
 @Composable
 private fun BusWithBackgroundPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Bus(),
             displayBorder = true,
@@ -180,7 +180,7 @@ private fun BusWithBackgroundPreview() {
 @Preview(group = previewWithBackground)
 @Composable
 private fun MetroWithBackgroundPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Metro(),
             displayBorder = true,
@@ -191,7 +191,7 @@ private fun MetroWithBackgroundPreview() {
 @Preview(group = previewWithBackground)
 @Composable
 private fun LightRailWithBackgroundPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.LightRail(),
             displayBorder = true,
@@ -202,7 +202,7 @@ private fun LightRailWithBackgroundPreview() {
 @Preview(group = previewWithBackground)
 @Composable
 private fun FerryWithBackgroundPreview() {
-    KrailTheme {
+    PreviewTheme {
         TransportModeIcon(
             transportMode = TransportMode.Ferry(),
             displayBorder = true,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
@@ -19,6 +19,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun WalkingLeg(
@@ -51,7 +52,7 @@ fun WalkingLeg(
 @Preview
 @Composable
 private fun PreviewWalkingLeg() {
-    KrailTheme {
+    PreviewTheme {
         WalkingLeg("5 mins")
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiAnim.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/loading/LoadingEmojiAnim.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun LoadingEmojiAnim(
@@ -75,7 +76,7 @@ fun LoadingEmojiAnim(
 @Preview
 @Composable
 private fun Preview() {
-    KrailTheme {
+    PreviewTheme {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             LoadingEmojiAnim(emoji = "\uD83D\uDE80")
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -43,6 +43,7 @@ import xyz.ksharma.krail.taj.components.DiscoverCardVerticalPager
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.components.isLargeFontScale
 
 @Composable
@@ -377,7 +378,7 @@ private fun BoxScope.DiscoverTitleBar(
 )
 @Composable
 private fun DiscoverScreenTabletLightPreview() {
-    KrailTheme {
+    PreviewTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(4).toImmutableList(),
@@ -409,7 +410,7 @@ private fun DiscoverScreenTabletLightPreview() {
 )
 @Composable
 private fun DiscoverScreenTabletDarkPreview() {
-    KrailTheme {
+    PreviewTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(4).toImmutableList(),
@@ -441,7 +442,7 @@ private fun DiscoverScreenTabletDarkPreview() {
 )
 @Composable
 private fun DiscoverScreenCompactLightPreview() {
-    KrailTheme {
+    PreviewTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(3).toImmutableList(),
@@ -472,7 +473,7 @@ private fun DiscoverScreenCompactLightPreview() {
 )
 @Composable
 private fun DiscoverScreenCompactDarkPreview() {
-    KrailTheme {
+    PreviewTheme {
         DiscoverScreen(
             state = DiscoverState(
                 discoverCardsList = previewDiscoverCardList.take(3).toImmutableList(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -45,6 +45,7 @@ import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
@@ -315,7 +316,7 @@ private fun SavedTripsTitle(
 
 @Composable
 private fun SavedTripsScreenPreview() {
-    KrailTheme {
+    PreviewTheme {
         SavedTripsScreen(savedTripsState = SavedTripsState())
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -64,6 +64,7 @@ import xyz.ksharma.krail.taj.components.TextField
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.StopSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
@@ -375,7 +376,7 @@ fun SearchStopScreen(
 
 @Composable
 private fun PreviewSearchStopScreenLoading() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -388,7 +389,7 @@ private fun PreviewSearchStopScreenLoading() {
 
 @Composable
 private fun PreviewSearchStopScreenError() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -401,7 +402,7 @@ private fun PreviewSearchStopScreenError() {
 
 @Composable
 private fun PreviewSearchStopScreenEmpty() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -418,7 +419,7 @@ private fun PreviewSearchStopScreenEmpty() {
 
 @Composable
 private fun PreviewSearchStopScreenTrain() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Train().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -431,7 +432,7 @@ private fun PreviewSearchStopScreenTrain() {
 
 @Composable
 private fun PreviewSearchStopScreenCoach() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Coach().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -444,7 +445,7 @@ private fun PreviewSearchStopScreenCoach() {
 
 @Composable
 private fun PreviewSearchStopScreenFerry() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Ferry().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -457,7 +458,7 @@ private fun PreviewSearchStopScreenFerry() {
 
 @Composable
 private fun PreviewSearchStopScreenMetro() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Metro().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -470,7 +471,7 @@ private fun PreviewSearchStopScreenMetro() {
 
 @Composable
 private fun PreviewSearchStopScreenLightRail() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.LightRail().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(
@@ -483,7 +484,7 @@ private fun PreviewSearchStopScreenLightRail() {
 
 @Composable
 private fun PreviewSearchStopScreenBus() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Bus().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             SearchStopScreen(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
@@ -42,6 +42,7 @@ import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.scalingKlickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.components.themeBackgroundColor
 
 @Composable
@@ -221,7 +222,7 @@ fun ThemeSelectionRadioButton(
 @Preview
 @Composable
 private fun ThemeSelectionRadioButtonPreview() {
-    KrailTheme {
+    PreviewTheme {
         ThemeSelectionRadioButton(
             themeStyle = KrailThemeStyle.Bus,
             onClick = {},
@@ -233,7 +234,7 @@ private fun ThemeSelectionRadioButtonPreview() {
 @Preview
 @Composable
 private fun ThemeSelectionRadioButtonUnselectedPreview() {
-    KrailTheme {
+    PreviewTheme {
         ThemeSelectionRadioButton(
             themeStyle = KrailThemeStyle.Bus,
             onClick = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -61,6 +61,7 @@ import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.ActionData
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
@@ -443,7 +444,7 @@ fun ActionButton(
 
 @Composable
 private fun PreviewTimeTableScreen() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Ferry().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             TimeTableScreen(
@@ -488,7 +489,7 @@ private fun PreviewTimeTableScreen() {
 
 @Composable
 private fun PreviewTimeTableScreenError() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Train().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             TimeTableScreen(
@@ -515,7 +516,7 @@ private fun PreviewTimeTableScreenError() {
 
 @Composable
 private fun PreviewTimeTableScreenNoResults() {
-    KrailTheme {
+    PreviewTheme {
         val themeColor = remember { mutableStateOf(TransportMode.Train().colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             TimeTableScreen(

--- a/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
+++ b/social/ui/src/commonMain/kotlin/xyz/ksharma/krail/social/ui/SocialConnectionRow.kt
@@ -15,6 +15,7 @@ import xyz.ksharma.krail.discover.state.Button.Social.PartnerSocial.PartnerSocia
 import xyz.ksharma.krail.social.state.KrailSocialType
 import xyz.ksharma.krail.taj.components.SocialConnectionIcon
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun SocialConnectionRow(
@@ -72,7 +73,7 @@ fun SocialConnectionRow(
 @Preview
 @Composable
 private fun SocialConnectionRowPreview() {
-    KrailTheme {
+    PreviewTheme {
         SocialConnectionRow(
             socialLinks = KrailSocialType.entries,
             onClick = {},

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CookieShapeBox.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CookieShapeBox.kt
@@ -21,6 +21,7 @@ import xyz.ksharma.krail.taj.magicBorderColors
 import xyz.ksharma.krail.taj.shapes.CookieShape
 import xyz.ksharma.krail.taj.shapes.buildCookiePath
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 /**
  * A box with a cookie-shaped background and optional multi-color stroke.
@@ -121,7 +122,7 @@ object CookieShapeBoxDefaults {
 @Preview
 @Composable
 private fun CookiePreviewBox() {
-    KrailTheme {
+    PreviewTheme {
         CookieShapeBox()
     }
 }
@@ -129,7 +130,7 @@ private fun CookiePreviewBox() {
 @Preview
 @Composable
 private fun CookiePreviewCanvas() {
-    KrailTheme {
+    PreviewTheme {
         CookieShapeCanvas()
     }
 }
@@ -152,7 +153,7 @@ private fun CookieShapeBoxSweepGradient() {
 @Preview
 @Composable
 private fun CookieShapeBoxRadialGradient() {
-    KrailTheme {
+    PreviewTheme {
         CookieShapeBox(
             outlineBrush = Brush.radialGradient(
                 colors = listOf(Color(0xFFFFEE58), Color(0xFFF57F17)),

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Divider.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Divider.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContainerColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun Divider(
@@ -50,7 +51,7 @@ enum class DividerType {
 
 @Composable
 private fun DividerPreview() {
-    KrailTheme {
+    PreviewTheme {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -65,7 +66,7 @@ private fun DividerPreview() {
 
 @Composable
 private fun DividerVerticalPreview() {
-    KrailTheme {
+    PreviewTheme {
         Box(
             modifier = Modifier
                 .size(30.dp)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/SeparatorIcon.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/SeparatorIcon.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.toAdaptiveSize
 
 @Composable
@@ -28,7 +29,7 @@ fun SeparatorIcon(modifier: Modifier = Modifier, color: Color = KrailTheme.color
 
 @Composable
 private fun SeparatorIconPreview() {
-    KrailTheme {
+    PreviewTheme {
         Box(
             modifier = Modifier
                 .background(KrailTheme.colors.surface)

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Text.kt
@@ -18,6 +18,7 @@ import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 @Composable
 fun Text(
@@ -82,7 +83,7 @@ fun Text(
 @Preview
 @Composable
 private fun TextPreview() {
-    KrailTheme {
+    PreviewTheme {
         Column(modifier = Modifier.background(color = KrailTheme.colors.surface)) {
             Text(text = "Typography")
             Text(text = "DisplayLarge", style = KrailTheme.typography.displayLarge)
@@ -95,7 +96,7 @@ private fun TextPreview() {
 @Preview
 @Composable
 private fun TextWithColorPreview() {
-    KrailTheme {
+    PreviewTheme {
         Column(modifier = Modifier.background(color = KrailTheme.colors.surface)) {
             Text(text = "Typography", color = KrailTheme.colors.error)
         }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Theme.kt
@@ -6,11 +6,7 @@ import xyz.ksharma.krail.taj.animations.createLightDarkModeAnimatedColors
 
 @Composable
 fun KrailTheme(
-    // default value is only set for usage in Previews, in prod code, this is be passed from KrailApp
-    themeController: ThemeController = ThemeController(
-        currentMode = ThemeMode.SYSTEM,
-        setThemeMode = {},
-    ),
+    themeController: ThemeController,
     content: @Composable () -> Unit,
 ) {
     val targetColors = if (themeController.isAppDarkMode()) KrailDarkColors else KrailLightColors


### PR DESCRIPTION
### TL;DR

Added a new `PreviewTheme` composable to simplify and standardize preview implementations across the app.

### What changed?

- Created a new `PreviewTheme` composable that wraps `KrailTheme` with default parameters for preview usage
- Replaced all instances of `KrailTheme` in preview composables with `PreviewTheme`
- Removed unnecessary background modifiers and CompositionLocalProviders in preview functions
- Added support for specifying a theme style in `PreviewTheme` for themed previews
- Enabled several previously commented-out preview functions

### How to test?

1. Run the app and verify that all UI components render correctly
2. Check that previews in Android Studio display properly with the expected themes
3. Verify that themed previews (e.g., Metro, Bus, Ferry) show the correct theme colors

### Why make this change?

This change improves code maintainability by:
- Reducing boilerplate in preview composables
- Providing a consistent approach to theming in previews
- Simplifying the process of creating themed previews
- Making it easier to update theme-related preview code in the future

The `PreviewTheme` composable handles default theme controller setup that was previously duplicated across many files, resulting in cleaner and more maintainable code.