### PR TITLE
Refactor: Simplify theme selection with immediate application and updated UI text

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionDestination.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.log.log
@@ -16,7 +15,6 @@ import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.taj.toHex
-import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
 import xyz.ksharma.krail.trip.planner.ui.state.usualride.ThemeSelectionEvent
 
@@ -31,17 +29,6 @@ internal fun NavGraphBuilder.themeSelectionDestination(navController: NavHostCon
 
         LaunchedEffect(state.selectedThemeStyle) {
             log("selectedTransportMode: ${state.selectedThemeStyle}")
-        }
-        LaunchedEffect(state.themeSelected) {
-            if (state.themeSelected) {
-                navController.navigate(
-                    route = SavedTripsRoute,
-                    navOptions = NavOptions.Builder()
-                        .setLaunchSingleTop(true)
-                        .setPopUpTo<SavedTripsRoute>(inclusive = false)
-                        .build(),
-                )
-            }
         }
 
         ThemeSelectionScreen(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.ButtonColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,15 +24,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.LocalThemeController
-import xyz.ksharma.krail.taj.theme.getForegroundColor
-import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens.DisabledContentAlpha
 
 @Composable
 fun ThemeSelectionScreen(
@@ -69,8 +65,8 @@ fun ThemeSelectionScreen(
 
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 Text(
-                    text = "Let's set the vibe!",
-                    style = KrailTheme.typography.headlineLarge.copy(fontWeight = FontWeight.Normal),
+                    text = "Pick your favourite colour!",
+                    style = KrailTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Normal),
                     modifier = Modifier
                         .padding(horizontal = 24.dp)
                         .padding(bottom = 32.dp),
@@ -82,6 +78,7 @@ fun ThemeSelectionScreen(
                         selected = selectedThemeColorId == theme.id,
                         onClick = { clickedThemeStyle ->
                             selectedThemeColorId = clickedThemeStyle.id
+                            onThemeSelected(clickedThemeStyle.id)
                         },
                     )
                 }
@@ -106,23 +103,6 @@ fun ThemeSelectionScreen(
                     onThemeModeSelect(newTheme.code)
                 },
             )
-
-            Button(
-                colors = ButtonColors(
-                    containerColor = buttonBackgroundColor,
-                    contentColor = getForegroundColor(buttonBackgroundColor),
-                    disabledContainerColor = buttonBackgroundColor.copy(alpha = DisabledContentAlpha),
-                    disabledContentColor = getForegroundColor(
-                        buttonBackgroundColor,
-                    ).copy(alpha = DisabledContentAlpha),
-                ),
-                onClick = {
-                    onThemeSelected(selectedThemeColorId)
-                },
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
-            ) {
-                Text(text = "Let's #KRAIL")
-            }
         }
     }
 }


### PR DESCRIPTION
### TL;DR

Simplified the theme selection flow by removing the navigation button and making theme selection immediate.

### What changed?

- Removed the "Let's #KRAIL" button at the bottom of the theme selection screen
- Changed the heading text from "Let's set the vibe!" to "Pick your favourite colour!"
- Modified the theme selection behavior to apply immediately when a theme is clicked
- Removed the navigation logic that redirected to SavedTripsRoute after theme selection
- Adjusted the heading text style from headlineLarge to headlineMedium
- Removed unused imports

### How to test?

1. Navigate to the theme selection screen
2. Tap on any theme color
3. Verify that the theme changes immediately without needing to press a confirmation button
4. Verify that the user remains on the same screen after selection

### Why make this change?

This change improves the user experience by making theme selection more intuitive and immediate. By removing the extra confirmation step, users can quickly try different themes and see the results in real-time, creating a more responsive and streamlined interface.