### PR TITLE
Feature: Show seen today events at top of seen cards instead of filtering them out

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/discover/RealDiscoverCardOrderingEngineTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/discover/RealDiscoverCardOrderingEngineTest.kt
@@ -83,7 +83,7 @@ class RealDiscoverCardOrderingEngineTest {
     }
 
     @Test
-    fun `getSortedCards - seen today events are filtered out`() = runTest {
+    fun `getSortedCards - seen today events appear at top of seen cards`() = runTest {
         val cards = listOf(
             createCard("card1", "Regular Card", null),
             createCard("card2", "Today Seen Event", today.toString(), today.toString()),
@@ -95,11 +95,11 @@ class RealDiscoverCardOrderingEngineTest {
 
         val result = orderingEngine.getSortedCards(cards)
 
-        assertEquals(3, result.size) // Seen today event filtered out
+        assertEquals(4, result.size) // Seen today event now included
         assertEquals("card3", result[0].cardId) // Unseen today event first
         assertEquals("card1", result[1].cardId) // Regular unseen second
         assertEquals("card4", result[2].cardId) // Regular unseen third
-        // card2 (seen today event) should not appear in results
+        assertEquals("card2", result[3].cardId) // Seen today event at top of seen cards
     }
 
     @Test
@@ -158,7 +158,7 @@ class RealDiscoverCardOrderingEngineTest {
     }
 
     @Test
-    fun `getSortedCards - today seen event is filtered out`() = runTest {
+    fun `getSortedCards - today seen event appears at top of seen cards`() = runTest {
         val cards = listOf(
             createCard("card1", "Regular Card", null),
             createCard("card2", "Today Seen", today.toString(), today.toString()),
@@ -169,10 +169,10 @@ class RealDiscoverCardOrderingEngineTest {
 
         val result = orderingEngine.getSortedCards(cards)
 
-        assertEquals(2, result.size) // Seen today event filtered out
+        assertEquals(3, result.size) // Seen today event now included
         assertEquals("card1", result[0].cardId) // Regular unseen first
         assertEquals("card3", result[1].cardId) // Regular unseen second
-        // card2 should not appear in results
+        assertEquals("card2", result[2].cardId) // Seen today event at top of seen cards
     }
 
     @Test
@@ -190,12 +190,13 @@ class RealDiscoverCardOrderingEngineTest {
 
         val result = orderingEngine.getSortedCards(cards)
 
-        assertEquals(4, result.size) // Past event AND seen today event filtered out
+        assertEquals(5, result.size) // Only past event filtered out, seen today event now included
         assertEquals("card2", result[0].cardId) // Today single unseen first
         assertEquals("card1", result[1].cardId) // Regular unseen second
         assertEquals("card4", result[2].cardId) // Today multi-day unseen third
-        assertEquals("card5", result[3].cardId) // Regular seen fourth
-        // card6 (seen today event) and card3 (past event) should not appear
+        assertEquals("card6", result[3].cardId) // Seen today event at top of seen cards
+        assertEquals("card5", result[4].cardId) // Regular seen fifth
+        // Only card3 (past event) should not appear
     }
 
     @Test

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
@@ -56,7 +56,8 @@ class RealDiscoverCardOrderingEngine(
      * Sorts the cards based on the following priority:
      * 1. Unseen today events (where startDate == endDate == today) at the top.
      * 2. All other unseen cards.
-     * 3. All other seen cards.
+     * 3. Seen today events.
+     * 4. All other seen cards.
      */
     private fun sortCardsByPriority(
         cards: List<DiscoverModel>,
@@ -66,9 +67,10 @@ class RealDiscoverCardOrderingEngine(
         val (todayEvents, otherCards) = cards.partition { it.isTodayEvent(today) }
 
         val unseenTodayEvents = todayEvents.filterNot { it.cardId in seenCardIds }
+        val seenTodayEvents = todayEvents.filter { it.cardId in seenCardIds }
         val (seenOthers, unseenOthers) = otherCards.partition { it.cardId in seenCardIds }
 
-        return unseenTodayEvents + unseenOthers + seenOthers
+        return unseenTodayEvents + unseenOthers + seenTodayEvents + seenOthers
     }
 
     private fun logSortingResults(


### PR DESCRIPTION
## Summary
Modified the discover card sorting logic to keep seen today events visible in the list instead of filtering them out completely. Seen today events now appear at the top of the seen cards section.

## Problem
Previously, when a user viewed a today event and navigated away from the discover screen, the event would completely disappear from the list upon returning. This created a confusing user experience where cards seemed to vanish unexpectedly.

## Solution
Updated `RealDiscoverCardOrderingEngine.sortCardsByPriority()` to maintain seen today events in the sorted list. The new sorting order is:

1. **Unseen today events** (highest priority)
2. **All other unseen cards** (future events, regular cards)
3. **Seen today events** (top of seen section)
4. **All other seen cards**

## Changes
- Modified `sortCardsByPriority()` in `RealDiscoverCardOrderingEngine.kt` to extract and position seen today events separately
- Updated unit tests to reflect the new expected behavior
- Updated test names and assertions to clarify that seen today events now appear at the top of seen cards

## Testing
All unit tests in `RealDiscoverCardOrderingEngineTest` have been updated and pass:
- ✅ Seen today events appear at top of seen cards section
- ✅ Multiple seen today events maintain proper ordering
- ✅ Complex scenarios with mixed event types work correctly
- ✅ Past events still filtered out as expected
- ✅ Unseen today events still prioritized at the top

## User Impact
- **Before**: Today events disappeared completely after being viewed, causing confusion when users returned to the discover screen
- **After**: Today events remain visible (but demoted to the seen section) so users can still see what's happening today even after viewing the cards

## Screenshots/Examples
**Scenario**: User views a today event, navigates away, and returns

**Before**: 
- Card list would be missing the viewed today event entirely

**After**:
- [Today Event - Unseen] ← New today events still on top
- [Regular Card - Unseen]
- [Future Event - Unseen]
- [Today Event - Seen] ← Previously viewed today events visible here
- [Regular Card - Seen]
