### PR TITLE
Feature: Add INVITE_FRIENDS tile type and enhance InfoTile component flexibility

### DIFF
--- a/info-tile/state/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/state/InfoTileState.kt
+++ b/info-tile/state/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/state/InfoTileState.kt
@@ -34,6 +34,7 @@ data class InfoTileData(
         CRITICAL_ALERT(1), // highest priority, should be shown at top of list
         INFO(priority = 100), // higher priority than app update
         APP_UPDATE(priority = 200), // lower priority than info, should be shown at bottom of list
+        INVITE_FRIENDS(priority = 500), // lowest priority
     }
 }
 
@@ -41,7 +42,7 @@ data class InfoTileData(
 @Serializable
 data class InfoTileCta(
     val text: String,
-    val url: String,
+    val url: String? = null,
 )
 
 enum class InfoTileState {

--- a/info-tile/ui/src/commonMain/kotlin/xyz/ksharma/krail/info/tiles/ui/InfoTile.kt
+++ b/info-tile/ui/src/commonMain/kotlin/xyz/ksharma/krail/info/tiles/ui/InfoTile.kt
@@ -56,17 +56,19 @@ object InfoTileDefaults {
     // endregion
 }
 
+@Suppress("LongParameterList")
 @Composable
 fun InfoTile(
     infoTileData: InfoTileData,
-    infoTileState: InfoTileState = InfoTileState.COLLAPSED,
     modifier: Modifier = Modifier,
+    initialState: InfoTileState = InfoTileState.COLLAPSED,
+    showDismissButton: Boolean = true,
     onCtaClick: (InfoTileData) -> Unit,
     onDismissClick: (InfoTileData) -> Unit,
     // required for analytics only
     onTileExpand: (InfoTileData) -> Unit = {},
 ) {
-    var state by rememberSaveable { mutableStateOf(infoTileState) }
+    var state by rememberSaveable { mutableStateOf(initialState) }
 
     Column(
         modifier = modifier
@@ -123,12 +125,14 @@ fun InfoTile(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
             ) {
-                TextButton(
-                    onClick = { onDismissClick(infoTileData) },
-                    dimensions = ButtonDefaults.mediumButtonSize(),
-                    modifier = Modifier.padding(end = 12.dp),
-                ) {
-                    Text(text = infoTileData.dismissCtaText)
+                if (showDismissButton) {
+                    TextButton(
+                        onClick = { onDismissClick(infoTileData) },
+                        dimensions = ButtonDefaults.mediumButtonSize(),
+                        modifier = Modifier.padding(end = 12.dp),
+                    ) {
+                        Text(text = infoTileData.dismissCtaText)
+                    }
                 }
 
                 infoTileData.primaryCta?.let { cta ->
@@ -183,6 +187,28 @@ private fun InfoTileDarkPreview() {
                 description = "All lines are now operating on their regular schedules.",
                 type = InfoTileData.InfoTileType.INFO,
             ),
+            onCtaClick = {},
+            onDismissClick = {},
+        )
+    }
+}
+
+@Preview(name = "InfoTile Expanded No Dismiss")
+@Composable
+private fun InfoTileExpandedNoDismissPreview() {
+    PreviewTheme {
+        InfoTile(
+            infoTileData = InfoTileData(
+                key = "expanded_tile",
+                title = "Always Expanded Tile",
+                description = "This tile starts expanded and has no dismiss button, perfect for persistent content.",
+                primaryCta = InfoTileCta(
+                    text = "Take Action",
+                ),
+                type = InfoTileData.InfoTileType.INFO,
+            ),
+            initialState = InfoTileState.EXPANDED,
+            showDismissButton = false,
             onCtaClick = {},
             onDismissClick = {},
         )


### PR DESCRIPTION
### TL;DR

Added support for invite friends tile type and enhanced InfoTile component flexibility.

### What changed?

- Added a new `INVITE_FRIENDS` type to `InfoTileData.InfoTileType` with the lowest priority (500)
- Made the `url` parameter in `InfoTileCta` nullable with a default value of `null`
- Renamed `infoTileState` parameter to `initialState` in the `InfoTile` composable
- Added a new `showDismissButton` parameter to control the visibility of the dismiss button
- Reordered parameters in the `InfoTile` composable for better API design
- Added a new preview for the expanded tile without a dismiss button

### How to test?

1. Create an InfoTile with the new `INVITE_FRIENDS` type
2. Create an InfoTile with a CTA that doesn't have a URL
3. Create an InfoTile with `showDismissButton = false` and verify the dismiss button is hidden
4. Create an InfoTile with `initialState = InfoTileState.EXPANDED` and verify it starts expanded

### Why make this change?

These changes provide more flexibility for the InfoTile component:
- The new tile type supports invite-a-friend functionality
- Making the URL optional allows for CTAs that trigger in-app actions rather than web links
- The ability to hide the dismiss button is useful for persistent tiles that shouldn't be dismissable
- Renaming the state parameter to "initialState" better reflects its purpose as the starting state