### PR TITLE
Refactor: Centralize JSON parsing with shared JsonConfig

### DIFF
--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -2,11 +2,11 @@ package xyz.ksharma.krail.discover.network.real
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
 import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.remoteconfig.JsonConfig
 import xyz.ksharma.krail.core.remoteconfig.RemoteConfigDefaults
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
@@ -25,11 +25,6 @@ internal class RealDiscoverSydneyManager(
     // Cache the parsed JSON card list to avoid repeated parsing.
     private var cachedFlagValue: FlagValue? = null
     private var cachedParsedCards: List<DiscoverModel>? = null
-
-    private val json = Json {
-        ignoreUnknownKeys = true // Ignore unknown keys in JSON
-        isLenient = true // Allow lenient parsing
-    }
 
     /**
      * Fetches Discover cards for the UI.
@@ -74,8 +69,8 @@ internal class RealDiscoverSydneyManager(
         return withContext(defaultDispatcher) {
             when (flagValue) {
                 is FlagValue.JsonValue -> {
-                    val jsonArray = json.parseToJsonElement(flagValue.value).jsonArray
-                    jsonArray.map { json.decodeFromJsonElement<DiscoverModel>(it) }
+                    val jsonArray = JsonConfig.lenient.parseToJsonElement(flagValue.value).jsonArray
+                    jsonArray.map { JsonConfig.lenient.decodeFromJsonElement<DiscoverModel>(it) }
                 }
 
                 else -> {
@@ -85,8 +80,8 @@ internal class RealDiscoverSydneyManager(
                     if (defaultJson == null) {
                         emptyList()
                     } else {
-                        val jsonArray = json.parseToJsonElement(defaultJson).jsonArray
-                        jsonArray.map { json.decodeFromJsonElement<DiscoverModel>(it) }
+                        val jsonArray = JsonConfig.lenient.parseToJsonElement(defaultJson).jsonArray
+                        jsonArray.map { JsonConfig.lenient.decodeFromJsonElement<DiscoverModel>(it) }
                     }
                 }
             }

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
@@ -1,9 +1,9 @@
 package xyz.ksharma.krail.park.ride.network
 
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import xyz.ksharma.krail.core.remoteconfig.JsonConfig
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
@@ -18,7 +18,7 @@ class RealNswParkRideFacilityManager(
 
         return when (flagValue) {
             is FlagValue.JsonValue -> {
-                val jsonArray = Json.parseToJsonElement(flagValue.value).jsonArray
+                val jsonArray = JsonConfig.lenient.parseToJsonElement(flagValue.value).jsonArray
                 jsonArray.map { element ->
                     val obj = element.jsonObject
                     NswParkRideFacility(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -2,10 +2,10 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.remoteconfig.JsonConfig
 import xyz.ksharma.krail.core.remoteconfig.RemoteConfigDefaults
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
@@ -126,7 +126,7 @@ class RealStopResultsManager(
         return when (this) {
             is FlagValue.JsonValue -> {
                 log("flagValue: ${this.value}")
-                val jsonObject = Json.parseToJsonElement(value).jsonObject
+                val jsonObject = JsonConfig.lenient.parseToJsonElement(value).jsonObject
                 jsonObject["stop_ids"]?.jsonArray?.map {
                     it.toString().trim('"')
                 } ?: emptyList()
@@ -135,7 +135,7 @@ class RealStopResultsManager(
             else -> {
                 val defaultJson: String = RemoteConfigDefaults.getDefaults()
                     .firstOrNull { it.first == FlagKeys.HIGH_PRIORITY_STOP_IDS.key }?.second as String
-                Json.parseToJsonElement(defaultJson).jsonArray.map {
+                JsonConfig.lenient.parseToJsonElement(defaultJson).jsonArray.map {
                     it.toString().trim('"')
                 }
             }


### PR DESCRIPTION
### TL;DR

Centralized JSON configuration by introducing `JsonConfig` class to replace duplicate JSON configuration blocks.

### What changed?

- Removed duplicate JSON configuration blocks from multiple manager classes:
  - `RealFestivalManager`
  - `RealDiscoverSydneyManager`
  - `RealNswParkRideFacilityManager`
  - `RealStopResultsManager`
- Introduced a centralized `JsonConfig` class with a `lenient` property that provides consistent JSON parsing configuration
- Updated all JSON parsing calls to use `JsonConfig.lenient` instead of local JSON instances

### How to test?

- Verify that all features using JSON parsing still work correctly:
  - Festival emoji display
  - Discover Sydney cards
  - NSW Park Ride facility information
  - Trip planner stop results

### Why make this change?

This refactoring improves code maintainability by:
1. Eliminating duplicate JSON configuration code across multiple classes
2. Centralizing JSON parsing configuration in a single location
3. Making it easier to update JSON parsing behavior consistently across the application
4. Reducing the risk of inconsistent JSON parsing behavior between different components