### PR TITLE
Feature: Add saved trip validation against current stops database

### DIFF
--- a/core/app-start/build.gradle.kts
+++ b/core/app-start/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.core.coroutinesExt)
                 implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.remoteConfig)

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -1,18 +1,20 @@
 package xyz.ksharma.krail.core.appstart
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.remoteconfig.RemoteConfig
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.io.gtfs.nswstops.StopsManager
 
 class RealAppStart(
     private val coroutineScope: CoroutineScope,
     private val remoteConfig: RemoteConfig,
     private val stopsManager: StopsManager,
+    private val defaultDispatcher: CoroutineDispatcher,
 ) : AppStart {
 
     override fun start() {
-        coroutineScope.launch {
+        coroutineScope.launchWithExceptionHandler<RealAppStart>(defaultDispatcher) {
             stopsManager.insertStops()
             setupRemoteConfig()
         }

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/di/AppStartModule.kt
@@ -1,18 +1,22 @@
 package xyz.ksharma.krail.core.appstart.di
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appstart.AppStart
 import xyz.ksharma.krail.core.appstart.RealAppStart
+import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.DefaultDispatcher
 
 val appStartModule = module {
     single<AppStart> {
+        val dispatcher = get<CoroutineDispatcher>(named(DefaultDispatcher))
         RealAppStart(
-            coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+            coroutineScope = CoroutineScope(dispatcher + SupervisorJob()),
             remoteConfig = get(),
             stopsManager = get(),
+            defaultDispatcher = dispatcher,
         )
     }
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeSandook.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/fakes/FakeSandook.kt
@@ -47,7 +47,9 @@ class FakeSandook : Sandook {
             fromStopName,
             toStopId,
             toStopName,
-            timestamp = null,
+            null, // timestamp
+            1L, // isFromStopValid - Long like database
+            1L, // isToStopValid - Long like database
         )
         val current = tripsFlow.value.toMutableList()
         current.removeAll { it.tripId == tripId }
@@ -75,6 +77,27 @@ class FakeSandook : Sandook {
 
     override fun clearSavedTrips() {
         tripsFlow.value = emptyList()
+    }
+
+    override fun updateStopValidity(
+        tripId: String,
+        isFromStopValid: Boolean,
+        isToStopValid: Boolean
+    ) {
+        val current = tripsFlow.value.toMutableList()
+        val index = current.indexOfFirst { it.tripId == tripId }
+        if (index != -1) {
+            val trip = current[index]
+            current[index] = trip.copy(
+                isFromStopValid = if (isFromStopValid) 1L else 0L,
+                isToStopValid = if (isToStopValid) 1L else 0L
+            )
+            tripsFlow.value = current
+        }
+    }
+
+    override fun checkStopExists(stopId: String): Boolean {
+        return stops.any { it.stopId == stopId }
     }
 
     // endregion

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
@@ -11,9 +11,14 @@ data class Trip(
     val fromStopName: String,
     val toStopId: String,
     val toStopName: String,
+    val isFromStopValid: Boolean = true,
+    val isToStopValid: Boolean = true,
 ) {
     val tripId: String
         get() = "$fromStopId$toStopId"
+
+    val isValidTrip: Boolean
+        get() = isFromStopValid && isToStopValid
 
     fun toJsonString() = Json.encodeToString(serializer(), this)
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -7,6 +7,7 @@ import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.DefaultDispatcher
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewModel
@@ -35,6 +36,7 @@ val viewModelsModule = module {
             platformOps = get(),
             preferences = get(),
             stopsManager = get(),
+            defaultDispatcher = get(named(DefaultDispatcher)),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroViewModel.kt
@@ -2,18 +2,19 @@ package xyz.ksharma.krail.trip.planner.ui.intro
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.IntroLetsKrailClickEvent.InteractionPage
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.io.gtfs.nswstops.StopsManager
 import xyz.ksharma.krail.platform.ops.PlatformOps
 import xyz.ksharma.krail.sandook.SandookPreferences
@@ -26,6 +27,7 @@ class IntroViewModel(
     private val platformOps: PlatformOps,
     private val preferences: SandookPreferences,
     private val stopsManager: StopsManager,
+    private val defaultDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<IntroState> = MutableStateFlow(IntroState.default())
@@ -49,7 +51,7 @@ class IntroViewModel(
             }
 
             is IntroUiEvent.Complete -> {
-                viewModelScope.launch {
+                viewModelScope.launchWithExceptionHandler<IntroViewModel>(defaultDispatcher) {
                     stopsManager.insertStops()
                     preferences.setBoolean(SandookPreferences.KEY_HAS_SEEN_INTRO, true)
                     analytics.track(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -295,6 +295,7 @@ class SavedTripsViewModel(
                 .distinctUntilChanged()
                 .collectLatest { savedTrips ->
                     log("Saved trips updated: $savedTrips")
+                    // Use pre-computed validity from database - no need to check again
                     val trips = savedTrips.map { it.toTrip() }.toImmutableList()
                     updateUiState { copy(savedTrips = trips, isSavedTripsLoading = false) }
 
@@ -712,11 +713,14 @@ class SavedTripsViewModel(
         observeParkRideFacilityFromDatabaseJob = null
         log("Cleanup jobs in SavedTripsViewModel completed.")
     }
-}
 
-private fun SavedTrip.toTrip(): Trip = Trip(
-    fromStopId = fromStopId,
-    fromStopName = fromStopName,
-    toStopId = toStopId,
-    toStopName = toStopName,
-)
+    private fun SavedTrip.toTrip(): Trip = Trip(
+        fromStopId = fromStopId,
+        fromStopName = fromStopName,
+        toStopId = toStopId,
+        toStopName = toStopName,
+        // Convert from database INTEGER (Long) to Boolean
+        isFromStopValid = isFromStopValid == 1L,
+        isToStopValid = isToStopValid == 1L,
+    )
+}

--- a/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/di/GtfsModule.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/di/GtfsModule.kt
@@ -12,6 +12,7 @@ val gtfsModule = module {
             ioDispatcher = get(named(IODispatcher)),
             sandook = get(),
             preferences = get(),
+            savedTripValidator = get(),
         )
     }
 }

--- a/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/NswStopsManager.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz.ksharma.krail.io.gtfs/nswstops/NswStopsManager.kt
@@ -10,11 +10,13 @@ import xyz.ksharma.krail.io.gtfs.nswstops.StopsManager.Companion.MINIMUM_REQUIRE
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SandookPreferences.Companion.NSW_STOPS_VERSION
+import xyz.ksharma.krail.sandook.SavedTripValidator
 
 class NswStopsManager(
     private val ioDispatcher: CoroutineDispatcher,
     private val sandook: Sandook,
     private val preferences: SandookPreferences,
+    private val savedTripValidator: SavedTripValidator,
 ) : StopsManager {
 
     init {
@@ -41,6 +43,10 @@ class NswStopsManager(
                 value = NSW_STOPS_VERSION,
             )
             log("NswStopsManager NswStops inserted in the database, new version: $NSW_STOPS_VERSION.")
+
+            // Validate saved trips after inserting new stops
+            log("NswStopsManager Validating saved trips against new stops...")
+            savedTripValidator.validateAllSavedTrips()
         } else {
             logError(
                 message = "NswStopsManager Failed to insert NSW Stops into the database.",

--- a/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/SandookCallback.kt
+++ b/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/SandookCallback.kt
@@ -25,10 +25,18 @@ class SandookCallback(
         log("Configuring database: ${db.version}")
     }
 
+    @Suppress("MagicNumber")
     override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
         super.onUpgrade(db, oldVersion, newVersion)
         log(
             "Upgrading database from version $oldVersion to $newVersion",
         )
+
+        // Log specific migrations for better debugging
+        when {
+            oldVersion < 8 && newVersion >= 8 -> {
+                log("Migration: Added isFromStopValid and isToStopValid columns to SavedTrip table")
+            }
+        }
     }
 }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -74,6 +74,22 @@ internal class RealSandook(
         query.clearSavedTrips()
     }
 
+    override fun updateStopValidity(
+        tripId: String,
+        isFromStopValid: Boolean,
+        isToStopValid: Boolean,
+    ) {
+        query.updateStopValidity(
+            isFromStopValid = if (isFromStopValid) 1L else 0L,
+            isToStopValid = if (isToStopValid) 1L else 0L,
+            tripId = tripId,
+        )
+    }
+
+    override fun checkStopExists(stopId: String): Boolean {
+        return nswStopsQueries.checkStopExists(stopId).executeAsOne() > 0
+    }
+
     // endregion
 
     // region Alerts

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSavedTripValidator.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSavedTripValidator.kt
@@ -1,0 +1,65 @@
+package xyz.ksharma.krail.sandook
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.core.log.log
+
+/**
+ * Default implementation of SavedTripValidator that validates saved trips against the current
+ * NSW stops database.
+ */
+class RealSavedTripValidator(
+    private val sandook: Sandook,
+    private val ioDispatcher: CoroutineDispatcher,
+) : SavedTripValidator {
+
+    override suspend fun validateAllSavedTrips() = withContext(ioDispatcher) {
+        val allSavedTrips = sandook.selectAllTrips()
+
+        if (allSavedTrips.isEmpty()) {
+            log("SavedTripValidator: No saved trips to validate")
+            return@withContext
+        }
+
+        log("SavedTripValidator: Validating ${allSavedTrips.size} saved trips")
+
+        // Collect all unique stop IDs from all trips
+        val allStopIds = allSavedTrips.flatMap { trip ->
+            listOf(trip.fromStopId, trip.toStopId)
+        }.toSet()
+
+        log("SavedTripValidator: Checking ${allStopIds.size} unique stops")
+
+        // Check existence for all unique stops once
+        val existingStops: Map<String, Boolean> = allStopIds.associateWith { stopId ->
+            sandook.checkStopExists(stopId)
+        }
+
+        // Validate each trip using the cached stop existence results
+        allSavedTrips.forEach { savedTrip ->
+            val fromStopExists = existingStops[savedTrip.fromStopId] ?: false
+            val toStopExists = existingStops[savedTrip.toStopId] ?: false
+
+            val currentFromStopValid = savedTrip.isFromStopValid == 1L
+            val currentToStopValid = savedTrip.isToStopValid == 1L
+
+            // Update trip validity if either stop validity has changed
+            if (fromStopExists != currentFromStopValid || toStopExists != currentToStopValid) {
+                sandook.updateStopValidity(
+                    tripId = savedTrip.tripId,
+                    isFromStopValid = fromStopExists,
+                    isToStopValid = toStopExists,
+                )
+
+                val status = if (fromStopExists && toStopExists) "VALID" else "INVALID"
+                log(
+                    "SavedTripValidator: Trip ${savedTrip.tripId} is $status - " +
+                        "fromStop: ${savedTrip.fromStopId} (exists: $fromStopExists), " +
+                        "toStop: ${savedTrip.toStopId} (exists: $toStopExists)",
+                )
+            }
+        }
+
+        log("SavedTripValidator: Validation complete")
+    }
+}

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -26,6 +26,8 @@ interface Sandook {
 
     fun selectTripById(tripId: String): SavedTrip?
     fun clearSavedTrips()
+    fun updateStopValidity(tripId: String, isFromStopValid: Boolean, isToStopValid: Boolean)
+    fun checkStopExists(stopId: String): Boolean
     // endregion
 
     // region Alerts

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SavedTripValidator.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SavedTripValidator.kt
@@ -1,0 +1,20 @@
+package xyz.ksharma.krail.sandook
+
+/**
+ * Interface for validating saved trips against the current NSW stops database.
+ *
+ * When new stops are inserted into the database, this validator checks if any saved trips
+ * reference stops that no longer exist. Invalid trips are marked in the database so they
+ * can be displayed with a warning to the user.
+ */
+interface SavedTripValidator {
+    /**
+     * Validates all saved trips against the current stops in the database.
+     * Marks trips as invalid if either the fromStopId or toStopId does not exist in NswStops.
+     * Marks trips as valid if both stops exist.
+     *
+     * Invalid trips are logged for debugging. The database is updated and changes will be
+     * reflected when observing saved trips.
+     */
+    suspend fun validateAllSavedTrips()
+}

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
@@ -11,9 +11,11 @@ import xyz.ksharma.krail.sandook.RealDiscoverCardSeenPreferences
 import xyz.ksharma.krail.sandook.RealNswParkRideSandook
 import xyz.ksharma.krail.sandook.RealSandook
 import xyz.ksharma.krail.sandook.RealSandookPreferences
+import xyz.ksharma.krail.sandook.RealSavedTripValidator
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookDriverFactory
 import xyz.ksharma.krail.sandook.SandookPreferences
+import xyz.ksharma.krail.sandook.SavedTripValidator
 
 val sandookModule = module {
     includes(sqlDriverModule)
@@ -58,6 +60,13 @@ val sandookModule = module {
     single<Sandook> {
         RealSandook(
             factory = get(),
+            ioDispatcher = get(named(DispatchersComponent.IODispatcher)),
+        )
+    }
+
+    single<SavedTripValidator> {
+        RealSavedTripValidator(
+            sandook = get(),
             ioDispatcher = get(named(DispatchersComponent.IODispatcher)),
         )
     }

--- a/sandook/src/commonMain/sqldelight/migrations/7.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/7.sqm
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS SavedTrip (
+    tripId TEXT PRIMARY KEY,
+    fromStopId TEXT NOT NULL,
+    fromStopName TEXT NOT NULL,
+    toStopId TEXT NOT NULL,
+    toStopName TEXT NOT NULL,
+    timestamp TEXT DEFAULT (datetime('now'))
+);
+
+ALTER TABLE SavedTrip ADD COLUMN isFromStopValid INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE SavedTrip ADD COLUMN isToStopValid INTEGER NOT NULL DEFAULT 1;

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/KrailSandook.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/KrailSandook.sq
@@ -20,12 +20,14 @@ CREATE TABLE SavedTrip (
     fromStopName TEXT NOT NULL,
     toStopId TEXT NOT NULL,
     toStopName TEXT NOT NULL,
-    timestamp TEXT DEFAULT (datetime('now'))
+    timestamp TEXT DEFAULT (datetime('now')),
+    isFromStopValid INTEGER NOT NULL DEFAULT 1,
+    isToStopValid INTEGER NOT NULL DEFAULT 1
 );
 
 insertOrReplaceTrip:
-INSERT OR REPLACE INTO SavedTrip(tripId, fromStopId, fromStopName, toStopId, toStopName, timestamp)
-VALUES (?, ?, ?, ?, ?, datetime('now'));
+INSERT OR REPLACE INTO SavedTrip(tripId, fromStopId, fromStopName, toStopId, toStopName, timestamp, isFromStopValid, isToStopValid)
+VALUES (?, ?, ?, ?, ?, datetime('now'), 1, 1);
 
 deleteTrip:
 DELETE FROM SavedTrip WHERE tripId = ?;
@@ -40,6 +42,13 @@ WHERE tripId = ?;
 
 clearSavedTrips:
 DELETE FROM SavedTrip;
+
+
+-- Update individual stop validity --
+updateStopValidity:
+UPDATE SavedTrip
+SET isFromStopValid = ?, isToStopValid = ?
+WHERE tripId = ?;
 
 -- Service Alerts Table --
 CREATE TABLE IF NOT EXISTS ServiceAlertsTable (

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswStops.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswStops.sq
@@ -54,3 +54,9 @@ WHERE (
     OR s.stopName LIKE '%' || :stopName || '%'  -- Use named parameter :stopName
 )
 GROUP BY s.stopId;
+
+-- Check if a stop exists by stopId --
+checkStopExists:
+SELECT COUNT(*)
+FROM NswStops
+WHERE stopId = ?;

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
@@ -9,6 +9,7 @@ import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter3
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter4
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter5
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter6
+import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter7
 
 class IosSandookDriverFactory : SandookDriverFactory {
     override fun createDriver(): SqlDriver {
@@ -19,6 +20,7 @@ class IosSandookDriverFactory : SandookDriverFactory {
         )
     }
 
+    @Suppress("MagicNumber")
     private fun getMigrationCallbacks(): Array<AfterVersion> = arrayOf(
         AfterVersion(1) { SandookMigrationAfter1.migrate(it) },
         AfterVersion(2) { SandookMigrationAfter2.migrate(it) },
@@ -26,5 +28,6 @@ class IosSandookDriverFactory : SandookDriverFactory {
         AfterVersion(4) { SandookMigrationAfter4.migrate(it) },
         AfterVersion(5) { SandookMigrationAfter5.migrate(it) },
         AfterVersion(6) { SandookMigrationAfter6.migrate(it) },
+        AfterVersion(7) { SandookMigrationAfter7.migrate(it) },
     )
 }

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter7.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/migrations/SandookMigrationAfter7.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.krail.sandook.migrations
+
+import app.cash.sqldelight.db.SqlDriver
+import xyz.ksharma.krail.core.log.log
+
+internal object SandookMigrationAfter7 : SandookMigration {
+
+    override fun migrate(sqlDriver: SqlDriver) {
+        log("Upgrading database from version 7 to 8")
+        sqlDriver.execute(
+            identifier = null,
+            sql = """
+                CREATE TABLE IF NOT EXISTS SavedTrip (
+                    tripId TEXT PRIMARY KEY,
+                    fromStopId TEXT NOT NULL,
+                    fromStopName TEXT NOT NULL,
+                    toStopId TEXT NOT NULL,
+                    toStopName TEXT NOT NULL,
+                    timestamp TEXT DEFAULT (datetime('now'))
+                );
+
+                ALTER TABLE SavedTrip ADD COLUMN isFromStopValid INTEGER NOT NULL DEFAULT 1;
+                ALTER TABLE SavedTrip ADD COLUMN isToStopValid INTEGER NOT NULL DEFAULT 1;
+            """.trimIndent(),
+            parameters = 0,
+        )
+        log("Added isFromStopValid and isToStopValid columns to SavedTrip table")
+    }
+}


### PR DESCRIPTION
### TL;DR

Added validation for saved trips to check if stops still exist in the database.

### What changed?

- Added `isFromStopValid` and `isToStopValid` columns to the `SavedTrip` table with a database migration
- Created a `SavedTripValidator` interface and implementation to validate saved trips against the current stops database
- Modified the `Trip` model to include validity flags and an `isValidTrip` property
- Updated the `NswStopsManager` to validate saved trips after inserting new stops
- Added methods to `Sandook` interface to check stop existence and update stop validity
- Enhanced the `IntroViewModel` to use exception handling for coroutines
- Improved `RealAppStart` to use structured exception handling

### How to test?

1. Add a saved trip with valid stops
2. Manually modify the database to include a trip with non-existent stops
3. Restart the app and verify that:
   - Valid trips show normally
   - Invalid trips are marked as invalid in the UI
4. Update the stops database and verify that trip validity is rechecked

### Why make this change?

When the stops database is updated, some stops might be removed or have their IDs changed. This change ensures that saved trips referencing stops that no longer exist are properly marked as invalid, improving the user experience by preventing errors when users try to use outdated trips.

The validation happens automatically when stops are inserted, and the UI can now display appropriate warnings for invalid trips, helping users understand why certain saved trips may not work correctly.