### PR TITLE
Feature: Add isDateTodayOrInFuture helper function for date validation

### DIFF
--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -158,4 +158,25 @@ object DateTimeHelper {
             false
         }
     }
+
+    /**
+     * Checks if the string represents today's date or a future date.
+     * The string should be in ISO-8601 format (e.g., "2023-12-31").
+     * Returns true if the date is today or in the future, false if it's in the past.
+     *
+     * @receiver String The date string to check.
+     * @return Boolean true if the date is today or in the future, false otherwise.
+     */
+    @OptIn(ExperimentalTime::class)
+    fun String.isDateTodayOrInFuture(): Boolean {
+        return try {
+            val localDate = LocalDate.parse(this)
+            val today = Clock.System.now()
+                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            localDate >= today
+        } catch (e: Exception) {
+            logError("Error parsing date string: $this", e)
+            false
+        }
+    }
 }

--- a/core/date-time/src/commonTest/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelperTest.kt
+++ b/core/date-time/src/commonTest/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelperTest.kt
@@ -7,6 +7,7 @@ import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateInFuture
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateTodayOrInFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToAEST
@@ -134,6 +135,43 @@ class DateTimeHelperTest {
     @Test
     fun testIsDateInFuture_invalidFormat() {
         assertEquals(false, "not-a-date".isDateInFuture())
+    }
+
+    // endregion
+
+    // region isDateTodayOrInFuture tests
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun testIsDateTodayOrInFuture_validFutureDate() {
+        val futureDate = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            .plus(1, DateTimeUnit.DAY)
+            .toString()
+        assertEquals(true, futureDate.isDateTodayOrInFuture())
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun testIsDateTodayOrInFuture_todayDate() {
+        val todayDate = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            .toString()
+        assertEquals(true, todayDate.isDateTodayOrInFuture())
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun testIsDateTodayOrInFuture_pastDate() {
+        val pastDate = Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            .minus(1, DateTimeUnit.DAY)
+            .toString()
+        assertEquals(false, pastDate.isDateTodayOrInFuture())
+    }
+
+    @Test
+    fun testIsDateTodayOrInFuture_invalidFormat() {
+        assertEquals(false, "not-a-date".isDateTodayOrInFuture())
     }
 
     // endregion

--- a/info-tile/network/real/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/real/RealInfoTileManager.kt
+++ b/info-tile/network/real/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/real/RealInfoTileManager.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.appversion.AppVersionManager
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateInFuture
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateTodayOrInFuture
 import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
@@ -82,7 +82,10 @@ class RealInfoTileManager(
         filter { isKeyNotInDismissedTiles(it.key) }
 
     private fun List<InfoTileData>.filterExpiredTiles(): List<InfoTileData> =
-        filter { it.endDate?.isDateInFuture() != false }
+        filter { tile ->
+            val endDate = tile.endDate
+            endDate == null || endDate.isDateTodayOrInFuture()
+        }
 
     private fun isKeyNotInDismissedTiles(key: String): Boolean {
         log(


### PR DESCRIPTION
### TL;DR

Added a new `isDateTodayOrInFuture()` extension function to DateTimeHelper and updated InfoTileManager to use it.

### What changed?

- Added a new `isDateTodayOrInFuture()` extension function to DateTimeHelper that checks if a date string represents today's date or a future date
- Added comprehensive unit tests for the new function
- Updated RealInfoTileManager to use `isDateTodayOrInFuture()` instead of `isDateInFuture()` when filtering expired tiles

### How to test?

1. Run the unit tests for DateTimeHelper to verify the new function works correctly
2. Test the InfoTileManager with tiles that have:
   - A future end date (should be displayed)
   - Today's date as end date (should now be displayed)
   - A past end date (should not be displayed)

### Why make this change?

Previously, tiles with today's date as their end date were being filtered out as expired. This change ensures that tiles remain visible until the end of their expiration day, providing a more intuitive user experience where content is available for the full duration of its validity period.