### PR TITLE
Feature: Add Protocol Buffers support for trip planner network module

### DIFF
--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.wire)
 }
 
 kotlin {
@@ -45,6 +46,7 @@ kotlin {
                 implementation(libs.ktor.serialization.kotlinx.json)
                 implementation(libs.kotlinx.datetime)
                 implementation(compose.runtime)
+                implementation(libs.wire.runtime)
 
                 api(libs.di.koinComposeViewmodel)
             }
@@ -63,5 +65,18 @@ kotlin {
                 implementation(libs.test.kotlinxCoroutineTest)
             }
         }
+    }
+}
+
+wire {
+    kotlin {
+        javaInterop = true
+        out = "$projectDir/build/generated/source/wire"
+    }
+    protoPath {
+        srcDir("src/commonMain/proto")
+    }
+    sourcePath {
+        srcDir("src/commonMain/proto")
     }
 }

--- a/feature/trip-planner/network/src/commonMain/proto/trip.proto
+++ b/feature/trip-planner/network/src/commonMain/proto/trip.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package app.krail.bff.proto;
+
+option java_package = "app.krail.bff.proto";
+option java_multiple_files = true;
+
+// Journey list response - contains all journey options
+message JourneyList {
+  repeated JourneyCardInfo journeys = 1;
+}
+
+// Journey Card Info - represents a single journey option
+message JourneyCardInfo {
+  string time_text = 1; // "in x mins"
+  optional string platform_text = 2; // "Platform 1"
+  optional string platform_number = 3; // "1", "2", "A" etc
+  string origin_time = 4; // "11:30pm"
+  string origin_utc_date_time = 5; // "2024-09-24T19:00:00Z"
+  string destination_time = 6; // "11:40pm"
+  string destination_utc_date_time = 7; // "2024-09-24T19:00:00Z"
+  string travel_time = 8; // "10 mins"
+  optional string total_walk_time = 9; // "5 mins"
+  repeated TransportModeLine transport_mode_lines = 10;
+  repeated Leg legs = 11;
+  int32 total_unique_service_alerts = 12;
+  optional DepartureDeviation departure_deviation = 13;
+}
+
+// Transport Mode Line
+message TransportModeLine {
+  string line_name = 1; // "T1", "L1" etc
+  int32 transport_mode_type = 2; // Product class: 1=Train, 2=Metro, etc
+}
+
+// Leg - can be either walking or transport
+message Leg {
+  oneof leg_type {
+    WalkingLeg walking_leg = 1;
+    TransportLeg transport_leg = 2;
+  }
+}
+
+// Walking Leg
+message WalkingLeg {
+  string duration = 1; // "10 mins"
+}
+
+// Transport Leg
+message TransportLeg {
+  TransportModeLine transport_mode_line = 1;
+  optional string display_text = 2; // "towards Liverpool"
+  string total_duration = 3; // "12 mins"
+  repeated Stop stops = 4;
+  optional WalkInterchange walk_interchange = 5;
+  repeated ServiceAlert service_alert_list = 6;
+  optional string trip_id = 7;
+}
+
+// Stop information
+message Stop {
+  string name = 1; // "Central Station, Platform 1"
+  string time = 2; // "12:00pm"
+  bool is_wheelchair_accessible = 3;
+}
+
+// Walk Interchange
+message WalkInterchange {
+  string duration = 1; // "5 mins"
+  WalkPosition position = 2;
+}
+
+// Walk Position enum
+enum WalkPosition {
+  WALK_POSITION_UNSPECIFIED = 0;
+  BEFORE = 1;
+  AFTER = 2;
+  IDEST = 3;
+}
+
+// Service Alert
+message ServiceAlert {
+  string id = 1;
+  string subtitle = 2;
+  string content = 3;
+  string priority = 4;
+  optional string url = 5;
+}
+
+// Departure Deviation
+message DepartureDeviation {
+  oneof deviation_type {
+    string late = 1; // "5 mins late"
+    string early = 2; // "2 mins early"
+    bool on_time = 3; // true
+  }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ appcompat = "1.7.1"
 roborazzi = "1.51.0"
 composablePreviewScanner = "0.7.1"
 robolectric = "4.16"
+wire = "5.4.0"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
@@ -113,6 +114,9 @@ molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref 
 # Image Loading
 coil3-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil3" }
 coil3-networkKtor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil3" }
+
+# Protocol Buffers
+wire-runtime = { module = "com.squareup.wire:wire-runtime", version.ref = "wire" }
 
 # Compose
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "ui-tooling" }


### PR DESCRIPTION
# Add Protocol Buffers support for Trip Planner

### TL;DR

Added Wire Protocol Buffers support to the trip planner feature with journey data models.

### What changed?

- Added Wire Protocol Buffers plugin to the trip planner network module
- Created a new `trip.proto` file with message definitions for journey planning
- Configured Wire plugin in build.gradle.kts to generate Kotlin code from proto files
- Added Wire runtime dependency to the project

### How to test?

1. Build the project to verify the Wire plugin generates code correctly
2. Verify the generated Kotlin classes from the proto definitions are accessible in the codebase
3. Try using the generated models in network requests/responses

### Why make this change?

Protocol Buffers provide a more efficient serialization format for network communication compared to JSON. The defined proto messages create a structured contract for journey data that includes:
- Journey list information
- Transport mode details
- Leg information (walking and transport)
- Stop information
- Service alerts
- Departure deviation data

This structured approach will improve type safety and performance when handling trip planning data.