### PR TITLE
Replace substring with take for hex color parsing

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -21,7 +21,7 @@ fun String.hexToComposeColor(): Color {
     return when (hex.length) {
         6 -> {
             // If the string is in the format RRGGBB, add full opacity (FF) at the start
-            val r = hex.substring(0, 2).toInt(16)
+            val r = hex.take(2).toInt(16)
             val g = hex.substring(2, 4).toInt(16)
             val b = hex.substring(4, 6).toInt(16)
             Color(red = r / 255f, green = g / 255f, blue = b / 255f)
@@ -29,7 +29,7 @@ fun String.hexToComposeColor(): Color {
 
         8 -> {
             // If the string is in the format AARRGGBB
-            val a = hex.substring(0, 2).toInt(16)
+            val a = hex.take(2).toInt(16)
             val r = hex.substring(2, 4).toInt(16)
             val g = hex.substring(4, 6).toInt(16)
             val b = hex.substring(6, 8).toInt(16)


### PR DESCRIPTION
### TL;DR

Replace `substring(0, 2)` with `take(2)` in the hex color conversion function.

### What changed?

Modified the `hexToComposeColor()` extension function to use Kotlin's more idiomatic `take(2)` function instead of `substring(0, 2)` when extracting the first two characters from hex color strings. This change was made in two places:
- When extracting the red component in 6-digit hex colors (RRGGBB)
- When extracting the alpha component in 8-digit hex colors (AARRGGBB)

### Why make this change?

This change improves code readability by using Kotlin's more idiomatic `take()` function, which clearly communicates the intent to extract the first n characters from a string. The `take()` function is also slightly more concise than `substring(0, n)`.