### PR TITLE
Add Buy Me a Coffee username to FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -10,6 +10,6 @@ liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
 polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+buy_me_a_coffee: krailapp
 thanks_dev: # Replace with a single thanks.dev username
 custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
### TL;DR

Added Buy Me a Coffee sponsorship link to the funding configuration.

### What changed?

Updated the `.github/FUNDING.yml` file to include "krailapp" as the Buy Me a Coffee username, enabling this sponsorship option for the project.

### How to test?

1. Visit the repository's GitHub page
2. Click on the "Sponsor" button
3. Verify that "Buy Me a Coffee" appears as a sponsorship option
4. Confirm that clicking the option directs to the correct krailapp page

### Why make this change?

To provide an additional, convenient way for users to support the project through the Buy Me a Coffee platform, expanding the available sponsorship options for the repository.