### PR TITLE
Bump version from 1.12.0 to 1.13.0 and reset iOS build number

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -16,7 +16,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             androidAppExtension().apply {
                 defaultConfig {
                     versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 115
-                    versionName = "1.12.0"
+                    versionName = "1.13.0"
                 }
             }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.12.0</string>
+	<string>1.13.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version from 1.12.0 to 1.13.0 for the next release.

### What changed?

- Updated Android application version name from 1.12.0 to 1.13.0 in `AndroidApplicationConventionPlugin.kt`
- Updated iOS app version from 1.12.0 to 1.13.0 in `Info.plist`
- Reset iOS build number from 2 to 1 for the new version

### How to test?

- Build the Android app and verify the version shows as 1.13.0 in app info
- Build the iOS app and verify the version shows as 1.13.0 with build number 1

### Why make this change?

Preparing for the next release cycle by incrementing the version number to reflect new features and improvements that will be included in version 1.13.0.