### PR TITLE
Bump iOS build number and NSW bus routes version

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.14.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -26,7 +26,7 @@ interface SandookPreferences {
         const val NSW_STOPS_VERSION = 23L
 
         // Increment this when bundling new bus routes data
-        const val NSW_BUS_ROUTES_VERSION = 3L
+        const val NSW_BUS_ROUTES_VERSION = 4L
 
         const val KEY_NSW_STOPS_VERSION = "KEY_NSW_STOPS_VERSION"
         const val KEY_HAS_SEEN_INTRO = "KEY_HAS_SEEN_INTRO"


### PR DESCRIPTION
### TL;DR

Incremented iOS build number and NSW bus routes version number.

### What changed?

- Incremented iOS build number from 4 to 5 in `Info.plist`
- Incremented `NSW_BUS_ROUTES_VERSION` constant from 3 to 4 in `SandookPreferences.kt`

### How to test?

- Verify the app builds correctly with the new version numbers
- Confirm that NSW bus routes data is properly loaded with the updated version number

### Why make this change?

This update prepares the app for a new release that includes updated NSW bus routes data. The version increments ensure that users will receive the latest bus route information when updating the app.