### PR TITLE
Fix TestFlight notification boolean comparison 

### DIFF
--- a/.github/workflows/distribute-testflight-manual.yml
+++ b/.github/workflows/distribute-testflight-manual.yml
@@ -14,6 +14,6 @@ jobs:
     uses: ./.github/workflows/distribute-testflight.yml
     with:
       artifact-name: iosApp-release-ipa-${{ github.run_id }}
-      notify-testers: ${{ github.event.inputs.notify-testers }}
+      notify-testers: ${{ github.event.inputs.notify-testers == 'true' }}
     secrets: inherit
 

--- a/docs/ios-quick-reference.md
+++ b/docs/ios-quick-reference.md
@@ -1,0 +1,64 @@
+# 🚀 iOS Release - Quick Reference Card
+
+## ✅ CONFIRMED: PRODUCTION RELEASE BUILD
+
+Your workflow builds **Release** (production), NOT Debug.
+
+---
+
+## Key Settings
+
+```ruby
+# iosApp/fastlane/Fastfile
+configuration: "Release"        # ✅ PRODUCTION
+export_method: "app-store"      # ✅ PRODUCTION
+```
+
+```
+# Xcode Project
+SWIFT_OPTIMIZATION_LEVEL = "-O"  # ✅ FULL OPTIMIZATION
+```
+
+---
+
+## What This Means
+
+✅ Production-ready builds  
+✅ Fully optimized code  
+✅ Can upload to TestFlight  
+✅ Can release to App Store  
+✅ Ready for real users  
+❌ NOT debug builds  
+
+---
+
+## How to Use
+
+1. **GitHub** → **Actions**
+2. Select: **"Manual Build & Distribute TestFlight"**
+3. Click: **"Run workflow"**
+4. Wait: ~5-10 minutes
+5. Check: **App Store Connect → TestFlight**
+
+---
+
+## Same as Android
+
+| Android | iOS |
+|---------|-----|
+| Release AAB ✅ | Release IPA ✅ |
+| Google Play | TestFlight |
+| Production | Production |
+
+---
+
+## Files
+
+- Workflow: `.github/workflows/distribute-testflight-manual.yml`
+- Fastlane: `iosApp/fastlane/Fastfile`
+- Docs: `docs/ios-distribution.md`
+
+---
+
+**YOU'RE READY TO SHIP!** 🎉
+


### PR DESCRIPTION
# Fix TestFlight notification parameter and add iOS quick reference guide

### TL;DR

Fixed a bug in the TestFlight manual distribution workflow and added a comprehensive quick reference guide for iOS releases.

### What changed?

- Fixed the `notify-testers` parameter in the TestFlight manual distribution workflow to properly convert string input to boolean
- Added a new `ios-quick-reference.md` document that serves as a quick reference card for iOS releases

### How to test?

1. Trigger a manual TestFlight distribution with the "notify-testers" option set to "true"
2. Verify testers receive notifications
3. Review the new iOS quick reference guide for accuracy and completeness

### Why make this change?

The TestFlight notification parameter wasn't working correctly because it was passing the string value "true" instead of converting it to a boolean. This fix ensures that testers are properly notified when new builds are available.

The new quick reference guide provides developers with clear, concise information about iOS release builds, making it easier to understand the production release process and configuration.