### PR TITLE
Update iOS TestFlight distribution workflow and add documentation

### DIFF
--- a/.github/workflows/distribute-testflight.yml
+++ b/.github/workflows/distribute-testflight.yml
@@ -31,7 +31,12 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
+          bundler-cache: false
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
 
       - run: brew install swiftlint
 
@@ -45,13 +50,13 @@ jobs:
         run: echo $DATA | base64 -d > iosApp/iosApp/GoogleService-Info.plist
 
       - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@v3
+        uses: Apple-Actions/import-codesign-certs@v6
         with:
-          p12-file-base64: ${{ secrets.IOS_DIST_SIGNING_KEY_BASE64 }}
+          p12-file-base64: ${{ secrets.IOS_DIST_SIGNING_KEY }}
           p12-password: ${{ secrets.IOS_DIST_SIGNING_KEY_PASSWORD }}
 
       - name: Download Provisioning Profiles
-        uses: Apple-Actions/download-provisioning-profiles@v3
+        uses: Apple-Actions/download-provisioning-profiles@v5
         with:
           bundle-id: xyz.ksharma.krail
           issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ google-services.json
 xcuserdata/
 
 # Ruby / Fastlane
-Gemfile.lock
 vendor/
 .bundle/
 fastlane/report.xml

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
-gem "cocoapods"
 

--- a/scripts/test-ios-local.sh
+++ b/scripts/test-ios-local.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+echo "🧪 Testing iOS Distribution Locally"
+echo "===================================="
+echo ""
+
+# Check Ruby version
+echo "1️⃣ Checking Ruby version..."
+ruby --version
+if [ $? -ne 0 ]; then
+  echo "❌ Ruby not found. Please install Ruby 4.0.0"
+  exit 1
+fi
+echo ""
+
+# Check Bundler
+echo "2️⃣ Checking Bundler..."
+if ! command -v bundle &> /dev/null; then
+  echo "📦 Installing Bundler..."
+  gem install bundler
+fi
+bundle --version
+echo ""
+
+# Install dependencies
+echo "3️⃣ Installing Fastlane dependencies..."
+bundle install
+if [ $? -ne 0 ]; then
+  echo "❌ Bundle install failed"
+  exit 1
+fi
+echo ""
+
+# Test Fastlane
+echo "4️⃣ Testing Fastlane..."
+cd iosApp
+bundle exec fastlane --version
+if [ $? -ne 0 ]; then
+  echo "❌ Fastlane not working"
+  exit 1
+fi
+echo ""
+
+# Show available lanes
+echo "5️⃣ Available Fastlane lanes:"
+bundle exec fastlane lanes
+echo ""
+
+echo "✅ Local setup is working!"
+echo ""
+echo "📝 To test build locally (requires certificates):"
+echo "   cd iosApp"
+echo "   bundle exec fastlane build_release"
+echo ""
+echo "⚠️  Note: Building requires:"
+echo "   - Valid Apple Distribution certificate in Keychain"
+echo "   - App Store provisioning profile"
+echo "   - Environment variable: IOS_NSW_TRANSPORT_API_KEY"
+


### PR DESCRIPTION
# iOS TestFlight Distribution Workflow Improvements

### TL;DR

Fixed TestFlight distribution workflow and added iOS documentation.

### What changed?

- Fixed boolean conversion in manual TestFlight distribution workflow
- Updated Apple code signing actions to newer versions (v3→v6 and v3→v5)
- Modified Ruby setup to explicitly install dependencies
- Removed cocoapods from Gemfile as it's not needed
- Added iOS quick reference documentation
- Created a local iOS testing script

### How to test?

1. Run the manual TestFlight distribution workflow from GitHub Actions
2. Verify the workflow completes successfully
3. Check that testers are notified correctly based on the input parameter
4. Try the local testing script with `bash scripts/test-ios-local.sh`

### Why make this change?

The TestFlight distribution workflow had issues with boolean parameter handling and was using outdated Apple GitHub Actions. These changes ensure more reliable iOS builds and provide better documentation for the iOS release process, making it easier for team members to understand and troubleshoot the distribution pipeline.