### PR TITLE
Ruby 4.0 removed ostruct from the standard library, and the old version of Fastlane (1.92.0) being installed depends on it

### DIFF
--- a/.github/workflows/distribute-testflight.yml
+++ b/.github/workflows/distribute-testflight.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler
+          bundle update
           bundle install
 
       - run: brew install swiftlint
@@ -49,6 +50,12 @@ jobs:
           DATA: ${{ secrets.FIREBASE_IOS_GOOGLE_INFO }}
         run: echo $DATA | base64 -d > iosApp/iosApp/GoogleService-Info.plist
 
+      - name: Create App Store Connect API Key
+        run: |
+          mkdir -p ~/private_keys
+          echo "${{ secrets.APPSTORE_PRIVATE_KEY }}" > ~/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
+          echo "APP_STORE_CONNECT_API_KEY_PATH=~/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8" >> $GITHUB_ENV
+
       - name: Import Code-Signing Certificates
         uses: Apple-Actions/import-codesign-certs@v6
         with:
@@ -59,15 +66,10 @@ jobs:
         uses: Apple-Actions/download-provisioning-profiles@v5
         with:
           bundle-id: xyz.ksharma.krail
+          profile-type: IOS_APP_STORE
           issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
           api-key-id: ${{ secrets.APPSTORE_KEY_ID }}
           api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
-
-      - name: Create App Store Connect API Key
-        run: |
-          mkdir -p ~/private_keys
-          echo "${{ secrets.APPSTORE_PRIVATE_KEY }}" > ~/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8
-          echo "APP_STORE_CONNECT_API_KEY_PATH=~/private_keys/AuthKey_${{ secrets.APPSTORE_KEY_ID }}.p8" >> $GITHUB_ENV
 
       - name: Build iOS App for Release
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "ostruct"
 


### PR DESCRIPTION
### TL;DR

Fixed TestFlight distribution workflow by reordering API key setup and adding required dependencies.

### What changed?

- Reordered the App Store Connect API key creation step to occur before downloading provisioning profiles
- Added `profile-type: IOS_APP_STORE` parameter to the download-provisioning-profiles step
- Added `bundle update` command to ensure dependencies are up to date
- Added the `ostruct` gem to the Gemfile to support the fastlane workflow

### How to test?

1. Trigger the TestFlight distribution workflow
2. Verify that the provisioning profiles are correctly downloaded
3. Confirm the build completes successfully and uploads to TestFlight

### Why make this change?

The previous workflow had an incorrect order of operations where provisioning profiles were being downloaded before the API key was properly set up. Additionally, the missing `ostruct` gem and outdated dependencies were causing failures in the build process. These changes ensure the TestFlight distribution works reliably.