### PR TITLE
Bump version to 1.15.0 and reset iOS build number

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/AndroidApplicationConventionPlugin.kt
@@ -16,7 +16,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             androidAppExtension().apply {
                 defaultConfig {
                     versionCode = findProperty("versionCode")?.toString()?.toInt() ?: 115
-                    versionName = "1.14.0"
+                    versionName = "1.15.0"
                 }
             }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.14.0</string>
+	<string>1.15.0</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
### TL;DR

Bump version to 1.15.0 for both Android and iOS apps.

### What changed?

- Updated Android app version from 1.14.0 to 1.15.0 in `AndroidApplicationConventionPlugin.kt`
- Updated iOS app version from 1.14.0 to 1.15.0 in `Info.plist`
- Reset iOS build number from 5 to 1 in `Info.plist`

### How to test?

1. Build the Android app and verify the version number in the app info
2. Build the iOS app and verify the version number in the app info
3. Ensure both platforms display version 1.15.0

### Why make this change?

Preparing for the next release (1.15.0) by updating version numbers across platforms to maintain consistency between Android and iOS apps.