### PR TITLE
Add case-insensitive search for NSW bus routes

### DIFF
--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswBusRoutes.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/NswBusRoutes.sq
@@ -77,19 +77,19 @@ DELETE FROM NswBusRouteGroups;
 selectRouteByShortName:
 SELECT routeShortName
 FROM NswBusRouteGroups
-WHERE routeShortName = :routeShortName;
+WHERE routeShortName = :routeShortName COLLATE NOCASE;
 
 -- Select all variants for a specific route --
 selectRouteVariantsByShortName:
 SELECT routeId, routeShortName, routeName
 FROM NswBusRouteVariants
-WHERE routeShortName = :routeShortName;
+WHERE routeShortName = :routeShortName COLLATE NOCASE;
 
 -- Select all trips for a specific route variant --
 selectTripsByRouteId:
 SELECT tripId, routeId, headsign
 FROM NswBusTripOptions
-WHERE routeId = :routeId;
+WHERE routeId = :routeId COLLATE NOCASE;
 
 -- Select all trips for multiple route variants (batch query to avoid N+1 problem) --
 selectTripsByRouteIds:


### PR DESCRIPTION
### TL;DR

Added case-insensitive matching to NSW bus route queries. When searching for 613X bus number, the results did not appear until the letter was entered in upper case.

### What changed?

Modified three SQL queries in `NswBusRoutes.sq` to use `COLLATE NOCASE` for case-insensitive string comparisons:
- `selectRouteByShortName`
- `selectRouteVariantsByShortName`
- `selectTripsByRouteId`

### How to test?

1. Search for bus routes using mixed case route names (e.g., "613x" instead of "613X")
2. Verify that results are returned regardless of case
3. Test with various case combinations to ensure all matching routes are found

### Why make this change?

This improves the user experience by making bus route searches case-insensitive. Users can now find routes regardless of how they type the route name (uppercase, lowercase, or mixed case), reducing friction and making the search functionality more forgiving.