### PR TITLE
Use exception handler in SavedTripsViewModel's observeSavedTrips method

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -290,7 +290,7 @@ class SavedTripsViewModel(
     private fun observeSavedTrips() {
         log("onStart - observeSavedTrips called")
         observeSavedTripsJob?.cancel()
-        observeSavedTripsJob = viewModelScope.launch(ioDispatcher) {
+        observeSavedTripsJob = viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
             updateUiState { copy(isSavedTripsLoading = true) }
             sandook.observeAllTrips()
                 .distinctUntilChanged()


### PR DESCRIPTION
### TL;DR

Updated the `SavedTripsViewModel` to use exception handling when launching coroutines.

### What changed?

Changed the coroutine launch method in `observeSavedTrips()` from standard `launch` to `launchWithExceptionHandler<SavedTripsViewModel>` to properly handle exceptions that might occur during saved trips observation.

### How to test?

1. Navigate to the Saved Trips screen
2. Verify that the app doesn't crash if there's an error while loading saved trips
3. Check logs to confirm exceptions are being properly caught and handled

### Why make this change?

This change improves error handling in the SavedTripsViewModel by using a custom exception handler for coroutines. This prevents app crashes when errors occur during the saved trips observation process and ensures a more robust user experience.