### PR TITLE
Add manual dispatch and build job to Google Play workflow

### DIFF
--- a/.github/workflows/distribute-google-play.yml
+++ b/.github/workflows/distribute-google-play.yml
@@ -1,4 +1,4 @@
-name: Distribute Google Play (Internal)
+name: Distribute Google Play
 
 on:
   workflow_call:
@@ -9,19 +9,43 @@ on:
       track:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Google Play track'
+        required: true
+        default: 'internal'
+        type: choice
+        options:
+          - internal
+
+permissions:
+  actions: write  # allows build-android.yml to write back ANDROID_VERSION_CODE
 
 jobs:
+  # Only runs for workflow_dispatch — builds a fresh signed AAB from the selected branch.
+  # workflow_call callers (release-2, release-3) pass a pre-built artifact instead.
+  build:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/build-android.yml
+    with:
+      variant: release
+    secrets: inherit
+
   distribute:
     runs-on: ubuntu-latest
     environment: Firebase
+    needs: [build]
+    # Run when build succeeded (workflow_dispatch) or was skipped (workflow_call).
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped')
     steps:
       - name: Download Release AAB artifact
         uses: actions/download-artifact@v8
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.artifact-name || format('androidApp-release-aab-{0}', github.run_id) }}
           path: aab
 
-      - name: Deploy to Play Store (Internal)
+      - name: Deploy to Play Store
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
### TL;DR

Enhanced the Google Play distribution workflow to support manual triggering and automatic builds while maintaining backward compatibility with existing release workflows.

### What changed?

- Added `workflow_dispatch` trigger allowing manual execution from any branch with track selection
- Introduced a new `build` job that runs only for manual triggers to create fresh signed AAB files
- Added `actions: write` permission to enable version code updates during builds
- Modified artifact name resolution to use run-specific naming for manual builds or fallback to provided artifact names
- Updated job dependencies so distribution waits for build completion or skip

### How to test?

1. Manually trigger the workflow from the GitHub Actions tab
2. Select "internal" from the track dropdown
3. Verify the workflow builds a new AAB and deploys it to Google Play
4. Test existing release workflows (release-2, release-3) still function with pre-built artifacts

### Why make this change?

This enables developers to manually deploy builds to Google Play without requiring a full release process, while preserving the existing automated release pipeline functionality.