### PR TITLE
Add departure board UI components and integrate with trip planner

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportMode.kt
@@ -1,6 +1,0 @@
-package xyz.ksharma.krail.trip.planner.ui.state
-
-// Moved to :core:transport.
-// These typealiases keep all existing import paths working — no need to touch other files.
-typealias TransportMode = xyz.ksharma.krail.core.transport.TransportMode
-typealias TransportModeSortOrder = xyz.ksharma.krail.core.transport.TransportModeSortOrder

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportModeLine.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/TransportModeLine.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.state
 
+import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.core.transport.nsw.NswTransportLine
 

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -72,6 +72,8 @@ kotlin {
                 implementation(projects.discover.network.api)
                 implementation(projects.discover.state)
                 implementation(projects.discover.ui)
+                implementation(projects.feature.departures.state)
+                implementation(projects.feature.departures.ui)
                 implementation(projects.feature.parkRide.network)
                 implementation(projects.feature.parkRide.ui)
                 implementation(projects.feature.tripPlanner.network)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardCard.kt
@@ -1,0 +1,410 @@
+@file:Suppress("MagicNumber", "TooManyFunctions", "CyclomaticComplexMethod")
+
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_arrow_down
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
+import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.Divider
+import xyz.ksharma.krail.taj.components.SubtleButton
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.CardShape
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
+
+/**
+ * Expand/collapse card for a stop's live departure board.
+ *
+ * The card header is rendered as a [SubtleButton] so it uses the app's established
+ * button visual language and integrates a scale-press animation via [scalingKlickable].
+ *
+ * Supports two modes:
+ * - **Uncontrolled** (default): manages its own expanded state via [rememberSaveable].
+ *   Filter state is also managed internally and reset on collapse.
+ *   Used in the stop details bottom sheet where only one card exists.
+ * - **Controlled**: caller drives expansion via [isExpanded] + [onExpandChange].
+ *   Used in the saved trips accordion where only one card can be open at a time.
+ *
+ * @param stopId          NSW Transport stop ID, e.g. "10111010".
+ * @param state           Current [DeparturesState] from the ViewModel or repository.
+ * @param onEvent         Callback to send events to the ViewModel (only used in uncontrolled mode).
+ * @param isExpanded      When non-null, puts the card in controlled mode with this expansion state.
+ * @param onExpandChange  When non-null, called with the desired new expanded state (controlled mode).
+ * @param title           Card header label. Defaults to "Departure Board".
+ * @param maxItems        Maximum number of departure rows to show. `null` means show all.
+ */
+@Composable
+fun DepartureBoardCard(
+    stopId: String,
+    state: DeparturesState,
+    onEvent: (DeparturesUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+    isExpanded: Boolean? = null,
+    onExpandChange: ((Boolean) -> Unit)? = null,
+    title: String = "Departure Board",
+    maxItems: Int? = null,
+) {
+    var internalExpanded by rememberSaveable { mutableStateOf(false) }
+    val expanded = isExpanded ?: internalExpanded
+
+    // Filter state — keyed to stopId so rotating the device while a filter is active
+    // restores the same selection. Empty string is the "no filter" sentinel (primitives only
+    // are safe across process death / configuration changes via rememberSaveable).
+    var selectedLineKey by rememberSaveable(key = "filter_$stopId") { mutableStateOf("") }
+    val selectedLine: String? = selectedLineKey.ifEmpty { null }
+
+    val filteredDepartures: ImmutableList<StopDeparture> = remember(state.departures, selectedLine) {
+        if (selectedLine == null) {
+            state.departures
+        } else {
+            state.departures.filter { it.lineNumber == selectedLine }.toImmutableList()
+        }
+    }
+
+    val arrowRotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "arrow-rotation",
+    )
+
+    LaunchedEffect(expanded, stopId) {
+        if (expanded && isExpanded == null) {
+            onEvent(DeparturesUiEvent.LoadDepartures(stopId))
+        }
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(CardShape)
+            .background(KrailTheme.colors.surface),
+    ) {
+        // ── Header — SubtleButton acts as the expand/collapse toggle ─────────
+        SubtleButton(
+            onClick = {
+                val next = !expanded
+                if (onExpandChange != null) onExpandChange(next) else internalExpanded = next
+            },
+            dimensions = ButtonDefaults.largeButtonSize(),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = title,
+                    style = KrailTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (expanded && state.silentLoading) {
+                        AnimatedDots(
+                            modifier = Modifier.size(width = 32.dp, height = 16.dp),
+                            color = KrailTheme.colors.softLabel,
+                        )
+                    }
+                    Image(
+                        painter = painterResource(Res.drawable.ic_arrow_down),
+                        contentDescription = if (expanded) "Collapse" else "Expand",
+                        colorFilter = ColorFilter.tint(KrailTheme.colors.softLabel),
+                        modifier = Modifier.size(18.dp).rotate(arrowRotation),
+                    )
+                }
+            }
+        }
+
+        // ── Expanded content ─────────────────────────────────────────────────
+        AnimatedVisibility(
+            visible = expanded,
+            enter = expandVertically(expandFrom = Alignment.Top) +
+                fadeIn(animationSpec = tween(durationMillis = 200)),
+            exit = shrinkVertically(shrinkTowards = Alignment.Top) +
+                fadeOut(animationSpec = tween(durationMillis = 150)),
+        ) {
+            Column {
+                when {
+                    state.isLoading -> LoadingContent()
+                    state.isError -> ErrorContent(
+                        onRetry = { if (isExpanded == null) onEvent(DeparturesUiEvent.Refresh) },
+                    )
+                    state.departures.isEmpty() -> EmptyContent()
+                    else -> {
+                        LinesServedRow(
+                            departures = state.departures,
+                            selectedLine = selectedLine,
+                            onLineSelect = { selectedLineKey = it ?: "" },
+                        )
+                        Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                        when {
+                            filteredDepartures.isEmpty() -> FilterEmptyContent()
+                            else -> DepartureRowList(
+                                departures = filteredDepartures,
+                                maxItems = maxItems,
+                            )
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+// ── Private content slots ─────────────────────────────────────────────────────
+
+@Composable
+private fun LoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 28.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedDots(
+            modifier = Modifier.size(width = 64.dp, height = 24.dp),
+            color = KrailTheme.colors.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun ErrorContent(onRetry: () -> Unit) {
+    ErrorMessage(
+        title = "Couldn't load departures",
+        message = "Check your connection and try again.",
+        actionData = ActionData(
+            actionText = "Retry",
+            onActionClick = onRetry,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+private fun EmptyContent() {
+    Text(
+        text = "No upcoming departures found.",
+        style = KrailTheme.typography.bodyMedium,
+        color = KrailTheme.colors.softLabel,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+    )
+}
+
+@Composable
+private fun FilterEmptyContent() {
+    Text(
+        text = "No departures match the selected line.",
+        style = KrailTheme.typography.bodyMedium,
+        color = KrailTheme.colors.softLabel,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+    )
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+private const val TRANSPORT_MODE_TRAIN = "Train"
+private const val TRANSPORT_MODE_BUS = "Bus"
+private const val TRANSPORT_MODE_FERRY = "Ferry"
+private const val SAMPLE_DATE_PREFIX = "2026-04-08T01:"
+
+private val previewTrainDepartures = persistentListOf(
+    StopDeparture(
+        lineNumber = "T1",
+        lineColorCode = "#F99D1C",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Liverpool via Strathfield",
+        departureTimeText = "11:30 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}30:00Z",
+        platformText = "Platform 4",
+        isRealTime = true,
+    ),
+    StopDeparture(
+        lineNumber = "T2",
+        lineColorCode = "#0098CD",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Bondi Junction",
+        departureTimeText = "11:33 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}33:00Z",
+        platformText = "Platform 7",
+        isRealTime = false,
+    ),
+    StopDeparture(
+        lineNumber = "T4",
+        lineColorCode = "#005AA3",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Illawarra via Sydenham",
+        departureTimeText = "11:36 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}36:00Z",
+        platformText = "Platform 2",
+        isRealTime = true,
+    ),
+)
+
+private val previewBusDepartures = persistentListOf(
+    StopDeparture(
+        lineNumber = "333",
+        lineColorCode = "#00B5EF",
+        transportModeName = TRANSPORT_MODE_BUS,
+        destinationName = "Parramatta Interchange",
+        departureTimeText = "11:40 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}40:00Z",
+        platformText = "Stand B",
+        isRealTime = true,
+    ),
+    StopDeparture(
+        lineNumber = "370",
+        lineColorCode = "#00B5EF",
+        transportModeName = TRANSPORT_MODE_BUS,
+        destinationName = "Coogee Beach",
+        departureTimeText = "11:45 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}45:00Z",
+        platformText = null,
+        isRealTime = false,
+    ),
+)
+
+private val previewFerryDepartures = persistentListOf(
+    StopDeparture(
+        lineNumber = "F1",
+        lineColorCode = "#00774B",
+        transportModeName = TRANSPORT_MODE_FERRY,
+        destinationName = "Manly Wharf",
+        departureTimeText = "11:30 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}30:00Z",
+        platformText = "Wharf 1",
+        isRealTime = true,
+    ),
+    StopDeparture(
+        lineNumber = "F2",
+        lineColorCode = "#144734",
+        transportModeName = TRANSPORT_MODE_FERRY,
+        destinationName = "Parramatta River",
+        departureTimeText = "11:45 AM",
+        departureUtcDateTime = "${SAMPLE_DATE_PREFIX}45:00Z",
+        platformText = "Wharf 3",
+        isRealTime = false,
+    ),
+)
+
+@Preview(name = "Collapsed", showBackground = true)
+@Composable
+private fun DepartureBoardCardCollapsedPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        DepartureBoardCard(
+            stopId = "10101010",
+            state = DeparturesState(),
+            onEvent = {},
+        )
+    }
+}
+
+@Preview(name = "Loading", showBackground = true)
+@Composable
+private fun DepartureBoardCardLoadingPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        Column { LoadingContent() }
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun DepartureBoardCardLoadedTrainPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        Column {
+            LinesServedRow(
+                departures = previewTrainDepartures,
+                selectedLine = "T2",
+                onLineSelect = {},
+            )
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            DepartureRowList(departures = previewTrainDepartures)
+        }
+    }
+}
+
+@Preview(name = "Loaded — Bus theme", showBackground = true)
+@Composable
+private fun DepartureBoardCardLoadedBusPreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        Column {
+            LinesServedRow(
+                departures = previewBusDepartures,
+                selectedLine = null,
+                onLineSelect = {},
+            )
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            DepartureRowList(departures = previewBusDepartures)
+        }
+    }
+}
+
+@Preview(name = "Error state", showBackground = true)
+@Composable
+private fun DepartureBoardCardErrorPreview() {
+    PreviewTheme(KrailThemeStyle.Metro) {
+        Column { ErrorContent(onRetry = {}) }
+    }
+}
+
+@Preview(name = "Ferry theme", showBackground = true)
+@Composable
+private fun DepartureBoardCardFerryPreview() {
+    PreviewTheme(KrailThemeStyle.Ferry) {
+        Column {
+            LinesServedRow(
+                departures = previewFerryDepartures,
+                selectedLine = null,
+                onLineSelect = {},
+            )
+            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            DepartureRowList(departures = previewFerryDepartures)
+        }
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardCard.kt
@@ -62,7 +62,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
  *
  * Supports two modes:
  * - **Uncontrolled** (default): manages its own expanded state via [rememberSaveable].
- *   Filter state is also managed internally and reset on collapse.
+ *   Filter state is managed internally and persists across collapse/expand and rotation.
  *   Used in the stop details bottom sheet where only one card exists.
  * - **Controlled**: caller drives expansion via [isExpanded] + [onExpandChange].
  *   Used in the saved trips accordion where only one card can be open at a time.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureDeviationIndicator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureDeviationIndicator.kt
@@ -1,0 +1,125 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.LocalContentAlpha
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
+
+/**
+ * Displays a coloured dot + label indicating whether a service is on time, late, or early.
+ *
+ * Mirrors the real-time deviation chip shown inside [JourneyCard].
+ */
+@Composable
+fun DepartureDeviationIndicator(
+    deviation: TimeTableState.JourneyCardInfo.DepartureDeviation,
+    modifier: Modifier = Modifier,
+) {
+    val (dotColor, label) = when (deviation) {
+        is TimeTableState.JourneyCardInfo.DepartureDeviation.Late ->
+            KrailTheme.colors.deviationLate to deviation.text
+
+        is TimeTableState.JourneyCardInfo.DepartureDeviation.Early ->
+            KrailTheme.colors.deviationEarly to deviation.text
+
+        TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime ->
+            KrailTheme.colors.deviationOnTime to "On time"
+    }
+    DepartureDeviationIndicator(dotColor = dotColor, label = label, modifier = modifier)
+}
+
+/**
+ * Low-level overload — optional coloured dot + label text.
+ *
+ * @param showDot When false the dot is hidden, useful when an external badge
+ *                already conveys the status (e.g. Live / Scheduled in [DepartureRow]).
+ */
+@Composable
+fun DepartureDeviationIndicator(
+    dotColor: Color,
+    label: String,
+    modifier: Modifier = Modifier,
+    showDot: Boolean = true,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (showDot) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(
+                        color = dotColor.copy(alpha = LocalContentAlpha.current),
+                        shape = CircleShape,
+                    ),
+            )
+        }
+        Text(
+            text = label,
+            style = KrailTheme.typography.bodyMedium,
+            color = KrailTheme.colors.onSurface,
+        )
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@PreviewComponent
+@Composable
+private fun DepartureDeviationIndicatorOnTimePreview() {
+    PreviewTheme {
+        DepartureDeviationIndicator(
+            deviation = TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureDeviationIndicatorLatePreview() {
+    PreviewTheme {
+        DepartureDeviationIndicator(
+            deviation = TimeTableState.JourneyCardInfo.DepartureDeviation.Late("3 mins late"),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureDeviationIndicatorEarlyPreview() {
+    PreviewTheme {
+        DepartureDeviationIndicator(
+            deviation = TimeTableState.JourneyCardInfo.DepartureDeviation.Early("1 min early"),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureDeviationIndicatorNoDotPreview() {
+    PreviewTheme {
+        DepartureDeviationIndicator(
+            dotColor = KrailTheme.colors.deviationOnTime,
+            label = "in 3 mins",
+            showDot = false,
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureRow.kt
@@ -1,0 +1,400 @@
+@file:Suppress("TooManyFunctions", "StringLiteralDuplication")
+
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
+import xyz.ksharma.krail.taj.components.Divider
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.departureboard.toTransportMode
+
+/**
+ * Displays a single departure row:
+ *
+ * ```
+ * in 5 mins  [B] [700]        Stand A   ← relative time + mode icon + line badge | platform
+ * 11:30 am                              ← departure time (label color); or strikethrough + delay label
+ * Schofields via ABC Road               ← destination (softLabel color)
+ * ```
+ */
+@Composable
+fun DepartureRow(
+    departure: StopDeparture,
+    modifier: Modifier = Modifier,
+) {
+    val lineColor = remember(departure.lineColorCode) { departure.lineColorCode.hexToComposeColor() }
+    val transportMode = remember(departure.transportModeName) {
+        departure.transportModeName.toTransportMode()
+    }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        // Line 1: relative time + mode icon + line badge (left) | platform text (right)
+        FlowRow(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            itemVerticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (departure.relativeTimeText.isNotBlank()) {
+                    Text(
+                        text = departure.relativeTimeText,
+                        style = KrailTheme.typography.titleMedium,
+                        color = lineColor,
+                    )
+                }
+
+                transportMode?.let {
+                    TransportModeIcon(
+                        transportMode = it,
+                        size = TransportModeIconSize.XSmall,
+                        displayBorder = false,
+                    )
+                }
+
+                TransportModeBadge(
+                    badgeText = departure.lineNumber,
+                    backgroundColor = lineColor,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+            }
+
+            departure.platformText?.let {
+                Text(
+                    text = it,
+                    textAlign = TextAlign.End,
+                    style = KrailTheme.typography.bodyMedium,
+                    color = KrailTheme.colors.label,
+                )
+            }
+        }
+
+        // Line 2: delay indicator (if delayed/early) + departure time
+        DepartureTimeRow(
+            departureTimeText = departure.departureTimeText,
+            scheduledTimeText = departure.scheduledTimeText,
+            delayMinutes = departure.delayMinutes,
+        )
+
+        // Line 3: destination in softLabel
+        Text(
+            text = departure.destinationName,
+            style = KrailTheme.typography.bodyMedium,
+            color = KrailTheme.colors.softLabel,
+        )
+    }
+}
+
+/**
+ * Shows departure time with optional delay indicator.
+ * - On time: just the time in label color
+ * - Delayed: strikethrough scheduled time + "Delayed X min" in deviationLate + actual time
+ * - Early: strikethrough scheduled time + "Early X min" in deviationEarly + actual time
+ */
+@Composable
+private fun DepartureTimeRow(
+    departureTimeText: String,
+    scheduledTimeText: String?,
+    delayMinutes: Int,
+    modifier: Modifier = Modifier,
+) {
+    if (scheduledTimeText != null && delayMinutes != 0) {
+        val isDelayed = delayMinutes > 0
+        val deviationColor = if (isDelayed) KrailTheme.colors.deviationLate else KrailTheme.colors.deviationEarly
+        val deviationLabel = if (isDelayed) "Delayed $delayMinutes min" else "Early ${-delayMinutes} min"
+        Column(modifier = modifier) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = buildAnnotatedString {
+                        withStyle(SpanStyle(textDecoration = TextDecoration.LineThrough)) {
+                            append(scheduledTimeText)
+                        }
+                    },
+                    style = KrailTheme.typography.bodyMedium,
+                    color = KrailTheme.colors.softLabel,
+                )
+                Text(
+                    text = deviationLabel,
+                    style = KrailTheme.typography.bodyMedium,
+                    color = deviationColor,
+                )
+            }
+            Text(
+                text = departureTimeText,
+                style = KrailTheme.typography.titleMedium,
+                color = KrailTheme.colors.label,
+            )
+        }
+    } else {
+        Text(
+            text = departureTimeText,
+            style = KrailTheme.typography.bodyMedium,
+            color = KrailTheme.colors.label,
+            modifier = modifier,
+        )
+    }
+}
+
+/**
+ * Renders departure rows with Taj dividers between them, and a date section header
+ * whenever the departure date changes (e.g. Today → Tomorrow → Wed 9 Apr).
+ * Uses a plain [Column] (not LazyColumn) so it can be safely embedded
+ * inside an outer vertically-scrollable container like a bottom sheet.
+ */
+@Composable
+fun DepartureRowList(
+    departures: ImmutableList<StopDeparture>,
+    modifier: Modifier = Modifier,
+    maxItems: Int? = null,
+) {
+    val displayDepartures = remember(departures, maxItems) {
+        if (maxItems != null) departures.take(maxItems) else departures
+    }
+    Column(modifier = modifier) {
+        var lastDateLabel = ""
+        displayDepartures.forEachIndexed { index, departure ->
+            if (departure.dateLabel != lastDateLabel) {
+                if (index > 0) Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                Text(
+                    text = departure.dateLabel,
+                    style = KrailTheme.typography.labelLarge,
+                    color = KrailTheme.colors.softLabel,
+                    modifier = Modifier
+                        .semantics { heading() }
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 8.dp),
+                )
+                lastDateLabel = departure.dateLabel
+            }
+
+            DepartureRow(departure = departure)
+
+            if (index < displayDepartures.lastIndex) {
+                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            }
+        }
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+private const val TRANSPORT_MODE_TRAIN = "Train"
+private const val TRANSPORT_MODE_BUS = "Bus"
+private const val TRANSPORT_MODE_FERRY = "Ferry"
+private const val BUS_LINE_700 = "700"
+private const val BUS_COLOR = "#00B5EF"
+private const val BUS_DESTINATION = "Schofields via ABC Road"
+private const val BUS_PLATFORM = "Stand A"
+private const val BUS_DEPARTURE_TIME = "11:30 am"
+private const val BUS_UTC_DATE = "2026-04-10T01:30:00Z"
+private const val RELATIVE_IN_5 = "in 5 mins"
+
+private val sampleDepartures = persistentListOf(
+    // On-time bus
+    StopDeparture(
+        lineNumber = BUS_LINE_700,
+        lineColorCode = BUS_COLOR,
+        transportModeName = TRANSPORT_MODE_BUS,
+        destinationName = BUS_DESTINATION,
+        departureTimeText = BUS_DEPARTURE_TIME,
+        departureUtcDateTime = BUS_UTC_DATE,
+        relativeTimeText = "in 100005 mins",
+        platformText = BUS_PLATFORM,
+        isRealTime = true,
+    ),
+    // Delayed bus
+    StopDeparture(
+        lineNumber = BUS_LINE_700,
+        lineColorCode = BUS_COLOR,
+        transportModeName = TRANSPORT_MODE_BUS,
+        destinationName = BUS_DESTINATION,
+        departureTimeText = BUS_DEPARTURE_TIME,
+        departureUtcDateTime = BUS_UTC_DATE,
+        relativeTimeText = RELATIVE_IN_5,
+        platformText = BUS_PLATFORM,
+        isRealTime = true,
+        scheduledTimeText = "11:28 am",
+        delayMinutes = 2,
+    ),
+    // Early bus
+    StopDeparture(
+        lineNumber = BUS_LINE_700,
+        lineColorCode = BUS_COLOR,
+        transportModeName = TRANSPORT_MODE_BUS,
+        destinationName = BUS_DESTINATION,
+        departureTimeText = "11:28 am",
+        departureUtcDateTime = "2026-01-7T01:28:00Z",
+        relativeTimeText = RELATIVE_IN_5,
+        platformText = BUS_PLATFORM,
+        isRealTime = true,
+        scheduledTimeText = BUS_DEPARTURE_TIME,
+        delayMinutes = -2,
+    ),
+    StopDeparture(
+        lineNumber = "T1",
+        lineColorCode = "#F99D1C",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Liverpool via Strathfield",
+        departureTimeText = "11:30 AM",
+        departureUtcDateTime = "2026-04-10T01:30:00Z",
+        relativeTimeText = "in 5 mins",
+        platformText = "Platform 4",
+        isRealTime = true,
+    ),
+    StopDeparture(
+        lineNumber = "F1",
+        lineColorCode = "#00774B",
+        transportModeName = TRANSPORT_MODE_FERRY,
+        destinationName = "Manly Wharf",
+        departureTimeText = "11:40 AM",
+        departureUtcDateTime = "2026-04-10T01:40:00Z",
+        relativeTimeText = "in 5 mins",
+        platformText = null,
+        isRealTime = false,
+    ),
+)
+
+@PreviewComponent
+@Composable
+private fun DepartureRowBusOnTimePreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        DepartureRow(departure = sampleDepartures[0])
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureRowBusDelayedPreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        DepartureRow(departure = sampleDepartures[1])
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureRowBusEarlyPreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        DepartureRow(departure = sampleDepartures[2])
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureRowTrainPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        DepartureRow(departure = sampleDepartures[3])
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureRowFerryNoPlatformPreview() {
+    PreviewTheme(KrailThemeStyle.Ferry) {
+        DepartureRow(departure = sampleDepartures[4])
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun DepartureRowListBusPreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        Column {
+            DepartureRowList(departures = sampleDepartures)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DepartureRowListMetroPreview() {
+    PreviewTheme(KrailThemeStyle.Metro) {
+        Column {
+            DepartureRowList(departures = sampleDepartures)
+        }
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun DepartureRowListMultiDayPreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        Column {
+            DepartureRowList(
+                departures = persistentListOf(
+                    StopDeparture(
+                        lineNumber = "700",
+                        lineColorCode = "#00B5EF",
+                        transportModeName = TRANSPORT_MODE_BUS,
+                        destinationName = "Schofields via ABC Road",
+                        departureTimeText = "11:30 pm",
+                        departureUtcDateTime = "2026-04-10T13:30:00Z",
+                        relativeTimeText = "in 5 mins",
+                        platformText = "Stand A",
+                        isRealTime = true,
+                        dateLabel = "Today",
+                    ),
+                    StopDeparture(
+                        lineNumber = "700",
+                        lineColorCode = "#00B5EF",
+                        transportModeName = TRANSPORT_MODE_BUS,
+                        destinationName = "Schofields via ABC Road",
+                        departureTimeText = "11:55 pm",
+                        departureUtcDateTime = "2026-04-10T13:55:00Z",
+                        relativeTimeText = "in 30 mins",
+                        platformText = "Stand A",
+                        isRealTime = true,
+                        dateLabel = "Today",
+                    ),
+                    StopDeparture(
+                        lineNumber = "700",
+                        lineColorCode = "#00B5EF",
+                        transportModeName = TRANSPORT_MODE_BUS,
+                        destinationName = "Schofields via ABC Road",
+                        departureTimeText = "12:10 am",
+                        departureUtcDateTime = "2026-04-11T02:10:00Z",
+                        relativeTimeText = "in 1 hr",
+                        platformText = "Stand A",
+                        isRealTime = false,
+                        dateLabel = "Tomorrow",
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -25,7 +23,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
@@ -244,43 +241,6 @@ private fun JourneyCardHeader(
                 modifier = Modifier.padding(top = 4.dp),
             )
         }
-    }
-}
-
-@Composable
-private fun DepartureDeviationIndicator(
-    deviation: TimeTableState.JourneyCardInfo.DepartureDeviation,
-    modifier: Modifier = Modifier,
-) {
-    val (dotColor, label) = when (deviation) {
-        is TimeTableState.JourneyCardInfo.DepartureDeviation.Late ->
-            KrailTheme.colors.deviationLate to deviation.text
-
-        is TimeTableState.JourneyCardInfo.DepartureDeviation.Early ->
-            KrailTheme.colors.deviationEarly to deviation.text
-
-        TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime ->
-            KrailTheme.colors.deviationOnTime to "On time"
-    }
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(12.dp)
-                .clip(CircleShape)
-                .background(
-                    color = dotColor.copy(alpha = LocalContentAlpha.current),
-                    shape = CircleShape,
-                ),
-        )
-        Text(
-            text = label,
-            style = KrailTheme.typography.bodyMedium,
-            color = KrailTheme.colors.onSurface,
-        )
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LinesServedRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LinesServedRow.kt
@@ -1,0 +1,124 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+
+/**
+ * Horizontally scrollable row of unique line badges for a stop, used as a departure filter.
+ *
+ * Each badge represents one service line (e.g. T1, T2, 333) derived from [departures].
+ * Tapping a badge selects it as the active filter (highlighted with a thick onSurface border).
+ * Tapping the currently selected badge deselects it (clears the filter).
+ *
+ * All badges use [BadgeSize.Large] so they meet accessibility touch-target guidelines and
+ * are easy to distinguish from the small badges shown inside departure rows.
+ *
+ * This composable is **stateless** — callers drive [selectedLine] and [onLineSelect].
+ * Typically the filter state lives in the nearest enclosing composable that owns the
+ * departure list (e.g. [DepartureBoardCard] or `DepartureBoardStopContent`).
+ *
+ * @param departures    Full (unfiltered) departure list — only used to derive unique lines.
+ * @param selectedLine  The currently active filter line number, or `null` for "show all".
+ * @param onLineSelect Called with the tapped line number, or `null` when toggling off.
+ */
+@Composable
+internal fun LinesServedRow(
+    departures: ImmutableList<StopDeparture>,
+    selectedLine: String?,
+    onLineSelect: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val uniqueLines = remember(departures) {
+        departures.distinctBy { it.lineNumber }
+    }
+
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier.padding(bottom = 12.dp),
+    ) {
+        items(uniqueLines, key = { it.lineNumber }) { departure ->
+            val isSelected = selectedLine == departure.lineNumber
+            TransportModeBadge(
+                badgeText = departure.lineNumber,
+                backgroundColor = departure.lineColorCode.hexToComposeColor(),
+                size = BadgeSize.Large,
+                selected = isSelected,
+                onClick = {
+                    onLineSelect(if (isSelected) null else departure.lineNumber)
+                },
+            )
+        }
+    }
+}
+
+// region Previews
+
+private const val TRANSPORT_MODE_TRAIN = "Train"
+
+private val previewDepartures: ImmutableList<StopDeparture> = persistentListOf(
+    StopDeparture(
+        lineNumber = "T1",
+        lineColorCode = "#F99D1C",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Liverpool",
+        departureTimeText = "11:30 AM",
+        departureUtcDateTime = "2026-04-11T01:30:00Z",
+    ),
+    StopDeparture(
+        lineNumber = "T2",
+        lineColorCode = "#0098CD",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Bondi Junction",
+        departureTimeText = "11:33 AM",
+        departureUtcDateTime = "2026-04-11T01:33:00Z",
+    ),
+    StopDeparture(
+        lineNumber = "T4",
+        lineColorCode = "#005AA3",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Illawarra",
+        departureTimeText = "11:36 AM",
+        departureUtcDateTime = "2026-04-11T01:36:00Z",
+    ),
+)
+
+@Preview(name = "No filter active")
+@Composable
+private fun LinesServedRowNoFilterPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        LinesServedRow(
+            departures = previewDepartures,
+            selectedLine = null,
+            onLineSelect = {},
+        )
+    }
+}
+
+@Preview(name = "T2 selected")
+@Composable
+private fun LinesServedRowSelectedPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        LinesServedRow(
+            departures = previewDepartures,
+            selectedLine = "T2",
+            onLineSelect = {},
+        )
+    }
+}
+
+// endregion

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TransportModeBadge.kt
@@ -1,16 +1,30 @@
+@file:Suppress("MatchingDeclarationName")
+
 package xyz.ksharma.krail.trip.planner.ui.components
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalContentAlpha
@@ -18,33 +32,121 @@ import xyz.ksharma.krail.taj.LocalTextColor
 import xyz.ksharma.krail.taj.LocalTextStyle
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens
 
+/**
+ * Sizes available for [TransportModeBadge].
+ *
+ * - [Small] — default, used inside departure rows (tight padding, no min-width constraint).
+ * - [Large] — ~1.5× larger, used in the "Services at this stop" filter row where the badge
+ *   must also meet accessibility touch-target guidelines (min width 44 dp).
+ */
+enum class BadgeSize { Small, Large }
+
+private val badgeShape = RoundedCornerShape(percent = 20)
+
+// Match InfoTile glow parameters for visual consistency across the app.
+private val GLOW_RADIUS = 3.dp
+private val GLOW_SPREAD = 1.dp
+
+/**
+ * Coloured pill badge showing a transport line number (e.g. "T1", "333", "F1").
+ *
+ * When [selected] is `true` the badge animates with:
+ *  - A spring-bounced scale-up (1.0 → 1.15) so it "pops" into focus.
+ *  - A [dropShadow] glow whose colour matches the line's own colour — same technique
+ *    used by InfoTile, so the effect is consistent across the app.
+ *    The glow alpha fades in/out with a short tween.
+ *
+ * @param badgeText       Short line identifier shown on the badge.
+ * @param backgroundColor Hex-derived colour for the badge background.
+ * @param size            [BadgeSize.Small] (default) or [BadgeSize.Large] for filter rows.
+ * @param selected        When `true`, triggers the scale + glow animation.
+ * @param onClick         Optional tap handler. When non-null the badge is clickable.
+ */
 @Composable
 fun TransportModeBadge(
     badgeText: String,
     backgroundColor: Color,
     modifier: Modifier = Modifier,
+    size: BadgeSize = BadgeSize.Small,
+    selected: Boolean = false,
+    onClick: (() -> Unit)? = null,
 ) {
+    val paddingValues: PaddingValues = when (size) {
+        BadgeSize.Small -> PaddingValues(horizontal = 4.dp, vertical = 2.dp)
+        BadgeSize.Large -> PaddingValues(horizontal = 10.dp, vertical = 7.dp)
+    }
+
+    // Scale: spring-bounced so selection "pops" with a satisfying physical feel.
+    val scale by animateFloatAsState(
+        targetValue = if (selected) 1.15f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium,
+        ),
+        label = "badge-scale",
+    )
+
+    // Glow alpha: fades the coloured dropShadow in/out smoothly.
+    val glowAlpha by animateFloatAsState(
+        targetValue = if (selected) 1f else 0f,
+        animationSpec = tween(durationMillis = 200),
+        label = "badge-glow-alpha",
+    )
+
     CompositionLocalProvider(
         LocalTextColor provides Color.White,
         LocalTextStyle provides KrailTheme.typography.titleMedium,
-        // Alpha should always be 100%
         LocalContentAlpha provides ContentAlphaTokens.EnabledContentAlpha,
     ) {
         Box(
             modifier = modifier
-                .clip(shape = RoundedCornerShape(percent = 20))
-                .background(color = backgroundColor),
+                .then(if (size == BadgeSize.Large) Modifier.widthIn(min = 44.dp) else Modifier)
+                // Scale outermost so glow and clip both scale with the badge.
+                .graphicsLayer {
+                    scaleX = scale
+                    scaleY = scale
+                }
+                // dropShadow before clip — same pattern as InfoTile.
+                // Uses the line's own colour as the glow colour for an on-brand feel.
+                .dropShadow(
+                    shape = badgeShape,
+                    shadow = Shadow(
+                        radius = GLOW_RADIUS,
+                        color = backgroundColor,
+                        spread = GLOW_SPREAD,
+                        alpha = glowAlpha,
+                    ),
+                )
+                .clip(badgeShape)
+                .border(
+                    width = 1.dp,
+                    color = Color.White.copy(alpha = glowAlpha * 0.45f),
+                    shape = badgeShape,
+                )
+                .background(backgroundColor)
+                .then(
+                    if (onClick != null) {
+                        Modifier.clickable(
+                            indication = null,
+                            interactionSource = null,
+                            onClick = onClick,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = badgeText,
                 color = Color.White,
                 modifier = Modifier
-                    .padding(horizontal = 4.dp, vertical = 2.dp)
+                    .padding(paddingValues)
                     .wrapContentWidth(),
             )
         }
@@ -75,13 +177,28 @@ private fun TransportModeBadgeTrainPreview() {
     }
 }
 
-@Preview
+@PreviewComponent
 @Composable
-private fun TransportModeBadgeFerryPreview() {
+private fun TransportModeBadgeLargePreview() {
     PreviewTheme {
         TransportModeBadge(
-            badgeText = "F1",
-            backgroundColor = "#5AB031".hexToComposeColor(),
+            badgeText = "T1",
+            backgroundColor = "#F99D1C".hexToComposeColor(),
+            size = BadgeSize.Large,
+        )
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun TransportModeBadgeLargeSelectedPreview() {
+    PreviewTheme {
+        TransportModeBadge(
+            badgeText = "T1",
+            backgroundColor = "#F99D1C".hexToComposeColor(),
+            size = BadgeSize.Large,
+            selected = true,
+            onClick = {},
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardExt.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardExt.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.krail.trip.planner.ui.departureboard
+
+import xyz.ksharma.krail.core.transport.TransportMode
+
+/**
+ * Maps a [String] transport mode name (e.g. [StopDeparture.transportModeName])
+ * to the corresponding [TransportMode] sealed class instance.
+ *
+ * Drives the lookup from [TransportMode.all] so no hardcoded strings are needed —
+ * adding a new mode to the sealed class automatically makes it resolvable here.
+ *
+ * Returns `null` for unknown or unrecognised mode names.
+ */
+fun String.toTransportMode(): TransportMode? =
+    TransportMode.all.firstOrNull { it.name.equals(trim(), ignoreCase = true) }
+
+/**
+ * Returns the single uppercase initial of the transport mode name for use inside
+ * the [TransportModeLineBadge] circle.
+ *
+ * Examples: `"Train"` → `"T"`, `"Bus"` → `"B"`, `"Light Rail"` → `"L"`
+ */
+fun String.toTransportModeInitial(): String = trim().firstOrNull()?.uppercaseChar()?.toString() ?: "?"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -1,0 +1,378 @@
+@file:Suppress("MagicNumber", "TooManyFunctions")
+
+package xyz.ksharma.krail.trip.planner.ui.departureboard
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_arrow_down
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
+import xyz.ksharma.krail.taj.components.Divider
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.CardShape
+import xyz.ksharma.krail.taj.modifier.cardBackground
+import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.components.DepartureRowList
+import xyz.ksharma.krail.trip.planner.ui.components.LinesServedRow
+import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.StopDepartureBoardEntry
+
+// ── LazyListScope extension ───────────────────────────────────────────────────
+
+/**
+ * Adds a stop accordion section as two stable [LazyListScope] items:
+ *  - `"${stopId}_header"` — sticky tappable card
+ *  - `"${stopId}_content"` — collapsible content with services row + departure list
+ *
+ * The content item hosts [DepartureBoardStopContent] which owns the per-stop filter state.
+ * Filter state naturally resets when the item collapses because [remember] is keyed to the
+ * item's composition lifetime.
+ */
+fun LazyListScope.departureBoardStopSection(
+    entry: StopDepartureBoardEntry,
+    isExpanded: Boolean,
+    onExpandChange: (Boolean) -> Unit,
+) {
+    stickyHeader(key = "${entry.stopId}_header", contentType = "stop_header") {
+        DepartureBoardStopSectionHeader(
+            entry = entry,
+            isExpanded = isExpanded,
+            onExpandChange = onExpandChange,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
+    }
+
+    if (isExpanded) {
+        item(key = "${entry.stopId}_content", contentType = "stop_content") {
+            DepartureBoardStopContent(
+                state = entry.state,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+// ── Header card composable ────────────────────────────────────────────────────
+
+/**
+ * The tappable header card for a stop section.
+ * Shared by [departureBoardStopSection] (lazy use) and [DepartureBoardStopSection] (preview use).
+ */
+@Composable
+internal fun DepartureBoardStopSectionHeader(
+    entry: StopDepartureBoardEntry,
+    isExpanded: Boolean,
+    onExpandChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val arrowRotation by animateFloatAsState(
+        targetValue = if (isExpanded) 180f else 0f,
+        animationSpec = tween(durationMillis = 300),
+        label = "arrow-rotation",
+    )
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .background(color = KrailTheme.colors.surface, shape = CardShape)
+            .cardBackground()
+            .klickable { onExpandChange(!isExpanded) }
+            .padding(horizontal = 16.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = entry.stopName,
+            style = KrailTheme.typography.titleMedium,
+            color = KrailTheme.colors.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (isExpanded && entry.state.silentLoading) {
+                AnimatedDots(
+                    modifier = Modifier.size(width = 32.dp, height = 16.dp),
+                    color = KrailTheme.colors.softLabel,
+                )
+            }
+
+            Image(
+                painter = painterResource(Res.drawable.ic_arrow_down),
+                contentDescription = if (isExpanded) "Collapse" else "Expand",
+                colorFilter = ColorFilter.tint(KrailTheme.colors.softLabel),
+                modifier = Modifier.size(18.dp).rotate(arrowRotation),
+            )
+        }
+    }
+}
+
+// ── Content composable ────────────────────────────────────────────────────────
+
+/**
+ * Content area for an expanded stop section.
+ *
+ * Owns the per-stop line filter state locally. Filter resets automatically when this
+ * composable leaves composition (i.e. when the section collapses), so re-expanding
+ * always starts with all services shown.
+ */
+@Composable
+private fun DepartureBoardStopContent(
+    state: DeparturesState,
+    modifier: Modifier = Modifier,
+) {
+    // Empty string = no filter. Non-null String is guaranteed safe through rememberSaveable
+    // (Bundle / SavedStateHandle only reliably round-trip primitives and String).
+    var selectedLineKey by rememberSaveable { mutableStateOf("") }
+    val selectedLine: String? = selectedLineKey.ifEmpty { null }
+
+    val filteredDepartures = remember(state.departures, selectedLine) {
+        if (selectedLine == null) {
+            state.departures
+        } else {
+            state.departures.filter { it.lineNumber == selectedLine }.toImmutableList()
+        }
+    }
+
+    Column(modifier = modifier) {
+        when {
+            state.isLoading -> SectionLoadingContent()
+            state.isError -> SectionErrorContent()
+            state.departures.isEmpty() -> SectionEmptyContent(hasActiveFilter = false)
+            else -> {
+                LinesServedRow(
+                    departures = state.departures,
+                    selectedLine = selectedLine,
+                    onLineSelect = { selectedLineKey = it ?: "" },
+                )
+                Divider(modifier = Modifier.padding(horizontal = 12.dp))
+                when {
+                    filteredDepartures.isEmpty() -> SectionEmptyContent(hasActiveFilter = true)
+                    else -> DepartureRowList(departures = filteredDepartures)
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+}
+
+// ── Standalone composable (previews only) ────────────────────────────────────
+
+/**
+ * Accordion section for a single stop. Uses a plain [Column] layout.
+ * Intended for standalone Compose Previews — the production saved trips screen uses
+ * [departureBoardStopSection] instead for per-item lazy list keys.
+ */
+@Composable
+fun DepartureBoardStopSection(
+    entry: StopDepartureBoardEntry,
+    isExpanded: Boolean,
+    onExpandChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        DepartureBoardStopSectionHeader(
+            entry = entry,
+            isExpanded = isExpanded,
+            onExpandChange = onExpandChange,
+        )
+
+        if (isExpanded) {
+            Column(modifier = Modifier.background(KrailTheme.colors.surface)) {
+                DepartureBoardStopContent(state = entry.state)
+            }
+        }
+    }
+}
+
+// ── Private content slots ─────────────────────────────────────────────────────
+
+@Composable
+private fun SectionLoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedDots(
+            modifier = Modifier.size(width = 64.dp, height = 24.dp),
+            color = KrailTheme.colors.onSurface,
+        )
+    }
+}
+
+@Composable
+private fun SectionErrorContent() {
+    Text(
+        text = "Couldn't load departures. Collapse and re-expand to retry.",
+        style = KrailTheme.typography.bodyMedium,
+        color = KrailTheme.colors.softLabel,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+    )
+}
+
+@Composable
+private fun SectionEmptyContent(hasActiveFilter: Boolean) {
+    Text(
+        text = if (hasActiveFilter) {
+            "No departures match the selected line."
+        } else {
+            "No upcoming departures found."
+        },
+        style = KrailTheme.typography.bodyMedium,
+        color = KrailTheme.colors.softLabel,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+    )
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+private const val TRANSPORT_MODE_TRAIN = "Train"
+private const val TRANSPORT_MODE_BUS = "Bus"
+
+private val previewTrainDepartures: ImmutableList<StopDeparture> = persistentListOf(
+    StopDeparture(
+        lineNumber = "T1",
+        lineColorCode = "#F99D1C",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Liverpool via Strathfield",
+        departureTimeText = "11:30 AM",
+        departureUtcDateTime = "2026-04-08T01:30:00Z",
+        platformText = "Platform 4",
+        isRealTime = true,
+    ),
+    StopDeparture(
+        lineNumber = "T2",
+        lineColorCode = "#0098CD",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Bondi Junction",
+        departureTimeText = "11:33 AM",
+        departureUtcDateTime = "2026-04-08T01:33:00Z",
+        platformText = "Platform 7",
+        isRealTime = false,
+    ),
+)
+
+private val previewMixedDepartures: ImmutableList<StopDeparture> = persistentListOf(
+    StopDeparture(
+        lineNumber = "T1",
+        lineColorCode = "#F99D1C",
+        transportModeName = TRANSPORT_MODE_TRAIN,
+        destinationName = "Liverpool via Strathfield",
+        departureTimeText = "11:30 AM",
+        departureUtcDateTime = "2026-04-08T01:30:00Z",
+        platformText = "Platform 4",
+        isRealTime = true,
+    ),
+    StopDeparture(
+        lineNumber = "333",
+        lineColorCode = "#00B5EF",
+        transportModeName = TRANSPORT_MODE_BUS,
+        destinationName = "Parramatta",
+        departureTimeText = "11:35 AM",
+        departureUtcDateTime = "2026-04-08T01:35:00Z",
+        platformText = "Stand A",
+        isRealTime = false,
+    ),
+)
+
+@PreviewComponent
+@Composable
+private fun DepartureBoardStopSectionCollapsedPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        DepartureBoardStopSection(
+            entry = StopDepartureBoardEntry(
+                stopId = "10111010",
+                stopName = "Toongabbie Station",
+                state = DeparturesState(isLoading = false, departures = previewTrainDepartures),
+            ),
+            isExpanded = false,
+            onExpandChange = {},
+        )
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun DepartureBoardStopSectionExpandedTrainPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        DepartureBoardStopSection(
+            entry = StopDepartureBoardEntry(
+                stopId = "10111010",
+                stopName = "Toongabbie Station",
+                state = DeparturesState(isLoading = false, departures = previewTrainDepartures),
+            ),
+            isExpanded = true,
+            onExpandChange = {},
+        )
+    }
+}
+
+@Preview(name = "Expanded — mixed modes")
+@Composable
+private fun DepartureBoardStopSectionMixedPreview() {
+    PreviewTheme(KrailThemeStyle.Bus) {
+        DepartureBoardStopSection(
+            entry = StopDepartureBoardEntry(
+                stopId = "10111010",
+                stopName = "Central Station",
+                state = DeparturesState(isLoading = false, departures = previewMixedDepartures),
+            ),
+            isExpanded = true,
+            onExpandChange = {},
+        )
+    }
+}
+
+@Preview(name = "Loading state")
+@Composable
+private fun DepartureBoardStopSectionLoadingPreview() {
+    PreviewTheme(KrailThemeStyle.Train) {
+        DepartureBoardStopSection(
+            entry = StopDepartureBoardEntry(
+                stopId = "10111010",
+                stopName = "Toongabbie Station",
+                state = DeparturesState(isLoading = true),
+            ),
+            isExpanded = true,
+            onExpandChange = {},
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/LineBadgeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/LineBadgeChip.kt
@@ -1,0 +1,147 @@
+package xyz.ksharma.krail.trip.planner.ui.departureboard
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.getForegroundColor
+
+private val chipShape = RoundedCornerShape(8.dp)
+private val chipMinHeight = 44.dp
+private val chipMinWidth = 44.dp
+
+/**
+ * A tappable, selectable chip that displays a transport line number using [lineColorCode].
+ *
+ * Intended for per-line departure filtering (Option C, see [DepartureBoardFilterStrategy]).
+ * Built today so the component is ready; the filter wiring will be added when Option C is enabled.
+ *
+ * Selected state:  solid [lineColorCode] background, accessible foreground text.
+ * Unselected state: transparent background, [lineColorCode] border and text.
+ *
+ * Touch target is at minimum [chipMinHeight] × [chipMinWidth] (44 × 44 dp) to satisfy
+ * accessibility guidelines.
+ *
+ * @param lineNumber   Short line identifier shown on the chip — "T1", "333", "F1".
+ * @param lineColorCode Hex colour code for the line, e.g. "#F99D1C".
+ * @param selected      Whether this chip is currently active.
+ * @param onClick       Invoked when the chip is tapped.
+ */
+@Composable
+fun LineBadgeChip(
+    lineNumber: String,
+    lineColorCode: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val lineColor = remember(lineColorCode) { lineColorCode.hexToComposeColor() }
+
+    val backgroundColor by animateColorAsState(
+        targetValue = if (selected) lineColor else Color.Transparent,
+        animationSpec = tween(durationMillis = 200),
+        label = "LineBadgeChip-bg",
+    )
+    val borderColor by animateColorAsState(
+        targetValue = if (selected) Color.Transparent else lineColor,
+        animationSpec = tween(durationMillis = 200),
+        label = "LineBadgeChip-border",
+    )
+    val textColor by animateColorAsState(
+        targetValue = if (selected) getForegroundColor(lineColor) else lineColor,
+        animationSpec = tween(durationMillis = 200),
+        label = "LineBadgeChip-text",
+    )
+
+    Box(
+        modifier = modifier
+            .heightIn(min = chipMinHeight)
+            .widthIn(min = chipMinWidth)
+            .clip(chipShape)
+            .background(backgroundColor)
+            .border(width = 2.dp, color = borderColor, shape = chipShape)
+            .clickable(indication = null, interactionSource = null, onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = lineNumber,
+            color = textColor,
+            style = KrailTheme.typography.titleMedium,
+        )
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@PreviewComponent
+@Composable
+private fun LineBadgeChipSelectedPreview() {
+    PreviewTheme {
+        LineBadgeChip(
+            lineNumber = "T1",
+            lineColorCode = "#F99D1C",
+            selected = true,
+            onClick = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LineBadgeChipUnselectedPreview() {
+    PreviewTheme {
+        LineBadgeChip(
+            lineNumber = "T1",
+            lineColorCode = "#F99D1C",
+            selected = false,
+            onClick = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LineBadgeChipBusSelectedPreview() {
+    PreviewTheme {
+        LineBadgeChip(
+            lineNumber = "333",
+            lineColorCode = "#00B5EF",
+            selected = true,
+            onClick = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LineBadgeChipBusUnselectedPreview() {
+    PreviewTheme {
+        LineBadgeChip(
+            lineNumber = "333",
+            lineColorCode = "#00B5EF",
+            selected = false,
+            onClick = {},
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/TransportModeLineBadge.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/TransportModeLineBadge.kt
@@ -1,0 +1,139 @@
+@file:Suppress("MagicNumber")
+
+package xyz.ksharma.krail.trip.planner.ui.departureboard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.LocalContentAlpha
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.tokens.ContentAlphaTokens
+
+/**
+ * A single pill-shaped badge that shows both the transport mode initial and the line number.
+ *
+ * Visual layout:
+ * ```
+ * ┌──────────────┐
+ * │  ●T  │  T1  │
+ * └──────────────┘
+ * ```
+ * The left circle uses a semi-transparent dark overlay on [lineColorCode] to differentiate
+ * the mode initial from the line number while keeping a single colour palette.
+ *
+ * This component replaces the plain [TransportModeBadge] inside [DepartureRow] so that
+ * the transport mode is always visible alongside the line number without extra layout space.
+ *
+ * @param transportModeInitial Single uppercase letter for the mode — "T", "B", "M", "F", "L".
+ *                             Derive via [String.toTransportModeInitial].
+ * @param lineNumber           Short line identifier — "T1", "333", "F1", "M".
+ * @param lineColorCode        Hex colour code for the badge background, e.g. "#F99D1C".
+ */
+@Composable
+fun TransportModeLineBadge(
+    transportModeInitial: String,
+    lineNumber: String,
+    lineColorCode: String,
+    modifier: Modifier = Modifier,
+) {
+    val lineColor = remember(lineColorCode) { lineColorCode.hexToComposeColor() }
+
+    CompositionLocalProvider(LocalContentAlpha provides ContentAlphaTokens.EnabledContentAlpha) {
+        Row(
+            modifier = modifier
+                .clip(RoundedCornerShape(percent = 20))
+                .background(lineColor),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Mode initial in a darkened overlay circle
+            Box(
+                modifier = Modifier
+                    .padding(3.dp)
+                    .size(22.dp)
+                    .clip(CircleShape)
+                    .background(Color.Black.copy(alpha = 0.25f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = transportModeInitial,
+                    color = Color.White,
+                    style = KrailTheme.typography.titleSmall,
+                )
+            }
+            // Line number
+            Text(
+                text = lineNumber,
+                color = Color.White,
+                style = KrailTheme.typography.titleMedium,
+                modifier = Modifier.padding(start = 4.dp, end = 6.dp),
+            )
+        }
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@PreviewComponent
+@Composable
+private fun TransportModeLineBadgeTrainPreview() {
+    PreviewTheme {
+        TransportModeLineBadge(
+            transportModeInitial = "T",
+            lineNumber = "T1",
+            lineColorCode = "#F99D1C",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TransportModeLineBadgeBusPreview() {
+    PreviewTheme {
+        TransportModeLineBadge(
+            transportModeInitial = "B",
+            lineNumber = "333",
+            lineColorCode = "#00B5EF",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TransportModeLineBadgeFerryPreview() {
+    PreviewTheme {
+        TransportModeLineBadge(
+            transportModeInitial = "F",
+            lineNumber = "F1",
+            lineColorCode = "#00774B",
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TransportModeLineBadgeMetroPreview() {
+    PreviewTheme {
+        TransportModeLineBadge(
+            transportModeInitial = "M",
+            lineNumber = "M",
+            lineColorCode = "#009B77",
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -13,6 +13,7 @@ import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewModel
 import xyz.ksharma.krail.trip.planner.ui.discover.DiscoverViewModel
 import xyz.ksharma.krail.trip.planner.ui.intro.IntroViewModel
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.DepartureBoardViewModel
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.InviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.RealInviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
@@ -106,6 +107,8 @@ val viewModelsModule = module {
             ioDispatcher = get(named(IODispatcher)),
         )
     }
+
+    viewModelOf(::DepartureBoardViewModel)
 
     single<InviteFriendsTileManager> { RealInviteFriendsTileManager(get()) }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.navigation.entries
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
@@ -13,6 +14,7 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.DepartureBoardViewModel
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsScreen
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -32,6 +34,14 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
         // Scoped ViewModel that survives navigation
         val viewModel: SavedTripsViewModel = koinViewModel(key = "SavedTripsNav")
         val savedTripState by viewModel.uiState.collectAsStateWithLifecycle()
+
+        val departureBoardViewModel: DepartureBoardViewModel = koinViewModel()
+        val departureBoardEntries by departureBoardViewModel.entries.collectAsStateWithLifecycle()
+        val expandedDepartureBoardStopId by departureBoardViewModel.expandedStopId.collectAsStateWithLifecycle()
+
+        LaunchedEffect(savedTripState.savedTrips) {
+            departureBoardViewModel.setTrips(savedTripState.savedTrips)
+        }
 
         // Listen for StopSelected results from SearchStop screen
         // This uses the singleton ResultEventBus to ensure results are received
@@ -112,6 +122,10 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
             },
             onEvent = { event -> viewModel.onEvent(event) },
             onInviteFriendsTileDisplay = { viewModel.markInviteFriendsTileAsSeen() },
+            departureBoardEntries = departureBoardEntries,
+            expandedDepartureBoardStopId = expandedDepartureBoardStopId,
+            onDepartureBoardExpand = departureBoardViewModel::onCardExpand,
+            onDepartureBoardCollapse = departureBoardViewModel::onCardCollapse,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
@@ -1,0 +1,118 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import xyz.ksharma.krail.departures.ui.DepartureBoardRepository
+import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+
+/**
+ * Represents a single stop entry in the Departure Board section of the saved trips screen.
+ *
+ * @param stopId NSW Transport stop ID.
+ * @param stopName Human-readable stop name.
+ * @param state Current departure state for this stop, updated by [DepartureBoardRepository].
+ */
+data class StopDepartureBoardEntry(
+    val stopId: String,
+    val stopName: String,
+    val state: DeparturesState,
+)
+
+/**
+ * ViewModel for the Departure Board section on the saved trips screen.
+ *
+ * Manages an accordion: at most one card is expanded at a time. Expanding a card
+ * delegates to [DepartureBoardRepository.setActiveStop], which enforces the single
+ * polling loop constraint across the whole app.
+ */
+class DepartureBoardViewModel(
+    private val repository: DepartureBoardRepository,
+) : ViewModel() {
+
+    // Unique stops derived from the saved trips list (both from- and to-stops, deduplicated).
+    private val _stops = MutableStateFlow<List<Pair<String, String>>>(emptyList())
+
+    private val _expandedStopId = MutableStateFlow<String?>(null)
+
+    /** The stop ID of the currently expanded card, or `null` if all cards are collapsed. */
+    val expandedStopId: StateFlow<String?> = _expandedStopId.asStateFlow()
+
+    /**
+     * One entry per unique stop from the saved trips list.
+     * Each entry's [StopDepartureBoardEntry.state] is kept live via [DepartureBoardRepository].
+     */
+    val entries: StateFlow<ImmutableList<StopDepartureBoardEntry>> = _stops
+        .flatMapLatest { stops ->
+            if (stops.isEmpty()) {
+                flowOf(persistentListOf())
+            } else {
+                combine(
+                    stops.map { (stopId, stopName) ->
+                        repository.observeStop(stopId).map { state ->
+                            StopDepartureBoardEntry(
+                                stopId = stopId,
+                                stopName = stopName,
+                                state = state,
+                            )
+                        }
+                    },
+                ) { array -> array.toList().toImmutableList() }
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = persistentListOf(),
+        )
+
+    /**
+     * Updates the stop list derived from [trips].
+     *
+     * Both the from- and to-stop of each trip are included; duplicates are removed
+     * by stop ID so each stop appears at most once.
+     */
+    fun setTrips(trips: ImmutableList<Trip>) {
+        val uniqueStops = trips
+            .flatMap { trip ->
+                listOf(
+                    trip.fromStopId to trip.fromStopName,
+                    trip.toStopId to trip.toStopName,
+                )
+            }
+            .distinctBy { it.first }
+        _stops.value = uniqueStops
+    }
+
+    /** Expands the card for [stopId], collapsing any previously open card instantly. */
+    fun onCardExpand(stopId: String) {
+        if (_expandedStopId.value == stopId) return
+        _expandedStopId.value?.let { repository.stopIfActive(it) }
+        _expandedStopId.value = stopId
+        repository.setActiveStop(stopId)
+    }
+
+    /** Collapses the currently open card and stops polling. */
+    fun onCardCollapse() {
+        val current = _expandedStopId.value ?: return
+        repository.stopIfActive(current)
+        _expandedStopId.value = null
+    }
+
+    override fun onCleared() {
+        _expandedStopId.value?.let { repository.stopIfActive(it) }
+        super.onCleared()
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
@@ -94,6 +94,14 @@ class DepartureBoardViewModel(
             }
             .distinctBy { it.first }
         _stops.value = uniqueStops
+
+        // If the expanded stop is no longer in the new stop list (e.g. the trip was deleted),
+        // stop polling and collapse the card so no dangling background fetch continues.
+        val expandedId = _expandedStopId.value
+        if (expandedId != null && uniqueStops.none { it.first == expandedId }) {
+            repository.stopIfActive(expandedId)
+            _expandedStopId.value = null
+        }
     }
 
     /** Expands the card for [stopId], collapsing any previously open card instantly. */

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,3 +1,5 @@
+@file:Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
+
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import androidx.compose.animation.AnimatedVisibility
@@ -34,6 +36,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_settings
 import org.jetbrains.compose.resources.painterResource
@@ -54,6 +57,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
+import xyz.ksharma.krail.trip.planner.ui.departureboard.departureBoardStopSection
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -71,6 +75,10 @@ fun SavedTripsScreen(
     onDiscoverButtonClick: () -> Unit = {},
     onEvent: (SavedTripUiEvent) -> Unit = {},
     onInviteFriendsTileDisplay: () -> Unit = {},
+    departureBoardEntries: ImmutableList<StopDepartureBoardEntry> = persistentListOf(),
+    expandedDepartureBoardStopId: String? = null,
+    onDepartureBoardExpand: (String) -> Unit = {},
+    onDepartureBoardCollapse: () -> Unit = {},
 ) {
     val emptyStateTip = remember {
         buildList {
@@ -119,9 +127,7 @@ fun SavedTripsScreen(
                 contentPadding = PaddingValues(bottom = 300.dp),
             ) {
                 when {
-                    savedTripsState.isSavedTripsLoading -> {
-                        Unit // display nothing while loading
-                    }
+                    savedTripsState.isSavedTripsLoading -> Unit
 
                     savedTripsState.savedTrips.isEmpty() -> {
                         savedTripsState.infoTiles?.let { infoTiles ->
@@ -194,7 +200,7 @@ fun SavedTripsScreen(
                                             "with friends and help Sydney ride better.",
                                         primaryCta = InfoTileCta(
                                             text = "Invite",
-                                            url = null, // Using nullable url from this version
+                                            url = null,
                                         ),
                                         type = InfoTileData.InfoTileType.INVITE_FRIENDS,
                                         showDismissButton = false,
@@ -224,6 +230,10 @@ fun SavedTripsScreen(
                             onEvent = onEvent,
                             onSavedTripCardClick = onSavedTripCardClick,
                             expandedMap = expandedMap,
+                            departureBoardEntries = departureBoardEntries,
+                            expandedDepartureBoardStopId = expandedDepartureBoardStopId,
+                            onDepartureBoardExpand = onDepartureBoardExpand,
+                            onDepartureBoardCollapse = onDepartureBoardCollapse,
                         )
                     }
                 }
@@ -256,7 +266,7 @@ private fun LazyListScope.infoTiles(
         AnimatedVisibility(
             visible = visible,
             exit = slideOutHorizontally(
-                targetOffsetX = { it }, // slide fully to the right
+                targetOffsetX = { it },
                 animationSpec = tween(300),
             ),
         ) {
@@ -279,6 +289,10 @@ private fun LazyListScope.savedTripsContent(
     onEvent: (SavedTripUiEvent) -> Unit,
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     expandedMap: SnapshotStateMap<String, Boolean>,
+    departureBoardEntries: ImmutableList<StopDepartureBoardEntry>,
+    expandedDepartureBoardStopId: String?,
+    onDepartureBoardExpand: (String) -> Unit,
+    onDepartureBoardCollapse: () -> Unit,
 ) {
     stickyHeader(key = "saved_trips_title") {
         SavedTripsTitle {
@@ -344,8 +358,26 @@ private fun LazyListScope.savedTripsContent(
 
             Spacer(modifier = Modifier.height(16.dp))
         }
+    }
 
-        item(key = "park_ride_spacer_bottom") {
+    if (departureBoardEntries.isNotEmpty()) {
+        stickyHeader(key = "departure_board_title") {
+            SavedTripsTitle {
+                Text(text = "Departure Board")
+            }
+        }
+
+        departureBoardEntries.forEach { entry ->
+            departureBoardStopSection(
+                entry = entry,
+                isExpanded = expandedDepartureBoardStopId == entry.stopId,
+                onExpandChange = { expand ->
+                    if (expand) onDepartureBoardExpand(entry.stopId) else onDepartureBoardCollapse()
+                },
+            )
+        }
+
+        item(key = "departure_board_bottom_spacer") {
             Spacer(modifier = Modifier.height(24.dp))
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
@@ -10,17 +10,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
+import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.departures.ui.DeparturesViewModel
 import xyz.ksharma.krail.park.ride.ui.components.ParkAndRideIcon
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardCard
 import xyz.ksharma.krail.trip.planner.ui.components.map.StopActionButton
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
 import xyz.ksharma.krail.trip.planner.ui.components.map.StopDetailsBottomSheet as SharedStopDetailsBottomSheet
@@ -36,6 +41,13 @@ fun StopDetailsBottomSheet(
     onSelectStop: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val departuresViewModel = koinViewModel<DeparturesViewModel>()
+    val departuresState by departuresViewModel.uiState.collectAsStateWithLifecycle()
+    // Collecting isActive keeps the relative-time tick loop alive (WhileSubscribed).
+
+    @Suppress("UNUSED_VARIABLE")
+    val isActive by departuresViewModel.isActive.collectAsStateWithLifecycle()
+
     SharedStopDetailsBottomSheet(
         stopId = stop.stopId,
         stopName = stop.stopName,
@@ -43,6 +55,15 @@ fun StopDetailsBottomSheet(
         onDismiss = onDismiss,
         modifier = modifier,
         additionalInfo = {
+            DepartureBoardCard(
+                stopId = stop.stopId,
+                state = departuresState,
+                onEvent = departuresViewModel::onEvent,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             // Parking section (if available)
             if (stop.hasParkAndRide) {
                 ParkingInfoSection(modifier = Modifier.padding(horizontal = 16.dp))

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -19,9 +19,9 @@ val md_theme_light_discover_chip_background = Color(0xFFF5F5F5)
 val md_theme_light_discover_card_background = Color(0xFFF5F5F5)
 
 // Light theme (Deviations colors)
-val md_theme_light_onTime = Color(0xFF31DB39)
-val md_theme_light_early = Color(0xFFFFC60F)
-val md_theme_light_late = Color(0xFFF12525)
+val md_theme_light_onTime = Color(0xFF31DB39) // DELETE
+val md_theme_light_early = Color(0xFF008913)
+val md_theme_light_late = Color(0xFFE72020)
 
 // Future and past journey colors
 val md_theme_light_future_journey = Color(0xFF3A3A3A)
@@ -53,8 +53,8 @@ val md_theme_dark_discover_chip_background = Color(0xFF292929)
 val md_theme_dark_discover_card_background = Color(0xFF292929)
 
 // Dark theme (Deviations colors)
-val md_theme_dark_onTime = Color(0xFF31DB39)
-val md_theme_dark_early = Color(0xFFFFC60F)
+val md_theme_dark_onTime = Color(0xFF31DB39) // DELETE
+val md_theme_dark_early = Color(0xFF00B219)
 val md_theme_dark_late = Color(0xFFFF2B2B)
 
 // Future and past journey colors

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -19,7 +19,7 @@ val md_theme_light_discover_chip_background = Color(0xFFF5F5F5)
 val md_theme_light_discover_card_background = Color(0xFFF5F5F5)
 
 // Light theme (Deviations colors)
-val md_theme_light_onTime = Color(0xFF31DB39) // DELETE
+val md_theme_light_onTime = Color(0xFF31DB39)
 val md_theme_light_early = Color(0xFF008913)
 val md_theme_light_late = Color(0xFFE72020)
 
@@ -53,7 +53,7 @@ val md_theme_dark_discover_chip_background = Color(0xFF292929)
 val md_theme_dark_discover_card_background = Color(0xFF292929)
 
 // Dark theme (Deviations colors)
-val md_theme_dark_onTime = Color(0xFF31DB39) // DELETE
+val md_theme_dark_onTime = Color(0xFF31DB39)
 val md_theme_dark_early = Color(0xFF00B219)
 val md_theme_dark_late = Color(0xFFFF2B2B)
 


### PR DESCRIPTION
## Add departure board UI components and integration

### New UI components:
- **DepartureBoardCard** — expandable stop card with animated header, filter chip row, and departure list section
- **DepartureBoardStopSection** — accordion-style grouped list of departure rows with sticky headers for LazyColumn
- **DepartureRow** — individual departure display showing line badge, relative/absolute time, destination, platform, and delay indicators
- **LinesServedRow** — horizontal scrollable filter row with selectable transport line badges
- **DepartureDeviationIndicator** — colored dot + text showing early/late/on-time status
- **TransportModeBadge** — enhanced mode badge with spring-bounced selection animation and colored glow effect
- **LineBadgeChip** — tappable filter chip with animated selection states
- **TransportModeLineBadge** — combined mode initial + line number in single pill badge
- **DepartureBoardExt** — utility functions for transport mode mapping and string formatting

### Integration:
- **DepartureBoardViewModel** added to ViewModelModule and wired into SavedTripsEntry navigation
- **SavedTripsScreen** now displays departure board section below saved trips with accordion expansion
- **StopDetailsBottomSheet** shows live departures for selected map stops
- **Dependencies** added for departures state and UI modules in build.gradle.kts
- **Color tokens** updated with new deviation colors for early/late indicators