### PR TITLE
Add previous departures feature with API date/time formatting and accordion UI improvements

### DIFF
--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -126,7 +126,8 @@ object DateTimeHelper {
     }
 
     /**
-     * Formats an [Instant] as a date string in YYYYMMDD format in the AEST timezone.
+     * Formats an [Instant] as a date string in YYYYMMDD format in the Australia/Sydney timezone
+     * (observes DST — AEST in winter, AEDT in summer).
      * Used as the `date` parameter for NSW Transport API requests (e.g. "20260412").
      */
     @OptIn(ExperimentalTime::class)
@@ -138,7 +139,8 @@ object DateTimeHelper {
     }
 
     /**
-     * Formats an [Instant] as a time string in HHMM 24-hour format in the AEST timezone.
+     * Formats an [Instant] as a time string in HHMM 24-hour format in the Australia/Sydney
+     * timezone (observes DST — AEST in winter, AEDT in summer).
      * Used as the `time` parameter for NSW Transport API requests (e.g. "1430").
      */
     @OptIn(ExperimentalTime::class)

--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -125,6 +125,29 @@ object DateTimeHelper {
         } ?: false
     }
 
+    /**
+     * Formats an [Instant] as a date string in YYYYMMDD format in the AEST timezone.
+     * Used as the `date` parameter for NSW Transport API requests (e.g. "20260412").
+     */
+    @OptIn(ExperimentalTime::class)
+    fun Instant.toApiDateString(): String {
+        val local = this.toLocalDateTime(TimeZone.of(AEST_TIMEZONE))
+        return "${local.year}" +
+            local.monthNumber.toString().padStart(2, '0') +
+            local.dayOfMonth.toString().padStart(2, '0')
+    }
+
+    /**
+     * Formats an [Instant] as a time string in HHMM 24-hour format in the AEST timezone.
+     * Used as the `time` parameter for NSW Transport API requests (e.g. "1430").
+     */
+    @OptIn(ExperimentalTime::class)
+    fun Instant.toApiTimeString(): String {
+        val local = this.toLocalDateTime(TimeZone.of(AEST_TIMEZONE))
+        return local.hour.toString().padStart(2, '0') +
+            local.minute.toString().padStart(2, '0')
+    }
+
     @OptIn(ExperimentalTime::class)
     fun Instant.isBefore(other: Instant): Boolean = this < other
 
@@ -194,8 +217,10 @@ object DateTimeHelper {
         return runCatching {
             val aestZone = TimeZone.of(AEST_TIMEZONE)
             val today = Clock.System.now().toLocalDateTime(aestZone).date
+            val yesterday = today.plus(-1, DateTimeUnit.DAY)
             val tomorrow = today.plus(1, DateTimeUnit.DAY)
             when (val departureDate = Instant.parse(this).toLocalDateTime(aestZone).date) {
+                yesterday -> "Yesterday"
                 today -> "Today"
                 tomorrow -> "Tomorrow"
                 else -> {

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesState.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesState.kt
@@ -51,7 +51,7 @@ data class DeparturesState(
     val departures: ImmutableList<StopDeparture> = persistentListOf(),
 
     /**
-     * Departures that occurred in the past ~15 minutes.
+     * Departures that occurred in the past [previousWindowMinutes] minutes.
      * Empty until the user requests them via the "Show previous" toggle.
      * Preserved across regular refreshes so the user doesn't lose the data on auto-refresh.
      */

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesState.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesState.kt
@@ -49,4 +49,24 @@ data class DeparturesState(
      * The ordered list of upcoming departures. Empty during loading / error states.
      */
     val departures: ImmutableList<StopDeparture> = persistentListOf(),
+
+    /**
+     * Departures that occurred in the past ~15 minutes.
+     * Empty until the user requests them via the "Show previous" toggle.
+     * Preserved across regular refreshes so the user doesn't lose the data on auto-refresh.
+     */
+    val previousDepartures: ImmutableList<StopDeparture> = persistentListOf(),
+
+    /**
+     * True while a past-departures fetch is in flight after the user taps "Show previous".
+     */
+    val isPreviousLoading: Boolean = false,
+
+    /**
+     * How many minutes into the past the "Show previous" window covers.
+     * Set by the repository from [DepartureBoardConfig.previousDeparturesWindowMinutes] so
+     * the UI can display the correct number without hardcoding it. Will reflect remote-config
+     * overrides automatically once that wiring is in place.
+     */
+    val previousWindowMinutes: Long = 30L,
 )

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesUiEvent.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesUiEvent.kt
@@ -24,4 +24,12 @@ sealed interface DeparturesUiEvent {
      * to true while the refresh is in flight so the UI can show a subtle indicator.
      */
     data object Refresh : DeparturesUiEvent
+
+    /**
+     * Requests past departures (~15 min window) for [stopId].
+     *
+     * Results land in [DeparturesState.previousDepartures] and are shown when the
+     * user taps "Show previous" in the departure board UI.
+     */
+    data class LoadPreviousDepartures(val stopId: String) : DeparturesUiEvent
 }

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesUiEvent.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesUiEvent.kt
@@ -32,4 +32,12 @@ sealed interface DeparturesUiEvent {
      * user taps "Show previous" in the departure board UI.
      */
     data class LoadPreviousDepartures(val stopId: String) : DeparturesUiEvent
+
+    /**
+     * Stops the active polling loop for the current stop.
+     *
+     * Typically fired when the departure board card collapses in uncontrolled mode
+     * so no background fetches run while departures are not visible.
+     */
+    data object StopPolling : DeparturesUiEvent
 }

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/model/StopDeparture.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/model/StopDeparture.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Stable
  * Used by the UI to apply different visual treatments (e.g. dimmed alpha for past departures).
  */
 enum class DepartureTiming {
-    /** Departure occurred in the past (~15 min window, shown via "Show previous" toggle). */
+    /** Departure occurred in the past (configurable window, shown via "Show previous" toggle). */
     Previous,
 
     /** Departure is upcoming. Default for all normally fetched departures. */

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/model/StopDeparture.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/model/StopDeparture.kt
@@ -3,6 +3,18 @@ package xyz.ksharma.krail.departures.ui.state.model
 import androidx.compose.runtime.Stable
 
 /**
+ * Timing context for a departure row — whether it has already departed or is upcoming.
+ * Used by the UI to apply different visual treatments (e.g. dimmed alpha for past departures).
+ */
+enum class DepartureTiming {
+    /** Departure occurred in the past (~15 min window, shown via "Show previous" toggle). */
+    Previous,
+
+    /** Departure is upcoming. Default for all normally fetched departures. */
+    Upcoming,
+}
+
+/**
  * A single upcoming departure from a stop, ready for display in the UI.
  *
  * This is a lean, UI-focused model derived from [DepartureMonitorResponse.StopEvent].
@@ -109,4 +121,11 @@ data class StopDeparture(
      * Null when either field is missing from the API response.
      */
     val tripId: String? = null,
+
+    /**
+     * Whether this departure is a past departure (shown via "Show previous") or upcoming.
+     * Defaults to [DepartureTiming.Upcoming] for all normally fetched departures.
+     * Set to [DepartureTiming.Previous] by the repository when loading past departures.
+     */
+    val timing: DepartureTiming = DepartureTiming.Upcoming,
 )

--- a/feature/departures/ui/build.gradle.kts
+++ b/feature/departures/ui/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.core.coroutinesExt)
                 implementation(projects.core.dateTime)
                 implementation(projects.core.di)
                 implementation(projects.core.log)

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardConfig.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardConfig.kt
@@ -11,9 +11,8 @@ package xyz.ksharma.krail.departures.ui
  * ```kotlin
  * single {
  *     DepartureBoardConfig(
- *         refreshIntervalMs  = remoteConfig.getLong("departure_refresh_interval_ms")
+ *         refreshIntervalMs = remoteConfig.getLong("departure_refresh_interval_ms")
  *                                 .takeIf { it > 0 } ?: DepartureBoardConfig.DEFAULT_REFRESH_INTERVAL_MS,
- *         relativeTimeRefreshMs = DepartureBoardConfig.DEFAULT_RELATIVE_TIME_REFRESH_MS,
  *     )
  * }
  * ```
@@ -22,19 +21,16 @@ package xyz.ksharma.krail.departures.ui
  *                                       The repository will not call the API more often than this,
  *                                       even if the same stop is expanded across both the map sheet
  *                                       and the saved trips screen simultaneously.
- * @param relativeTimeRefreshMs          Milliseconds between "in X mins" text recomputes (default 10 s).
  * @param previousDeparturesWindowMinutes Minutes into the past to fetch when the user taps
  *                                       "Show previous" (default 30 min). Can be driven from
  *                                       remote config or feature flags without changing call sites.
  */
 data class DepartureBoardConfig(
     val refreshIntervalMs: Long = DEFAULT_REFRESH_INTERVAL_MS,
-    val relativeTimeRefreshMs: Long = DEFAULT_RELATIVE_TIME_REFRESH_MS,
     val previousDeparturesWindowMinutes: Long = DEFAULT_PREVIOUS_WINDOW_MINUTES,
 ) {
     companion object {
         const val DEFAULT_REFRESH_INTERVAL_MS = 30_000L
-        const val DEFAULT_RELATIVE_TIME_REFRESH_MS = 10_000L
         const val DEFAULT_PREVIOUS_WINDOW_MINUTES = 30L
     }
 }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardConfig.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardConfig.kt
@@ -18,18 +18,23 @@ package xyz.ksharma.krail.departures.ui
  * }
  * ```
  *
- * @param refreshIntervalMs       Milliseconds between full API re-fetches (default 30 s).
- *                                 The repository will not call the API more often than this,
- *                                 even if the same stop is expanded across both the map sheet
- *                                 and the saved trips screen simultaneously.
- * @param relativeTimeRefreshMs   Milliseconds between "in X mins" text recomputes (default 10 s).
+ * @param refreshIntervalMs              Milliseconds between full API re-fetches (default 30 s).
+ *                                       The repository will not call the API more often than this,
+ *                                       even if the same stop is expanded across both the map sheet
+ *                                       and the saved trips screen simultaneously.
+ * @param relativeTimeRefreshMs          Milliseconds between "in X mins" text recomputes (default 10 s).
+ * @param previousDeparturesWindowMinutes Minutes into the past to fetch when the user taps
+ *                                       "Show previous" (default 30 min). Can be driven from
+ *                                       remote config or feature flags without changing call sites.
  */
 data class DepartureBoardConfig(
     val refreshIntervalMs: Long = DEFAULT_REFRESH_INTERVAL_MS,
     val relativeTimeRefreshMs: Long = DEFAULT_RELATIVE_TIME_REFRESH_MS,
+    val previousDeparturesWindowMinutes: Long = DEFAULT_PREVIOUS_WINDOW_MINUTES,
 ) {
     companion object {
         const val DEFAULT_REFRESH_INTERVAL_MS = 30_000L
         const val DEFAULT_RELATIVE_TIME_REFRESH_MS = 10_000L
+        const val DEFAULT_PREVIOUS_WINDOW_MINUTES = 30L
     }
 }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -47,7 +47,10 @@ class DepartureBoardRepository(
 
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
-    // Accessed only from the Main thread (ViewModel calls), so a plain map is safe.
+    // Cache entries are always pre-created on the Main thread (via observeStop / setActiveStop)
+    // before any IO coroutine calls stateFor(). IO coroutines only read existing entries —
+    // they never insert new keys — so a plain map is safe without additional locking.
+    // IMPORTANT: preserve this invariant if you add new entry points to stateFor().
     private val cache = mutableMapOf<String, MutableStateFlow<DeparturesState>>()
 
     // Guards lastFetchTime and lastPreviousFetchTime — both maps are written from IO

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -5,11 +5,12 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
@@ -18,6 +19,8 @@ import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
+import xyz.ksharma.krail.coroutines.ext.suspendSafeResult
 import xyz.ksharma.krail.departures.network.api.service.DeparturesService
 import xyz.ksharma.krail.departures.ui.business.toStopDepartures
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
@@ -38,7 +41,7 @@ import kotlin.time.Instant
  */
 class DepartureBoardRepository(
     private val departuresService: DeparturesService,
-    ioDispatcher: CoroutineDispatcher,
+    private val ioDispatcher: CoroutineDispatcher,
     private val config: DepartureBoardConfig = DepartureBoardConfig(),
 ) {
 
@@ -94,7 +97,10 @@ class DepartureBoardRepository(
         if (!hasData) stateFor(stopId).update { DeparturesState(isLoading = true) }
         log("[$LOG_TAG] setActiveStop → stopId=$stopId, hasData=$hasData")
 
-        activeJob = scope.launch {
+        activeJob = scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
+            // Check cancellation before any work — covers the gap between launch() and the
+            // first suspension point (the withLock below).
+            ensureActive()
             val nowMs = Clock.System.now().toEpochMilliseconds()
             val elapsedMs = nowMs - (fetchTimeMutex.withLock { lastFetchTime[stopId] } ?: 0L)
 
@@ -110,14 +116,19 @@ class DepartureBoardRepository(
             }
             while (true) {
                 delay(config.refreshIntervalMs)
+                // delay() throws CancellationException when the job is cancelled. The explicit
+                // ensureActive() here is a belt-and-suspenders guard in case a future refactor
+                // moves delay() away from being the first statement.
+                ensureActive()
                 log("[$LOG_TAG] auto-refresh for stopId=$stopId")
                 fetchDepartures(stopId = stopId, showFullLoading = false)
             }
         }
 
-        relativeTimeJob = scope.launch {
+        relativeTimeJob = scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
             while (true) {
                 delay(config.relativeTimeRefreshMs)
+                ensureActive()
                 updateRelativeTime(stopId)
             }
         }
@@ -161,7 +172,9 @@ class DepartureBoardRepository(
 
     /** Triggers an immediate silent refresh for [stopId], independent of the poll loop. */
     fun refresh(stopId: String) {
-        scope.launch { fetchDepartures(stopId = stopId, showFullLoading = false) }
+        scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
+            fetchDepartures(stopId = stopId, showFullLoading = false)
+        }
     }
 
     private fun stateFor(stopId: String): MutableStateFlow<DeparturesState> =
@@ -169,6 +182,8 @@ class DepartureBoardRepository(
 
     @OptIn(ExperimentalTime::class)
     private suspend fun fetchDepartures(stopId: String, showFullLoading: Boolean) {
+        // Throw immediately if this coroutine was cancelled before we touch any state.
+        currentCoroutineContext().ensureActive()
         val flow = stateFor(stopId)
         if (showFullLoading) {
             flow.update { DeparturesState(isLoading = true) }
@@ -176,9 +191,13 @@ class DepartureBoardRepository(
             flow.update { it.copy(silentLoading = true) }
         }
         fetchTimeMutex.withLock { lastFetchTime[stopId] = Clock.System.now().toEpochMilliseconds() }
-        runCatching {
-            departuresService.departures(stopId = stopId, date = null, time = null)
+        // suspendSafeResult re-throws CancellationException so it is never silently swallowed.
+        departuresService.suspendSafeResult(ioDispatcher) {
+            departures(stopId = stopId, date = null, time = null)
         }.onSuccess { response ->
+            // Check again after the network call — the job may have been cancelled while
+            // the request was in flight.
+            currentCoroutineContext().ensureActive()
             val departures = response.toStopDepartures()
             log("[$LOG_TAG] success — ${departures.size} departures for stopId=$stopId")
             flow.update { current ->
@@ -217,26 +236,29 @@ class DepartureBoardRepository(
      */
     @OptIn(ExperimentalTime::class)
     fun loadPreviousDepartures(stopId: String) {
-        scope.launch {
+        scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
             val nowMs = Clock.System.now().toEpochMilliseconds()
             val elapsedMs = nowMs - (fetchTimeMutex.withLock { lastPreviousFetchTime[stopId] } ?: 0L)
             val flow = stateFor(stopId)
 
             // If we already have data and it's still within the refresh window, skip the fetch.
-            if (elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()) {
+            val isCacheHit = elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()
+            if (isCacheHit) {
                 log("[$LOG_TAG] previous departures cache hit for stopId=$stopId (${elapsedMs}ms ago)")
-                return@launch
+                return@launchWithExceptionHandler
             }
 
             flow.update { it.copy(isPreviousLoading = true) }
             val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
-            runCatching {
-                departuresService.departures(
+            // suspendSafeResult re-throws CancellationException so it is never silently swallowed.
+            departuresService.suspendSafeResult(ioDispatcher) {
+                departures(
                     stopId = stopId,
                     date = fromTime.toApiDateString(),
                     time = fromTime.toApiTimeString(),
                 )
             }.onSuccess { response ->
+                currentCoroutineContext().ensureActive()
                 val now = Clock.System.now()
                 val previous = response.toStopDepartures()
                     .filter { departure ->
@@ -246,8 +268,12 @@ class DepartureBoardRepository(
                     }
                     .map { it.copy(timing = DepartureTiming.Previous) }
                     .toImmutableList()
+
                 log("[$LOG_TAG] previous departures — ${previous.size} found for stopId=$stopId")
-                fetchTimeMutex.withLock { lastPreviousFetchTime[stopId] = Clock.System.now().toEpochMilliseconds() }
+                fetchTimeMutex.withLock {
+                    lastPreviousFetchTime[stopId] = Clock.System.now().toEpochMilliseconds()
+                }
+
                 flow.update {
                     it.copy(
                         previousDepartures = previous,

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -11,14 +11,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.departures.network.api.service.DeparturesService
 import xyz.ksharma.krail.departures.ui.business.toStopDepartures
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.state.model.DepartureTiming
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Singleton repository that owns the departure-polling loop.
@@ -43,6 +48,10 @@ class DepartureBoardRepository(
     // Tracks the epoch-ms of the last successful fetch per stop, to avoid redundant
     // API calls when a stop is collapsed then re-expanded within the 30-second window.
     private val lastFetchTime = mutableMapOf<String, Long>()
+
+    // Same guard for previous-departures fetches — avoids a new API call if the user
+    // collapses and re-expands "Show previous" within the same refresh window.
+    private val lastPreviousFetchTime = mutableMapOf<String, Long>()
 
     private var activeJob: Job? = null
     private var relativeTimeJob: Job? = null
@@ -121,17 +130,27 @@ class DepartureBoardRepository(
     @OptIn(ExperimentalTime::class)
     private fun updateRelativeTime(stopId: String) {
         val flow = stateFor(stopId)
-        val current = flow.value
-        if (current.departures.isEmpty()) return
-        val updated = current.departures.map { departure ->
-            departure.copy(
-                relativeTimeText = runCatching {
-                    calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
-                        .toGenericFormattedTimeString()
-                }.getOrDefault(""),
+        if (flow.value.departures.isEmpty() && flow.value.previousDepartures.isEmpty()) return
+        flow.update { state ->
+            state.copy(
+                departures = state.departures.map { d ->
+                    d.copy(
+                        relativeTimeText = runCatching {
+                            calculateTimeDifferenceFromNow(d.departureUtcDateTime)
+                                .toGenericFormattedTimeString()
+                        }.getOrDefault(""),
+                    )
+                }.toImmutableList(),
+                previousDepartures = state.previousDepartures.map { d ->
+                    d.copy(
+                        relativeTimeText = runCatching {
+                            calculateTimeDifferenceFromNow(d.departureUtcDateTime)
+                                .toGenericFormattedTimeString()
+                        }.getOrDefault(""),
+                    )
+                }.toImmutableList(),
             )
-        }.toImmutableList()
-        flow.update { it.copy(departures = updated) }
+        }
     }
 
     /** Triggers an immediate silent refresh for [stopId], independent of the poll loop. */
@@ -156,12 +175,15 @@ class DepartureBoardRepository(
         }.onSuccess { response ->
             val departures = response.toStopDepartures()
             log("[$LOG_TAG] success — ${departures.size} departures for stopId=$stopId")
-            flow.update {
+            flow.update { current ->
                 DeparturesState(
                     isLoading = false,
                     silentLoading = false,
                     isError = false,
                     departures = departures,
+                    // Preserve previously fetched past departures across regular refreshes.
+                    previousDepartures = current.previousDepartures,
+                    isPreviousLoading = current.isPreviousLoading,
                 )
             }
         }.onFailure { throwable ->
@@ -175,6 +197,63 @@ class DepartureBoardRepository(
                     silentLoading = false,
                     isError = it.departures.isEmpty(),
                 )
+            }
+        }
+    }
+
+    /**
+     * Fetches departures from the past [PREVIOUS_WINDOW_MINUTES] minutes for [stopId]
+     * and stores only the ones with a departure time before now.
+     *
+     * Called when the user taps "Show previous" in the departure board UI.
+     * Results are stored in [DeparturesState.previousDepartures] and survive regular refreshes.
+     */
+    @OptIn(ExperimentalTime::class)
+    fun loadPreviousDepartures(stopId: String) {
+        scope.launch {
+            val nowMs = Clock.System.now().toEpochMilliseconds()
+            val elapsedMs = nowMs - (lastPreviousFetchTime[stopId] ?: 0L)
+            val flow = stateFor(stopId)
+
+            // If we already have data and it's still within the refresh window, skip the fetch.
+            if (elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()) {
+                log("[$LOG_TAG] previous departures cache hit for stopId=$stopId (${elapsedMs}ms ago)")
+                return@launch
+            }
+
+            flow.update { it.copy(isPreviousLoading = true) }
+            val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
+            runCatching {
+                departuresService.departures(
+                    stopId = stopId,
+                    date = fromTime.toApiDateString(),
+                    time = fromTime.toApiTimeString(),
+                )
+            }.onSuccess { response ->
+                val now = Clock.System.now()
+                val previous = response.toStopDepartures()
+                    .filter { departure ->
+                        runCatching {
+                            Instant.parse(departure.departureUtcDateTime) < now
+                        }.getOrDefault(false)
+                    }
+                    .map { it.copy(timing = DepartureTiming.Previous) }
+                    .toImmutableList()
+                log("[$LOG_TAG] previous departures — ${previous.size} found for stopId=$stopId")
+                lastPreviousFetchTime[stopId] = Clock.System.now().toEpochMilliseconds()
+                flow.update {
+                    it.copy(
+                        previousDepartures = previous,
+                        isPreviousLoading = false,
+                        previousWindowMinutes = config.previousDeparturesWindowMinutes,
+                    )
+                }
+            }.onFailure { throwable ->
+                logError(
+                    message = "[$LOG_TAG] failed to fetch previous departures for stopId=$stopId",
+                    throwable = throwable,
+                )
+                flow.update { it.copy(isPreviousLoading = false) }
             }
         }
     }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
@@ -44,6 +46,10 @@ class DepartureBoardRepository(
 
     // Accessed only from the Main thread (ViewModel calls), so a plain map is safe.
     private val cache = mutableMapOf<String, MutableStateFlow<DeparturesState>>()
+
+    // Guards lastFetchTime and lastPreviousFetchTime — both maps are written from IO
+    // dispatcher coroutines so they need synchronization.
+    private val fetchTimeMutex = Mutex()
 
     // Tracks the epoch-ms of the last successful fetch per stop, to avoid redundant
     // API calls when a stop is collapsed then re-expanded within the 30-second window.
@@ -90,7 +96,7 @@ class DepartureBoardRepository(
 
         activeJob = scope.launch {
             val nowMs = Clock.System.now().toEpochMilliseconds()
-            val elapsedMs = nowMs - (lastFetchTime[stopId] ?: 0L)
+            val elapsedMs = nowMs - (fetchTimeMutex.withLock { lastFetchTime[stopId] } ?: 0L)
 
             if (elapsedMs >= config.refreshIntervalMs) {
                 // Either never fetched, or the 30-second window has expired — fetch now.
@@ -169,7 +175,7 @@ class DepartureBoardRepository(
         } else {
             flow.update { it.copy(silentLoading = true) }
         }
-        lastFetchTime[stopId] = Clock.System.now().toEpochMilliseconds()
+        fetchTimeMutex.withLock { lastFetchTime[stopId] = Clock.System.now().toEpochMilliseconds() }
         runCatching {
             departuresService.departures(stopId = stopId, date = null, time = null)
         }.onSuccess { response ->
@@ -184,6 +190,7 @@ class DepartureBoardRepository(
                     // Preserve previously fetched past departures across regular refreshes.
                     previousDepartures = current.previousDepartures,
                     isPreviousLoading = current.isPreviousLoading,
+                    previousWindowMinutes = current.previousWindowMinutes,
                 )
             }
         }.onFailure { throwable ->
@@ -202,8 +209,8 @@ class DepartureBoardRepository(
     }
 
     /**
-     * Fetches departures from the past [PREVIOUS_WINDOW_MINUTES] minutes for [stopId]
-     * and stores only the ones with a departure time before now.
+     * Fetches departures from the past [DepartureBoardConfig.previousDeparturesWindowMinutes]
+     * minutes for [stopId] and stores only the ones with a departure time before now.
      *
      * Called when the user taps "Show previous" in the departure board UI.
      * Results are stored in [DeparturesState.previousDepartures] and survive regular refreshes.
@@ -212,7 +219,7 @@ class DepartureBoardRepository(
     fun loadPreviousDepartures(stopId: String) {
         scope.launch {
             val nowMs = Clock.System.now().toEpochMilliseconds()
-            val elapsedMs = nowMs - (lastPreviousFetchTime[stopId] ?: 0L)
+            val elapsedMs = nowMs - (fetchTimeMutex.withLock { lastPreviousFetchTime[stopId] } ?: 0L)
             val flow = stateFor(stopId)
 
             // If we already have data and it's still within the refresh window, skip the fetch.
@@ -240,7 +247,7 @@ class DepartureBoardRepository(
                     .map { it.copy(timing = DepartureTiming.Previous) }
                     .toImmutableList()
                 log("[$LOG_TAG] previous departures — ${previous.size} found for stopId=$stopId")
-                lastPreviousFetchTime[stopId] = Clock.System.now().toEpochMilliseconds()
+                fetchTimeMutex.withLock { lastPreviousFetchTime[stopId] = Clock.System.now().toEpochMilliseconds() }
                 flow.update {
                     it.copy(
                         previousDepartures = previous,

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -13,10 +13,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
@@ -66,7 +64,6 @@ class DepartureBoardRepository(
     private val lastPreviousFetchTime = mutableMapOf<String, Long>()
 
     private var activeJob: Job? = null
-    private var relativeTimeJob: Job? = null
     private var activeStopId: String? = null
 
     /**
@@ -87,8 +84,6 @@ class DepartureBoardRepository(
         if (activeStopId == stopId) return
         activeJob?.cancel()
         activeJob = null
-        relativeTimeJob?.cancel()
-        relativeTimeJob = null
         activeStopId = stopId
         if (stopId == null) {
             log("[$LOG_TAG] setActiveStop → null, polling stopped")
@@ -127,14 +122,6 @@ class DepartureBoardRepository(
                 fetchDepartures(stopId = stopId, showFullLoading = false)
             }
         }
-
-        relativeTimeJob = scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            while (true) {
-                delay(config.relativeTimeRefreshMs)
-                ensureActive()
-                updateRelativeTime(stopId)
-            }
-        }
     }
 
     /**
@@ -145,32 +132,6 @@ class DepartureBoardRepository(
      */
     fun stopIfActive(stopId: String) {
         if (activeStopId == stopId) setActiveStop(null)
-    }
-
-    @OptIn(ExperimentalTime::class)
-    private fun updateRelativeTime(stopId: String) {
-        val flow = stateFor(stopId)
-        if (flow.value.departures.isEmpty() && flow.value.previousDepartures.isEmpty()) return
-        flow.update { state ->
-            state.copy(
-                departures = state.departures.map { d ->
-                    d.copy(
-                        relativeTimeText = runCatching {
-                            calculateTimeDifferenceFromNow(d.departureUtcDateTime)
-                                .toGenericFormattedTimeString()
-                        }.getOrDefault(""),
-                    )
-                }.toImmutableList(),
-                previousDepartures = state.previousDepartures.map { d ->
-                    d.copy(
-                        relativeTimeText = runCatching {
-                            calculateTimeDifferenceFromNow(d.departureUtcDateTime)
-                                .toGenericFormattedTimeString()
-                        }.getOrDefault(""),
-                    )
-                }.toImmutableList(),
-            )
-        }
     }
 
     /** Triggers an immediate silent refresh for [stopId], independent of the poll loop. */

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -17,12 +17,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
 import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
 import kotlin.time.ExperimentalTime
@@ -61,7 +59,7 @@ class DeparturesViewModel(
 
     init {
         // Collect repository flow into _uiState so updateRelativeTimeText() can mutate it.
-        viewModelScope.launch {
+        viewModelScope.launchWithExceptionHandler<DeparturesViewModel>(ioDispatcher) {
             activeStopId
                 .flatMapLatest { stopId ->
                     if (stopId != null) {
@@ -74,33 +72,36 @@ class DeparturesViewModel(
         }
     }
 
+    // Compute relative time inside the atomic update lambda so it always operates on the
+    // current state — never on a stale snapshot. The previous pattern (snapshot → withContext
+    // → update) had a window where the repository could push a new departure between the
+    // snapshot and the update call, causing that departure to be silently dropped.
+    //
+    // withContext(ioDispatcher) is also removed — we are already on ioDispatcher (launched
+    // via launchWithExceptionHandler(ioDispatcher)), so it was a no-op context switch.
     @OptIn(ExperimentalTime::class)
     private fun updateRelativeTimeText() =
         viewModelScope.launchWithExceptionHandler<DeparturesViewModel>(ioDispatcher) {
-            val current = _uiState.value
-            val updatedDepartures = withContext(ioDispatcher) {
-                current.departures.map { departure ->
-                    departure.copy(
-                        relativeTimeText = runCatching {
-                            calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
-                                .toGenericFormattedTimeString()
-                        }.getOrDefault(""),
-                    )
-                }.toImmutableList()
+            _uiState.update { current ->
+                current.copy(
+                    departures = current.departures.map { departure ->
+                        departure.copy(
+                            relativeTimeText = runCatching {
+                                calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
+                                    .toGenericFormattedTimeString()
+                            }.getOrDefault(""),
+                        )
+                    }.toImmutableList(),
+                    previousDepartures = current.previousDepartures.map { departure ->
+                        departure.copy(
+                            relativeTimeText = runCatching {
+                                calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
+                                    .toGenericFormattedTimeString()
+                            }.getOrDefault(""),
+                        )
+                    }.toImmutableList(),
+                )
             }
-            ensureActive()
-            val updatedPrevious = withContext(ioDispatcher) {
-                current.previousDepartures.map { departure ->
-                    departure.copy(
-                        relativeTimeText = runCatching {
-                            calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
-                                .toGenericFormattedTimeString()
-                        }.getOrDefault(""),
-                    )
-                }.toImmutableList()
-            }
-            ensureActive()
-            _uiState.update { it.copy(departures = updatedDepartures, previousDepartures = updatedPrevious) }
         }
 
     fun onEvent(event: DeparturesUiEvent) {

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +19,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.log.log
@@ -41,6 +44,10 @@ class DeparturesViewModel(
      */
     val isActive: StateFlow<Boolean> = MutableStateFlow(false).onStart {
         while (true) {
+            // Throw if the collecting coroutine was cancelled — avoids launching unnecessary
+            // work between the end of delay() (which already throws on cancel) and the guard
+            // check, and makes the intent explicit.
+            currentCoroutineContext().ensureActive()
             if (_uiState.value.departures.isNotEmpty()) {
                 updateRelativeTimeText()
             }
@@ -68,30 +75,33 @@ class DeparturesViewModel(
     }
 
     @OptIn(ExperimentalTime::class)
-    private fun updateRelativeTimeText() = viewModelScope.launch {
-        val current = _uiState.value
-        val updatedDepartures = withContext(ioDispatcher) {
-            current.departures.map { departure ->
-                departure.copy(
-                    relativeTimeText = runCatching {
-                        calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
-                            .toGenericFormattedTimeString()
-                    }.getOrDefault(""),
-                )
-            }.toImmutableList()
+    private fun updateRelativeTimeText() =
+        viewModelScope.launchWithExceptionHandler<DeparturesViewModel>(ioDispatcher) {
+            val current = _uiState.value
+            val updatedDepartures = withContext(ioDispatcher) {
+                current.departures.map { departure ->
+                    departure.copy(
+                        relativeTimeText = runCatching {
+                            calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
+                                .toGenericFormattedTimeString()
+                        }.getOrDefault(""),
+                    )
+                }.toImmutableList()
+            }
+            ensureActive()
+            val updatedPrevious = withContext(ioDispatcher) {
+                current.previousDepartures.map { departure ->
+                    departure.copy(
+                        relativeTimeText = runCatching {
+                            calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
+                                .toGenericFormattedTimeString()
+                        }.getOrDefault(""),
+                    )
+                }.toImmutableList()
+            }
+            ensureActive()
+            _uiState.update { it.copy(departures = updatedDepartures, previousDepartures = updatedPrevious) }
         }
-        val updatedPrevious = withContext(ioDispatcher) {
-            current.previousDepartures.map { departure ->
-                departure.copy(
-                    relativeTimeText = runCatching {
-                        calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
-                            .toGenericFormattedTimeString()
-                    }.getOrDefault(""),
-                )
-            }.toImmutableList()
-        }
-        _uiState.update { it.copy(departures = updatedDepartures, previousDepartures = updatedPrevious) }
-    }
 
     fun onEvent(event: DeparturesUiEvent) {
         when (event) {

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -109,24 +109,23 @@ class DeparturesViewModel(
             is DeparturesUiEvent.LoadDepartures -> {
                 val current = activeStopId.value
                 // Guard: same stop already loaded without error → no-op (rotation-safe)
-                if (event.stopId == current &&
-                    !uiState.value.isError &&
-                    !uiState.value.isLoading
-                ) {
+                if (event.stopId == current && !uiState.value.isError && !uiState.value.isLoading) {
                     log("[$LOG_TAG] LoadDepartures ignored — stop ${event.stopId} already loaded")
-                    return
+                } else {
+                    log("[$LOG_TAG] LoadDepartures → stopId=${event.stopId}")
+                    // Stop polling the previous stop if this ViewModel owns it
+                    current?.let { repository.stopIfActive(it) }
+                    activeStopId.value = event.stopId
+                    repository.setActiveStop(event.stopId)
                 }
-                log("[$LOG_TAG] LoadDepartures → stopId=${event.stopId}")
-                // Stop polling the previous stop if this ViewModel owns it
-                current?.let { repository.stopIfActive(it) }
-                activeStopId.value = event.stopId
-                repository.setActiveStop(event.stopId)
             }
 
             DeparturesUiEvent.Refresh -> {
-                val stopId = activeStopId.value ?: return
-                log("[$LOG_TAG] Refresh → stopId=$stopId")
-                repository.refresh(stopId)
+                val stopId = activeStopId.value
+                if (stopId != null) {
+                    log("[$LOG_TAG] Refresh → stopId=$stopId")
+                    repository.refresh(stopId)
+                }
             }
 
             is DeparturesUiEvent.LoadPreviousDepartures -> {
@@ -135,10 +134,12 @@ class DeparturesViewModel(
             }
 
             DeparturesUiEvent.StopPolling -> {
-                val stopId = activeStopId.value ?: return
-                log("[$LOG_TAG] StopPolling → stopId=$stopId")
-                repository.stopIfActive(stopId)
-                activeStopId.value = null
+                val stopId = activeStopId.value
+                if (stopId != null) {
+                    log("[$LOG_TAG] StopPolling → stopId=$stopId")
+                    repository.stopIfActive(stopId)
+                    activeStopId.value = null
+                }
             }
         }
     }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -122,6 +122,13 @@ class DeparturesViewModel(
                 log("[$LOG_TAG] LoadPreviousDepartures → stopId=${event.stopId}")
                 repository.loadPreviousDepartures(event.stopId)
             }
+
+            DeparturesUiEvent.StopPolling -> {
+                val stopId = activeStopId.value ?: return
+                log("[$LOG_TAG] StopPolling → stopId=$stopId")
+                repository.stopIfActive(stopId)
+                activeStopId.value = null
+            }
         }
     }
 

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -69,8 +69,9 @@ class DeparturesViewModel(
 
     @OptIn(ExperimentalTime::class)
     private fun updateRelativeTimeText() = viewModelScope.launch {
-        val updated = withContext(ioDispatcher) {
-            _uiState.value.departures.map { departure ->
+        val current = _uiState.value
+        val updatedDepartures = withContext(ioDispatcher) {
+            current.departures.map { departure ->
                 departure.copy(
                     relativeTimeText = runCatching {
                         calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
@@ -79,7 +80,17 @@ class DeparturesViewModel(
                 )
             }.toImmutableList()
         }
-        _uiState.update { it.copy(departures = updated) }
+        val updatedPrevious = withContext(ioDispatcher) {
+            current.previousDepartures.map { departure ->
+                departure.copy(
+                    relativeTimeText = runCatching {
+                        calculateTimeDifferenceFromNow(departure.departureUtcDateTime)
+                            .toGenericFormattedTimeString()
+                    }.getOrDefault(""),
+                )
+            }.toImmutableList()
+        }
+        _uiState.update { it.copy(departures = updatedDepartures, previousDepartures = updatedPrevious) }
     }
 
     fun onEvent(event: DeparturesUiEvent) {
@@ -105,6 +116,11 @@ class DeparturesViewModel(
                 val stopId = activeStopId.value ?: return
                 log("[$LOG_TAG] Refresh → stopId=$stopId")
                 repository.refresh(stopId)
+            }
+
+            is DeparturesUiEvent.LoadPreviousDepartures -> {
+                log("[$LOG_TAG] LoadPreviousDepartures → stopId=${event.stopId}")
+                repository.loadPreviousDepartures(event.stopId)
             }
         }
     }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
@@ -98,8 +98,16 @@ internal fun DepartureMonitorResponse.StopEvent.toStopDeparture(): StopDeparture
 // platform/stand/wharf keyword is found.
 private fun DepartureMonitorResponse.Location.resolvePlatformText(): String? {
     val locationLabel = disassembledName ?: return null
-    log("[DEPARTURES] resolvePlatformText — disassembledName=\"$locationLabel\" parent=\"${parent?.disassembledName}\"")
-    val regex = Regex("(Platform|Stand|Wharf|Side)\\s*(\\d+|[A-Z])", RegexOption.IGNORE_CASE)
+    // Without a parent, this location IS the stop itself — no platform sub-label to extract.
+    val parentNode = parent ?: return null
+    log(
+        "[DEPARTURES] resolvePlatformText — disassembledName=\"$locationLabel\" " +
+            "parent=\"${parentNode.disassembledName}\"",
+    )
+    val regex = Regex(
+        "(Platform|Stand|Wharf|Side)\\s*(\\d+|[A-Z])",
+        RegexOption.IGNORE_CASE,
+    )
     val matches = regex.findAll(locationLabel).toList()
     val result = if (matches.isNotEmpty()) matches.joinToString(", ") { it.value } else null
     log("[DEPARTURES] resolvePlatformText → result=\"$result\"")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -47,6 +47,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.components.TextButton
 import xyz.ksharma.krail.taj.modifier.CardShape
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -76,7 +77,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
  * @param maxItems        Maximum number of departure rows to show. `null` means show all.
  */
 @Composable
-fun DepartureBoardCard(
+fun DepartureBoardStopCard(
     stopId: String,
     state: DeparturesState,
     onEvent: (DeparturesUiEvent) -> Unit,
@@ -89,6 +90,8 @@ fun DepartureBoardCard(
     var internalExpanded by rememberSaveable { mutableStateOf(false) }
     val expanded = isExpanded ?: internalExpanded
 
+    var showPrevious by remember { mutableStateOf(false) }
+
     // Filter state — keyed to stopId so rotating the device while a filter is active
     // restores the same selection. Empty string is the "no filter" sentinel (primitives only
     // are safe across process death / configuration changes via rememberSaveable).
@@ -100,6 +103,14 @@ fun DepartureBoardCard(
             state.departures
         } else {
             state.departures.filter { it.lineNumber == selectedLine }.toImmutableList()
+        }
+    }
+
+    val filteredPreviousDepartures: ImmutableList<StopDeparture> = remember(state.previousDepartures, selectedLine) {
+        if (selectedLine == null) {
+            state.previousDepartures
+        } else {
+            state.previousDepartures.filter { it.lineNumber == selectedLine }.toImmutableList()
         }
     }
 
@@ -182,12 +193,56 @@ fun DepartureBoardCard(
                             onLineSelect = { selectedLineKey = it ?: "" },
                         )
                         Divider(modifier = Modifier.padding(horizontal = 16.dp))
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        // "Show previous / Hide previous" toggle
+                        Box(
+                            modifier = Modifier.fillMaxWidth(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            TextButton(
+                                onClick = {
+                                    showPrevious = !showPrevious
+                                    if (showPrevious && state.previousDepartures.isEmpty() &&
+                                        !state.isPreviousLoading
+                                    ) {
+                                        onEvent(DeparturesUiEvent.LoadPreviousDepartures(stopId))
+                                    }
+                                },
+                            ) {
+                                Text(text = if (showPrevious) "Hide previous" else "Show previous")
+                            }
+                        }
+
                         when {
-                            filteredDepartures.isEmpty() -> FilterEmptyContent()
-                            else -> DepartureRowList(
-                                departures = filteredDepartures,
+                            showPrevious && state.isPreviousLoading -> {
+                                LoadingContent()
+                                when {
+                                    filteredDepartures.isEmpty() -> FilterEmptyContent()
+                                    else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
+                                }
+                            }
+                            showPrevious && filteredPreviousDepartures.isEmpty() -> {
+                                Text(
+                                    text = "No previous departures in the last ${state.previousWindowMinutes} minutes.",
+                                    style = KrailTheme.typography.bodyMedium,
+                                    color = KrailTheme.colors.softLabel,
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                                )
+                                when {
+                                    filteredDepartures.isEmpty() -> FilterEmptyContent()
+                                    else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
+                                }
+                            }
+                            showPrevious -> DepartureRowList(
+                                departures = remember(filteredPreviousDepartures, filteredDepartures) {
+                                    (filteredPreviousDepartures + filteredDepartures).toImmutableList()
+                                },
                                 maxItems = maxItems,
                             )
+                            filteredDepartures.isEmpty() -> FilterEmptyContent()
+                            else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
                         }
                     }
                 }
@@ -335,9 +390,9 @@ private val previewFerryDepartures = persistentListOf(
 
 @Preview(name = "Collapsed", showBackground = true)
 @Composable
-private fun DepartureBoardCardCollapsedPreview() {
+private fun DepartureBoardStopCardCollapsedPreview() {
     PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardCard(
+        DepartureBoardStopCard(
             stopId = "10101010",
             state = DeparturesState(),
             onEvent = {},
@@ -347,7 +402,7 @@ private fun DepartureBoardCardCollapsedPreview() {
 
 @Preview(name = "Loading", showBackground = true)
 @Composable
-private fun DepartureBoardCardLoadingPreview() {
+private fun DepartureBoardStopCardLoadingPreview() {
     PreviewTheme(KrailThemeStyle.Train) {
         Column { LoadingContent() }
     }
@@ -355,7 +410,7 @@ private fun DepartureBoardCardLoadingPreview() {
 
 @PreviewComponent
 @Composable
-private fun DepartureBoardCardLoadedTrainPreview() {
+private fun DepartureBoardStopCardLoadedTrainPreview() {
     PreviewTheme(KrailThemeStyle.Train) {
         Column {
             LinesServedRow(
@@ -371,7 +426,7 @@ private fun DepartureBoardCardLoadedTrainPreview() {
 
 @Preview(name = "Loaded — Bus theme", showBackground = true)
 @Composable
-private fun DepartureBoardCardLoadedBusPreview() {
+private fun DepartureBoardStopCardLoadedBusPreview() {
     PreviewTheme(KrailThemeStyle.Bus) {
         Column {
             LinesServedRow(
@@ -387,7 +442,7 @@ private fun DepartureBoardCardLoadedBusPreview() {
 
 @Preview(name = "Error state", showBackground = true)
 @Composable
-private fun DepartureBoardCardErrorPreview() {
+private fun DepartureBoardStopCardErrorPreview() {
     PreviewTheme(KrailThemeStyle.Metro) {
         Column { ErrorContent(onRetry = {}) }
     }
@@ -395,7 +450,7 @@ private fun DepartureBoardCardErrorPreview() {
 
 @Preview(name = "Ferry theme", showBackground = true)
 @Composable
-private fun DepartureBoardCardFerryPreview() {
+private fun DepartureBoardStopCardFerryPreview() {
     PreviewTheme(KrailThemeStyle.Ferry) {
         Column {
             LinesServedRow(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -121,8 +121,13 @@ fun DepartureBoardStopCard(
     )
 
     LaunchedEffect(expanded, stopId) {
-        if (expanded && isExpanded == null) {
-            onEvent(DeparturesUiEvent.LoadDepartures(stopId))
+        if (isExpanded == null) {
+            // Uncontrolled mode: start polling on expand, stop it on collapse.
+            if (expanded) {
+                onEvent(DeparturesUiEvent.LoadDepartures(stopId))
+            } else {
+                onEvent(DeparturesUiEvent.StopPolling)
+            }
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureRow.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,7 +24,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.departures.ui.state.model.DepartureTiming
 import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
+import xyz.ksharma.krail.taj.LocalContentAlpha
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -47,74 +50,79 @@ fun DepartureRow(
     departure: StopDeparture,
     modifier: Modifier = Modifier,
 ) {
-    val lineColor = remember(departure.lineColorCode) { departure.lineColorCode.hexToComposeColor() }
+    val isPrevious = departure.timing == DepartureTiming.Previous
+    val lineColor = remember(departure.lineColorCode) {
+        departure.lineColorCode.hexToComposeColor()
+    }
     val transportMode = remember(departure.transportModeName) {
         departure.transportModeName.toTransportMode()
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        // Line 1: relative time + mode icon + line badge (left) | platform text (right)
-        FlowRow(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-            itemVerticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth(),
+    CompositionLocalProvider(LocalContentAlpha provides if (isPrevious) 0.5f else 1f) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
+            // Line 1: relative time + mode icon + line badge (left) | platform text (right)
+            FlowRow(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                itemVerticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
             ) {
-                if (departure.relativeTimeText.isNotBlank()) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (departure.relativeTimeText.isNotBlank()) {
+                        Text(
+                            text = departure.relativeTimeText,
+                            style = KrailTheme.typography.titleMedium,
+                            color = lineColor,
+                        )
+                    }
+
+                    transportMode?.let {
+                        TransportModeIcon(
+                            transportMode = it,
+                            size = TransportModeIconSize.XSmall,
+                            displayBorder = false,
+                        )
+                    }
+
+                    TransportModeBadge(
+                        badgeText = departure.lineNumber,
+                        backgroundColor = lineColor,
+                        modifier = Modifier.padding(end = 8.dp),
+                    )
+                }
+
+                departure.platformText?.let {
                     Text(
-                        text = departure.relativeTimeText,
-                        style = KrailTheme.typography.titleMedium,
-                        color = lineColor,
+                        text = it,
+                        textAlign = TextAlign.End,
+                        style = KrailTheme.typography.bodyMedium,
+                        color = KrailTheme.colors.label,
                     )
                 }
-
-                transportMode?.let {
-                    TransportModeIcon(
-                        transportMode = it,
-                        size = TransportModeIconSize.XSmall,
-                        displayBorder = false,
-                    )
-                }
-
-                TransportModeBadge(
-                    badgeText = departure.lineNumber,
-                    backgroundColor = lineColor,
-                    modifier = Modifier.padding(end = 8.dp),
-                )
             }
 
-            departure.platformText?.let {
-                Text(
-                    text = it,
-                    textAlign = TextAlign.End,
-                    style = KrailTheme.typography.bodyMedium,
-                    color = KrailTheme.colors.label,
-                )
-            }
+            // Line 2: delay indicator (if delayed/early) + departure time
+            DepartureTimeRow(
+                departureTimeText = departure.departureTimeText,
+                scheduledTimeText = departure.scheduledTimeText,
+                delayMinutes = departure.delayMinutes,
+            )
+
+            // Line 3: destination in softLabel
+            Text(
+                text = departure.destinationName,
+                style = KrailTheme.typography.bodyMedium,
+                color = KrailTheme.colors.softLabel,
+            )
         }
-
-        // Line 2: delay indicator (if delayed/early) + departure time
-        DepartureTimeRow(
-            departureTimeText = departure.departureTimeText,
-            scheduledTimeText = departure.scheduledTimeText,
-            delayMinutes = departure.delayMinutes,
-        )
-
-        // Line 3: destination in softLabel
-        Text(
-            text = departure.destinationName,
-            style = KrailTheme.typography.bodyMedium,
-            color = KrailTheme.colors.softLabel,
-        )
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LinesServedRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LinesServedRow.kt
@@ -29,7 +29,7 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
  *
  * This composable is **stateless** — callers drive [selectedLine] and [onLineSelect].
  * Typically the filter state lives in the nearest enclosing composable that owns the
- * departure list (e.g. [DepartureBoardCard] or `DepartureBoardStopContent`).
+ * departure list (e.g. [DepartureBoardStopCard] or `DepartureBoardStopContent`).
  *
  * @param departures    Full (unfiltered) departure list — only used to derive unique lines.
  * @param selectedLine  The currently active filter line number, or `null` for "show all".

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LinesServedRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LinesServedRow.kt
@@ -29,7 +29,7 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
  *
  * This composable is **stateless** — callers drive [selectedLine] and [onLineSelect].
  * Typically the filter state lives in the nearest enclosing composable that owns the
- * departure list (e.g. [DepartureBoardStopCard] or `DepartureBoardStopContent`).
+ * departure list (e.g. [DepartureBoardStopCard] or [DepartureBoardAccordionContent]).
  *
  * @param departures    Full (unfiltered) departure list — only used to derive unique lines.
  * @param selectedLine  The currently active filter line number, or `null` for "show all".

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -2,6 +2,7 @@
 
 package xyz.ksharma.krail.trip.planner.ui.departureboard
 
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,13 +40,13 @@ import xyz.ksharma.krail.departures.ui.state.DeparturesState
 import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.modifier.CardShape
-import xyz.ksharma.krail.taj.modifier.cardBackground
+import xyz.ksharma.krail.taj.components.TextButton
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.DepartureRowList
 import xyz.ksharma.krail.trip.planner.ui.components.LinesServedRow
 import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
@@ -61,13 +63,14 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.StopDepartureBoardEntry
  * Filter state naturally resets when the item collapses because [remember] is keyed to the
  * item's composition lifetime.
  */
-fun LazyListScope.departureBoardStopSection(
+fun LazyListScope.departureBoardAccordionSection(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
     onExpandChange: (Boolean) -> Unit,
+    onLoadPreviousDepartures: (String) -> Unit = {},
 ) {
     stickyHeader(key = "${entry.stopId}_header", contentType = "stop_header") {
-        DepartureBoardStopSectionHeader(
+        DepartureBoardAccordionSectionHeader(
             entry = entry,
             isExpanded = isExpanded,
             onExpandChange = onExpandChange,
@@ -77,8 +80,10 @@ fun LazyListScope.departureBoardStopSection(
 
     if (isExpanded) {
         item(key = "${entry.stopId}_content", contentType = "stop_content") {
-            DepartureBoardStopContent(
+            DepartureBoardAccordionContent(
+                stopId = entry.stopId,
                 state = entry.state,
+                onLoadPreviousDepartures = onLoadPreviousDepartures,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -89,10 +94,10 @@ fun LazyListScope.departureBoardStopSection(
 
 /**
  * The tappable header card for a stop section.
- * Shared by [departureBoardStopSection] (lazy use) and [DepartureBoardStopSection] (preview use).
+ * Shared by [departureBoardAccordionSection] (lazy use) and [DepartureBoardAccordionSection] (preview use).
  */
 @Composable
-internal fun DepartureBoardStopSectionHeader(
+internal fun DepartureBoardAccordionSectionHeader(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
     onExpandChange: (Boolean) -> Unit,
@@ -103,13 +108,24 @@ internal fun DepartureBoardStopSectionHeader(
         animationSpec = tween(durationMillis = 300),
         label = "arrow-rotation",
     )
+    val outerPadding by animateDpAsState(
+        targetValue = if (isExpanded) 0.dp else 16.dp,
+        animationSpec = tween(durationMillis = 300),
+        label = "outer-padding",
+    )
+    val cornerRadius by animateDpAsState(
+        targetValue = if (isExpanded) 0.dp else 16.dp,
+        animationSpec = tween(durationMillis = 300),
+        label = "corner-radius",
+    )
+    val animatedShape = RoundedCornerShape(cornerRadius)
 
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .background(color = KrailTheme.colors.surface, shape = CardShape)
-            .cardBackground()
+            .padding(horizontal = outerPadding)
+            .background(color = KrailTheme.colors.surface, shape = animatedShape)
+            .background(color = themeBackgroundColor(), shape = animatedShape)
             .klickable { onExpandChange(!isExpanded) }
             .padding(horizontal = 16.dp, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -152,9 +168,12 @@ internal fun DepartureBoardStopSectionHeader(
  * composable leaves composition (i.e. when the section collapses), so re-expanding
  * always starts with all services shown.
  */
+@Suppress("CyclomaticComplexMethod") // todo split this method
 @Composable
-private fun DepartureBoardStopContent(
+private fun DepartureBoardAccordionContent(
+    stopId: String,
     state: DeparturesState,
+    onLoadPreviousDepartures: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Empty string = no filter. Non-null String is guaranteed safe through rememberSaveable
@@ -162,11 +181,21 @@ private fun DepartureBoardStopContent(
     var selectedLineKey by rememberSaveable { mutableStateOf("") }
     val selectedLine: String? = selectedLineKey.ifEmpty { null }
 
+    var showPrevious by remember { mutableStateOf(false) }
+
     val filteredDepartures = remember(state.departures, selectedLine) {
         if (selectedLine == null) {
             state.departures
         } else {
             state.departures.filter { it.lineNumber == selectedLine }.toImmutableList()
+        }
+    }
+
+    val filteredPreviousDepartures = remember(state.previousDepartures, selectedLine) {
+        if (selectedLine == null) {
+            state.previousDepartures
+        } else {
+            state.previousDepartures.filter { it.lineNumber == selectedLine }.toImmutableList()
         }
     }
 
@@ -182,7 +211,47 @@ private fun DepartureBoardStopContent(
                     onLineSelect = { selectedLineKey = it ?: "" },
                 )
                 Divider(modifier = Modifier.padding(horizontal = 12.dp))
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // "Show previous / Hide previous" toggle
+                ShowPreviousButton(
+                    showPrevious = showPrevious,
+                    onClick = {
+                        showPrevious = !showPrevious
+                        if (showPrevious && state.previousDepartures.isEmpty() && !state.isPreviousLoading) {
+                            onLoadPreviousDepartures(stopId)
+                        }
+                    },
+                )
+
                 when {
+                    // Previous fetch in progress — show inline loader above upcoming
+                    showPrevious && state.isPreviousLoading -> {
+                        SectionLoadingContent()
+                        when {
+                            filteredDepartures.isEmpty() -> SectionEmptyContent(hasActiveFilter = true)
+                            else -> DepartureRowList(departures = filteredDepartures)
+                        }
+                    }
+                    // Previous fetched but none match current filter — show message then upcoming
+                    showPrevious && filteredPreviousDepartures.isEmpty() -> {
+                        Text(
+                            text = "No previous departures in the last ${state.previousWindowMinutes} minutes.",
+                            style = KrailTheme.typography.bodyMedium,
+                            color = KrailTheme.colors.softLabel,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        )
+                        when {
+                            filteredDepartures.isEmpty() -> SectionEmptyContent(hasActiveFilter = true)
+                            else -> DepartureRowList(departures = filteredDepartures)
+                        }
+                    }
+                    // Previous + upcoming combined — date labels flow as one unified list
+                    showPrevious -> DepartureRowList(
+                        departures = remember(filteredPreviousDepartures, filteredDepartures) {
+                            (filteredPreviousDepartures + filteredDepartures).toImmutableList()
+                        },
+                    )
                     filteredDepartures.isEmpty() -> SectionEmptyContent(hasActiveFilter = true)
                     else -> DepartureRowList(departures = filteredDepartures)
                 }
@@ -197,17 +266,18 @@ private fun DepartureBoardStopContent(
 /**
  * Accordion section for a single stop. Uses a plain [Column] layout.
  * Intended for standalone Compose Previews — the production saved trips screen uses
- * [departureBoardStopSection] instead for per-item lazy list keys.
+ * [departureBoardAccordionSection] instead for per-item lazy list keys.
  */
 @Composable
-fun DepartureBoardStopSection(
+fun DepartureBoardAccordionSection(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
     onExpandChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    onLoadPreviousDepartures: (String) -> Unit = {},
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
-        DepartureBoardStopSectionHeader(
+        DepartureBoardAccordionSectionHeader(
             entry = entry,
             isExpanded = isExpanded,
             onExpandChange = onExpandChange,
@@ -215,8 +285,30 @@ fun DepartureBoardStopSection(
 
         if (isExpanded) {
             Column(modifier = Modifier.background(KrailTheme.colors.surface)) {
-                DepartureBoardStopContent(state = entry.state)
+                DepartureBoardAccordionContent(
+                    stopId = entry.stopId,
+                    state = entry.state,
+                    onLoadPreviousDepartures = onLoadPreviousDepartures,
+                )
             }
+        }
+    }
+}
+
+// ── Show previous button ──────────────────────────────────────────────────────
+
+@Composable
+private fun ShowPreviousButton(
+    showPrevious: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        TextButton(onClick = onClick) {
+            Text(text = if (showPrevious) "Hide previous" else "Show previous")
         }
     }
 }
@@ -317,7 +409,7 @@ private val previewMixedDepartures: ImmutableList<StopDeparture> = persistentLis
 @Composable
 private fun DepartureBoardStopSectionCollapsedPreview() {
     PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardStopSection(
+        DepartureBoardAccordionSection(
             entry = StopDepartureBoardEntry(
                 stopId = "10111010",
                 stopName = "Toongabbie Station",
@@ -333,7 +425,7 @@ private fun DepartureBoardStopSectionCollapsedPreview() {
 @Composable
 private fun DepartureBoardStopSectionExpandedTrainPreview() {
     PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardStopSection(
+        DepartureBoardAccordionSection(
             entry = StopDepartureBoardEntry(
                 stopId = "10111010",
                 stopName = "Toongabbie Station",
@@ -349,7 +441,7 @@ private fun DepartureBoardStopSectionExpandedTrainPreview() {
 @Composable
 private fun DepartureBoardStopSectionMixedPreview() {
     PreviewTheme(KrailThemeStyle.Bus) {
-        DepartureBoardStopSection(
+        DepartureBoardAccordionSection(
             entry = StopDepartureBoardEntry(
                 stopId = "10111010",
                 stopName = "Central Station",
@@ -365,7 +457,7 @@ private fun DepartureBoardStopSectionMixedPreview() {
 @Composable
 private fun DepartureBoardStopSectionLoadingPreview() {
     PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardStopSection(
+        DepartureBoardAccordionSection(
             entry = StopDepartureBoardEntry(
                 stopId = "10111010",
                 stopName = "Toongabbie Station",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -59,7 +60,7 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.StopDepartureBoardEntry
  *  - `"${stopId}_header"` — sticky tappable card
  *  - `"${stopId}_content"` — collapsible content with services row + departure list
  *
- * The content item hosts [DepartureBoardStopContent] which owns the per-stop filter state.
+ * The content item hosts [DepartureBoardAccordionContent] which owns the per-stop filter state.
  * Filter state naturally resets when the item collapses because [remember] is keyed to the
  * item's composition lifetime.
  */
@@ -182,6 +183,15 @@ private fun DepartureBoardAccordionContent(
     val selectedLine: String? = selectedLineKey.ifEmpty { null }
 
     var showPrevious by remember { mutableStateOf(false) }
+    // Tracks whether a previous-departures fetch has been requested but isPreviousLoading
+    // hasn't arrived yet. Without this, the "No previous departures" text flashes for one
+    // frame before the repository sets isPreviousLoading = true.
+    var previousRequested by remember { mutableStateOf(false) }
+
+    // Clear the local guard once the repository acknowledges the request (loading starts/ends).
+    LaunchedEffect(state.isPreviousLoading) {
+        if (!state.isPreviousLoading) previousRequested = false
+    }
 
     val filteredDepartures = remember(state.departures, selectedLine) {
         if (selectedLine == null) {
@@ -219,14 +229,16 @@ private fun DepartureBoardAccordionContent(
                     onClick = {
                         showPrevious = !showPrevious
                         if (showPrevious && state.previousDepartures.isEmpty() && !state.isPreviousLoading) {
+                            previousRequested = true
                             onLoadPreviousDepartures(stopId)
                         }
                     },
                 )
 
                 when {
-                    // Previous fetch in progress — show inline loader above upcoming
-                    showPrevious && state.isPreviousLoading -> {
+                    // Previous fetch in progress (or requested but not yet acknowledged) —
+                    // show inline loader above upcoming departures.
+                    showPrevious && (state.isPreviousLoading || previousRequested) -> {
                         SectionLoadingContent()
                         when {
                             filteredDepartures.isEmpty() -> SectionEmptyContent(hasActiveFilter = true)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -126,6 +126,7 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
             expandedDepartureBoardStopId = expandedDepartureBoardStopId,
             onDepartureBoardExpand = departureBoardViewModel::onCardExpand,
             onDepartureBoardCollapse = departureBoardViewModel::onCardCollapse,
+            onLoadPreviousDepartures = departureBoardViewModel::onLoadPreviousDepartures,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
@@ -112,6 +112,15 @@ class DepartureBoardViewModel(
         repository.setActiveStop(stopId)
     }
 
+    /**
+     * Triggers a one-shot fetch of past departures (~15 min window) for [stopId].
+     * Results land in [DeparturesState.previousDepartures] and are shown when the user
+     * has toggled "Show previous" in the UI.
+     */
+    fun onLoadPreviousDepartures(stopId: String) {
+        repository.loadPreviousDepartures(stopId)
+    }
+
     /** Collapses the currently open card and stops polling. */
     fun onCardCollapse() {
         val current = _expandedStopId.value ?: return

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -57,7 +57,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
-import xyz.ksharma.krail.trip.planner.ui.departureboard.departureBoardStopSection
+import xyz.ksharma.krail.trip.planner.ui.departureboard.departureBoardAccordionSection
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -79,6 +79,7 @@ fun SavedTripsScreen(
     expandedDepartureBoardStopId: String? = null,
     onDepartureBoardExpand: (String) -> Unit = {},
     onDepartureBoardCollapse: () -> Unit = {},
+    onLoadPreviousDepartures: (String) -> Unit = {},
 ) {
     val emptyStateTip = remember {
         buildList {
@@ -234,6 +235,7 @@ fun SavedTripsScreen(
                             expandedDepartureBoardStopId = expandedDepartureBoardStopId,
                             onDepartureBoardExpand = onDepartureBoardExpand,
                             onDepartureBoardCollapse = onDepartureBoardCollapse,
+                            onLoadPreviousDepartures = onLoadPreviousDepartures,
                         )
                     }
                 }
@@ -293,6 +295,7 @@ private fun LazyListScope.savedTripsContent(
     expandedDepartureBoardStopId: String?,
     onDepartureBoardExpand: (String) -> Unit,
     onDepartureBoardCollapse: () -> Unit,
+    onLoadPreviousDepartures: (String) -> Unit = {},
 ) {
     stickyHeader(key = "saved_trips_title") {
         SavedTripsTitle {
@@ -368,12 +371,13 @@ private fun LazyListScope.savedTripsContent(
         }
 
         departureBoardEntries.forEach { entry ->
-            departureBoardStopSection(
+            departureBoardAccordionSection(
                 entry = entry,
                 isExpanded = expandedDepartureBoardStopId == entry.stopId,
                 onExpandChange = { expand ->
                     if (expand) onDepartureBoardExpand(entry.stopId) else onDepartureBoardCollapse()
                 },
+                onLoadPreviousDepartures = onLoadPreviousDepartures,
             )
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
@@ -25,7 +25,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
-import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardCard
+import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardStopCard
 import xyz.ksharma.krail.trip.planner.ui.components.map.StopActionButton
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
 import xyz.ksharma.krail.trip.planner.ui.components.map.StopDetailsBottomSheet as SharedStopDetailsBottomSheet
@@ -55,7 +55,7 @@ fun StopDetailsBottomSheet(
         onDismiss = onDismiss,
         modifier = modifier,
         additionalInfo = {
-            DepartureBoardCard(
+            DepartureBoardStopCard(
                 stopId = stop.stopId,
                 state = departuresState,
                 onEvent = departuresViewModel::onEvent,


### PR DESCRIPTION
## Add "Show previous departures" toggle for past 30-minute window

Allows users to tap a toggle to see departures from the past 30 minutes.

### State layer (departures/state):
- **DeparturesState**: adds `previousDepartures`, `isPreviousLoading`, `previousWindowMinutes` fields
- **DeparturesUiEvent**: adds `LoadPreviousDepartures` event for fetching past departures
- **StopDeparture**: adds `DepartureTiming` enum (Previous/Upcoming) and `timing` field

### Business layer (departures/ui):
- **DepartureBoardConfig**: adds `previousDeparturesWindowMinutes` (default 30 min)
- **DepartureBoardRepository**: adds `loadPreviousDepartures()` — fetches a past time window, filters to only items before now, marks them `DepartureTiming.Previous`, and preserves them across regular auto-refreshes
- **DeparturesViewModel**: handles `LoadPreviousDepartures` event and updates relative time for both upcoming and previous departures
- **DepartureMonitorMapper**: guards `resolvePlatformText` against parent-less locations (past-departure API returns location without a parent node)
- **DateTimeHelper**: adds `toApiDateString`/`toApiTimeString` for past-window requests, adds "Yesterday" support to date formatting

### UI layer (trip-planner):
- **DepartureBoardCard** renamed → **DepartureBoardStopCard** (and section functions renamed to Accordion* prefix for clarity)
- **DepartureBoardStopSection**: adds "Show previous" TextButton toggle, animated accordion header with dynamic padding/corners, `LocalContentAlpha` dimming for past rows
- **DepartureRow**: applies 50% alpha for previous departures using `LocalContentAlpha`
- **SavedTripsScreen**: wires up `onLoadPreviousDepartures` callback through the component hierarchy