### PR TITLE
Create CameraFollowState

### DIFF
--- a/core/maps/state/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/state/UserLocationConfig.kt
+++ b/core/maps/state/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/state/UserLocationConfig.kt
@@ -18,4 +18,7 @@ object UserLocationConfig {
 
     /** Camera animation duration (ms) for manual re-center taps. */
     const val RECENTER_ANIMATION_MS = 1_000L
+
+    /** Camera animation duration (ms) for each follow-mode location update. */
+    const val FOLLOW_ANIMATION_MS = 800L
 }

--- a/core/maps/ui/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/ui/utils/CameraFollowState.kt
+++ b/core/maps/ui/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/ui/utils/CameraFollowState.kt
@@ -1,0 +1,90 @@
+package xyz.ksharma.krail.core.maps.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.spatialk.geojson.Position
+import xyz.ksharma.krail.core.maps.state.LatLng
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Manages camera follow-mode state for a map.
+ *
+ * When [isFollowing] is true, the camera animates to every incoming location update.
+ * Follow mode is disengaged automatically when the user manually pans the map, detected
+ * via [manualPan].
+ *
+ * [isProgrammaticMove] suppresses [manualPan] emissions during our own [animateTo] calls so
+ * that programmatic camera moves don't inadvertently stop follow mode.
+ */
+@Stable
+class CameraFollowState(
+    private val cameraState: CameraState,
+    private val scope: CoroutineScope,
+) {
+    var isFollowing: Boolean by mutableStateOf(false)
+        private set
+
+    // True while we are animating programmatically — suppresses manual-pan detection.
+    private var isProgrammaticMove: Boolean by mutableStateOf(false)
+
+    /**
+     * Emits [Unit] whenever the user manually pans the map (i.e. a camera target change that is
+     * NOT caused by one of our own [animateTo] calls).
+     */
+    val manualPan: Flow<Unit> = snapshotFlow { cameraState.position.target }
+        .distinctUntilChanged()
+        .filter { !isProgrammaticMove }
+        .map { }
+
+    fun startFollowing() {
+        isFollowing = true
+    }
+
+    fun stopFollowing() {
+        isFollowing = false
+    }
+
+    /**
+     * Animates the camera to [latLng].
+     *
+     * @param zoom Target zoom level. When null the current zoom is preserved — useful for
+     *   follow-mode updates where the user may have zoomed in/out and we should respect that.
+     * @param durationMs Animation duration in milliseconds.
+     */
+    fun animateTo(latLng: LatLng, zoom: Double? = null, durationMs: Long = 1_000L) {
+        scope.launch {
+            isProgrammaticMove = true
+            try {
+                cameraState.animateTo(
+                    CameraPosition(
+                        target = Position(latitude = latLng.latitude, longitude = latLng.longitude),
+                        zoom = zoom ?: cameraState.position.zoom,
+                    ),
+                    duration = durationMs.milliseconds,
+                )
+            } finally {
+                isProgrammaticMove = false
+            }
+        }
+    }
+}
+
+@Composable
+fun rememberCameraFollowState(cameraState: CameraState): CameraFollowState {
+    val scope = rememberCoroutineScope()
+    return remember(cameraState) { CameraFollowState(cameraState, scope) }
+}

--- a/core/maps/ui/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/ui/utils/CameraFollowState.kt
+++ b/core/maps/ui/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/ui/utils/CameraFollowState.kt
@@ -10,10 +10,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraMoveReason
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.CameraState
 import org.maplibre.spatialk.geojson.Position
@@ -27,8 +27,9 @@ import kotlin.time.Duration.Companion.milliseconds
  * Follow mode is disengaged automatically when the user manually pans the map, detected
  * via [manualPan].
  *
- * [isProgrammaticMove] suppresses [manualPan] emissions during our own [animateTo] calls so
- * that programmatic camera moves don't inadvertently stop follow mode.
+ * [manualPan] uses MapLibre's own [CameraMoveReason] to distinguish user gestures from
+ * programmatic animations — this avoids race conditions that occur when multiple animations
+ * overlap and a shared boolean flag gets reset prematurely.
  */
 @Stable
 class CameraFollowState(
@@ -38,24 +39,30 @@ class CameraFollowState(
     var isFollowing: Boolean by mutableStateOf(false)
         private set
 
-    // True while we are animating programmatically — suppresses manual-pan detection.
-    private var isProgrammaticMove: Boolean by mutableStateOf(false)
+    /**
+     * True while a recenter animation is in progress (camera moving *toward* the dot).
+     * Cleared automatically when [animateTo] completes so the dot switches to camera-mirror mode.
+     */
+    var isRecentering: Boolean by mutableStateOf(false)
+        private set
 
     /**
-     * Emits [Unit] whenever the user manually pans the map (i.e. a camera target change that is
-     * NOT caused by one of our own [animateTo] calls).
+     * Emits [Unit] whenever the user manually pans the map.
+     * Uses [CameraMoveReason.GESTURE] from MapLibre so that our own programmatic animations
+     * never falsely trigger this — even when two animations overlap.
      */
-    val manualPan: Flow<Unit> = snapshotFlow { cameraState.position.target }
-        .distinctUntilChanged()
-        .filter { !isProgrammaticMove }
+    val manualPan: Flow<Unit> = snapshotFlow { cameraState.moveReason }
+        .filter { it == CameraMoveReason.GESTURE }
         .map { }
 
     fun startFollowing() {
         isFollowing = true
+        isRecentering = true
     }
 
     fun stopFollowing() {
         isFollowing = false
+        isRecentering = false
     }
 
     /**
@@ -67,18 +74,16 @@ class CameraFollowState(
      */
     fun animateTo(latLng: LatLng, zoom: Double? = null, durationMs: Long = 1_000L) {
         scope.launch {
-            isProgrammaticMove = true
-            try {
-                cameraState.animateTo(
-                    CameraPosition(
-                        target = Position(latitude = latLng.latitude, longitude = latLng.longitude),
-                        zoom = zoom ?: cameraState.position.zoom,
-                    ),
-                    duration = durationMs.milliseconds,
-                )
-            } finally {
-                isProgrammaticMove = false
-            }
+            cameraState.animateTo(
+                CameraPosition(
+                    target = Position(latitude = latLng.latitude, longitude = latLng.longitude),
+                    zoom = zoom ?: cameraState.position.zoom,
+                ),
+                duration = durationMs.milliseconds,
+            )
+            // Camera has arrived at the target. Clear recentering so the dot switches to
+            // camera-mirror mode for subsequent GPS-driven animations.
+            isRecentering = false
         }
     }
 }
@@ -87,4 +92,33 @@ class CameraFollowState(
 fun rememberCameraFollowState(cameraState: CameraState): CameraFollowState {
     val scope = rememberCoroutineScope()
     return remember(cameraState) { CameraFollowState(cameraState, scope) }
+}
+
+/**
+ * Returns the position to display for the user location dot.
+ *
+ * - **Not following**: returns [userLocation] so the dot stays on the last GPS fix.
+ * - **Following, recentering**: returns [userLocation]. The camera is moving *toward* the dot
+ *   (recenter animation), so the dot should stay put — not jump to the camera's current position.
+ * - **Following, not recentering**: mirrors the camera's animated target, keeping the dot
+ *   frame-perfectly in sync with no vibration from two independent animation systems.
+ *
+ * Call this inside the [MaplibreMap] content lambda so that state reads are scoped to
+ * the inner recomposition scope — only the map content recomposes on each animation frame,
+ * not the entire screen composable.
+ *
+ * @param userLocation Last known GPS fix, or null if no fix has been received yet.
+ * @param cameraState The map camera whose animated position is used in follow mode.
+ */
+@Composable
+fun CameraFollowState.dotLocation(
+    userLocation: LatLng?,
+    cameraState: CameraState,
+): LatLng? = when {
+    userLocation == null -> null
+    isFollowing && !isRecentering -> {
+        val t = cameraState.position.target
+        LatLng(latitude = t.latitude, longitude = t.longitude)
+    }
+    else -> userLocation
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.map.MaplibreMap
@@ -33,6 +32,7 @@ import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.maps.state.UserLocationConfig
 import xyz.ksharma.krail.core.maps.ui.components.LocationPermissionBanner
+import xyz.ksharma.krail.core.maps.ui.utils.rememberCameraFollowState
 import xyz.ksharma.krail.core.maps.ui.components.MapTimetableDataBadge
 import xyz.ksharma.krail.core.maps.ui.components.UserLocationButton
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
 import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.map.MaplibreMap
@@ -32,18 +33,18 @@ import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.maps.state.UserLocationConfig
 import xyz.ksharma.krail.core.maps.ui.components.LocationPermissionBanner
-import xyz.ksharma.krail.core.maps.ui.utils.rememberCameraFollowState
 import xyz.ksharma.krail.core.maps.ui.components.MapTimetableDataBadge
 import xyz.ksharma.krail.core.maps.ui.components.UserLocationButton
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig
 import xyz.ksharma.krail.core.maps.ui.config.MapTileProvider
 import xyz.ksharma.krail.core.maps.ui.utils.MapCameraUtils
+import xyz.ksharma.krail.core.maps.ui.utils.dotLocation
+import xyz.ksharma.krail.core.maps.ui.utils.rememberCameraFollowState
 import xyz.ksharma.krail.core.permission.PermissionStatus
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.TrackUserLocation
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyStopFeature
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.StopType
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
@@ -126,12 +127,13 @@ private fun JourneyMapContent(
     }
 
     val cameraState = rememberCameraState(firstPosition = cameraPosition)
+    val cameraFollowState = rememberCameraFollowState(cameraState)
 
     TrackUserLocation(
         userLocationManager = userLocationManager,
-        cameraState = cameraState,
+        cameraFollowState = cameraFollowState,
         allowPermissionRequest = allowPermissionRequest,
-        autoCenter = false,
+        autoCenter = true,
         onLocationUpdate = { latLng ->
             showPermissionBanner = false
             userLocation = latLng
@@ -140,6 +142,11 @@ private fun JourneyMapContent(
             showPermissionBanner = true
         },
     )
+
+    // Disengage follow mode when the user manually pans the map.
+    LaunchedEffect(cameraFollowState) {
+        cameraFollowState.manualPan.collect { cameraFollowState.stopFollowing() }
+    }
 
     Box(modifier = modifier.fillMaxSize()) {
         MaplibreMap(
@@ -160,7 +167,7 @@ private fun JourneyMapContent(
         ) {
             JourneyMapLayers(
                 mapState = mapState,
-                userLocation = userLocation,
+                userLocation = cameraFollowState.dotLocation(userLocation, cameraState),
                 onStopSelect = { selectedStop = it },
             )
         }
@@ -169,18 +176,17 @@ private fun JourneyMapContent(
         UserLocationButton(
             onClick = {
                 onLocationButtonClick(userLocation != null)
-                scope.launch {
-                    val userLoc = userLocation
-                    if (userLoc != null) {
-                        // Re-center camera on latest known position
-                        cameraState.animateTo(
-                            CameraPosition(
-                                target = Position(latitude = userLoc.latitude, longitude = userLoc.longitude),
-                                zoom = UserLocationConfig.RECENTER_ZOOM,
-                            ),
-                            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-                        )
-                    } else {
+                val userLoc = userLocation
+                if (userLoc != null) {
+                    // Re-center camera and enter follow mode so the camera tracks the user.
+                    cameraFollowState.startFollowing()
+                    cameraFollowState.animateTo(
+                        latLng = userLoc,
+                        zoom = UserLocationConfig.RECENTER_ZOOM,
+                        durationMs = UserLocationConfig.RECENTER_ANIMATION_MS,
+                    )
+                } else {
+                    scope.launch {
                         val status = userLocationManager.checkPermissionStatus()
                         if (status is PermissionStatus.Denied) {
                             showPermissionBanner = true

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -47,6 +47,7 @@ import xyz.ksharma.krail.core.maps.ui.components.MapTimetableDataBadge
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig.Ornaments.ATTRIBUTION_ENABLED
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig.Ornaments.LOGO_ENABLED
 import xyz.ksharma.krail.core.maps.ui.config.MapTileProvider.OPEN_FREE_MAP_LIBERTY
+import xyz.ksharma.krail.core.maps.ui.utils.dotLocation
 import xyz.ksharma.krail.core.maps.ui.utils.rememberCameraFollowState
 import xyz.ksharma.krail.core.permission.PermissionStatus
 import xyz.ksharma.krail.core.transport.TransportMode
@@ -247,9 +248,11 @@ private fun MapContent(
                     log("[NEARBY_STOPS_UI] No stops to render")
                 }
 
-                // Render user location as red circle (always on top)
                 UserLocationLayer(
-                    userLocation = mapState.mapDisplay.userLocation,
+                    userLocation = cameraFollowState.dotLocation(
+                        userLocation = mapState.mapDisplay.userLocation,
+                        cameraState = cameraState,
+                    ),
                 )
             }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -47,6 +47,7 @@ import xyz.ksharma.krail.core.maps.ui.components.MapTimetableDataBadge
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig.Ornaments.ATTRIBUTION_ENABLED
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig.Ornaments.LOGO_ENABLED
 import xyz.ksharma.krail.core.maps.ui.config.MapTileProvider.OPEN_FREE_MAP_LIBERTY
+import xyz.ksharma.krail.core.maps.ui.utils.rememberCameraFollowState
 import xyz.ksharma.krail.core.permission.PermissionStatus
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
@@ -59,7 +60,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
-import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun SearchStopMap(
@@ -162,6 +162,7 @@ private fun MapContent(
                 zoom = NearbyStopsConfig.DEFAULT_ZOOM,
             ),
         )
+        val cameraFollowState = rememberCameraFollowState(cameraState)
 
         // Trigger initial load with default camera position
         LaunchedEffect(Unit) {
@@ -178,7 +179,7 @@ private fun MapContent(
 
         TrackUserLocation(
             userLocationManager = userLocationManager,
-            cameraState = cameraState,
+            cameraFollowState = cameraFollowState,
             allowPermissionRequest = allowPermissionRequest,
             onLocationUpdate = { latLng ->
                 permissionStatus = PermissionStatus.Granted
@@ -203,6 +204,11 @@ private fun MapContent(
                         ),
                     )
                 }
+        }
+
+        // Disengage follow mode when the user manually pans the map.
+        LaunchedEffect(cameraFollowState) {
+            cameraFollowState.manualPan.collect { cameraFollowState.stopFollowing() }
         }
 
         Box(modifier = Modifier.fillMaxSize()) {
@@ -259,18 +265,17 @@ private fun MapContent(
                     onEvent(
                         SearchStopUiEvent.LocationButtonClicked(hadLocation = mapState.mapDisplay.userLocation != null),
                     )
-                    scope.launch {
-                        val userLoc = mapState.mapDisplay.userLocation
-                        if (userLoc != null) {
-                            // Tracking is running — re-center camera on latest known position
-                            cameraState.animateTo(
-                                CameraPosition(
-                                    target = userLoc.toPosition(),
-                                    zoom = UserLocationConfig.RECENTER_ZOOM,
-                                ),
-                                duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-                            )
-                        } else {
+                    val userLoc = mapState.mapDisplay.userLocation
+                    if (userLoc != null) {
+                        // Re-center camera and enter follow mode so the camera tracks the user.
+                        cameraFollowState.startFollowing()
+                        cameraFollowState.animateTo(
+                            latLng = userLoc,
+                            zoom = UserLocationConfig.RECENTER_ZOOM,
+                            durationMs = UserLocationConfig.RECENTER_ANIMATION_MS,
+                        )
+                    } else {
+                        scope.launch {
                             val status = userLocationManager.checkPermissionStatus()
                             if (status is PermissionStatus.Denied) {
                                 // Cannot request — direct user to Settings instead
@@ -380,8 +385,6 @@ private fun MapContent(
         }
     }
 }
-
-private fun LatLng.toPosition(): Position = Position(latitude = latitude, longitude = longitude)
 
 // region Previews
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/UserLocationEffect.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/UserLocationEffect.kt
@@ -87,8 +87,10 @@ internal fun TrackUserLocation(
                     onLocationUpdate(latLng)
 
                     if (autoCenter && !hasAutoCentered) {
-                        // Auto-center once on first fix; does not start follow mode.
+                        // Auto-center on first fix and enter follow mode so the camera
+                        // continues tracking the user on every subsequent GPS update.
                         hasAutoCentered = true
+                        cameraFollowState.startFollowing()
                         cameraFollowState.animateTo(
                             latLng = latLng,
                             zoom = UserLocationConfig.AUTO_CENTER_ZOOM,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/UserLocationEffect.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/UserLocationEffect.kt
@@ -5,17 +5,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.lifecycle.compose.LifecycleStartEffect
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
-import org.maplibre.compose.camera.CameraPosition
-import org.maplibre.compose.camera.CameraState
-import org.maplibre.spatialk.geojson.Position
-import xyz.ksharma.krail.core.location.Location
 import xyz.ksharma.krail.core.location.LocationConfig
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.maps.data.location.UserLocationManager
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.maps.state.UserLocationConfig
+import xyz.ksharma.krail.core.maps.ui.utils.CameraFollowState
 import xyz.ksharma.krail.core.permission.PermissionStatus
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Lifecycle-aware side-effect that tracks the user's location while the screen is visible.
@@ -33,7 +29,9 @@ import kotlin.time.Duration.Companion.milliseconds
  *   This should only be true after an explicit user action (location button tap).
  *
  * @param userLocationManager Provides location updates and permission check/request APIs.
- * @param cameraState MapLibre camera used to animate to the user's position when [autoCenter] is true.
+ * @param cameraFollowState Follow-mode camera state. Used to auto-center on first fix when
+ *   [autoCenter] is true, and to track the user on every update when
+ *   [CameraFollowState.isFollowing] is true.
  * @param onLocationUpdate Called on every location fix with the latest [LatLng]. Use this to update
  *   the user-location dot on the map or any other UI that depends on the current position.
  * @param onPermissionDeny Called when location permission is permanently denied so the screen can
@@ -48,7 +46,7 @@ import kotlin.time.Duration.Companion.milliseconds
 @Composable
 internal fun TrackUserLocation(
     userLocationManager: UserLocationManager,
-    cameraState: CameraState,
+    cameraFollowState: CameraFollowState,
     onLocationUpdate: (LatLng) -> Unit,
     onPermissionDeny: (PermissionStatus) -> Unit,
     allowPermissionRequest: Boolean,
@@ -85,18 +83,22 @@ internal fun TrackUserLocation(
                 }
                 .collect { location ->
                     log("[USER_LOCATION] Location update: loc=$location")
-                    onLocationUpdate(LatLng(location.latitude, location.longitude))
-                    // Only pan once: avoids fighting the user's manual camera gestures after
-                    // the first fix. If autoCenter is false (e.g. journey map where the camera
-                    // is already positioned at the journey origin), skip entirely.
+                    val latLng = LatLng(location.latitude, location.longitude)
+                    onLocationUpdate(latLng)
+
                     if (autoCenter && !hasAutoCentered) {
+                        // Auto-center once on first fix; does not start follow mode.
                         hasAutoCentered = true
-                        cameraState.animateTo(
-                            CameraPosition(
-                                target = location.toPosition(),
-                                zoom = UserLocationConfig.AUTO_CENTER_ZOOM,
-                            ),
-                            duration = UserLocationConfig.AUTO_CENTER_ANIMATION_MS.milliseconds,
+                        cameraFollowState.animateTo(
+                            latLng = latLng,
+                            zoom = UserLocationConfig.AUTO_CENTER_ZOOM,
+                            durationMs = UserLocationConfig.AUTO_CENTER_ANIMATION_MS,
+                        )
+                    } else if (cameraFollowState.isFollowing) {
+                        // Follow mode: animate to new position, preserve user's current zoom.
+                        cameraFollowState.animateTo(
+                            latLng = latLng,
+                            durationMs = UserLocationConfig.FOLLOW_ANIMATION_MS,
                         )
                     }
                 }
@@ -108,5 +110,3 @@ internal fun TrackUserLocation(
         }
     }
 }
-
-private fun Location.toPosition(): Position = Position(latitude = latitude, longitude = longitude)


### PR DESCRIPTION
Create CameraFollowState

When the user's location updates arrive, the location dot walks off the visible map area because the camera stays fixed after its initial position.

A reusable CameraFollowState helper is built in core/maps/ui so both screens share identical logic

Add smooth location dot animation between GPS fixes

  Animate the user location dot between consecutive GPS fixes using
  Compose Animatable<LatLng> with LinearEasing over 800 ms (matching
  the camera follow animation duration). First fix snaps immediately so
  the dot doesn't fly in from (0, 0). Subsequent fixes glide smoothly,
  eliminating the jump at 50+ km/h train speeds. Both SearchStopMap and
  JourneyMap use the same LatLngToVector TwoWayConverter.