### PR TITLE
Refactor departure polling to collection-driven flows and improve time formatting

### DIFF
--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -80,13 +80,17 @@ object DateTimeHelper {
     }
 
     fun Duration.toGenericFormattedTimeString(): String {
+        val totalSeconds = this.toLong(DurationUnit.SECONDS)
         val totalMinutes = this.toLong(DurationUnit.MINUTES)
         val hours = this.toLong(DurationUnit.HOURS)
         val partialMinutes = totalMinutes - (hours * 60.minutes.inWholeMinutes)
 
         return when {
             totalMinutes < 0 -> "${totalMinutes.absoluteValue} ${if (totalMinutes.absoluteValue == 1L) "min" else "mins"} ago"
-            totalMinutes == 0L -> "Now"
+            // Just departed or departing within 15 seconds — show "Now"
+            totalSeconds <= 15L -> "Now"
+            // 16–59 seconds upcoming — floor to "in 1 min" rather than "Now"
+            totalMinutes == 0L -> "in 1 min"
             hours == 1L -> "in ${hours.absoluteValue}h ${partialMinutes.absoluteValue}m"
             hours >= 2 -> "in ${hours.absoluteValue}h"
             else -> "in ${totalMinutes.absoluteValue} ${if (totalMinutes.absoluteValue == 1L) "min" else "mins"}"

--- a/feature/departures/ui/build.gradle.kts
+++ b/feature/departures/ui/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
             dependencies {
                 implementation(libs.test.kotlin)
                 implementation(libs.test.kotlinxCoroutineTest)
+                implementation(libs.test.turbine)
             }
         }
     }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -193,7 +193,7 @@ class DepartureBoardRepository(
         // Throw immediately if this coroutine was cancelled before we touch any state.
         currentCoroutineContext().ensureActive()
         val fetchStart = nowMs()
-        log("[$LOG_TAG] t=$fetchStart session=#$sessionId fetchDepartures START stopId=$stopId showFullLoading=$showFullLoading")
+        log("[$LOG_TAG] t=$fetchStart session=#$sessionId fetchDepartures START [API] stopId=$stopId showFullLoading=$showFullLoading")
         val flow = stateFor(stopId)
         if (showFullLoading) {
             flow.update { DeparturesState(isLoading = true) }
@@ -275,7 +275,7 @@ class DepartureBoardRepository(
                 return@launchWithExceptionHandler
             }
 
-            log("[$LOG_TAG] t=$t0 loadPreviousDepartures START stopId=$stopId lastFetch=$elapsedLabel windowMinutes=${config.previousDeparturesWindowMinutes}")
+            log("[$LOG_TAG] t=$t0 loadPreviousDepartures START [API] stopId=$stopId lastFetch=$elapsedLabel windowMinutes=${config.previousDeparturesWindowMinutes}")
             flow.update { it.copy(isPreviousLoading = true) }
             val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
             // suspendSafeResult re-throws CancellationException so it is never silently swallowed.

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.departures.ui
 
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -142,7 +143,8 @@ class DepartureBoardRepository(
         val nowMs = Clock.System.now().toEpochMilliseconds()
         val lastFetch = mutex.withLock { lastFetchTime[stopId] ?: 0L }
         val elapsedMs = nowMs - lastFetch
-        log("[$LOG_TAG] t=$t0 session=#$sessionId lastFetchTime=$lastFetch elapsedMs=$elapsedMs refreshIntervalMs=${config.refreshIntervalMs}")
+        val elapsedLabel = if (lastFetch == 0L) "never fetched" else "${elapsedMs}ms ago"
+        log("[$LOG_TAG] t=$t0 session=#$sessionId lastFetch=$elapsedLabel refreshIntervalMs=${config.refreshIntervalMs}")
 
         mutex.withLock {
             if (activeStopId != stopId) {
@@ -210,6 +212,16 @@ class DepartureBoardRepository(
             // the request was in flight.
             currentCoroutineContext().ensureActive()
             val departures = response.toStopDepartures()
+            // Check whether the cached "previous departures" are too old to keep.
+            // If the last previous-fetch is older than the look-back window (default 30 min),
+            // the data has fully rolled out of the window — clear it so the UI shows a fresh
+            // "Show previous" button instead of hour-old past trips.
+            val prevFetchTime = mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
+            val prevWindowMs = config.previousDeparturesWindowMinutes * 60_000L
+            val isPrevStale = prevFetchTime > 0L && (fetchEnd - prevFetchTime) > prevWindowMs
+            if (isPrevStale) {
+                log("[$LOG_TAG] t=$fetchEnd session=#$sessionId previousDepartures STALE — clearing (age=${fetchEnd - prevFetchTime}ms > window=${prevWindowMs}ms)")
+            }
             log("[$LOG_TAG] t=$fetchEnd session=#$sessionId fetchDepartures SUCCESS stopId=$stopId count=${departures.size} durationMs=${fetchEnd - fetchStart}")
             flow.update { current ->
                 DeparturesState(
@@ -217,9 +229,10 @@ class DepartureBoardRepository(
                     silentLoading = false,
                     isError = false,
                     departures = departures,
-                    // Preserve previously fetched past departures across regular refreshes.
-                    previousDepartures = current.previousDepartures,
-                    isPreviousLoading = current.isPreviousLoading,
+                    // Preserve previously fetched past departures across regular refreshes,
+                    // but discard them if the cache is older than the look-back window.
+                    previousDepartures = if (isPrevStale) persistentListOf() else current.previousDepartures,
+                    isPreviousLoading = if (isPrevStale) false else current.isPreviousLoading,
                     previousWindowMinutes = current.previousWindowMinutes,
                 )
             }
@@ -252,16 +265,17 @@ class DepartureBoardRepository(
             val t0 = nowMs()
             val lastPrevFetch = mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
             val elapsedMs = t0 - lastPrevFetch
+            val elapsedLabel = if (lastPrevFetch == 0L) "never fetched" else "${elapsedMs}ms ago"
             val flow = stateFor(stopId)
 
             // If we already have data and it's still within the refresh window, skip the fetch.
             val isCacheHit = elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()
             if (isCacheHit) {
-                log("[$LOG_TAG] t=$t0 loadPreviousDepartures CACHE HIT stopId=$stopId elapsedMs=$elapsedMs count=${flow.value.previousDepartures.size}")
+                log("[$LOG_TAG] t=$t0 loadPreviousDepartures CACHE HIT stopId=$stopId lastFetch=$elapsedLabel count=${flow.value.previousDepartures.size}")
                 return@launchWithExceptionHandler
             }
 
-            log("[$LOG_TAG] t=$t0 loadPreviousDepartures START stopId=$stopId elapsedMs=$elapsedMs windowMinutes=${config.previousDeparturesWindowMinutes}")
+            log("[$LOG_TAG] t=$t0 loadPreviousDepartures START stopId=$stopId lastFetch=$elapsedLabel windowMinutes=${config.previousDeparturesWindowMinutes}")
             flow.update { it.copy(isPreviousLoading = true) }
             val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
             // suspendSafeResult re-throws CancellationException so it is never silently swallowed.

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -59,6 +59,12 @@ class DepartureBoardRepository(
     private var activeJob: Job? = null
     private var activeStopId: String? = null
 
+    /** Monotonically increasing counter — each `startPolling` call gets its own session ID. */
+    private var pollSessionCounter = 0
+
+    @OptIn(ExperimentalTime::class)
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
+
     /**
      * Returns a hot [Flow] of [DeparturesState] for [stopId].
      * Backed by a [MutableStateFlow] kept in the in-memory cache.
@@ -74,16 +80,23 @@ class DepartureBoardRepository(
      */
     fun setActiveStop(stopId: String?) {
         scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            mutex.withLock {
-                if (activeStopId == stopId) return@launchWithExceptionHandler
+            val t = nowMs()
+            val prev = mutex.withLock {
+                if (activeStopId == stopId) {
+                    log("[$LOG_TAG] t=$t setActiveStop NOOP — already active: $stopId")
+                    return@launchWithExceptionHandler
+                }
+                val old = activeStopId
                 activeJob?.cancel()
                 activeJob = null
                 activeStopId = stopId
+                old
             }
             if (stopId == null) {
-                log("[$LOG_TAG] setActiveStop → null, polling stopped")
+                log("[$LOG_TAG] t=$t setActiveStop → null (was $prev), polling stopped")
                 return@launchWithExceptionHandler
             }
+            log("[$LOG_TAG] t=$t setActiveStop → $stopId (was $prev), cancelled prior job, starting polling")
             startPolling(stopId)
         }
     }
@@ -96,12 +109,15 @@ class DepartureBoardRepository(
      */
     fun stopIfActive(stopId: String) {
         scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
+            val t = nowMs()
             mutex.withLock {
                 if (activeStopId == stopId) {
                     activeJob?.cancel()
                     activeJob = null
                     activeStopId = null
-                    log("[$LOG_TAG] stopIfActive → stopped polling for $stopId")
+                    log("[$LOG_TAG] t=$t stopIfActive MATCHED — stopped polling for $stopId")
+                } else {
+                    log("[$LOG_TAG] t=$t stopIfActive NOOP — active=$activeStopId, requested=$stopId")
                 }
             }
         }
@@ -110,21 +126,29 @@ class DepartureBoardRepository(
     /** Triggers an immediate silent refresh for [stopId], independent of the poll loop. */
     fun refresh(stopId: String) {
         scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
+            log("[$LOG_TAG] t=${nowMs()} refresh triggered for stopId=$stopId")
             fetchDepartures(stopId = stopId, showFullLoading = false)
         }
     }
 
     @OptIn(ExperimentalTime::class)
     private suspend fun startPolling(stopId: String) {
+        val sessionId = ++pollSessionCounter
+        val t0 = nowMs()
         val hasData = stateFor(stopId).value.departures.isNotEmpty()
         if (!hasData) stateFor(stopId).update { DeparturesState(isLoading = true) }
-        log("[$LOG_TAG] setActiveStop → stopId=$stopId, hasData=$hasData")
+        log("[$LOG_TAG] t=$t0 startPolling session=#$sessionId stopId=$stopId hasData=$hasData")
 
         val nowMs = Clock.System.now().toEpochMilliseconds()
-        val elapsedMs = nowMs - mutex.withLock { lastFetchTime[stopId] ?: 0L }
+        val lastFetch = mutex.withLock { lastFetchTime[stopId] ?: 0L }
+        val elapsedMs = nowMs - lastFetch
+        log("[$LOG_TAG] t=$t0 session=#$sessionId lastFetchTime=$lastFetch elapsedMs=$elapsedMs refreshIntervalMs=${config.refreshIntervalMs}")
 
         mutex.withLock {
-            if (activeStopId != stopId) return  // guard: stop was switched while we prepared
+            if (activeStopId != stopId) {
+                log("[$LOG_TAG] t=${this@DepartureBoardRepository.nowMs()} session=#$sessionId ABORTED — active stop changed to $activeStopId before job launched")
+                return  // guard: stop was switched while we prepared
+            }
             activeJob = scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
                 // Check cancellation before any work — covers the gap between launch() and the
                 // first suspension point.
@@ -132,23 +156,28 @@ class DepartureBoardRepository(
                 if (elapsedMs >= config.refreshIntervalMs) {
                     // Either never fetched, or the 30-second window has expired — fetch now.
                     // If we have cached data, do a silent refresh (dots in header, not a spinner).
-                    fetchDepartures(stopId = stopId, showFullLoading = !hasData)
+                    log("[$LOG_TAG] t=${nowMs()} session=#$sessionId window expired ($elapsedMs >= ${config.refreshIntervalMs}ms), fetching now (showFullLoading=${!hasData})")
+                    fetchDepartures(stopId = stopId, showFullLoading = !hasData, sessionId = sessionId)
                 } else {
                     // Still within the 30-second window — show cached data, wait for the remainder.
-                    log("[$LOG_TAG] within refresh window for $stopId, waiting ${config.refreshIntervalMs - elapsedMs}ms")
-                    delay(config.refreshIntervalMs - elapsedMs)
-                    fetchDepartures(stopId = stopId, showFullLoading = false)
+                    val waitMs = config.refreshIntervalMs - elapsedMs
+                    log("[$LOG_TAG] t=${nowMs()} session=#$sessionId within refresh window, waiting ${waitMs}ms before first fetch")
+                    delay(waitMs)
+                    fetchDepartures(stopId = stopId, showFullLoading = false, sessionId = sessionId)
                 }
+                var iteration = 1
                 while (true) {
                     delay(config.refreshIntervalMs)
                     // delay() throws CancellationException when the job is cancelled. The explicit
                     // ensureActive() here is a belt-and-suspenders guard in case a future refactor
                     // moves delay() away from being the first statement.
                     ensureActive()
-                    log("[$LOG_TAG] auto-refresh for stopId=$stopId")
-                    fetchDepartures(stopId = stopId, showFullLoading = false)
+                    log("[$LOG_TAG] t=${nowMs()} session=#$sessionId auto-refresh #$iteration for stopId=$stopId")
+                    fetchDepartures(stopId = stopId, showFullLoading = false, sessionId = sessionId)
+                    iteration++
                 }
             }
+            log("[$LOG_TAG] t=${nowMs()} session=#$sessionId job launched: $activeJob")
         }
     }
 
@@ -158,9 +187,11 @@ class DepartureBoardRepository(
         }
 
     @OptIn(ExperimentalTime::class)
-    private suspend fun fetchDepartures(stopId: String, showFullLoading: Boolean) {
+    private suspend fun fetchDepartures(stopId: String, showFullLoading: Boolean, sessionId: Int = -1) {
         // Throw immediately if this coroutine was cancelled before we touch any state.
         currentCoroutineContext().ensureActive()
+        val fetchStart = nowMs()
+        log("[$LOG_TAG] t=$fetchStart session=#$sessionId fetchDepartures START stopId=$stopId showFullLoading=$showFullLoading")
         val flow = stateFor(stopId)
         if (showFullLoading) {
             flow.update { DeparturesState(isLoading = true) }
@@ -171,14 +202,15 @@ class DepartureBoardRepository(
         departuresService.suspendSafeResult(ioDispatcher) {
             departures(stopId = stopId, date = null, time = null)
         }.onSuccess { response ->
+            val fetchEnd = nowMs()
             // Record fetch time only on success — a failed request should not block the
             // refresh window, so the next setActiveStop can retry immediately.
-            mutex.withLock { lastFetchTime[stopId] = Clock.System.now().toEpochMilliseconds() }
+            mutex.withLock { lastFetchTime[stopId] = fetchEnd }
             // Check again after the network call — the job may have been cancelled while
             // the request was in flight.
             currentCoroutineContext().ensureActive()
             val departures = response.toStopDepartures()
-            log("[$LOG_TAG] success — ${departures.size} departures for stopId=$stopId")
+            log("[$LOG_TAG] t=$fetchEnd session=#$sessionId fetchDepartures SUCCESS stopId=$stopId count=${departures.size} durationMs=${fetchEnd - fetchStart}")
             flow.update { current ->
                 DeparturesState(
                     isLoading = false,
@@ -192,8 +224,9 @@ class DepartureBoardRepository(
                 )
             }
         }.onFailure { throwable ->
+            val fetchEnd = nowMs()
             logError(
-                message = "[$LOG_TAG] failed to fetch departures for stopId=$stopId",
+                message = "[$LOG_TAG] t=$fetchEnd session=#$sessionId fetchDepartures FAILURE stopId=$stopId durationMs=${fetchEnd - fetchStart}",
                 throwable = throwable,
             )
             flow.update {
@@ -216,17 +249,19 @@ class DepartureBoardRepository(
     @OptIn(ExperimentalTime::class)
     fun loadPreviousDepartures(stopId: String) {
         scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            val nowMs = Clock.System.now().toEpochMilliseconds()
-            val elapsedMs = nowMs - mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
+            val t0 = nowMs()
+            val lastPrevFetch = mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
+            val elapsedMs = t0 - lastPrevFetch
             val flow = stateFor(stopId)
 
             // If we already have data and it's still within the refresh window, skip the fetch.
             val isCacheHit = elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()
             if (isCacheHit) {
-                log("[$LOG_TAG] previous departures cache hit for stopId=$stopId (${elapsedMs}ms ago)")
+                log("[$LOG_TAG] t=$t0 loadPreviousDepartures CACHE HIT stopId=$stopId elapsedMs=$elapsedMs count=${flow.value.previousDepartures.size}")
                 return@launchWithExceptionHandler
             }
 
+            log("[$LOG_TAG] t=$t0 loadPreviousDepartures START stopId=$stopId elapsedMs=$elapsedMs windowMinutes=${config.previousDeparturesWindowMinutes}")
             flow.update { it.copy(isPreviousLoading = true) }
             val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
             // suspendSafeResult re-throws CancellationException so it is never silently swallowed.
@@ -239,7 +274,8 @@ class DepartureBoardRepository(
             }.onSuccess { response ->
                 currentCoroutineContext().ensureActive()
                 val now = Clock.System.now()
-                val previous = response.toStopDepartures()
+                val allFromResponse = response.toStopDepartures()
+                val previous = allFromResponse
                     .filter { departure ->
                         runCatching {
                             Instant.parse(departure.departureUtcDateTime) < now
@@ -247,8 +283,9 @@ class DepartureBoardRepository(
                     }
                     .map { it.copy(timing = DepartureTiming.Previous) }
                     .toImmutableList()
-                log("[$LOG_TAG] previous departures — ${previous.size} found for stopId=$stopId")
-                mutex.withLock { lastPreviousFetchTime[stopId] = Clock.System.now().toEpochMilliseconds() }
+                val t1 = nowMs()
+                log("[$LOG_TAG] t=$t1 loadPreviousDepartures SUCCESS stopId=$stopId total=${allFromResponse.size} filtered=${previous.size} durationMs=${t1 - t0}")
+                mutex.withLock { lastPreviousFetchTime[stopId] = t1 }
                 flow.update {
                     it.copy(
                         previousDepartures = previous,
@@ -257,8 +294,9 @@ class DepartureBoardRepository(
                     )
                 }
             }.onFailure { throwable ->
+                val t1 = nowMs()
                 logError(
-                    message = "[$LOG_TAG] failed to fetch previous departures for stopId=$stopId",
+                    message = "[$LOG_TAG] t=$t1 loadPreviousDepartures FAILURE stopId=$stopId durationMs=${t1 - t0}",
                     throwable = throwable,
                 )
                 flow.update { it.copy(isPreviousLoading = false) }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -3,24 +3,22 @@ package xyz.ksharma.krail.departures.ui
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
-import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.coroutines.ext.suspendSafeResult
 import xyz.ksharma.krail.departures.network.api.service.DeparturesService
 import xyz.ksharma.krail.departures.ui.business.toStopDepartures
@@ -32,17 +30,16 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
- * Singleton repository that owns the departure-polling loop.
+ * Repository that owns departure data and the polling lifecycle.
  *
- * At most **one stop** is polled at a time. Callers switch the active stop via
- * [setActiveStop] and observe a stop's state via [observeStop].
+ * **Polling is collection-driven**: callers obtain a polling flow via [pollStop] and collect it;
+ * the network loop runs exactly as long as the flow is collected. When the collector cancels
+ * (e.g. [SharingStarted.WhileSubscribed] stops the chain because the UI went to background, or
+ * [flatMapLatest] switches to a different stop), the loop stops automatically and loading flags
+ * are cleared in a `finally` block — no separate `stopIfActive` call required.
  *
- * The in-memory cache survives for the app lifetime, so previously loaded data
- * remains available while offline or when a card is re-expanded.
- *
- * Thread safety: all mutable state ([cache], [lastFetchTime], [activeStopId], job
- * references) is protected by [mutex]. Callers (ViewModels) may invoke public
- * functions from any thread — the mutex serialises access.
+ * The in-memory [cache] survives the app lifetime, so previously loaded data is always
+ * available while offline or when a card is re-expanded.
  */
 class DepartureBoardRepository(
     private val departuresService: DeparturesService,
@@ -50,152 +47,82 @@ class DepartureBoardRepository(
     private val config: DepartureBoardConfig = DepartureBoardConfig(),
 ) {
 
-    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
     private val mutex = Mutex()
-
     private val cache = mutableMapOf<String, MutableStateFlow<DeparturesState>>()
     private val lastFetchTime = mutableMapOf<String, Long>()
     private val lastPreviousFetchTime = mutableMapOf<String, Long>()
 
-    private var activeJob: Job? = null
-    private var activeStopId: String? = null
-
-    /** Monotonically increasing counter — each `startPolling` call gets its own session ID. */
+    /** Monotonically increasing counter for log correlation — not shared across threads safely,
+     *  but only used for debugging so a rare tear is acceptable. */
     private var pollSessionCounter = 0
 
     @OptIn(ExperimentalTime::class)
     private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
 
     /**
-     * Returns a hot [Flow] of [DeparturesState] for [stopId].
-     * Backed by a [MutableStateFlow] kept in the in-memory cache.
+     * Returns a cold [Flow] of [DeparturesState] for [stopId] backed by the in-memory cache.
+     * Does **not** trigger any network calls. Use [pollStop] when active polling is needed.
      */
     fun observeStop(stopId: String): Flow<DeparturesState> = flow { emitAll(stateFor(stopId)) }
 
     /**
-     * Switches the active polling stop to [stopId].
+     * Returns a cold [Flow] that polls [stopId] for departures **while collected**.
      *
-     * - [stopId] == current active stop → no-op.
-     * - [stopId] is `null` → cancels the current poll, nothing new starts.
-     * - Otherwise → cancels the current poll, starts a 30-second refresh loop for [stopId].
-     */
-    fun setActiveStop(stopId: String?) {
-        scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            val t = nowMs()
-            val prev = mutex.withLock {
-                if (activeStopId == stopId) {
-                    log("[$LOG_TAG] t=$t setActiveStop NOOP — already active: $stopId")
-                    return@launchWithExceptionHandler
-                }
-                val old = activeStopId
-                activeJob?.cancel()
-                activeJob = null
-                activeStopId = stopId
-                old
-            }
-            // If we cancelled a mid-flight job for the previous stop, its onSuccess/onFailure
-            // callbacks never run — clear any stale loading state so the UI doesn't show
-            // spinning dots indefinitely.
-            if (prev != null) {
-                cache[prev]?.update { it.copy(isLoading = false, silentLoading = false) }
-                log("[$LOG_TAG] t=$t setActiveStop CLEARED loading state for abandoned stop $prev")
-            }
-            if (stopId == null) {
-                log("[$LOG_TAG] t=$t setActiveStop → null (was $prev), polling stopped")
-                return@launchWithExceptionHandler
-            }
-            log("[$LOG_TAG] t=$t setActiveStop → $stopId (was $prev), cancelled prior job, starting polling")
-            startPolling(stopId)
-        }
-    }
-
-    /**
-     * Cancels the active poll only if [stopId] is currently the active stop.
+     * - Collection starts → polling loop starts, loading state set if no cached data.
+     * - Collection cancelled → loop stops, loading flags cleared via `finally`.
+     * - Refresh-window guard: if data was fetched recently (within [DepartureBoardConfig.refreshIntervalMs]),
+     *   the flow waits for the remainder of the window before the first fetch.
      *
-     * Safe to call from `ViewModel.onCleared()` — prevents a stale ViewModel from
-     * accidentally stopping a loop started by another consumer.
+     * Designed to be consumed via `flatMapLatest` + `SharingStarted.WhileSubscribed` so that:
+     * - Switching the expanded card cancels the old polling and starts the new one automatically.
+     * - Backgrounding the app stops all polling without any lifecycle-hook wiring.
      */
-    fun stopIfActive(stopId: String) {
-        scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            val t = nowMs()
-            val wasActive = mutex.withLock {
-                if (activeStopId == stopId) {
-                    activeJob?.cancel()
-                    activeJob = null
-                    activeStopId = null
-                    log("[$LOG_TAG] t=$t stopIfActive MATCHED — stopped polling for $stopId")
-                    true
-                } else {
-                    log("[$LOG_TAG] t=$t stopIfActive NOOP — active=$activeStopId, requested=$stopId")
-                    false
-                }
-            }
-            // If we cancelled a mid-flight job, its onSuccess/onFailure callbacks never run —
-            // clear any stale loading state so the UI doesn't show spinning dots indefinitely.
-            if (wasActive) {
-                cache[stopId]?.update { it.copy(isLoading = false, silentLoading = false) }
-                log("[$LOG_TAG] t=${nowMs()} stopIfActive CLEARED loading state for $stopId")
-            }
-        }
-    }
-
-    /** Triggers an immediate silent refresh for [stopId], independent of the poll loop. */
-    fun refresh(stopId: String) {
-        scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            log("[$LOG_TAG] t=${nowMs()} refresh triggered for stopId=$stopId")
-            fetchDepartures(stopId = stopId, showFullLoading = false)
-        }
-    }
-
-    @OptIn(ExperimentalTime::class)
-    private suspend fun startPolling(stopId: String) {
+    fun pollStop(stopId: String): Flow<DeparturesState> = channelFlow {
         val sessionId = ++pollSessionCounter
-        val t0 = nowMs()
-        val hasData = stateFor(stopId).value.departures.isNotEmpty()
-        if (!hasData) stateFor(stopId).update { DeparturesState(isLoading = true) }
-        log("[$LOG_TAG] t=$t0 startPolling session=#$sessionId stopId=$stopId hasData=$hasData")
+        val stateFlow = stateFor(stopId)
 
-        val nowMs = Clock.System.now().toEpochMilliseconds()
-        val lastFetch = mutex.withLock { lastFetchTime[stopId] ?: 0L }
-        val elapsedMs = nowMs - lastFetch
-        val elapsedLabel = if (lastFetch == 0L) "never fetched" else "${elapsedMs}ms ago"
-        log("[$LOG_TAG] t=$t0 session=#$sessionId lastFetch=$elapsedLabel refreshIntervalMs=${config.refreshIntervalMs}")
+        // Forward all cache updates to this channel while the flow is collected.
+        launch { stateFlow.collect { send(it) } }
 
-        mutex.withLock {
-            if (activeStopId != stopId) {
-                log("[$LOG_TAG] t=${this@DepartureBoardRepository.nowMs()} session=#$sessionId ABORTED — active stop changed to $activeStopId before job launched")
-                return  // guard: stop was switched while we prepared
+        try {
+            val hasData = stateFlow.value.departures.isNotEmpty()
+            if (!hasData) stateFlow.update { DeparturesState(isLoading = true) }
+
+            val lastFetch = mutex.withLock { lastFetchTime[stopId] ?: 0L }
+            val t0 = nowMs()
+            val elapsedMs = t0 - lastFetch
+            val elapsedLabel = if (lastFetch == 0L) "never fetched" else "${elapsedMs}ms ago"
+            log("[$LOG_TAG] t=$t0 session=#$sessionId pollStop START stopId=$stopId hasData=$hasData lastFetch=$elapsedLabel refreshIntervalMs=${config.refreshIntervalMs}")
+
+            if (lastFetch == 0L || elapsedMs >= config.refreshIntervalMs) {
+                fetchDepartures(stopId, showFullLoading = !hasData, sessionId = sessionId)
+            } else {
+                val waitMs = config.refreshIntervalMs - elapsedMs
+                log("[$LOG_TAG] t=$t0 session=#$sessionId within refresh window, waiting ${waitMs}ms before first fetch")
+                delay(waitMs)
+                fetchDepartures(stopId, showFullLoading = false, sessionId = sessionId)
             }
-            activeJob = scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-                // Check cancellation before any work — covers the gap between launch() and the
-                // first suspension point.
+
+            var iteration = 1
+            while (true) {
+                delay(config.refreshIntervalMs)
                 ensureActive()
-                if (elapsedMs >= config.refreshIntervalMs) {
-                    // Either never fetched, or the 30-second window has expired — fetch now.
-                    // If we have cached data, do a silent refresh (dots in header, not a spinner).
-                    log("[$LOG_TAG] t=${nowMs()} session=#$sessionId window expired ($elapsedMs >= ${config.refreshIntervalMs}ms), fetching now (showFullLoading=${!hasData})")
-                    fetchDepartures(stopId = stopId, showFullLoading = !hasData, sessionId = sessionId)
-                } else {
-                    // Still within the 30-second window — show cached data, wait for the remainder.
-                    val waitMs = config.refreshIntervalMs - elapsedMs
-                    log("[$LOG_TAG] t=${nowMs()} session=#$sessionId within refresh window, waiting ${waitMs}ms before first fetch")
-                    delay(waitMs)
-                    fetchDepartures(stopId = stopId, showFullLoading = false, sessionId = sessionId)
-                }
-                var iteration = 1
-                while (true) {
-                    delay(config.refreshIntervalMs)
-                    // delay() throws CancellationException when the job is cancelled. The explicit
-                    // ensureActive() here is a belt-and-suspenders guard in case a future refactor
-                    // moves delay() away from being the first statement.
-                    ensureActive()
-                    log("[$LOG_TAG] t=${nowMs()} session=#$sessionId auto-refresh #$iteration for stopId=$stopId")
-                    fetchDepartures(stopId = stopId, showFullLoading = false, sessionId = sessionId)
-                    iteration++
-                }
+                log("[$LOG_TAG] t=${nowMs()} session=#$sessionId auto-refresh #$iteration for stopId=$stopId")
+                fetchDepartures(stopId, showFullLoading = false, sessionId = sessionId)
+                iteration++
             }
-            log("[$LOG_TAG] t=${nowMs()} session=#$sessionId job launched: $activeJob")
+        } finally {
+            // Runs on cancellation (WhileSubscribed, flatMapLatest switch) or completion.
+            // Clears stale loading flags so cached state stays consistent for the next collect.
+            stateFlow.update { it.copy(isLoading = false, silentLoading = false) }
+            log("[$LOG_TAG] t=${nowMs()} session=#$sessionId pollStop ENDED for stopId=$stopId")
         }
+    }
+
+    /** Triggers an immediate silent refresh for [stopId], independent of any polling flow. */
+    suspend fun refresh(stopId: String) {
+        log("[$LOG_TAG] t=${nowMs()} refresh triggered for stopId=$stopId")
+        fetchDepartures(stopId = stopId, showFullLoading = false)
     }
 
     private suspend fun stateFor(stopId: String): MutableStateFlow<DeparturesState> =
@@ -205,7 +132,6 @@ class DepartureBoardRepository(
 
     @OptIn(ExperimentalTime::class)
     private suspend fun fetchDepartures(stopId: String, showFullLoading: Boolean, sessionId: Int = -1) {
-        // Throw immediately if this coroutine was cancelled before we touch any state.
         currentCoroutineContext().ensureActive()
         val fetchStart = nowMs()
         log("[$LOG_TAG] t=$fetchStart session=#$sessionId fetchDepartures START [API] stopId=$stopId showFullLoading=$showFullLoading")
@@ -215,22 +141,13 @@ class DepartureBoardRepository(
         } else {
             flow.update { it.copy(silentLoading = true) }
         }
-        // suspendSafeResult re-throws CancellationException so it is never silently swallowed.
         departuresService.suspendSafeResult(ioDispatcher) {
             departures(stopId = stopId, date = null, time = null)
         }.onSuccess { response ->
             val fetchEnd = nowMs()
-            // Record fetch time only on success — a failed request should not block the
-            // refresh window, so the next setActiveStop can retry immediately.
             mutex.withLock { lastFetchTime[stopId] = fetchEnd }
-            // Check again after the network call — the job may have been cancelled while
-            // the request was in flight.
             currentCoroutineContext().ensureActive()
             val departures = response.toStopDepartures()
-            // Check whether the cached "previous departures" are too old to keep.
-            // If the last previous-fetch is older than the look-back window (default 30 min),
-            // the data has fully rolled out of the window — clear it so the UI shows a fresh
-            // "Show previous" button instead of hour-old past trips.
             val prevFetchTime = mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
             val prevWindowMs = config.previousDeparturesWindowMinutes * 60_000L
             val isPrevStale = prevFetchTime > 0L && (fetchEnd - prevFetchTime) > prevWindowMs
@@ -244,8 +161,6 @@ class DepartureBoardRepository(
                     silentLoading = false,
                     isError = false,
                     departures = departures,
-                    // Preserve previously fetched past departures across regular refreshes,
-                    // but discard them if the cache is older than the look-back window.
                     previousDepartures = if (isPrevStale) persistentListOf() else current.previousDepartures,
                     isPreviousLoading = if (isPrevStale) false else current.isPreviousLoading,
                     previousWindowMinutes = current.previousWindowMinutes,
@@ -275,61 +190,57 @@ class DepartureBoardRepository(
      * Results are stored in [DeparturesState.previousDepartures] and survive regular refreshes.
      */
     @OptIn(ExperimentalTime::class)
-    fun loadPreviousDepartures(stopId: String) {
-        scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
-            val t0 = nowMs()
-            val lastPrevFetch = mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
-            val elapsedMs = t0 - lastPrevFetch
-            val elapsedLabel = if (lastPrevFetch == 0L) "never fetched" else "${elapsedMs}ms ago"
-            val flow = stateFor(stopId)
+    suspend fun loadPreviousDepartures(stopId: String) {
+        val t0 = nowMs()
+        val lastPrevFetch = mutex.withLock { lastPreviousFetchTime[stopId] ?: 0L }
+        val elapsedMs = t0 - lastPrevFetch
+        val elapsedLabel = if (lastPrevFetch == 0L) "never fetched" else "${elapsedMs}ms ago"
+        val flow = stateFor(stopId)
 
-            // If we already have data and it's still within the refresh window, skip the fetch.
-            val isCacheHit = elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()
-            if (isCacheHit) {
-                log("[$LOG_TAG] t=$t0 loadPreviousDepartures CACHE HIT stopId=$stopId lastFetch=$elapsedLabel count=${flow.value.previousDepartures.size}")
-                return@launchWithExceptionHandler
-            }
+        val isCacheHit = elapsedMs < config.refreshIntervalMs && flow.value.previousDepartures.isNotEmpty()
+        if (isCacheHit) {
+            log("[$LOG_TAG] t=$t0 loadPreviousDepartures CACHE HIT stopId=$stopId lastFetch=$elapsedLabel count=${flow.value.previousDepartures.size}")
+            return
+        }
 
-            log("[$LOG_TAG] t=$t0 loadPreviousDepartures START [API] stopId=$stopId lastFetch=$elapsedLabel windowMinutes=${config.previousDeparturesWindowMinutes}")
-            flow.update { it.copy(isPreviousLoading = true) }
-            val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
-            // suspendSafeResult re-throws CancellationException so it is never silently swallowed.
-            departuresService.suspendSafeResult(ioDispatcher) {
-                departures(
-                    stopId = stopId,
-                    date = fromTime.toApiDateString(),
-                    time = fromTime.toApiTimeString(),
-                )
-            }.onSuccess { response ->
-                currentCoroutineContext().ensureActive()
-                val now = Clock.System.now()
-                val allFromResponse = response.toStopDepartures()
-                val previous = allFromResponse
-                    .filter { departure ->
-                        runCatching {
-                            Instant.parse(departure.departureUtcDateTime) < now
-                        }.getOrDefault(false)
-                    }
-                    .map { it.copy(timing = DepartureTiming.Previous) }
-                    .toImmutableList()
-                val t1 = nowMs()
-                log("[$LOG_TAG] t=$t1 loadPreviousDepartures SUCCESS stopId=$stopId total=${allFromResponse.size} filtered=${previous.size} durationMs=${t1 - t0}")
-                mutex.withLock { lastPreviousFetchTime[stopId] = t1 }
-                flow.update {
-                    it.copy(
-                        previousDepartures = previous,
-                        isPreviousLoading = false,
-                        previousWindowMinutes = config.previousDeparturesWindowMinutes,
-                    )
+        log("[$LOG_TAG] t=$t0 loadPreviousDepartures START [API] stopId=$stopId lastFetch=$elapsedLabel windowMinutes=${config.previousDeparturesWindowMinutes}")
+        flow.update { it.copy(isPreviousLoading = true) }
+        val fromTime = Clock.System.now() - config.previousDeparturesWindowMinutes.minutes
+        departuresService.suspendSafeResult(ioDispatcher) {
+            departures(
+                stopId = stopId,
+                date = fromTime.toApiDateString(),
+                time = fromTime.toApiTimeString(),
+            )
+        }.onSuccess { response ->
+            currentCoroutineContext().ensureActive()
+            val now = Clock.System.now()
+            val allFromResponse = response.toStopDepartures()
+            val previous = allFromResponse
+                .filter { departure ->
+                    runCatching {
+                        Instant.parse(departure.departureUtcDateTime) < now
+                    }.getOrDefault(false)
                 }
-            }.onFailure { throwable ->
-                val t1 = nowMs()
-                logError(
-                    message = "[$LOG_TAG] t=$t1 loadPreviousDepartures FAILURE stopId=$stopId durationMs=${t1 - t0}",
-                    throwable = throwable,
+                .map { it.copy(timing = DepartureTiming.Previous) }
+                .toImmutableList()
+            val t1 = nowMs()
+            log("[$LOG_TAG] t=$t1 loadPreviousDepartures SUCCESS stopId=$stopId total=${allFromResponse.size} filtered=${previous.size} durationMs=${t1 - t0}")
+            mutex.withLock { lastPreviousFetchTime[stopId] = t1 }
+            flow.update {
+                it.copy(
+                    previousDepartures = previous,
+                    isPreviousLoading = false,
+                    previousWindowMinutes = config.previousDeparturesWindowMinutes,
                 )
-                flow.update { it.copy(isPreviousLoading = false) }
             }
+        }.onFailure { throwable ->
+            val t1 = nowMs()
+            logError(
+                message = "[$LOG_TAG] t=$t1 loadPreviousDepartures FAILURE stopId=$stopId durationMs=${t1 - t0}",
+                throwable = throwable,
+            )
+            flow.update { it.copy(isPreviousLoading = false) }
         }
     }
 

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt
@@ -93,6 +93,13 @@ class DepartureBoardRepository(
                 activeStopId = stopId
                 old
             }
+            // If we cancelled a mid-flight job for the previous stop, its onSuccess/onFailure
+            // callbacks never run — clear any stale loading state so the UI doesn't show
+            // spinning dots indefinitely.
+            if (prev != null) {
+                cache[prev]?.update { it.copy(isLoading = false, silentLoading = false) }
+                log("[$LOG_TAG] t=$t setActiveStop CLEARED loading state for abandoned stop $prev")
+            }
             if (stopId == null) {
                 log("[$LOG_TAG] t=$t setActiveStop → null (was $prev), polling stopped")
                 return@launchWithExceptionHandler
@@ -111,15 +118,23 @@ class DepartureBoardRepository(
     fun stopIfActive(stopId: String) {
         scope.launchWithExceptionHandler<DepartureBoardRepository>(ioDispatcher) {
             val t = nowMs()
-            mutex.withLock {
+            val wasActive = mutex.withLock {
                 if (activeStopId == stopId) {
                     activeJob?.cancel()
                     activeJob = null
                     activeStopId = null
                     log("[$LOG_TAG] t=$t stopIfActive MATCHED — stopped polling for $stopId")
+                    true
                 } else {
                     log("[$LOG_TAG] t=$t stopIfActive NOOP — active=$activeStopId, requested=$stopId")
+                    false
                 }
+            }
+            // If we cancelled a mid-flight job, its onSuccess/onFailure callbacks never run —
+            // clear any stale loading state so the UI doesn't show spinning dots indefinitely.
+            if (wasActive) {
+                cache[stopId]?.update { it.copy(isLoading = false, silentLoading = false) }
+                log("[$LOG_TAG] t=${nowMs()} stopIfActive CLEARED loading state for $stopId")
             }
         }
     }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -124,9 +124,13 @@ class DeparturesViewModel(
         when (event) {
             is DeparturesUiEvent.LoadDepartures -> {
                 val current = activeStopId.value
-                // Guard: same stop already loaded without error → no-op (rotation-safe)
+                // Guard: same stop already in a good state — don't restart the polling loop,
+                // but always call setActiveStop so the repository can revive a stopped poll
+                // (e.g. after a long screen-lock where Android paused or killed background work).
+                // The repository has its own NOOP guard when the loop is already running.
                 if (event.stopId == current && !uiState.value.isError && !uiState.value.isLoading) {
-                    log("[$LOG_TAG] t=$t onEvent LoadDepartures NOOP — stop ${event.stopId} already loaded (isLoading=${uiState.value.isLoading} isError=${uiState.value.isError})")
+                    log("[$LOG_TAG] t=$t onEvent LoadDepartures SAME STOP — ensuring polling live for ${event.stopId}")
+                    repository.setActiveStop(event.stopId)
                 } else {
                     log("[$LOG_TAG] t=$t onEvent LoadDepartures → stopId=${event.stopId} (was $current)")
                     // Stop polling the previous stop if this ViewModel owns it

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -23,6 +23,7 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
 import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
+import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class DeparturesViewModel(
@@ -32,6 +33,9 @@ class DeparturesViewModel(
 
     // Tracks which stop this ViewModel instance is responsible for polling.
     private val activeStopId = MutableStateFlow<String?>(null)
+
+    @OptIn(ExperimentalTime::class)
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
 
     private val _uiState: MutableStateFlow<DeparturesState> = MutableStateFlow(DeparturesState())
     val uiState: StateFlow<DeparturesState> = _uiState.asStateFlow()
@@ -57,18 +61,25 @@ class DeparturesViewModel(
         initialValue = true,
     )
 
+    private var relativeTimeTickCount = 0
+
     init {
+        log("[$LOG_TAG] t=${nowMs()} ViewModel CREATED")
         // Collect repository flow into _uiState so updateRelativeTimeText() can mutate it.
         viewModelScope.launchWithExceptionHandler<DeparturesViewModel>(ioDispatcher) {
             activeStopId
                 .flatMapLatest { stopId ->
+                    log("[$LOG_TAG] t=${nowMs()} activeStopId changed → $stopId, switching repo flow")
                     if (stopId != null) {
                         repository.observeStop(stopId)
                     } else {
                         flowOf(DeparturesState(isLoading = false))
                     }
                 }
-                .collect { state -> _uiState.value = state }
+                .collect { state ->
+                    log("[$LOG_TAG] t=${nowMs()} repo state received: isLoading=${state.isLoading} silentLoading=${state.silentLoading} isError=${state.isError} departures=${state.departures.size} prevDepartures=${state.previousDepartures.size}")
+                    _uiState.value = state
+                }
         }
     }
 
@@ -82,8 +93,10 @@ class DeparturesViewModel(
     @OptIn(ExperimentalTime::class)
     private fun updateRelativeTimeText() =
         viewModelScope.launchWithExceptionHandler<DeparturesViewModel>(ioDispatcher) {
+            val tick = ++relativeTimeTickCount
+            val t = nowMs()
             _uiState.update { current ->
-                current.copy(
+                val updated = current.copy(
                     departures = current.departures.map { departure ->
                         departure.copy(
                             relativeTimeText = runCatching {
@@ -101,18 +114,21 @@ class DeparturesViewModel(
                         )
                     }.toImmutableList(),
                 )
+                log("[$LOG_TAG] t=$t relativeTime tick=#$tick updated departures=${updated.departures.size} prev=${updated.previousDepartures.size}")
+                updated
             }
         }
 
     fun onEvent(event: DeparturesUiEvent) {
+        val t = nowMs()
         when (event) {
             is DeparturesUiEvent.LoadDepartures -> {
                 val current = activeStopId.value
                 // Guard: same stop already loaded without error → no-op (rotation-safe)
                 if (event.stopId == current && !uiState.value.isError && !uiState.value.isLoading) {
-                    log("[$LOG_TAG] LoadDepartures ignored — stop ${event.stopId} already loaded")
+                    log("[$LOG_TAG] t=$t onEvent LoadDepartures NOOP — stop ${event.stopId} already loaded (isLoading=${uiState.value.isLoading} isError=${uiState.value.isError})")
                 } else {
-                    log("[$LOG_TAG] LoadDepartures → stopId=${event.stopId}")
+                    log("[$LOG_TAG] t=$t onEvent LoadDepartures → stopId=${event.stopId} (was $current)")
                     // Stop polling the previous stop if this ViewModel owns it
                     current?.let { repository.stopIfActive(it) }
                     activeStopId.value = event.stopId
@@ -123,29 +139,36 @@ class DeparturesViewModel(
             DeparturesUiEvent.Refresh -> {
                 val stopId = activeStopId.value
                 if (stopId != null) {
-                    log("[$LOG_TAG] Refresh → stopId=$stopId")
+                    log("[$LOG_TAG] t=$t onEvent Refresh → stopId=$stopId")
                     repository.refresh(stopId)
+                } else {
+                    log("[$LOG_TAG] t=$t onEvent Refresh NOOP — no active stop")
                 }
             }
 
             is DeparturesUiEvent.LoadPreviousDepartures -> {
-                log("[$LOG_TAG] LoadPreviousDepartures → stopId=${event.stopId}")
+                log("[$LOG_TAG] t=$t onEvent LoadPreviousDepartures → stopId=${event.stopId}")
                 repository.loadPreviousDepartures(event.stopId)
             }
 
             DeparturesUiEvent.StopPolling -> {
                 val stopId = activeStopId.value
                 if (stopId != null) {
-                    log("[$LOG_TAG] StopPolling → stopId=$stopId")
+                    log("[$LOG_TAG] t=$t onEvent StopPolling → stopId=$stopId")
                     repository.stopIfActive(stopId)
                     activeStopId.value = null
+                } else {
+                    log("[$LOG_TAG] t=$t onEvent StopPolling NOOP — no active stop")
                 }
             }
         }
     }
 
     override fun onCleared() {
-        activeStopId.value?.let { repository.stopIfActive(it) }
+        val t = nowMs()
+        val stopId = activeStopId.value
+        log("[$LOG_TAG] t=$t ViewModel CLEARED activeStopId=$stopId")
+        stopId?.let { repository.stopIfActive(it) }
         super.onCleared()
     }
 

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.calculateTimeDifferenceFromNow
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.log.log
@@ -71,7 +72,7 @@ class DeparturesViewModel(
                 .flatMapLatest { stopId ->
                     log("[$LOG_TAG] t=${nowMs()} activeStopId changed → $stopId, switching repo flow")
                     if (stopId != null) {
-                        repository.observeStop(stopId)
+                        repository.pollStop(stopId)
                     } else {
                         flowOf(DeparturesState(isLoading = false))
                     }
@@ -124,19 +125,13 @@ class DeparturesViewModel(
         when (event) {
             is DeparturesUiEvent.LoadDepartures -> {
                 val current = activeStopId.value
-                // Guard: same stop already in a good state — don't restart the polling loop,
-                // but always call setActiveStop so the repository can revive a stopped poll
-                // (e.g. after a long screen-lock where Android paused or killed background work).
-                // The repository has its own NOOP guard when the loop is already running.
-                if (event.stopId == current && !uiState.value.isError && !uiState.value.isLoading) {
-                    log("[$LOG_TAG] t=$t onEvent LoadDepartures SAME STOP — ensuring polling live for ${event.stopId}")
-                    repository.setActiveStop(event.stopId)
-                } else {
+                if (event.stopId != current) {
                     log("[$LOG_TAG] t=$t onEvent LoadDepartures → stopId=${event.stopId} (was $current)")
-                    // Stop polling the previous stop if this ViewModel owns it
-                    current?.let { repository.stopIfActive(it) }
+                    // Switching activeStopId causes flatMapLatest to cancel the old pollStop
+                    // flow and start a new one — no manual stopIfActive/setActiveStop needed.
                     activeStopId.value = event.stopId
-                    repository.setActiveStop(event.stopId)
+                } else {
+                    log("[$LOG_TAG] t=$t onEvent LoadDepartures SAME STOP — already polling ${event.stopId}")
                 }
             }
 
@@ -144,7 +139,7 @@ class DeparturesViewModel(
                 val stopId = activeStopId.value
                 if (stopId != null) {
                     log("[$LOG_TAG] t=$t onEvent Refresh → stopId=$stopId")
-                    repository.refresh(stopId)
+                    viewModelScope.launch { repository.refresh(stopId) }
                 } else {
                     log("[$LOG_TAG] t=$t onEvent Refresh NOOP — no active stop")
                 }
@@ -152,14 +147,15 @@ class DeparturesViewModel(
 
             is DeparturesUiEvent.LoadPreviousDepartures -> {
                 log("[$LOG_TAG] t=$t onEvent LoadPreviousDepartures → stopId=${event.stopId}")
-                repository.loadPreviousDepartures(event.stopId)
+                viewModelScope.launch { repository.loadPreviousDepartures(event.stopId) }
             }
 
             DeparturesUiEvent.StopPolling -> {
                 val stopId = activeStopId.value
                 if (stopId != null) {
                     log("[$LOG_TAG] t=$t onEvent StopPolling → stopId=$stopId")
-                    repository.stopIfActive(stopId)
+                    // Setting to null switches flatMapLatest to flowOf(idle state),
+                    // which cancels the pollStop flow and stops the polling loop.
                     activeStopId.value = null
                 } else {
                     log("[$LOG_TAG] t=$t onEvent StopPolling NOOP — no active stop")
@@ -169,10 +165,9 @@ class DeparturesViewModel(
     }
 
     override fun onCleared() {
-        val t = nowMs()
-        val stopId = activeStopId.value
-        log("[$LOG_TAG] t=$t ViewModel CLEARED activeStopId=$stopId")
-        stopId?.let { repository.stopIfActive(it) }
+        log("[$LOG_TAG] t=${nowMs()} ViewModel CLEARED activeStopId=${activeStopId.value}")
+        // viewModelScope cancellation propagates to the flatMapLatest → pollStop chain,
+        // which clears loading state via its finally block. No manual cleanup needed.
         super.onCleared()
     }
 

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepositoryTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepositoryTest.kt
@@ -30,267 +30,174 @@ class DepartureBoardRepositoryTest {
         config = testConfig,
     )
 
-    // ── setActiveStop / observeStop ───────────────────────────────────────────
+    // ── pollStop — initial fetch ──────────────────────────────────────────────
 
     @Test
-    fun `Given no active stop When setActiveStop is called Then observeStop emits loading state`() =
-        runTest {
-            val service = FakeDeparturesService()
-            val repo = makeRepo(service)
-
-            repo.observeStop(STOP_A).test {
-                // Initial state before setActiveStop
-                val initial = awaitItem()
-                assertFalse(initial.isLoading, "Initial state should not be loading")
-
-                repo.setActiveStop(STOP_A)
-                advanceUntilIdle()
-
-                // After setActiveStop with no cached data, repository emits loading=true
-                val loading = awaitItem()
-                assertTrue(loading.isLoading, "Should show full loading when no cached data")
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `Given active stop set When API succeeds Then observeStop emits departures`() =
+    fun `Given no cached data When pollStop collected Then emits loading then success`() =
         runTest {
             val service = FakeDeparturesService(response = buildResponse(count = 3))
             val repo = makeRepo(service)
 
-            repo.observeStop(STOP_A).test {
-                awaitItem() // initial
+            repo.pollStop(STOP_A).test {
+                // loading
+                val loading = awaitItem()
+                assertTrue(loading.isLoading, "Should show full loading when no cached data")
 
-                repo.setActiveStop(STOP_A)
                 advanceUntilIdle()
 
-                // loading state
-                awaitItem()
-
-                val result = awaitItem()
-                assertFalse(result.isLoading)
-                assertFalse(result.isError)
-                assertEquals(3, result.departures.size)
+                val success = awaitItem()
+                assertFalse(success.isLoading)
+                assertFalse(success.isError)
+                assertEquals(3, success.departures.size)
 
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `Given active stop set When API fails Then observeStop emits error state`() =
+    fun `Given no cached data When API fails Then emits error state`() = runTest {
+        val service = FakeDeparturesService(shouldThrow = true)
+        val repo = makeRepo(service)
+
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+
+            advanceUntilIdle()
+
+            val error = awaitItem()
+            assertFalse(error.isLoading)
+            assertTrue(error.isError, "Should show error when API fails with no cached data")
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── pollStop — cancellation clears loading state ──────────────────────────
+
+    @Test
+    fun `Given pollStop collected When collection cancelled Then loading flags cleared`() =
         runTest {
-            val service = FakeDeparturesService(shouldThrow = true)
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
             val repo = makeRepo(service)
 
+            repo.pollStop(STOP_A).test {
+                awaitItem() // loading — cancelled mid-flight
+                cancelAndIgnoreRemainingEvents()
+            }
+            advanceUntilIdle()
+
+            // After cancellation, cache should have isLoading=false
             repo.observeStop(STOP_A).test {
-                awaitItem() // initial
+                val state = awaitItem()
+                assertFalse(state.isLoading, "isLoading must be cleared after pollStop cancelled")
+                assertFalse(state.silentLoading, "silentLoading must be cleared after pollStop cancelled")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
-                repo.setActiveStop(STOP_A)
-                advanceUntilIdle()
+    // ── pollStop — auto-refresh loop ──────────────────────────────────────────
 
+    @Test
+    fun `Given active pollStop When refresh interval elapses Then API is called again`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.pollStop(STOP_A).test {
                 awaitItem() // loading
+                advanceUntilIdle()
+                awaitItem() // first success
+                val callsAfterFirst = service.callCount
 
-                val result = awaitItem()
-                assertFalse(result.isLoading)
-                assertTrue(result.isError, "Should show error when API fails and no cached data")
+                advanceTimeBy(testConfig.refreshIntervalMs + 100)
+                advanceUntilIdle()
 
+                assertTrue(service.callCount > callsAfterFirst, "Auto-refresh should fire after interval elapses")
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
-    @Test
-    fun `Given setActiveStop called with same stop When already active Then NOOP - no extra loading emitted`() =
-        runTest {
-            val service = FakeDeparturesService(response = buildResponse(count = 2))
-            val repo = makeRepo(service)
-
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-
-            val callCountBefore = service.callCount
-
-            repo.setActiveStop(STOP_A) // same stop — should NOOP
-            advanceUntilIdle()
-
-            assertEquals(callCountBefore, service.callCount, "No extra API call for same stop")
-        }
+    // ── pollStop — refresh window (cache hit) ─────────────────────────────────
 
     @Test
-    fun `Given stop A is active When setActiveStop called with null Then polling stops`() =
+    fun `Given recent successful fetch When pollStop re-collected quickly Then waits for window before fetch`() =
         runTest {
             val service = FakeDeparturesService(response = buildResponse(count = 1))
             val repo = makeRepo(service)
 
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-            val callsAfterFirstActivation = service.callCount
+            // First collection — fetches immediately
+            repo.pollStop(STOP_A).test {
+                awaitItem() // loading
+                advanceUntilIdle()
+                awaitItem() // success
+                cancelAndIgnoreRemainingEvents()
+            }
+            val callsAfterFirst = service.callCount
 
-            repo.setActiveStop(null)
-            advanceUntilIdle()
-
-            // Advance past the refresh interval — no new calls should fire
-            advanceTimeBy(testConfig.refreshIntervalMs * 3)
-            advanceUntilIdle()
-
-            assertEquals(callsAfterFirstActivation, service.callCount, "No further calls after stop set to null")
+            // Re-collect immediately — still within the refresh window
+            repo.pollStop(STOP_A).test {
+                // Should NOT emit a new loading state (has cached data)
+                advanceUntilIdle()
+                // No new fetch should have fired yet
+                assertEquals(callsAfterFirst, service.callCount, "No immediate re-fetch within the refresh window")
+                cancelAndIgnoreRemainingEvents()
+            }
         }
 
-    // ── stopIfActive ─────────────────────────────────────────────────────────
+    // ── observeStop — reads cache without polling ─────────────────────────────
 
     @Test
-    fun `Given stop A is active When stopIfActive called with A Then loading state is cleared`() =
+    fun `Given no active polling When observeStop collected Then emits idle state — no API call`() =
         runTest {
             val service = FakeDeparturesService(response = buildResponse(count = 2))
             val repo = makeRepo(service)
 
             repo.observeStop(STOP_A).test {
-                awaitItem() // initial
-
-                repo.setActiveStop(STOP_A)
-                advanceUntilIdle()
-
-                // Consume loading + success
-                awaitItem()
-                awaitItem()
-
-                repo.stopIfActive(STOP_A)
-                advanceUntilIdle()
-
-                // After stopIfActive, loading flags must be false
-                // (the repo clears them even if a job was cancelled mid-flight)
-                expectNoEvents()
-
+                val initial = awaitItem()
+                assertFalse(initial.isLoading, "observeStop should not trigger loading")
+                assertEquals(0, service.callCount, "observeStop must not call the API")
                 cancelAndIgnoreRemainingEvents()
             }
-        }
-
-    @Test
-    fun `Given stop A is active When stopIfActive called with stop B Then polling for A continues`() =
-        runTest {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
-
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-            val callsAfterActivation = service.callCount
-
-            repo.stopIfActive(STOP_B) // wrong stop — should NOOP
-            advanceUntilIdle()
-
-            // Advance past one refresh window — polling should still fire
-            advanceTimeBy(testConfig.refreshIntervalMs + 100)
-            advanceUntilIdle()
-
-            assertTrue(service.callCount > callsAfterActivation, "Polling should continue after NOOP stopIfActive")
         }
 
     // ── refresh ───────────────────────────────────────────────────────────────
 
     @Test
-    fun `Given active stop When refresh called Then API is called immediately`() =
-        runTest {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
+    fun `Given cached data When refresh called Then API is called immediately`() = runTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 1))
+        val repo = makeRepo(service)
 
-            repo.setActiveStop(STOP_A)
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
             advanceUntilIdle()
+            awaitItem() // success
             val callsBefore = service.callCount
 
             repo.refresh(STOP_A)
             advanceUntilIdle()
 
             assertEquals(callsBefore + 1, service.callCount, "refresh should trigger one extra API call")
+            cancelAndIgnoreRemainingEvents()
         }
-
-    // ── refresh window (cache hit) ────────────────────────────────────────────
-
-    @Test
-    fun `Given recent fetch When setActiveStop same stop then switch back quickly Then no duplicate fetch`() =
-        runTest {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
-
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-            val callsAfterFirst = service.callCount
-
-            repo.setActiveStop(STOP_B)
-            advanceUntilIdle()
-            repo.setActiveStop(STOP_A) // return to A quickly — should be within the refresh window
-            advanceUntilIdle()
-
-            // Stop A was fetched recently — the window check in startPolling means no immediate re-fetch
-            assertEquals(callsAfterFirst, service.callCount - 1, "Re-activating stop A within window should wait, not fetch immediately")
-        }
-
-    // ── auto-refresh loop ─────────────────────────────────────────────────────
-
-    @Test
-    fun `Given active stop When refresh interval elapses Then API is called again`() =
-        runTest {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
-
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-            val callsAfterFirst = service.callCount
-
-            advanceTimeBy(testConfig.refreshIntervalMs + 100)
-            advanceUntilIdle()
-
-            assertTrue(service.callCount > callsAfterFirst, "Auto-refresh should fire after interval elapses")
-        }
-
-    // ── stale loading state cleared on job cancel ─────────────────────────────
-
-    @Test
-    fun `Given silent refresh in flight When setActiveStop switches stop Then abandoned stop loading is cleared`() =
-        runTest {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
-
-            // Load stop A once so it has data (enabling silent refresh on re-activation)
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-
-            repo.observeStop(STOP_A).test {
-                awaitItem() // current state
-
-                // Switch away — cancels any in-flight job for stop A
-                repo.setActiveStop(STOP_B)
-                advanceUntilIdle()
-
-                // Stop A's loading flags should be cleared after the job is cancelled
-                val stateAfterSwitch = expectMostRecentItem()
-                assertFalse(stateAfterSwitch.isLoading, "isLoading must be false after stop switched away")
-                assertFalse(stateAfterSwitch.silentLoading, "silentLoading must be false after stop switched away")
-
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
+    }
 
     // ── loadPreviousDepartures ────────────────────────────────────────────────
 
     @Test
     fun `Given loadPreviousDepartures called When API succeeds Then previousDepartures populated`() =
         runTest {
-            // Use a departure time in the past so the filter keeps it
             val pastTime = "2020-01-01T00:00:00Z"
             val service = FakeDeparturesService(response = buildResponse(count = 2, plannedTime = pastTime))
             val repo = makeRepo(service)
 
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
-
-            repo.observeStop(STOP_A).test {
-                awaitItem() // current state after initial fetch
+            repo.pollStop(STOP_A).test {
+                awaitItem() // loading
+                advanceUntilIdle()
+                awaitItem() // success
 
                 repo.loadPreviousDepartures(STOP_A)
                 advanceUntilIdle()
 
-                // isPreviousLoading = true then false
                 val loading = awaitItem()
                 assertTrue(loading.isPreviousLoading)
 
@@ -308,14 +215,12 @@ class DepartureBoardRepositoryTest {
             val service = FakeDeparturesService(response = buildResponse(count = 1))
             val repo = makeRepo(service)
 
-            repo.setActiveStop(STOP_A)
-            advanceUntilIdle()
+            repo.pollStop(STOP_A).test {
+                awaitItem() // loading
+                advanceUntilIdle()
+                awaitItem() // success
 
-            // Now make service throw for the next call (previous departures fetch)
-            service.shouldThrow = true
-
-            repo.observeStop(STOP_A).test {
-                awaitItem() // current state
+                service.shouldThrow = true
 
                 repo.loadPreviousDepartures(STOP_A)
                 advanceUntilIdle()
@@ -326,6 +231,35 @@ class DepartureBoardRepositoryTest {
                 val done = awaitItem()
                 assertFalse(done.isPreviousLoading, "isPreviousLoading must be cleared even on failure")
 
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // ── silent-loading cleared on cancellation ────────────────────────────────
+
+    @Test
+    fun `Given silent refresh in flight When collection cancelled Then silentLoading cleared`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            // First collect — populates cache so next collect does a silent refresh
+            repo.pollStop(STOP_A).test {
+                awaitItem() // loading
+                advanceUntilIdle()
+                awaitItem() // success
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            // Second collect — cancels while silentLoading may be in flight
+            repo.pollStop(STOP_A).test {
+                cancelAndIgnoreRemainingEvents()
+            }
+            advanceUntilIdle()
+
+            repo.observeStop(STOP_A).test {
+                val state = awaitItem()
+                assertFalse(state.silentLoading, "silentLoading must be cleared after cancellation")
                 cancelAndIgnoreRemainingEvents()
             }
         }

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepositoryTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepositoryTest.kt
@@ -1,0 +1,383 @@
+package xyz.ksharma.krail.departures.ui
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
+import xyz.ksharma.krail.departures.network.api.service.DeparturesService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DepartureBoardRepositoryTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    // Minimal config with a short refresh interval so tests don't wait 30 s.
+    private val testConfig = DepartureBoardConfig(
+        refreshIntervalMs = 1_000L,
+        previousDeparturesWindowMinutes = 30L,
+    )
+
+    private fun makeRepo(service: DeparturesService) = DepartureBoardRepository(
+        departuresService = service,
+        ioDispatcher = testDispatcher,
+        config = testConfig,
+    )
+
+    // ── setActiveStop / observeStop ───────────────────────────────────────────
+
+    @Test
+    fun `Given no active stop When setActiveStop is called Then observeStop emits loading state`() =
+        runTest {
+            val service = FakeDeparturesService()
+            val repo = makeRepo(service)
+
+            repo.observeStop(STOP_A).test {
+                // Initial state before setActiveStop
+                val initial = awaitItem()
+                assertFalse(initial.isLoading, "Initial state should not be loading")
+
+                repo.setActiveStop(STOP_A)
+                advanceUntilIdle()
+
+                // After setActiveStop with no cached data, repository emits loading=true
+                val loading = awaitItem()
+                assertTrue(loading.isLoading, "Should show full loading when no cached data")
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given active stop set When API succeeds Then observeStop emits departures`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 3))
+            val repo = makeRepo(service)
+
+            repo.observeStop(STOP_A).test {
+                awaitItem() // initial
+
+                repo.setActiveStop(STOP_A)
+                advanceUntilIdle()
+
+                // loading state
+                awaitItem()
+
+                val result = awaitItem()
+                assertFalse(result.isLoading)
+                assertFalse(result.isError)
+                assertEquals(3, result.departures.size)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given active stop set When API fails Then observeStop emits error state`() =
+        runTest {
+            val service = FakeDeparturesService(shouldThrow = true)
+            val repo = makeRepo(service)
+
+            repo.observeStop(STOP_A).test {
+                awaitItem() // initial
+
+                repo.setActiveStop(STOP_A)
+                advanceUntilIdle()
+
+                awaitItem() // loading
+
+                val result = awaitItem()
+                assertFalse(result.isLoading)
+                assertTrue(result.isError, "Should show error when API fails and no cached data")
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given setActiveStop called with same stop When already active Then NOOP - no extra loading emitted`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 2))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+
+            val callCountBefore = service.callCount
+
+            repo.setActiveStop(STOP_A) // same stop — should NOOP
+            advanceUntilIdle()
+
+            assertEquals(callCountBefore, service.callCount, "No extra API call for same stop")
+        }
+
+    @Test
+    fun `Given stop A is active When setActiveStop called with null Then polling stops`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+            val callsAfterFirstActivation = service.callCount
+
+            repo.setActiveStop(null)
+            advanceUntilIdle()
+
+            // Advance past the refresh interval — no new calls should fire
+            advanceTimeBy(testConfig.refreshIntervalMs * 3)
+            advanceUntilIdle()
+
+            assertEquals(callsAfterFirstActivation, service.callCount, "No further calls after stop set to null")
+        }
+
+    // ── stopIfActive ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `Given stop A is active When stopIfActive called with A Then loading state is cleared`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 2))
+            val repo = makeRepo(service)
+
+            repo.observeStop(STOP_A).test {
+                awaitItem() // initial
+
+                repo.setActiveStop(STOP_A)
+                advanceUntilIdle()
+
+                // Consume loading + success
+                awaitItem()
+                awaitItem()
+
+                repo.stopIfActive(STOP_A)
+                advanceUntilIdle()
+
+                // After stopIfActive, loading flags must be false
+                // (the repo clears them even if a job was cancelled mid-flight)
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given stop A is active When stopIfActive called with stop B Then polling for A continues`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+            val callsAfterActivation = service.callCount
+
+            repo.stopIfActive(STOP_B) // wrong stop — should NOOP
+            advanceUntilIdle()
+
+            // Advance past one refresh window — polling should still fire
+            advanceTimeBy(testConfig.refreshIntervalMs + 100)
+            advanceUntilIdle()
+
+            assertTrue(service.callCount > callsAfterActivation, "Polling should continue after NOOP stopIfActive")
+        }
+
+    // ── refresh ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Given active stop When refresh called Then API is called immediately`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+            val callsBefore = service.callCount
+
+            repo.refresh(STOP_A)
+            advanceUntilIdle()
+
+            assertEquals(callsBefore + 1, service.callCount, "refresh should trigger one extra API call")
+        }
+
+    // ── refresh window (cache hit) ────────────────────────────────────────────
+
+    @Test
+    fun `Given recent fetch When setActiveStop same stop then switch back quickly Then no duplicate fetch`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+            val callsAfterFirst = service.callCount
+
+            repo.setActiveStop(STOP_B)
+            advanceUntilIdle()
+            repo.setActiveStop(STOP_A) // return to A quickly — should be within the refresh window
+            advanceUntilIdle()
+
+            // Stop A was fetched recently — the window check in startPolling means no immediate re-fetch
+            assertEquals(callsAfterFirst, service.callCount - 1, "Re-activating stop A within window should wait, not fetch immediately")
+        }
+
+    // ── auto-refresh loop ─────────────────────────────────────────────────────
+
+    @Test
+    fun `Given active stop When refresh interval elapses Then API is called again`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+            val callsAfterFirst = service.callCount
+
+            advanceTimeBy(testConfig.refreshIntervalMs + 100)
+            advanceUntilIdle()
+
+            assertTrue(service.callCount > callsAfterFirst, "Auto-refresh should fire after interval elapses")
+        }
+
+    // ── stale loading state cleared on job cancel ─────────────────────────────
+
+    @Test
+    fun `Given silent refresh in flight When setActiveStop switches stop Then abandoned stop loading is cleared`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            // Load stop A once so it has data (enabling silent refresh on re-activation)
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+
+            repo.observeStop(STOP_A).test {
+                awaitItem() // current state
+
+                // Switch away — cancels any in-flight job for stop A
+                repo.setActiveStop(STOP_B)
+                advanceUntilIdle()
+
+                // Stop A's loading flags should be cleared after the job is cancelled
+                val stateAfterSwitch = expectMostRecentItem()
+                assertFalse(stateAfterSwitch.isLoading, "isLoading must be false after stop switched away")
+                assertFalse(stateAfterSwitch.silentLoading, "silentLoading must be false after stop switched away")
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // ── loadPreviousDepartures ────────────────────────────────────────────────
+
+    @Test
+    fun `Given loadPreviousDepartures called When API succeeds Then previousDepartures populated`() =
+        runTest {
+            // Use a departure time in the past so the filter keeps it
+            val pastTime = "2020-01-01T00:00:00Z"
+            val service = FakeDeparturesService(response = buildResponse(count = 2, plannedTime = pastTime))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+
+            repo.observeStop(STOP_A).test {
+                awaitItem() // current state after initial fetch
+
+                repo.loadPreviousDepartures(STOP_A)
+                advanceUntilIdle()
+
+                // isPreviousLoading = true then false
+                val loading = awaitItem()
+                assertTrue(loading.isPreviousLoading)
+
+                val done = awaitItem()
+                assertFalse(done.isPreviousLoading)
+                assertTrue(done.previousDepartures.isNotEmpty(), "Previous departures should be populated")
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given loadPreviousDepartures called When API fails Then isPreviousLoading is reset to false`() =
+        runTest {
+            val service = FakeDeparturesService(response = buildResponse(count = 1))
+            val repo = makeRepo(service)
+
+            repo.setActiveStop(STOP_A)
+            advanceUntilIdle()
+
+            // Now make service throw for the next call (previous departures fetch)
+            service.shouldThrow = true
+
+            repo.observeStop(STOP_A).test {
+                awaitItem() // current state
+
+                repo.loadPreviousDepartures(STOP_A)
+                advanceUntilIdle()
+
+                val loading = awaitItem()
+                assertTrue(loading.isPreviousLoading)
+
+                val done = awaitItem()
+                assertFalse(done.isPreviousLoading, "isPreviousLoading must be cleared even on failure")
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun buildResponse(
+        count: Int,
+        plannedTime: String = "2099-01-01T09:00:00Z",
+    ) = DepartureMonitorResponse(
+        stopEvents = List(count) {
+            DepartureMonitorResponse.StopEvent(
+                departureTimePlanned = plannedTime,
+                departureTimeEstimated = null,
+                transportation = DepartureMonitorResponse.Transportation(
+                    id = "T1",
+                    disassembledName = "T1",
+                    destination = DepartureMonitorResponse.Destination(
+                        id = "dest",
+                        name = "Destination $it",
+                    ),
+                    product = DepartureMonitorResponse.Product(cls = 1, iconId = 1, name = "Train"),
+                ),
+                location = null,
+            )
+        },
+    )
+
+    private companion object {
+        const val STOP_A = "10111010"
+        const val STOP_B = "10111020"
+    }
+}
+
+/**
+ * Fake [DeparturesService] that returns a configurable response or throws.
+ */
+class FakeDeparturesService(
+    var response: DepartureMonitorResponse = DepartureMonitorResponse(stopEvents = emptyList()),
+    var shouldThrow: Boolean = false,
+) : DeparturesService {
+
+    var callCount = 0
+        private set
+
+    override suspend fun departures(
+        stopId: String,
+        date: String?,
+        time: String?,
+    ): DepartureMonitorResponse {
+        callCount++
+        if (shouldThrow) throw RuntimeException("Fake network error")
+        return response
+    }
+}

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModelTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModelTest.kt
@@ -1,0 +1,211 @@
+package xyz.ksharma.krail.departures.ui
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
+import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeparturesViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testConfig = DepartureBoardConfig(
+        refreshIntervalMs = 1_000L,
+        previousDeparturesWindowMinutes = 30L,
+    )
+
+    private lateinit var fakeService: FakeDeparturesService
+    private lateinit var repository: DepartureBoardRepository
+    private lateinit var viewModel: DeparturesViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        fakeService = FakeDeparturesService(response = buildResponse(2))
+        repository = DepartureBoardRepository(
+            departuresService = fakeService,
+            ioDispatcher = testDispatcher,
+            config = testConfig,
+        )
+        viewModel = DeparturesViewModel(
+            repository = repository,
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // ── LoadDepartures ────────────────────────────────────────────────────────
+
+    @Test
+    fun `Given initial state When no event sent Then uiState is default`() = runTest {
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            // DeparturesState() defaults: isLoading=true, not error, no departures
+            assertTrue(initial.isLoading || !initial.isError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `Given LoadDepartures event sent When API succeeds Then uiState has departures`() =
+        runTest {
+            viewModel.uiState.test {
+                awaitItem() // initial
+
+                viewModel.onEvent(DeparturesUiEvent.LoadDepartures(STOP_A))
+                advanceUntilIdle()
+
+                // loading
+                awaitItem()
+
+                val success = awaitItem()
+                assertFalse(success.isLoading)
+                assertFalse(success.isError)
+                assertEquals(2, success.departures.size)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given LoadDepartures event sent When API fails Then uiState shows error`() = runTest {
+        fakeService.shouldThrow = true
+
+        viewModel.uiState.test {
+            awaitItem() // initial
+
+            viewModel.onEvent(DeparturesUiEvent.LoadDepartures(STOP_A))
+            advanceUntilIdle()
+
+            awaitItem() // loading
+
+            val error = awaitItem()
+            assertFalse(error.isLoading)
+            assertTrue(error.isError)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── StopPolling ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `Given active stop When StopPolling sent Then uiState resets to idle`() = runTest {
+        viewModel.uiState.test {
+            awaitItem() // initial
+
+            viewModel.onEvent(DeparturesUiEvent.LoadDepartures(STOP_A))
+            advanceUntilIdle()
+
+            awaitItem() // loading
+            awaitItem() // success
+
+            viewModel.onEvent(DeparturesUiEvent.StopPolling)
+            advanceUntilIdle()
+
+            // After StopPolling the VM switches activeStopId to null → repo emits idle state
+            val idle = awaitItem()
+            assertFalse(idle.isLoading, "Should not be loading after polling stopped")
+            assertFalse(idle.isError)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // ── Refresh ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Given active stop When Refresh sent Then API is called again`() = runTest {
+        viewModel.onEvent(DeparturesUiEvent.LoadDepartures(STOP_A))
+        advanceUntilIdle()
+        val callsBefore = fakeService.callCount
+
+        viewModel.onEvent(DeparturesUiEvent.Refresh)
+        advanceUntilIdle()
+
+        assertEquals(callsBefore + 1, fakeService.callCount)
+    }
+
+    @Test
+    fun `Given no active stop When Refresh sent Then NOOP - no API call`() = runTest {
+        // No LoadDepartures sent → no active stop
+        val callsBefore = fakeService.callCount
+
+        viewModel.onEvent(DeparturesUiEvent.Refresh)
+        advanceUntilIdle()
+
+        assertEquals(callsBefore, fakeService.callCount, "Refresh with no active stop should be a NOOP")
+    }
+
+    // ── LoadPreviousDepartures ────────────────────────────────────────────────
+
+    @Test
+    fun `Given active stop When LoadPreviousDepartures sent Then isPreviousLoading transitions true then false`() =
+        runTest {
+            // Use a past departure time so the previous departures filter keeps the rows
+            fakeService.response = buildResponse(count = 1, plannedTime = "2020-01-01T00:00:00Z")
+
+            viewModel.onEvent(DeparturesUiEvent.LoadDepartures(STOP_A))
+            advanceUntilIdle()
+
+            viewModel.uiState.test {
+                awaitItem() // current success state
+
+                viewModel.onEvent(DeparturesUiEvent.LoadPreviousDepartures(STOP_A))
+                advanceUntilIdle()
+
+                val loading = awaitItem()
+                assertTrue(loading.isPreviousLoading)
+
+                val done = awaitItem()
+                assertFalse(done.isPreviousLoading)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun buildResponse(
+        count: Int,
+        plannedTime: String = "2099-01-01T09:00:00Z",
+    ) = DepartureMonitorResponse(
+        stopEvents = List(count) {
+            DepartureMonitorResponse.StopEvent(
+                departureTimePlanned = plannedTime,
+                departureTimeEstimated = null,
+                transportation = DepartureMonitorResponse.Transportation(
+                    id = "T1",
+                    disassembledName = "T1",
+                    destination = DepartureMonitorResponse.Destination(
+                        id = "dest",
+                        name = "Destination $it",
+                    ),
+                    product = DepartureMonitorResponse.Product(cls = 1, iconId = 1, name = "Train"),
+                ),
+                location = null,
+            )
+        },
+    )
+
+    private companion object {
+        const val STOP_A = "10111010"
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -25,6 +25,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import xyz.ksharma.krail.core.log.log
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -99,11 +102,28 @@ fun DepartureBoardStopCard(
         if (isExpanded == null) {
             // Uncontrolled mode: start polling on expand, stop it on collapse.
             if (expanded) {
+                log("[DEPARTURES] UI card EXPANDED stopId=$stopId — sending LoadDepartures")
                 onEvent(DeparturesUiEvent.LoadDepartures(stopId))
             } else {
+                log("[DEPARTURES] UI card COLLAPSED stopId=$stopId — sending StopPolling")
                 onEvent(DeparturesUiEvent.StopPolling)
             }
         }
+    }
+
+    // Lifecycle events — lets us see when the Activity/Fragment goes to background / returns,
+    // and correlate with repository polling behaviour in the logs.
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
+        log("[DEPARTURES] UI ON_PAUSE stopId=$stopId expanded=$expanded")
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        log("[DEPARTURES] UI ON_STOP stopId=$stopId expanded=$expanded — polling continues in repo scope")
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        log("[DEPARTURES] UI ON_START stopId=$stopId expanded=$expanded")
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        log("[DEPARTURES] UI ON_RESUME stopId=$stopId expanded=$expanded")
     }
 
     Column(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -5,9 +5,7 @@ import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import org.koin.compose.viewmodel.koinViewModel
@@ -43,14 +41,6 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
 
         LaunchedEffect(savedTripState.savedTrips) {
             departureBoardViewModel.setTrips(savedTripState.savedTrips)
-        }
-
-        // Re-activate the polling loop when returning to this screen.
-        // If the user visited another screen (e.g. map stop picker) while a departure
-        // card was expanded, that screen's ViewModel may have cancelled the repo's
-        // polling loop. ON_START fires every time the screen comes back into view.
-        LifecycleEventEffect(Lifecycle.Event.ON_START) {
-            departureBoardViewModel.resumeActivePolling()
         }
 
         // Listen for StopSelected results from SearchStop screen

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -5,7 +5,9 @@ import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import org.koin.compose.viewmodel.koinViewModel
@@ -41,6 +43,14 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
 
         LaunchedEffect(savedTripState.savedTrips) {
             departureBoardViewModel.setTrips(savedTripState.savedTrips)
+        }
+
+        // Re-activate the polling loop when returning to this screen.
+        // If the user visited another screen (e.g. map stop picker) while a departure
+        // card was expanded, that screen's ViewModel may have cancelled the repo's
+        // polling loop. ON_START fires every time the screen comes back into view.
+        LifecycleEventEffect(Lifecycle.Event.ON_START) {
+            departureBoardViewModel.resumeActivePolling()
         }
 
         // Listen for StopSelected results from SearchStop screen

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import xyz.ksharma.krail.departures.ui.DepartureBoardRepository
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
@@ -34,9 +35,13 @@ data class StopDepartureBoardEntry(
 /**
  * ViewModel for the Departure Board section on the saved trips screen.
  *
- * Manages an accordion: at most one card is expanded at a time. Expanding a card
- * delegates to [DepartureBoardRepository.setActiveStop], which enforces the single
- * polling loop constraint across the whole app.
+ * Manages an accordion: at most one card is expanded at a time.
+ *
+ * **Polling is collection-driven**: expanding a card switches [_expandedStopId], which causes
+ * [entries]'s [flatMapLatest] to cancel the previous [DepartureBoardRepository.pollStop] flow
+ * and start a new one. When the UI stops collecting [entries] (app backgrounded,
+ * [SharingStarted.WhileSubscribed] times out), the entire chain — including network polling —
+ * stops automatically. No lifecycle hooks are required.
  */
 class DepartureBoardViewModel(
     private val repository: DepartureBoardRepository,
@@ -52,31 +57,35 @@ class DepartureBoardViewModel(
 
     /**
      * One entry per unique stop from the saved trips list.
-     * Each entry's [StopDepartureBoardEntry.state] is kept live via [DepartureBoardRepository].
+     *
+     * The **expanded** stop is polled via [DepartureBoardRepository.pollStop] — its network loop
+     * runs exactly while this StateFlow has active subscribers. All other stops observe the cache
+     * via [DepartureBoardRepository.observeStop] (no network calls).
+     *
+     * [flatMapLatest] ensures that switching the expanded stop (or changing the stop list)
+     * cancels the previous inner subscription before starting the new one, so only one polling
+     * loop ever runs at a time.
      */
-    val entries: StateFlow<ImmutableList<StopDepartureBoardEntry>> = _stops
-        .flatMapLatest { stops ->
-            if (stops.isEmpty()) {
-                flowOf(persistentListOf())
-            } else {
-                combine(
-                    stops.map { (stopId, stopName) ->
-                        repository.observeStop(stopId).map { state ->
-                            StopDepartureBoardEntry(
-                                stopId = stopId,
-                                stopName = stopName,
-                                state = state,
-                            )
-                        }
-                    },
-                ) { array -> array.toList().toImmutableList() }
+    val entries: StateFlow<ImmutableList<StopDepartureBoardEntry>> =
+        combine(_stops, _expandedStopId) { stops, expandedId -> stops to expandedId }
+            .flatMapLatest { (stops, expandedId) ->
+                if (stops.isEmpty()) {
+                    flowOf(persistentListOf())
+                } else {
+                    combine(
+                        stops.map { (stopId, stopName) ->
+                            (if (stopId == expandedId) repository.pollStop(stopId)
+                            else repository.observeStop(stopId))
+                                .map { state -> StopDepartureBoardEntry(stopId, stopName, state) }
+                        },
+                    ) { array -> array.toList().toImmutableList() }
+                }
             }
-        }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = persistentListOf(),
-        )
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = persistentListOf(),
+            )
 
     /**
      * Updates the stop list derived from [trips].
@@ -96,38 +105,33 @@ class DepartureBoardViewModel(
         _stops.value = uniqueStops
 
         // If the expanded stop is no longer in the new stop list (e.g. the trip was deleted),
-        // stop polling and collapse the card so no dangling background fetch continues.
+        // collapse the card — flatMapLatest will cancel its pollStop flow automatically.
         val expandedId = _expandedStopId.value
         if (expandedId != null && uniqueStops.none { it.first == expandedId }) {
-            repository.stopIfActive(expandedId)
             _expandedStopId.value = null
         }
     }
 
-    /** Expands the card for [stopId], collapsing any previously open card instantly. */
+    /**
+     * Expands the card for [stopId].
+     *
+     * Setting [_expandedStopId] triggers [flatMapLatest] in [entries] which cancels the previous
+     * [DepartureBoardRepository.pollStop] flow and starts a new one for [stopId] — the old
+     * polling loop is stopped and loading state is cleaned up via the flow's `finally` block.
+     */
     fun onCardExpand(stopId: String) {
         if (_expandedStopId.value == stopId) return
-        _expandedStopId.value?.let { repository.stopIfActive(it) }
         _expandedStopId.value = stopId
-        repository.setActiveStop(stopId)
     }
 
-    /**
-     * Re-activates the polling loop for the currently expanded stop.
-     *
-     * Call this when the screen returns to the foreground (ON_START). If the user navigated
-     * away (e.g. to the map stop-picker) the repository's active polling loop may have been
-     * cancelled by another consumer. Calling [repository.setActiveStop] restarts it so the
-     * departure board shows fresh data rather than a stale cache snapshot.
-     */
-    fun resumeActivePolling() {
-        val stopId = _expandedStopId.value ?: return
-        repository.setActiveStop(stopId)
+    /** Collapses the currently open card. [flatMapLatest] cancels the polling loop. */
+    fun onCardCollapse() {
+        _expandedStopId.value = null
     }
 
     /** Triggers an immediate silent refresh for [stopId] without disrupting the poll loop. */
     fun onRefreshStop(stopId: String) {
-        repository.refresh(stopId)
+        viewModelScope.launch { repository.refresh(stopId) }
     }
 
     /**
@@ -136,18 +140,6 @@ class DepartureBoardViewModel(
      * has toggled "Show previous" in the UI.
      */
     fun onLoadPreviousDepartures(stopId: String) {
-        repository.loadPreviousDepartures(stopId)
-    }
-
-    /** Collapses the currently open card and stops polling. */
-    fun onCardCollapse() {
-        val current = _expandedStopId.value ?: return
-        repository.stopIfActive(current)
-        _expandedStopId.value = null
-    }
-
-    override fun onCleared() {
-        _expandedStopId.value?.let { repository.stopIfActive(it) }
-        super.onCleared()
+        viewModelScope.launch { repository.loadPreviousDepartures(stopId) }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
@@ -112,6 +112,19 @@ class DepartureBoardViewModel(
         repository.setActiveStop(stopId)
     }
 
+    /**
+     * Re-activates the polling loop for the currently expanded stop.
+     *
+     * Call this when the screen returns to the foreground (ON_START). If the user navigated
+     * away (e.g. to the map stop-picker) the repository's active polling loop may have been
+     * cancelled by another consumer. Calling [repository.setActiveStop] restarts it so the
+     * departure board shows fresh data rather than a stale cache snapshot.
+     */
+    fun resumeActivePolling() {
+        val stopId = _expandedStopId.value ?: return
+        repository.setActiveStop(stopId)
+    }
+
     /** Triggers an immediate silent refresh for [stopId] without disrupting the poll loop. */
     fun onRefreshStop(stopId: String) {
         repository.refresh(stopId)


### PR DESCRIPTION
## Refactor departure polling to collection-driven flows with comprehensive testing

### Core Architecture Changes

**Replace imperative polling with collection-driven flows**
- Remove `setActiveStop`, `stopIfActive`, and repo-owned `SupervisorJob` scope
- Add `pollStop(stopId): Flow<DeparturesState>` — a cold `channelFlow` that runs the network loop exactly while collected
- `finally` block clears loading flags on cancellation so cached state stays consistent across collect/cancel cycles
- `refresh` and `loadPreviousDepartures` become suspend functions; callers launch them in their own scope

**Stop background polling via WhileSubscribed instead of lifecycle hooks**
- `DepartureBoardViewModel.entries` is now `combine(_stops, _expandedStopId).flatMapLatest { use pollStop for expanded stop, observeStop for others }.stateIn(WhileSubscribed(5_000))`
- When UI stops collecting entries (app backgrounded, screen changed): `WhileSubscribed` cancels upstream → `flatMapLatest` cancels → `pollStop`'s finally block clears loading state
- Switching expanded card sets `_expandedStopId` → `flatMapLatest` cancels old `pollStop` and starts new one automatically
- `DeparturesViewModel` follows same pattern: `observeStop` replaced by `pollStop` in `activeStopId.flatMapLatest` chain

### Data Consistency Fixes

**Fix stale data after screen lock + stale previousDepartures**
- ViewModel NOOP guard now calls repository instead of doing nothing when same stop re-opened in good state
- `previousDepartures` cleared on next successful refresh if older than `previousDeparturesWindowMinutes` (30 min default)
- Fixed misleading `elapsedMs` log when `lastFetchTime=0` — now logs 'never fetched'

**Narrow "Now" window to ≤15 seconds; show "in 1 min" for 16–59s**
- Previously any departure within next 59 seconds showed "Now"
- New thresholds: ≤15s → "Now", 16–59s → "in 1 min" (floor, not round), 60+s → floor to whole minutes

### Testing & Diagnostics

**Add comprehensive test coverage**
- `DepartureBoardRepositoryTest` (12 tests): initial fetch, error handling, auto-refresh loop, cancellation cleanup, refresh window cache hits, previous departures
- `DeparturesViewModelTest` (7 tests): event handling, state transitions, API success/failure paths
- `FakeDeparturesService` for controlled test scenarios

**Add timestamped concurrency diagnostics logs**
- Repository logs: session IDs, fetch START/SUCCESS/FAILURE with duration, cache hits, window expiry
- ViewModel logs: CREATED/CLEARED, `activeStopId` changes, repo state emissions, event handling with NOOP guards
- UI lifecycle logs: `ON_PAUSE/STOP/START/RESUME` with stopId and expanded state
- Real network fetches marked with `[API]` to distinguish from cache-hit paths