### PR TITLE
Update iOS workflows to require Xcode 26+ for iOS 26 SDK compliance

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -23,11 +23,11 @@ jobs:
           echo "Current default xcodebuild version:"
           xcodebuild -version
 
-      # Automatically selects the latest stable Xcode version
+      # Requires Xcode 26+ for iOS 26 SDK (App Store mandate from April 28 2026)
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 'latest-stable'
+          xcode-version: '~26'
 
       - name: Verify Selection
         run: |

--- a/.github/workflows/distribute-testflight.yml
+++ b/.github/workflows/distribute-testflight.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   distribute:
-    runs-on: macos-15
+    runs-on: macos-latest
     environment: Firebase
     permissions:
       actions: write  # required to write back IOS_BUILD_NUMBER repo variable
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '~16'  # pin to stable Xcode 16.x; latest-stable can pick up pre-releases
+          xcode-version: '~26'  # Xcode 26+ required: iOS 26 SDK mandatory for App Store uploads from April 28 2026
 
       - name: Setup environment variables
         run: |


### PR DESCRIPTION
### TL;DR

Updated iOS build workflows to use Xcode 26 to meet App Store requirements for iOS 26 SDK

### What changed?

- Changed Xcode version from `latest-stable` to `~26` in the iOS build workflow
- Updated TestFlight distribution workflow to use `macos-latest` runner and Xcode `~26`
- Added comments explaining the requirement for Xcode 26+ to support iOS 26 SDK

### How to test?

- Trigger the iOS build workflow and verify it uses Xcode 26
- Run the TestFlight distribution workflow to ensure it completes successfully with the new Xcode version
- Confirm that builds can be uploaded to the App Store without SDK version warnings

### Why make this change?

Apple mandates that all App Store uploads must use the iOS 26 SDK starting April 28, 2026, which requires Xcode 26 or later. This change ensures our CI/CD pipeline remains compliant with App Store requirements.