### PR TITLE
BUG: Crash fix Optimize TransportMode companion object properties with lazy initialization

### DIFF
--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
@@ -33,9 +33,9 @@ sealed class TransportMode(
     @Serializable object Coach : TransportMode("#742282", "Coach", 7, 6)
 
     companion object {
-        val all: List<TransportMode> = listOf(Train, Metro, Bus, LightRail, Ferry, Coach)
+        val all: List<TransportMode> by lazy { listOf(Train, Metro, Bus, LightRail, Ferry, Coach) }
 
-        private val byProductClass: Map<Int, TransportMode> = all.associateBy { it.productClass }
+        private val byProductClass: Map<Int, TransportMode> by lazy { all.associateBy { it.productClass } }
 
         fun fromProductClass(productClass: Int): TransportMode? = byProductClass[productClass]
     }


### PR DESCRIPTION
## Fix JVM class initialization circularity crash in TransportMode

This was a JVM class initialization circularity crash:
`IntroState.default()` accessed `NswTransportMode.Ferry`, which retrieved `TransportMode.Ferry`
Loading `TransportMode$Ferry` triggered its static initializer → called `super("#5AB031", ...)` → triggered `TransportMode` class initialization
`TransportMode`'s companion object eagerly evaluated `val all = listOf(Train, ..., Ferry, Coach)`, trying to read `TransportMode$Ferry.INSTANCE`
But `TransportMode$Ferry` was still mid-initialization — its `INSTANCE` was still null
null entered the list, then `associateBy { it.productClass }` threw a `NullPointerException`, which the JVM wrapped as `ExceptionInInitializerError`

### Fix
Changed `all` and `byProductClass` in the companion object from eagerly-evaluated properties to `by lazy` delegates:
```kotlin
val all: List<TransportMode> by lazy { listOf(Train, Metro, Bus, LightRail, Ferry, Coach) }
private val byProductClass: Map<Int, TransportMode> by lazy { all.associateBy { it.productClass } }
```

With `by lazy`, neither value is evaluated during `TransportMode`'s static initialization. By the time they are first accessed, all `@Serializable object` singletons will be fully initialized — breaking the circular dependency.