### PR TITLE
fix: resolve null duration leg causing bus journeys to be silently dropped

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -157,7 +157,8 @@ private fun List<TripResponse.Leg>.getLegsList() = mapNotNull { it.toUiModel() }
 @OptIn(ExperimentalTime::class)
 private fun String.getTimeText() = toDepartureRelativeString()
 
-@Suppress("ComplexCondition")
+@OptIn(ExperimentalTime::class)
+@Suppress("ComplexCondition", "CyclomaticComplexMethod")
 private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
     val transportMode =
         transportation?.product?.productClass?.toInt()
@@ -171,7 +172,9 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
         else -> transportation?.description
     }
     val numberOfStops = stopSequence?.size
-    val displayDuration = duration?.seconds?.toFormattedDurationTimeString()
+    // duration can be null for some legs (e.g. first bus leg in a multi-leg journey).
+    // Fall back to calculating duration from departure/arrival times via resolveDurationSeconds().
+    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
     val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
     val alerts = infos?.mapNotNull { it.toAlert() }?.toImmutableList()
 
@@ -211,6 +214,33 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
                 null
             }
         }
+    }
+}
+
+/**
+ * Resolves the duration of a leg in seconds.
+ *
+ * The API sometimes omits [TripResponse.Leg.duration] (returns null) for certain legs —
+ * commonly the first short bus hop in a multi-leg journey. In those cases we calculate
+ * the duration from the departure and arrival timestamps that are always present.
+ *
+ * Priority: explicit [TripResponse.Leg.duration] > calculated from dep/arr timestamps > null
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Leg.resolveDurationSeconds(): Long? {
+    if (duration != null) return duration
+    val dep = origin?.departureTimeEstimated ?: origin?.departureTimePlanned
+    val arr = destination?.arrivalTimeEstimated ?: destination?.arrivalTimePlanned
+    return if (dep != null && arr != null) {
+        runCatching {
+            val depInstant = Instant.parse(dep)
+            val arrInstant = Instant.parse(arr)
+            (arrInstant - depInstant).inWholeSeconds.takeIf { it > 0 }
+        }.onFailure { error ->
+            logError("error - $error")
+        }.getOrNull()
+    } else {
+        null
     }
 }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
@@ -1,0 +1,272 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import kotlinx.serialization.json.Json
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures.OranParkToSevenHillsFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+import kotlin.test.assertNull
+
+/**
+ * Tests for [TripResponse.Leg.resolveDurationSeconds], specifically the duration-resolution logic.
+ *
+ * Background: The NSW Transport API sometimes omits the `duration` field for certain legs
+ * (e.g., the first short bus hop in a multi-leg journey). Without a fallback the leg
+ * would be silently dropped from the UI. [TripResponse.Leg.resolveDurationSeconds] ensures
+ * the duration is computed from departure/arrival timestamps when the raw field is absent.
+ */
+class TripResponseMapperTest {
+
+    // Lenient JSON parser — mirrors how Ktor deserialises API responses in production
+    private val json = Json { ignoreUnknownKeys = true }
+
+    //region resolveDurationSeconds
+
+    @Test
+    fun `resolveDurationSeconds returns explicit duration when present`() {
+        // Arrange: leg with an explicit duration of 60 seconds
+        val leg = buildLeg(
+            duration = 60L,
+            depTime = "2026-04-18T22:48:00Z",
+            arrTime = "2026-04-18T22:49:00Z",
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: the explicit duration wins over the calculated one
+        assertEquals(60L, result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds calculates duration from timestamps when duration is null`() {
+        // Arrange: leg where the API did NOT include a duration field (real-world occurrence
+        // observed for the first bus leg, e.g., bus 858 Oran Park — 2 stops, 1 minute ride).
+        // 22:48 → 22:49 = 60 seconds
+        val leg = buildLeg(
+            duration = null,
+            depTime = "2026-04-18T22:48:00Z",
+            arrTime = "2026-04-18T22:49:00Z",
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: 60 seconds calculated from timestamps
+        assertEquals(60L, result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds prefers estimated times over planned times`() {
+        // Arrange: leg where estimated times differ from planned (real-time delay scenario).
+        // Planned: 22:48 → 22:49 = 60 s; Estimated: 22:48 → 22:51 = 180 s
+        val leg = TripResponse.Leg(
+            duration = null,
+            origin = TripResponse.StopSequence(
+                departureTimePlanned = "2026-04-18T22:48:00Z",
+                departureTimeEstimated = "2026-04-18T22:48:00Z", // estimated dep same
+            ),
+            destination = TripResponse.StopSequence(
+                arrivalTimePlanned = "2026-04-18T22:49:00Z",
+                arrivalTimeEstimated = "2026-04-18T22:51:00Z",  // estimated arr 2 min late
+            ),
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: uses estimated arrival → 3 minutes (180 s)
+        assertEquals(180L, result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds returns null when both duration and timestamps are null`() {
+        // Arrange: completely empty leg (edge case / malformed API response)
+        val leg = TripResponse.Leg(
+            duration = null,
+            origin = null,
+            destination = null,
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: nothing to compute from, must be null
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds returns null when arrival is before departure`() {
+        // Arrange: timestamps inverted (shouldn't happen in practice but API data can be noisy)
+        val leg = buildLeg(
+            duration = null,
+            depTime = "2026-04-18T22:49:00Z",
+            arrTime = "2026-04-18T22:48:00Z", // arrival BEFORE departure
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: negative duration is meaningless; method returns null via takeIf { it > 0 }
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds returns null for zero-second duration (same timestamps)`() {
+        // Arrange: departure == arrival (e.g., instantaneous interchange stop)
+        val leg = buildLeg(
+            duration = null,
+            depTime = "2026-04-18T22:48:00Z",
+            arrTime = "2026-04-18T22:48:00Z",
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: 0 is not > 0, so returns null (no meaningful duration to show)
+        assertNull(result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds handles longer journeys correctly`() {
+        // Arrange: 24-minute leg (1440 seconds) — typical for a multi-stop bus run
+        val leg = buildLeg(
+            duration = null,
+            depTime = "2026-04-18T23:00:00Z",
+            arrTime = "2026-04-18T23:24:00Z",
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert
+        assertEquals(1440L, result)
+    }
+
+    @Test
+    fun `resolveDurationSeconds falls back to planned times when estimated times are absent`() {
+        // Arrange: no real-time data available (common for timetable-only requests)
+        val leg = TripResponse.Leg(
+            duration = null,
+            origin = TripResponse.StopSequence(
+                departureTimePlanned = "2026-04-18T22:48:00Z",
+                departureTimeEstimated = null,
+            ),
+            destination = TripResponse.StopSequence(
+                arrivalTimePlanned = "2026-04-18T22:49:00Z",
+                arrivalTimeEstimated = null,
+            ),
+        )
+
+        // Act
+        val result = leg.resolveDurationSeconds()
+
+        // Assert: planned timestamps used as fallback → 60 seconds
+        assertEquals(60L, result)
+    }
+
+    //endregion
+
+    //region buildJourneyList — end-to-end fixture tests (OranPark → SevenHills)
+
+    /**
+     * End-to-end smoke test using [OranParkToSevenHillsFixture].
+     *
+     * Verifies that [buildJourneyList] produces the expected number of journey cards.
+     * A regression here means the mapper is silently dropping journeys.
+     */
+    @Test
+    fun `buildJourneyList returns expected journey count from OranPark fixture`() {
+        // Arrange: parse the real-world-shaped fixture JSON into a TripResponse
+        val response = json.decodeFromString<TripResponse>(OranParkToSevenHillsFixture.JSON)
+
+        // Act
+        val journeys = response.buildJourneyList()
+
+        // Assert: both journeys survive — including the one with null duration on the first leg
+        assertEquals(
+            OranParkToSevenHillsFixture.EXPECTED_JOURNEY_COUNT,
+            journeys?.size,
+            "Journey with null-duration first leg must not be dropped",
+        )
+    }
+
+    /**
+     * Regression test: the journey whose first bus leg has NO `duration` field in the API
+     * response must still appear as a valid journey card.
+     *
+     * Prior to the fix, [buildJourneyList] logged:
+     * "Something is null - NOT adding Transport LEG: ... displayDuration: null"
+     * and dropped the entire journey card from the UI.
+     */
+    @Test
+    fun `buildJourneyList includes journey where first leg duration is null`() {
+        // Arrange: the second journey in the fixture has duration omitted on its first leg
+        val response = json.decodeFromString<TripResponse>(OranParkToSevenHillsFixture.JSON)
+
+        // Act
+        val journeys = response.buildJourneyList()
+
+        // Assert: the null-duration journey (index 1) must be present, not null
+        val nullDurationJourney = journeys?.getOrNull(1)
+        assertEquals(
+            true,
+            nullDurationJourney != null,
+            "Journey with null-duration leg must be present in the result list",
+        )
+    }
+
+    /**
+     * Verifies that [buildJourneyList] with a null-duration leg correctly calculates
+     * the leg duration from timestamps (21:46 → 21:47 = 60 seconds = 1 min).
+     */
+    @Test
+    fun `buildJourneyList calculates 1-min duration for null-duration leg from timestamps`() {
+        // Arrange
+        val response = json.decodeFromString<TripResponse>(OranParkToSevenHillsFixture.JSON)
+
+        // Act
+        val journeys = response.buildJourneyList()
+
+        // Assert: leg duration derived from 21:46→21:47 timestamps shows as "1 min"
+        val firstLegOfNullDurationJourney = journeys
+            ?.getOrNull(1)         // second journey = the null-duration one
+            ?.legs
+            ?.firstOrNull()        // first TransportLeg
+        val legDuration = (firstLegOfNullDurationJourney
+            as? xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState.JourneyCardInfo.Leg.TransportLeg)
+            ?.totalDuration
+
+        assertEquals("1 min", legDuration, "Null-duration leg duration should be calculated as 1 min")
+    }
+
+    //endregion
+
+    //region helpers
+
+    /**
+     * Builds a minimal [TripResponse.Leg] for duration-resolution tests.
+     *
+     * @param duration   Raw API duration value (null simulates the field being absent).
+     * @param depTime    Departure time in UTC ISO-8601.
+     * @param arrTime    Arrival time in UTC ISO-8601.
+     */
+    private fun buildLeg(
+        duration: Long?,
+        depTime: String,
+        arrTime: String,
+    ) = TripResponse.Leg(
+        duration = duration,
+        origin = TripResponse.StopSequence(
+            departureTimePlanned = depTime,
+            departureTimeEstimated = depTime,
+        ),
+        destination = TripResponse.StopSequence(
+            arrivalTimePlanned = arrTime,
+            arrivalTimeEstimated = arrTime,
+        ),
+    )
+
+    // endregion
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/fixtures/OranParkToSevenHillsFixture.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/fixtures/OranParkToSevenHillsFixture.kt
@@ -1,0 +1,225 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures
+
+/**
+ * Fixture for a real NSW Transport API trip response: Oran Park → Seven Hills.
+ *
+ * Source: real API response captured 2026-04-18 (see `/feature/trip-planner/network/src/commonTest/assets/trip_oranpark_sevenhills.json`
+ * for the full response).
+ *
+ * This fixture captures the **null-duration bug** observed in production logs:
+ * the first bus leg (Bus 858, 2 stops, ~1 min) sometimes returns `"duration": null`
+ * from the API. Without a fallback, the leg — and its entire journey card — would be
+ * silently dropped from the UI.
+ *
+ * Journeys included:
+ *   [0] Normal journey   — first leg has explicit duration (60s). Expected: included ✅
+ *   [1] Null-duration    — first leg has `duration` omitted.  Expected: included ✅ (bug fix)
+ */
+internal object OranParkToSevenHillsFixture {
+
+    /**
+     * Number of journeys that must survive [buildJourneyList] mapping.
+     * Counts only journeys where every leg has enough info to build a UI card.
+     */
+    const val EXPECTED_JOURNEY_COUNT = 2
+
+    /**
+     * Minimal TripResponse JSON containing two representative journeys:
+     *   - Journey 0: explicit `duration` on the first leg (the happy path).
+     *   - Journey 1: `duration` field completely absent on the first leg (the bug case).
+     *
+     * Times are kept as captured from the real API (UTC).
+     * Non-essential fields are stripped to keep the fixture readable.
+     */
+    val JSON = """
+        {
+          "version": "10.6.21.17",
+          "journeys": [
+            {
+              "rating": 0,
+              "isAdditional": true,
+              "interchanges": 3,
+              "legs": [
+                {
+                  "duration": 60,
+                  "origin": {
+                    "id": "2570303",
+                    "name": "Oran Park High School, Podium Way, Oran Park",
+                    "disassembledName": "Oran Park High School, Podium Way",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-04-18T22:48:00Z",
+                    "departureTimeEstimated": "2026-04-18T22:48:00Z"
+                  },
+                  "destination": {
+                    "id": "2570339",
+                    "name": "Oran Park Town Centre, Oran Park Dr, Oran Park",
+                    "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-04-18T22:49:00Z",
+                    "arrivalTimeEstimated": "2026-04-18T22:49:00Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:12858: :H:sj2",
+                    "name": "Sydney Buses Network 858",
+                    "disassembledName": "858",
+                    "number": "858",
+                    "description": "Leppington to Oran Park",
+                    "product": { "id": 5, "class": 5, "name": "Sydney Buses Network", "iconId": 5 },
+                    "destination": { "id": "10126161", "name": "Oran Park Town Ctr", "type": "stop" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "2570303",
+                      "name": "Oran Park High School, Podium Way, Oran Park",
+                      "disassembledName": "Oran Park High School, Podium Way",
+                      "type": "platform",
+                      "departureTimePlanned": "2026-04-18T22:48:00Z"
+                    },
+                    {
+                      "id": "2570339",
+                      "name": "Oran Park Town Centre, Oran Park Dr, Oran Park",
+                      "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                      "type": "platform",
+                      "arrivalTimePlanned": "2026-04-18T22:49:00Z"
+                    }
+                  ]
+                },
+                {
+                  "duration": 1440,
+                  "origin": {
+                    "id": "2570339",
+                    "name": "Oran Park Town Centre, Oran Park Dr, Oran Park",
+                    "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-04-18T22:49:00Z",
+                    "departureTimeEstimated": "2026-04-18T22:49:00Z"
+                  },
+                  "destination": {
+                    "id": "203513",
+                    "name": "Leppington Station, Platform 2",
+                    "disassembledName": "Leppington Station, Platform 2",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-04-19T00:13:00Z",
+                    "arrivalTimeEstimated": "2026-04-19T00:13:00Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:12858: :R:sj2",
+                    "name": "Sydney Buses Network 858",
+                    "disassembledName": "858",
+                    "number": "858",
+                    "description": "Oran Park to Leppington",
+                    "product": { "id": 5, "class": 5, "name": "Sydney Buses Network", "iconId": 5 },
+                    "destination": { "id": "203513", "name": "Leppington Station", "type": "stop" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "2570339",
+                      "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                      "type": "platform",
+                      "departureTimePlanned": "2026-04-18T22:49:00Z"
+                    },
+                    {
+                      "id": "203513",
+                      "disassembledName": "Leppington Station, Platform 2",
+                      "type": "platform",
+                      "arrivalTimePlanned": "2026-04-19T00:13:00Z"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "rating": 0,
+              "isAdditional": true,
+              "interchanges": 3,
+              "legs": [
+                {
+                  "origin": {
+                    "id": "2570303",
+                    "name": "Oran Park High School, Podium Way, Oran Park",
+                    "disassembledName": "Oran Park High School, Podium Way",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-04-18T21:46:00Z",
+                    "departureTimeEstimated": "2026-04-18T21:46:00Z"
+                  },
+                  "destination": {
+                    "id": "2570339",
+                    "name": "Oran Park Town Centre, Oran Park Dr, Oran Park",
+                    "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-04-18T21:47:00Z",
+                    "arrivalTimeEstimated": "2026-04-18T21:47:00Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:12858: :R:sj2",
+                    "name": "Sydney Buses Network 858",
+                    "disassembledName": "858",
+                    "number": "858",
+                    "description": "Leppington to Oran Park",
+                    "product": { "id": 5, "class": 5, "name": "Sydney Buses Network", "iconId": 5 },
+                    "destination": { "id": "10126161", "name": "Oran Park Town Ctr", "type": "stop" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "2570303",
+                      "disassembledName": "Oran Park High School, Podium Way",
+                      "type": "platform",
+                      "departureTimePlanned": "2026-04-18T21:46:00Z"
+                    },
+                    {
+                      "id": "2570339",
+                      "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                      "type": "platform",
+                      "arrivalTimePlanned": "2026-04-18T21:47:00Z"
+                    }
+                  ]
+                },
+                {
+                  "duration": 1260,
+                  "origin": {
+                    "id": "2570339",
+                    "name": "Oran Park Town Centre, Oran Park Dr, Oran Park",
+                    "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-04-18T21:47:00Z",
+                    "departureTimeEstimated": "2026-04-18T21:47:00Z"
+                  },
+                  "destination": {
+                    "id": "203513",
+                    "name": "Leppington Station, Platform 2",
+                    "disassembledName": "Leppington Station, Platform 2",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-04-18T23:08:00Z",
+                    "arrivalTimeEstimated": "2026-04-18T23:08:00Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:12858: :R:sj2b",
+                    "name": "Sydney Buses Network 858",
+                    "disassembledName": "858",
+                    "number": "858",
+                    "description": "Oran Park to Leppington",
+                    "product": { "id": 5, "class": 5, "name": "Sydney Buses Network", "iconId": 5 },
+                    "destination": { "id": "203513", "name": "Leppington Station", "type": "stop" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "2570339",
+                      "disassembledName": "Oran Park Town Centre, Oran Park Dr",
+                      "type": "platform",
+                      "departureTimePlanned": "2026-04-18T21:47:00Z"
+                    },
+                    {
+                      "id": "203513",
+                      "disassembledName": "Leppington Station, Platform 2",
+                      "type": "platform",
+                      "arrivalTimePlanned": "2026-04-18T23:08:00Z"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+    """.trimIndent()
+}
+


### PR DESCRIPTION
The NSW Transport API occasionally omits the `duration` field on certain
legs (e.g. the first short bus hop, Bus 858 Oran Park — 2 stops, ~1 min).
The mapper required a non-null `displayDuration` to build a TransportLeg,
so the entire journey card was silently dropped from the UI.

Changes:
- Extract `resolveDurationSeconds()` on `TripResponse.Leg` that falls back
  to computing duration from departure/arrival timestamps when the field is
  absent; uses `runCatching` with Error rethrow for safe exception handling
- Wire fallback into `toUiModel()` via the new method
- Add `OranParkToSevenHillsFixture` with minimal inline JSON (2 journeys:
  one with explicit duration, one with duration omitted) sourced from a
  real API capture stored in network test assets
- Add `TripResponseMapperTest` covering `resolveDurationSeconds` edge cases
  (explicit duration, null duration, estimated vs planned preference,
  inverted/zero timestamps, no timestamps) and end-to-end `buildJourneyList`
  regression tests using the fixture