### PR TITLE
fix: align departure board destination label with leg view

### DIFF
--- a/core/transport/build.gradle.kts
+++ b/core/transport/build.gradle.kts
@@ -30,5 +30,10 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(libs.test.kotlin)
+            }
+        }
     }
 }

--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfig.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfig.kt
@@ -33,4 +33,30 @@ object NswTransportConfig : TransportConfig {
 
     override fun lineColor(lineKey: String): String? =
         NswTransportLine.entries.firstOrNull { it.key == lineKey }?.hexColor
+
+    /**
+     * Resolves the human-readable direction label shown on departure boards and leg views.
+     *
+     * NSW convention:
+     *  - **Train / Metro**: `"towards <destination>"` — the API [description] is the full
+     *    route label (e.g. "Emu Plains or Richmond to City") which is unhelpful on a board;
+     *    [destinationName] (the actual terminus) is far more useful.
+     *  - **All other modes**: [description] already contains a concise route label
+     *    (e.g. "Seven Hills to Rouse Hill Station via Norwest") — use it directly.
+     *
+     * @param productClass NSW product class int (1 = Train, 2 = Metro, 5 = Bus, etc.).
+     * @param destinationName The terminus stop name from `transportation.destination.name`.
+     * @param description     The route description from `transportation.description`.
+     * @return A display-ready string, or null if both inputs are null.
+     */
+    fun resolveServiceDisplayText(
+        productClass: Int?,
+        destinationName: String?,
+        description: String?,
+    ): String? = when (productClass) {
+        TransportMode.Train.productClass,
+        TransportMode.Metro.productClass,
+        -> destinationName?.let { "towards $it" } ?: description
+        else -> description ?: destinationName
+    }
 }

--- a/core/transport/src/commonTest/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfigTest.kt
+++ b/core/transport/src/commonTest/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfigTest.kt
@@ -1,0 +1,131 @@
+package xyz.ksharma.krail.core.transport.nsw
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NswTransportConfigTest {
+
+    // Train productClass = 1, Metro = 2, Bus = 5, Ferry = 9, LightRail = 4, Coach = 7
+
+    // region: Train (cls=1)
+
+    @Test
+    fun `Given Train productClass with destination When resolving display text Then returns towards destination`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 1,
+            destinationName = "Bondi Junction via Central",
+            description = "Waterfall or Cronulla to Bondi Junction",
+        )
+        assertEquals("towards Bondi Junction via Central", result)
+    }
+
+    @Test
+    fun `Given Train productClass with null destination When resolving display text Then falls back to description`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 1,
+            destinationName = null,
+            description = "Waterfall or Cronulla to Bondi Junction",
+        )
+        assertEquals("Waterfall or Cronulla to Bondi Junction", result)
+    }
+
+    @Test
+    fun `Given Train productClass with both null When resolving display text Then returns null`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 1,
+            destinationName = null,
+            description = null,
+        )
+        assertNull(result)
+    }
+
+    // region: Metro (cls=2)
+
+    @Test
+    fun `Given Metro productClass with destination When resolving display text Then returns towards destination`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 2,
+            destinationName = "Tallawong",
+            description = "Sydenham to Tallawong",
+        )
+        assertEquals("towards Tallawong", result)
+    }
+
+    @Test
+    fun `Given Metro productClass with null destination When resolving display text Then falls back to description`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 2,
+            destinationName = null,
+            description = "Sydenham to Tallawong",
+        )
+        assertEquals("Sydenham to Tallawong", result)
+    }
+
+    // region: Bus (cls=5)
+
+    @Test
+    fun `Given Bus productClass with description When resolving display text Then returns description as-is`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 5,
+            destinationName = "Rouse Hill Station",
+            description = "Seven Hills to Rouse Hill Station via Norwest & Kellyville",
+        )
+        assertEquals("Seven Hills to Rouse Hill Station via Norwest & Kellyville", result)
+    }
+
+    @Test
+    fun `Given Bus productClass with null description When resolving display text Then falls back to destination name`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 5,
+            destinationName = "Rouse Hill Station",
+            description = null,
+        )
+        assertEquals("Rouse Hill Station", result)
+    }
+
+    @Test
+    fun `Given Bus productClass with both null When resolving display text Then returns null`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 5,
+            destinationName = null,
+            description = null,
+        )
+        assertNull(result)
+    }
+
+    // region: Ferry (cls=9)
+
+    @Test
+    fun `Given Ferry productClass with description When resolving display text Then returns description`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = 9,
+            destinationName = "Manly Wharf",
+            description = "Circular Quay to Manly",
+        )
+        assertEquals("Circular Quay to Manly", result)
+    }
+
+    // region: null productClass
+
+    @Test
+    fun `Given null productClass with description When resolving display text Then returns description`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = null,
+            destinationName = "Liverpool",
+            description = "Parramatta to Liverpool",
+        )
+        assertEquals("Parramatta to Liverpool", result)
+    }
+
+    @Test
+    fun `Given null productClass with null description When resolving display text Then falls back to destination name`() {
+        val result = NswTransportConfig.resolveServiceDisplayText(
+            productClass = null,
+            destinationName = "Liverpool",
+            description = null,
+        )
+        assertEquals("Liverpool", result)
+    }
+}
+

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
@@ -74,7 +74,11 @@ internal fun DepartureMonitorResponse.StopEvent.toStopDeparture(): StopDeparture
             productClass = transportation?.product?.cls,
         ),
         transportModeName = resolveTransportModeName(transportation?.product?.cls),
-        destinationName = transportation?.description ?: transportation?.destination?.name ?: "",
+        destinationName = NswTransportConfig.resolveServiceDisplayText(
+            productClass = transportation?.product?.cls,
+            destinationName = transportation?.destination?.name,
+            description = transportation?.description,
+        ) ?: "",
         departureTimeText = runCatching { departureUtc.utcToLocalDateTimeAEST().toHHMM() }
             .getOrDefault(departureUtc),
         departureUtcDateTime = departureUtc,

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapperTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapperTest.kt
@@ -263,17 +263,90 @@ class DepartureMonitorMapperTest {
     }
 
     // region: destination name
+    // Logic mirrors TripResponseMapper: Train/Metro → "towards <destination>", others → description.
 
     @Test
-    fun `Given transportation with destination When mapped Then destinationName is correct`() {
-        val event = buildStopEvent(destinationName = "Cronulla Station")
+    fun `Given Train event with destination When mapped Then destinationName is towards destination`() {
+        // Train (cls=1): must show directional label, not the full route description
+        val event = buildStopEvent(
+            productClass = 1,
+            destinationName = "Cronulla Station",
+            description = "Waterfall or Cronulla to Bondi Junction",
+        )
 
-        assertEquals("Cronulla Station", event.toStopDeparture()?.destinationName)
+        assertEquals("towards Cronulla Station", event.toStopDeparture()?.destinationName)
     }
 
     @Test
-    fun `Given transportation with no destination When mapped Then destinationName is empty`() {
-        val event = buildStopEvent(destinationName = null)
+    fun `Given Metro event with destination When mapped Then destinationName is towards destination`() {
+        val event = buildStopEvent(
+            productClass = 2,
+            destinationName = "Tallawong",
+            description = "Sydenham to Tallawong",
+        )
+
+        assertEquals("towards Tallawong", event.toStopDeparture()?.destinationName)
+    }
+
+    @Test
+    fun `Given Train event with no destination but has description When mapped Then destinationName uses description`() {
+        // Falls back to description when destination.name is absent
+        val event = buildStopEvent(
+            productClass = 1,
+            destinationName = null,
+            description = "Emu Plains or Richmond to City",
+        )
+
+        assertEquals("Emu Plains or Richmond to City", event.toStopDeparture()?.destinationName)
+    }
+
+    @Test
+    fun `Given Train event with no destination and no description When mapped Then destinationName is empty`() {
+        val event = buildStopEvent(productClass = 1, destinationName = null, description = null)
+
+        assertEquals("", event.toStopDeparture()?.destinationName)
+    }
+
+    @Test
+    fun `Given Bus event with description When mapped Then destinationName uses description as-is`() {
+        // Bus (cls=5): description is a concise route label — use it directly
+        val event = buildStopEvent(
+            productClass = 5,
+            destinationName = "Rouse Hill Station",
+            description = "Seven Hills to Rouse Hill Station via Norwest & Kellyville",
+        )
+
+        assertEquals(
+            "Seven Hills to Rouse Hill Station via Norwest & Kellyville",
+            event.toStopDeparture()?.destinationName,
+        )
+    }
+
+    @Test
+    fun `Given Bus event with no description When mapped Then destinationName falls back to destination name`() {
+        val event = buildStopEvent(
+            productClass = 5,
+            destinationName = "Rouse Hill Station",
+            description = null,
+        )
+
+        assertEquals("Rouse Hill Station", event.toStopDeparture()?.destinationName)
+    }
+
+    @Test
+    fun `Given Ferry event with description When mapped Then destinationName uses description`() {
+        val event = buildStopEvent(
+            productClass = 9,
+            destinationName = "Manly Wharf",
+            description = "Circular Quay to Manly",
+        )
+
+        assertEquals("Circular Quay to Manly", event.toStopDeparture()?.destinationName)
+    }
+
+    @Test
+    fun `Given transportation with no destination and no description When mapped Then destinationName is empty`() {
+        val event = buildStopEvent(destinationName = null, description = null)
 
         assertEquals("", event.toStopDeparture()?.destinationName)
     }
@@ -310,6 +383,7 @@ class DepartureMonitorMapperTest {
         lineNumber: String = "T1",
         productClass: Int? = 1,
         destinationName: String? = "Cronulla Station",
+        description: String? = null,
         locationDisassembledName: String? = "Platform 1",
         parentDisassembledName: String? = "Town Hall",
         /** Mirrors `location.properties.platformName` from the live NSW Transport API. */
@@ -340,6 +414,7 @@ class DepartureMonitorMapperTest {
         transportation = DepartureMonitorResponse.Transportation(
             id = "sydneytrains:$lineNumber:H",
             disassembledName = lineNumber,
+            description = description,
             destination = destinationName?.let {
                 DepartureMonitorResponse.Destination(id = "stop_id", name = it)
             },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -11,7 +11,6 @@ import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
-import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
@@ -165,12 +164,11 @@ private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
             ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
     val lineName = transportation?.disassembledName
 
-    val productClass = transportation?.product?.productClass?.toInt()
-    val displayText = when (productClass) {
-        NswTransportMode.Train.productClass, NswTransportMode.Metro.productClass ->
-            "towards ${transportation?.destination?.name}"
-        else -> transportation?.description
-    }
+    val displayText = NswTransportConfig.resolveServiceDisplayText(
+        productClass = transportation?.product?.productClass?.toInt(),
+        destinationName = transportation?.destination?.name,
+        description = transportation?.description,
+    )
     val numberOfStops = stopSequence?.size
     // duration can be null for some legs (e.g. first bus leg in a multi-leg journey).
     // Fall back to calculating duration from departure/arrival times via resolveDurationSeconds().

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.timetable.business
 
 import kotlinx.serialization.json.Json
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures.OranParkToSevenHillsFixture
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -234,11 +235,75 @@ class TripResponseMapperTest {
             ?.getOrNull(1)         // second journey = the null-duration one
             ?.legs
             ?.firstOrNull()        // first TransportLeg
-        val legDuration = (firstLegOfNullDurationJourney
-            as? xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState.JourneyCardInfo.Leg.TransportLeg)
-            ?.totalDuration
+        val legDuration =
+            (firstLegOfNullDurationJourney as? TimeTableState.JourneyCardInfo.Leg.TransportLeg)
+                ?.totalDuration
 
-        assertEquals("1 min", legDuration, "Null-duration leg duration should be calculated as 1 min")
+        assertEquals(
+            "1 min",
+            legDuration,
+            "Null-duration leg duration should be calculated as 1 min"
+        )
+    }
+
+    //endregion
+
+    //endregion
+
+    //region displayText on TransportLeg
+
+    @Test
+    fun `Given Train leg with destination When buildJourneyList Then displayText is towards destination`() {
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 1L,
+                    destinationName = "Bondi Junction via Central",
+                    description = "Waterfall or Cronulla to Bondi Junction"
+                )
+            ),
+        )
+
+        val leg = response.buildJourneyList()
+            ?.firstOrNull()?.legs?.firstOrNull() as? TimeTableState.JourneyCardInfo.Leg.TransportLeg
+
+        assertEquals("towards Bondi Junction via Central", leg?.displayText)
+    }
+
+    @Test
+    fun `Given Metro leg with destination When buildJourneyList Then displayText is towards destination`() {
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 2L,
+                    destinationName = "Tallawong",
+                    description = "Sydenham to Tallawong"
+                )
+            ),
+        )
+
+        val leg = response.buildJourneyList()
+            ?.firstOrNull()?.legs?.firstOrNull() as? TimeTableState.JourneyCardInfo.Leg.TransportLeg
+
+        assertEquals("towards Tallawong", leg?.displayText)
+    }
+
+    @Test
+    fun `Given Bus leg with description When buildJourneyList Then displayText uses description`() {
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 5L,
+                    destinationName = "Rouse Hill Station",
+                    description = "Seven Hills to Rouse Hill Station via Norwest"
+                )
+            ),
+        )
+
+        val leg = response.buildJourneyList()
+            ?.firstOrNull()?.legs?.firstOrNull() as? TimeTableState.JourneyCardInfo.Leg.TransportLeg
+
+        assertEquals("Seven Hills to Rouse Hill Station via Norwest", leg?.displayText)
     }
 
     //endregion
@@ -265,6 +330,60 @@ class TripResponseMapperTest {
         destination = TripResponse.StopSequence(
             arrivalTimePlanned = arrTime,
             arrivalTimeEstimated = arrTime,
+        ),
+    )
+
+    /**
+     * Builds a minimal [TripResponse.Journey] with a single public transport leg.
+     * The leg has two stops, a duration, and the given transport mode/destination fields.
+     * This lets end-to-end [buildJourneyList] tests verify the leg's displayText without JSON fixtures.
+     */
+    private fun buildJourneyWithTransportLeg(
+        productClass: Long,
+        destinationName: String?,
+        description: String?,
+        depTime: String = "2026-04-18T22:00:00Z",
+        arrTime: String = "2026-04-18T22:30:00Z",
+    ) = TripResponse.Journey(
+        legs = listOf(
+            TripResponse.Leg(
+                duration = 1800L,
+                origin = TripResponse.StopSequence(
+                    name = "Origin Station",
+                    disassembledName = "Origin Station, Platform 1",
+                    departureTimePlanned = depTime,
+                    departureTimeEstimated = depTime,
+                ),
+                destination = TripResponse.StopSequence(
+                    name = "Destination Station",
+                    disassembledName = "Destination Station, Platform 2",
+                    arrivalTimePlanned = arrTime,
+                    arrivalTimeEstimated = arrTime,
+                ),
+                stopSequence = listOf(
+                    TripResponse.StopSequence(
+                        name = "Origin Station",
+                        disassembledName = "Origin Station, Platform 1",
+                        departureTimePlanned = depTime,
+                        departureTimeEstimated = depTime,
+                    ),
+                    TripResponse.StopSequence(
+                        name = "Destination Station",
+                        disassembledName = "Destination Station, Platform 2",
+                        arrivalTimePlanned = arrTime,
+                        arrivalTimeEstimated = arrTime,
+                    ),
+                ),
+                transportation = TripResponse.Transportation(
+                    disassembledName = "T1",
+                    description = description,
+                    destination = destinationName?.let { TripResponse.OperatorClass(name = it) },
+                    product = TripResponse.Product(
+                        productClass = productClass,
+                        name = "Train",
+                    ),
+                ),
+            ),
         ),
     )
 


### PR DESCRIPTION
DepartureRow was showing transportation.description for trains/metro
(e.g. "Emu Plains or Richmond to City") — the full route label covering
both ends of the line. LegView was already showing the correct directional
label ("towards Hornsby via Gordon") using transportation.destination.name.

Extract shared logic into NswTransportConfig.resolveServiceDisplayText():
- Train / Metro → "towards <destination.name>"
- All other modes → description (fallback: destination.name)

Apply to both mappers so DepartureRow and LegView always show identical
text for the same service.

* core/transport: add resolveServiceDisplayText() to NswTransportConfig
* feature/departures/ui: use resolveServiceDisplayText in DepartureMonitorMapper
* feature/trip-planner/ui: use resolveServiceDisplayText in TripResponseMapper
* core/transport: add NswTransportConfigTest (10 cases)
* feature/departures/ui: fix + expand DepartureMonitorMapperTest destination name tests
* feature/trip-planner/ui: add displayText end-to-end tests to TripResponseMapperTest