### PR TITLE
fix: use onSurface color for animated dots and arrow in departure board header

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -136,14 +136,14 @@ internal fun DepartureBoardAccordionSectionHeader(
             if (isExpanded && entry.state.silentLoading) {
                 AnimatedDots(
                     modifier = Modifier.size(width = 32.dp, height = 16.dp),
-                    color = KrailTheme.colors.softLabel,
+                    color = KrailTheme.colors.onSurface,
                 )
             }
 
             Image(
                 painter = painterResource(Res.drawable.ic_arrow_down),
                 contentDescription = if (isExpanded) "Collapse" else "Expand",
-                colorFilter = ColorFilter.tint(KrailTheme.colors.softLabel),
+                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
                 modifier = Modifier.size(18.dp).rotate(arrowRotation),
             )
         }


### PR DESCRIPTION
### TL;DR

Updated icon and animated dots colors on the Departure Board accordion header to use `onSurface` instead of `softLabel`.

### What changed?

The `AnimatedDots` and arrow `Image` tint color in `DepartureBoardAccordionSectionHeader` were updated from `KrailTheme.colors.softLabel` to `KrailTheme.colors.onSurface`.

### How to test?

1. Navigate to the Departure Board screen.
2. Expand and collapse an accordion section.
3. Verify the arrow icon and animated loading dots display using the `onSurface` color rather than the previous `softLabel` color.

### Why make this change?

`softLabel` was not providing sufficient contrast or visual consistency for these UI elements. Switching to `onSurface` ensures the arrow and loading indicators are more legible and aligned with the theme's surface color semantics.