### PR TITLE
Add optional share text with journey details to ShareManager

### DIFF
--- a/core/share/src/androidMain/kotlin/xyz/ksharma/krail/core/share/AndroidShareManager.kt
+++ b/core/share/src/androidMain/kotlin/xyz/ksharma/krail/core/share/AndroidShareManager.kt
@@ -13,20 +13,17 @@ import java.io.File
 
 class AndroidShareManager(private val context: Context) : ShareManager {
 
-    override suspend fun shareImage(bitmap: ImageBitmap, title: String): Result<Unit> =
+    override suspend fun shareImage(bitmap: ImageBitmap, title: String, text: String?): Result<Unit> =
         runCatching {
-            // Heavy work: bitmap compression + file write — must not block the Main thread.
             val uri = withContext(Dispatchers.IO) {
                 saveBitmapToCache(bitmap.asAndroidBitmap())
             }
-
-            // startActivity is a UI operation and must run on the Main thread.
-            // FLAG_ACTIVITY_NEW_TASK is required when starting from a non-Activity context.
             withContext(Dispatchers.Main) {
                 val shareIntent = Intent(Intent.ACTION_SEND).apply {
                     type = "image/png"
                     putExtra(Intent.EXTRA_STREAM, uri)
                     putExtra(Intent.EXTRA_SUBJECT, title)
+                    if (text != null) putExtra(Intent.EXTRA_TEXT, text)
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
                 val chooser = Intent.createChooser(shareIntent, title).apply {

--- a/core/share/src/commonMain/kotlin/xyz/ksharma/krail/core/share/ShareManager.kt
+++ b/core/share/src/commonMain/kotlin/xyz/ksharma/krail/core/share/ShareManager.kt
@@ -15,6 +15,12 @@ interface ShareManager {
      *
      * @param bitmap The image to share.
      * @param title Optional chooser title (Android) or subject.
+     * @param text Optional text to accompany the image — used as a caption/message body
+     *             by apps that support it (e.g. WhatsApp, Messages, Instagram).
      */
-    suspend fun shareImage(bitmap: ImageBitmap, title: String = "Krail Journey"): Result<Unit>
+    suspend fun shareImage(
+        bitmap: ImageBitmap,
+        title: String = "Krail Journey",
+        text: String? = null,
+    ): Result<Unit>
 }

--- a/core/share/src/iosMain/kotlin/xyz/ksharma/krail/core/share/IosShareManager.kt
+++ b/core/share/src/iosMain/kotlin/xyz/ksharma/krail/core/share/IosShareManager.kt
@@ -20,7 +20,7 @@ import platform.UIKit.UIViewController
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 class IosShareManager : ShareManager {
 
-    override suspend fun shareImage(bitmap: ImageBitmap, title: String): Result<Unit> =
+    override suspend fun shareImage(bitmap: ImageBitmap, title: String, text: String?): Result<Unit> =
         runCatching {
             // Skia PNG encoding is CPU-heavy — run on Default to keep the Main thread free.
             val byteArray = withContext(Dispatchers.Default) {
@@ -44,8 +44,14 @@ class IosShareManager : ShareManager {
 
             // All UIKit calls (UIActivityViewController, presentViewController) must be on Main.
             withContext(Dispatchers.Main) {
+                // iOS: pass both image and text in activityItems — apps like Messages, WhatsApp
+                // use the text as the message body/caption alongside the image.
+                val activityItems = buildList {
+                    add(uiImage)
+                    if (text != null) add(text)
+                }
                 val activityVC = UIActivityViewController(
-                    activityItems = listOf(uiImage),
+                    activityItems = activityItems,
                     applicationActivities = null,
                 )
                 val topVC = checkNotNull(topmostViewController()) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -185,10 +185,16 @@ fun JourneyCard(
                                 textColor = onSurfaceColor,
                                 density = screenDensity,
                             )
-                        shareManager.shareImage(bitmap)
-                            .onFailure { error ->
-                                logError("error while sharing image: $error")
-                            }
+                        shareManager.shareImage(
+                            bitmap = bitmap,
+                            text = buildShareText(
+                                legList = legList,
+                                destinationTime = destinationTime,
+                                totalTravelTime = totalTravelTime,
+                            ),
+                        ).onFailure { error ->
+                            logError("error while sharing image: $error")
+                        }
                     }
                 },
                 modifier = Modifier.clickable(
@@ -478,6 +484,39 @@ private fun JourneyOriginTimeRow(
         onTimeTextStyle = KrailTheme.typography.titleMedium,
         modifier = modifier,
     )
+}
+
+/**
+ * Builds the share text for a journey.
+ *
+ * Example output:
+ * ```
+ * Hey mate!
+ *
+ * I'll reach Central Station, Platform 1 at 8:40am — about 30 mins away.
+ *
+ * Plan your trip on KRAIL!
+ * https://krail.app
+ * ```
+ */
+private fun buildShareText(
+    legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
+    destinationTime: String,
+    totalTravelTime: String,
+): String {
+    val lastStopName = legList
+        .filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+        .lastOrNull()
+        ?.stops
+        ?.lastOrNull()
+        ?.name
+
+    val journeyLine = if (lastStopName != null) {
+        "I'll reach $lastStopName at $destinationTime — about $totalTravelTime away."
+    } else {
+        "I'll arrive at $destinationTime — about $totalTravelTime away."
+    }
+    return "Hey mate!\n\n$journeyLine\n\nPlan your trip on KRAIL!\nhttps://krail.app"
 }
 
 // region Previews


### PR DESCRIPTION
### TL;DR

Adds optional share text to journey sharing, so apps like WhatsApp and Messages receive a friendly caption alongside the shared image.

### What changed?

`ShareManager.shareImage` now accepts an optional `text` parameter. On Android, this is passed as `EXTRA_TEXT` in the share intent. On iOS, the text is included alongside the image in `activityItems`, allowing supporting apps to use it as a message body or caption.

When sharing a journey card, a human-readable message is generated using the destination stop name, arrival time, and total travel time — for example:

```
Hey mate!

I'll reach Central Station, Platform 1 at 8:40am — about 30 mins away.

Plan your trip on KRAIL!
https://krail.app
```

If no destination stop can be resolved from the leg list, a fallback message using only the arrival time is used instead.

### How to test?

1. Open a journey result and expand a journey card.
2. Tap **Share with Friend**.
3. Share to an app that supports both image and text (e.g. WhatsApp, Messages).
4. Verify the shared content includes the journey image and the generated caption with the correct destination, time, and travel duration.
5. Repeat on both Android and iOS.

### Why make this change?

Sharing just an image provides little context to the recipient. Including a short, friendly message makes the shared journey immediately understandable without the recipient needing to interpret the screenshot.