### PR TITLE
feat: add analytics tracking to departure board screens and events

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -14,4 +14,6 @@ sealed class AnalyticsScreen(val name: String) {
     // Map screens — used for ScreenViewEvent + BigQuery engagement_time_msec queries
     data object SearchStopMap : AnalyticsScreen(name = "SearchStopMap")
     data object JourneyMap : AnalyticsScreen(name = "JourneyMap")
+
+    data object DepartureBoard : AnalyticsScreen(name = "DepartureBoard")
 }

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -6,6 +6,8 @@ import kotlin.time.ExperimentalTime
 
 private const val PROP_STOP_ID = "stopId"
 private const val PROP_SOURCE = "source"
+private const val PROP_EXPAND = "expand"
+private const val PROP_STOP_NAME = "stopName"
 
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
 
@@ -351,7 +353,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         properties = mapOf(
             PROP_STOP_ID to stopId.trim(),
             "facilityId" to facilityId.trim(),
-            "expand" to expand.toString().trim(),
+            PROP_EXPAND to expand.toString().trim(),
             "time" to time.toString().trim(),
         ),
     )
@@ -601,6 +603,136 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // endregion
 
+    // region DepartureBoard
+
+    /**
+     * Identifies which departure board surface fired the event.
+     *
+     *  - [SAVED_TRIPS] — the accordion on the Saved Trips screen (driven by [DepartureBoardViewModel])
+     *  - [STOP_SHEET]  — the bottom sheet opened when a user taps a stop
+     *                    (driven by [DeparturesViewModel])
+     */
+    enum class DepartureBoardSource(val value: String) {
+        SAVED_TRIPS("saved_trips"),
+        STOP_SHEET("stop_sheet"),
+    }
+
+    /**
+     * Fired when departure polling starts for a stop (i.e. the board is opened / becomes active).
+     * Use to measure how often users check live departures and which stops are most viewed.
+     *
+     * @param stopId   NSW Transport stop ID being polled.
+     * @param stopName Human-readable stop name shown in the UI.
+     * @param source   Which surface opened the board.
+     */
+    data class DepartureBoardScreenViewEvent(
+        val stopId: String,
+        val stopName: String,
+        val source: DepartureBoardSource,
+    ) : AnalyticsEvent(
+        name = "dep_board_screen_view",
+        properties = mapOf(
+            PROP_STOP_ID to stopId,
+            PROP_STOP_NAME to stopName,
+            PROP_SOURCE to source.value,
+        ),
+    )
+
+    /**
+     * Fired when the user taps a line chip to filter or clear departures.
+     * Use to understand which lines users care about most at each stop and
+     * how often they reset the filter.
+     *
+     * @param stopId        Stop where the chip was tapped.
+     * @param selected      `true` = filter applied; `false` = filter cleared.
+     * @param lineNumber    The affected line, e.g. "T1", "333". Always present — even when
+     *                      [selected] is `false`, the previously selected line is passed so
+     *                      we know which line was deselected.
+     * @param transportMode Human-readable mode name, e.g. "Train". Always present alongside [lineNumber].
+     * @param source        Which surface the tap came from.
+     */
+    data class DepartureBoardLineFilterClickEvent(
+        val stopId: String,
+        val selected: Boolean,
+        val lineNumber: String? = null,
+        val transportMode: String? = null,
+        val source: DepartureBoardSource,
+    ) : AnalyticsEvent(
+        name = "dep_board_line_filter_click",
+        properties = buildMap {
+            put(PROP_STOP_ID, stopId)
+            put("selected", selected)
+            put(PROP_SOURCE, source.value)
+            lineNumber?.let { put("lineNumber", it) }
+            transportMode?.let { put("transportMode", it) }
+        },
+    )
+
+    /**
+     * Fired when the user toggles the "Show / Hide previous departures" panel.
+     * Use to measure demand for past departure data and validate the UX of the toggle.
+     *
+     * @param stopId Stop whose previous departures the user wants to see.
+     * @param show   `true` = user opened the panel; `false` = user closed it.
+     * @param source Which surface the toggle was used on.
+     */
+    data class DepartureBoardShowPreviousEvent(
+        val stopId: String,
+        val show: Boolean,
+        val source: DepartureBoardSource,
+    ) : AnalyticsEvent(
+        name = "dep_board_show_previous",
+        properties = mapOf(
+            PROP_STOP_ID to stopId,
+            "show" to show,
+            PROP_SOURCE to source.value,
+        ),
+    )
+
+    /**
+     * Fired when the user taps a stop card in the saved-trips departure board accordion.
+     * Use to track which stops users most frequently monitor and expand/collapse patterns.
+     *
+     * @param stopId   Stop that was tapped.
+     * @param stopName Human-readable stop name.
+     * @param expand   `true` = card is being expanded; `false` = card is being collapsed.
+     */
+    data class DepartureBoardStopClickEvent(
+        val stopId: String,
+        val stopName: String,
+        val expand: Boolean,
+    ) : AnalyticsEvent(
+        name = "dep_board_stop_click",
+        properties = mapOf(
+            PROP_STOP_ID to stopId,
+            PROP_STOP_NAME to stopName,
+            PROP_EXPAND to expand,
+        ),
+    )
+
+    /**
+     * Fired when the user taps the Departure Board header in the nearby-stop bottom sheet
+     * (stop selection / stop details sheet) to expand or collapse the live board.
+     *
+     * @param stopId   NSW Transport stop ID of the nearby stop.
+     * @param stopName Human-readable stop name.
+     * @param expand   `true` = board is being expanded; `false` = board is being collapsed.
+     */
+    data class NearbyStopDepartureBoardClickEvent(
+        val stopId: String,
+        val stopName: String,
+        val expand: Boolean,
+    ) : AnalyticsEvent(
+        name = "nearby_stop_dep_board_click",
+        properties = mapOf(
+            PROP_STOP_ID to stopId,
+            PROP_STOP_NAME to stopName,
+            PROP_EXPAND to expand,
+        ),
+    )
+
+    // endregion
+
     // region InfoTiles
 
     data class InfoTileInteraction(
@@ -615,7 +747,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         ).apply {
             dismiss?.let { put("dismiss", dismiss) }
             ctaUrl?.let { put("cta_click", ctaUrl) }
-            expand?.let { put("expand", expand) }
+            expand?.let { put(PROP_EXPAND, expand) }
         },
     )
 

--- a/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesUiEvent.kt
+++ b/feature/departures/state/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/state/DeparturesUiEvent.kt
@@ -13,9 +13,10 @@ sealed interface DeparturesUiEvent {
      * Triggers a full load — replaces any existing departures and shows the
      * loading indicator. Typically fired when the departures surface first appears.
      *
-     * @param stopId NSW Transport stop ID, e.g. "10111010".
+     * @param stopId   NSW Transport stop ID, e.g. "10111010".
+     * @param stopName Human-readable stop name shown in the UI header (used for analytics).
      */
-    data class LoadDepartures(val stopId: String) : DeparturesUiEvent
+    data class LoadDepartures(val stopId: String, val stopName: String = "") : DeparturesUiEvent
 
     /**
      * Requests a silent refresh of the currently displayed stop's departures.
@@ -40,4 +41,50 @@ sealed interface DeparturesUiEvent {
      * so no background fetches run while departures are not visible.
      */
     data object StopPolling : DeparturesUiEvent
+
+    /**
+     * Notifies the ViewModel that the user changed the line filter.
+     *
+     * Fired by the UI whenever the selected filter chip changes. The ViewModel uses
+     * this to log analytics — no departure data is re-fetched.
+     *
+     * @param stopId        The stop whose departures are currently displayed.
+     * @param selected      `true` = filter applied; `false` = filter cleared.
+     * @param lineNumber    The affected line (e.g. "T1", "333"). Always present — even when
+     *                      [selected] is `false`, the previously selected line is passed.
+     * @param transportMode Human-readable mode name for the selected line (e.g. "Train"),
+     *                      or `null` if unavailable.
+     */
+    data class LineFilterChanged(
+        val stopId: String,
+        val selected: Boolean,
+        val lineNumber: String?,
+        val transportMode: String?,
+    ) : DeparturesUiEvent
+
+    /**
+     * Notifies the ViewModel that the user tapped the "Show / Hide previous departures" button.
+     * Fired on every toggle — both show and hide — so analytics is tracked per click.
+     *
+     * @param stopId The stop whose previous departures are toggled.
+     * @param show   `true` = user opened the panel; `false` = user closed it.
+     */
+    data class TogglePreviousDepartures(
+        val stopId: String,
+        val show: Boolean,
+    ) : DeparturesUiEvent
+
+    /**
+     * Notifies the ViewModel that the user tapped the Departure Board header in the
+     * nearby-stop bottom sheet to expand or collapse the live board.
+     *
+     * @param stopId   The nearby stop's ID.
+     * @param stopName The nearby stop's human-readable name.
+     * @param expand   `true` = board is being expanded; `false` = board is being collapsed.
+     */
+    data class NearbyStopDepartureBoardToggle(
+        val stopId: String,
+        val stopName: String,
+        val expand: Boolean,
+    ) : DeparturesUiEvent
 }

--- a/feature/departures/ui/build.gradle.kts
+++ b/feature/departures/ui/build.gradle.kts
@@ -36,6 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
+                implementation(projects.core.analytics)
                 implementation(projects.core.coroutinesExt)
                 implementation(projects.core.dateTime)
                 implementation(projects.core.di)
@@ -56,6 +57,7 @@ kotlin {
                 implementation(libs.test.kotlinxCoroutineTest)
                 implementation(libs.test.turbine)
                 implementation(libs.kotlinx.serialization.json)
+                implementation(projects.core.analytics)
             }
         }
     }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesAnalytics.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesAnalytics.kt
@@ -1,0 +1,50 @@
+package xyz.ksharma.krail.departures.ui
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
+import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+
+internal fun Analytics.trackDepartureBoardScreenView(
+    stopId: String,
+    stopName: String,
+    source: DepartureBoardSource,
+) {
+    trackScreenViewEvent(AnalyticsScreen.DepartureBoard)
+    track(AnalyticsEvent.DepartureBoardScreenViewEvent(stopId = stopId, stopName = stopName, source = source))
+}
+
+fun Analytics.trackDepartureBoardLineFilterClick(
+    stopId: String,
+    selected: Boolean,
+    lineNumber: String?,
+    transportMode: String?,
+    source: DepartureBoardSource,
+) {
+    track(
+        AnalyticsEvent.DepartureBoardLineFilterClickEvent(
+            stopId = stopId,
+            selected = selected,
+            lineNumber = lineNumber,
+            transportMode = transportMode,
+            source = source,
+        ),
+    )
+}
+
+fun Analytics.trackDepartureBoardShowPrevious(
+    stopId: String,
+    show: Boolean,
+    source: DepartureBoardSource,
+) {
+    track(AnalyticsEvent.DepartureBoardShowPreviousEvent(stopId = stopId, show = show, source = source))
+}
+
+fun Analytics.trackDepartureBoardStopClick(stopId: String, stopName: String, expand: Boolean) {
+    track(AnalyticsEvent.DepartureBoardStopClickEvent(stopId = stopId, stopName = stopName, expand = expand))
+}
+
+fun Analytics.trackNearbyStopDepartureBoardClick(stopId: String, stopName: String, expand: Boolean) {
+    track(AnalyticsEvent.NearbyStopDepartureBoardClickEvent(stopId = stopId, stopName = stopName, expand = expand))
+}

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
@@ -18,6 +19,8 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toDepartureRelativeString
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
@@ -26,8 +29,11 @@ import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("TooManyFunctions", "")
 class DeparturesViewModel(
     private val repository: DepartureBoardRepository,
+    private val analytics: Analytics,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
 
@@ -123,47 +129,102 @@ class DeparturesViewModel(
         }
 
     fun onEvent(event: DeparturesUiEvent) {
-        val t = nowMs()
         when (event) {
-            is DeparturesUiEvent.LoadDepartures -> {
-                val current = activeStopId.value
-                if (event.stopId != current) {
-                    log("[$LOG_TAG] t=$t onEvent LoadDepartures → stopId=${event.stopId} (was $current)")
-                    // Switching activeStopId causes flatMapLatest to cancel the old pollStop
-                    // flow and start a new one — no manual stopIfActive/setActiveStop needed.
-                    activeStopId.value = event.stopId
-                } else {
-                    log("[$LOG_TAG] t=$t onEvent LoadDepartures SAME STOP — already polling ${event.stopId}")
-                }
-            }
-
-            DeparturesUiEvent.Refresh -> {
-                val stopId = activeStopId.value
-                if (stopId != null) {
-                    log("[$LOG_TAG] t=$t onEvent Refresh → stopId=$stopId")
-                    viewModelScope.launch { repository.refresh(stopId) }
-                } else {
-                    log("[$LOG_TAG] t=$t onEvent Refresh NOOP — no active stop")
-                }
-            }
-
-            is DeparturesUiEvent.LoadPreviousDepartures -> {
-                log("[$LOG_TAG] t=$t onEvent LoadPreviousDepartures → stopId=${event.stopId}")
-                viewModelScope.launch { repository.loadPreviousDepartures(event.stopId) }
-            }
-
-            DeparturesUiEvent.StopPolling -> {
-                val stopId = activeStopId.value
-                if (stopId != null) {
-                    log("[$LOG_TAG] t=$t onEvent StopPolling → stopId=$stopId")
-                    // Setting to null switches flatMapLatest to flowOf(idle state),
-                    // which cancels the pollStop flow and stops the polling loop.
-                    activeStopId.value = null
-                } else {
-                    log("[$LOG_TAG] t=$t onEvent StopPolling NOOP — no active stop")
-                }
-            }
+            is DeparturesUiEvent.LoadDepartures -> onLoadDepartures(event)
+            DeparturesUiEvent.Refresh -> onRefresh()
+            is DeparturesUiEvent.LoadPreviousDepartures -> onLoadPreviousDepartures(event.stopId)
+            DeparturesUiEvent.StopPolling -> onStopPolling()
+            is DeparturesUiEvent.LineFilterChanged -> onLineFilterChanged(event)
+            is DeparturesUiEvent.TogglePreviousDepartures -> onTogglePreviousDepartures(event)
+            is DeparturesUiEvent.NearbyStopDepartureBoardToggle -> onNearbyStopDepartureBoardToggle(event)
         }
+    }
+
+    private fun onLoadDepartures(event: DeparturesUiEvent.LoadDepartures) {
+        val t = nowMs()
+        val current = activeStopId.value
+        if (event.stopId != current) {
+            log(
+                "[$LOG_TAG] t=$t onEvent LoadDepartures → stopId=${event.stopId} " +
+                    "(was $current)",
+            )
+            analytics.trackDepartureBoardScreenView(
+                stopId = event.stopId,
+                stopName = event.stopName,
+                source = DepartureBoardSource.STOP_SHEET,
+            )
+            activeStopId.value = event.stopId
+        } else {
+            log(
+                "[$LOG_TAG] t=$t onEvent LoadDepartures SAME STOP — already polling " +
+                    event.stopId,
+            )
+        }
+    }
+
+    private fun onRefresh() {
+        val t = nowMs()
+        val stopId = activeStopId.value
+        if (stopId != null) {
+            log("[$LOG_TAG] t=$t onEvent Refresh → stopId=$stopId")
+            viewModelScope.launch { repository.refresh(stopId) }
+        } else {
+            log("[$LOG_TAG] t=$t onEvent Refresh NOOP — no active stop")
+        }
+    }
+
+    private fun onLoadPreviousDepartures(stopId: String) {
+        log("[$LOG_TAG] t=${nowMs()} onEvent LoadPreviousDepartures → stopId=$stopId")
+        viewModelScope.launch { repository.loadPreviousDepartures(stopId) }
+    }
+
+    private fun onStopPolling() {
+        val t = nowMs()
+        val stopId = activeStopId.value
+        if (stopId != null) {
+            log("[$LOG_TAG] t=$t onEvent StopPolling → stopId=$stopId")
+            activeStopId.value = null
+        } else {
+            log("[$LOG_TAG] t=$t onEvent StopPolling NOOP — no active stop")
+        }
+    }
+
+    private fun onLineFilterChanged(event: DeparturesUiEvent.LineFilterChanged) {
+        log(
+            "[$LOG_TAG] t=${nowMs()} onEvent LineFilterChanged → stopId=${event.stopId} " +
+                "line=${event.lineNumber} selected=${event.selected}",
+        )
+        analytics.trackDepartureBoardLineFilterClick(
+            stopId = event.stopId,
+            selected = event.selected,
+            lineNumber = event.lineNumber,
+            transportMode = event.transportMode,
+            source = DepartureBoardSource.STOP_SHEET,
+        )
+    }
+
+    private fun onTogglePreviousDepartures(event: DeparturesUiEvent.TogglePreviousDepartures) {
+        log(
+            "[$LOG_TAG] t=${nowMs()} onEvent TogglePreviousDepartures → stopId=${event.stopId} " +
+                "show=${event.show}",
+        )
+        analytics.trackDepartureBoardShowPrevious(
+            stopId = event.stopId,
+            show = event.show,
+            source = DepartureBoardSource.STOP_SHEET,
+        )
+    }
+
+    private fun onNearbyStopDepartureBoardToggle(event: DeparturesUiEvent.NearbyStopDepartureBoardToggle) {
+        log(
+            "[$LOG_TAG] t=${nowMs()} onEvent NearbyStopDepartureBoardToggle → " +
+                "stopId=${event.stopId} expand=${event.expand}",
+        )
+        analytics.trackNearbyStopDepartureBoardClick(
+            stopId = event.stopId,
+            stopName = event.stopName,
+            expand = event.expand,
+        )
     }
 
     override fun onCleared() {

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/di/DeparturesUiModule.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/di/DeparturesUiModule.kt
@@ -20,6 +20,6 @@ val departuresUiModule = module {
         )
     }
     viewModel {
-        DeparturesViewModel(repository = get())
+        DeparturesViewModel(repository = get(), analytics = get())
     }
 }

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModelTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModelTest.kt
@@ -8,8 +8,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
-import xyz.ksharma.krail.departures.ui.state.DeparturesState
 import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -53,6 +54,7 @@ class DeparturesViewModelTest {
         )
         viewModel = DeparturesViewModel(
             repository = repository,
+            analytics = NoOpAnalytics,
             ioDispatcher = testDispatcher,
         )
     }
@@ -257,4 +259,11 @@ class DeparturesViewModelTest {
         const val STOP_A = "10111010"
         const val STOP_B = "10111020"
     }
+}
+
+/** No-op [Analytics] for tests — discards all events. */
+private object NoOpAnalytics : Analytics {
+    override fun track(event: AnalyticsEvent) = Unit
+    override fun setUserId(userId: String) = Unit
+    override fun setUserProperty(name: String, value: String) = Unit
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/departureboard/DepartureBoardUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/departureboard/DepartureBoardUiEvent.kt
@@ -1,0 +1,60 @@
+package xyz.ksharma.krail.trip.planner.ui.state.departureboard
+
+/**
+ * User-initiated events for the Departure Board accordion on the Saved Trips screen.
+ *
+ * All UI interactions are funnelled through a single [DepartureBoardViewModel.onEvent] call,
+ * mirroring the pattern used by [SavedTripUiEvent] and [DeparturesUiEvent].
+ */
+sealed interface DepartureBoardUiEvent {
+
+    /**
+     * Expands the departure board card for [stopId], starting live polling.
+     * If the same stop is already expanded this is a no-op.
+     */
+    data class ExpandStop(val stopId: String) : DepartureBoardUiEvent
+
+    /**
+     * Collapses the currently open departure board card, stopping polling.
+     */
+    data object CollapseStop : DepartureBoardUiEvent
+
+    /**
+     * Triggers a one-shot fetch of past departures for [stopId].
+     * Results appear in [DeparturesState.previousDepartures].
+     */
+    data class LoadPreviousDepartures(val stopId: String) : DepartureBoardUiEvent
+
+    /**
+     * Requests a silent refresh of the departures for [stopId] without clearing the list.
+     */
+    data class RefreshStop(val stopId: String) : DepartureBoardUiEvent
+
+    /**
+     * Notifies the ViewModel that the user changed the line filter on the saved-trips accordion.
+     *
+     * @param stopId        The stop whose departures are filtered.
+     * @param selected      `true` = filter applied; `false` = filter cleared.
+     * @param lineNumber    The affected line, or `null` if unavailable. Always the affected line
+     *                      even when [selected] is `false`.
+     * @param transportMode Human-readable mode name for the selected line, or `null` when cleared.
+     */
+    data class LineFilterChanged(
+        val stopId: String,
+        val selected: Boolean,
+        val lineNumber: String?,
+        val transportMode: String?,
+    ) : DepartureBoardUiEvent
+
+    /**
+     * Notifies the ViewModel that the user tapped the "Show / Hide previous departures" button.
+     * Fired on every toggle so analytics is tracked per click.
+     *
+     * @param stopId The stop whose previous departures are toggled.
+     * @param show   `true` = user opened the panel; `false` = user closed it.
+     */
+    data class TogglePreviousDepartures(
+        val stopId: String,
+        val show: Boolean,
+    ) : DepartureBoardUiEvent
+}

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -126,6 +126,7 @@ kotlin {
                 implementation(libs.test.kotlinxCoroutineTest)
                 implementation(libs.test.turbine)
 
+                implementation(projects.core.analytics)
                 implementation(projects.sandook)
                 implementation(projects.feature.departures.network)
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardBody.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardBody.kt
@@ -40,6 +40,12 @@ import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
  * @param onRetry                  Called when the user taps "Retry" on the error state.
  * @param onLoadPreviousDepartures Called when the user first opens the "Show previous" panel
  *                                 and no previous departures have been fetched yet.
+ * @param onLineFilterChange       Optional: called when the user selects or clears a line filter.
+ *                                 Receives the affected line number, its transport mode, and
+ *                                 whether the filter was applied (`true`) or cleared (`false`).
+ *                                 The line number is always the affected line — even on deselect.
+ * @param onShowPreviousToggle     Optional: called on every "Show / Hide previous" toggle.
+ *                                 `true` = user showed the panel; `false` = user hid it.
  * @param maxItems                 Maximum departure rows to show. `null` = show all.
  */
 @Composable
@@ -48,6 +54,8 @@ internal fun DepartureBoardBody(
     onRetry: () -> Unit,
     onLoadPreviousDepartures: () -> Unit,
     modifier: Modifier = Modifier,
+    onLineFilterChange: ((lineNumber: String?, transportMode: String?, selected: Boolean) -> Unit)? = null,
+    onShowPreviousToggle: ((show: Boolean) -> Unit)? = null,
     maxItems: Int? = null,
 ) {
     // Empty string = no filter. rememberSaveable round-trips safely as a String primitive.
@@ -90,7 +98,17 @@ internal fun DepartureBoardBody(
                     LinesServedRow(
                         departures = state.departures,
                         selectedLine = selectedLine,
-                        onLineSelect = { selectedLineKey = it ?: "" },
+                        onLineSelect = { newLine ->
+                            // Capture the previously selected line BEFORE updating state so
+                            // we can report it when the filter is being cleared (deselected).
+                            val previousLine = selectedLine
+                            selectedLineKey = newLine ?: ""
+                            val affectedLine = newLine ?: previousLine
+                            val transportMode = affectedLine?.let { line ->
+                                state.departures.firstOrNull { it.lineNumber == line }?.transportModeName
+                            }
+                            onLineFilterChange?.invoke(affectedLine, transportMode, newLine != null)
+                        },
                     )
                 }
 
@@ -103,6 +121,7 @@ internal fun DepartureBoardBody(
                     TextButton(
                         onClick = {
                             showPrevious = !showPrevious
+                            onShowPreviousToggle?.invoke(showPrevious)
                             if (showPrevious &&
                                 state.previousDepartures.isEmpty() &&
                                 !state.isPreviousLoading

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -63,6 +63,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
  *   Used in the saved trips accordion where only one card can be open at a time.
  *
  * @param stopId          NSW Transport stop ID, e.g. "10111010".
+ * @param stopName        Human-readable stop name. Used in analytics for uncontrolled mode.
  * @param state           Current [DeparturesState] from the ViewModel or repository.
  * @param onEvent         Callback to send events to the ViewModel (only used in uncontrolled mode).
  * @param isExpanded      When non-null, puts the card in controlled mode with this expansion state.
@@ -76,6 +77,7 @@ fun DepartureBoardStopCard(
     state: DeparturesState,
     onEvent: (DeparturesUiEvent) -> Unit,
     modifier: Modifier = Modifier,
+    stopName: String = "",
     isExpanded: Boolean? = null,
     onExpandChange: ((Boolean) -> Unit)? = null,
     title: String = "Departure Board",
@@ -106,7 +108,7 @@ fun DepartureBoardStopCard(
             // Uncontrolled mode: start polling on expand, stop it on collapse.
             if (expanded) {
                 log("[DEPARTURES] UI card EXPANDED stopId=$stopId — sending LoadDepartures")
-                onEvent(DeparturesUiEvent.LoadDepartures(stopId))
+                onEvent(DeparturesUiEvent.LoadDepartures(stopId, stopName))
             } else {
                 log("[DEPARTURES] UI card COLLAPSED stopId=$stopId — sending StopPolling")
                 onEvent(DeparturesUiEvent.StopPolling)
@@ -144,7 +146,13 @@ fun DepartureBoardStopCard(
             arrowRotation = arrowRotation,
             onClick = {
                 val next = !expanded
-                if (onExpandChange != null) onExpandChange(next) else internalExpanded = next
+                if (onExpandChange != null) {
+                    onExpandChange(next)
+                } else {
+                    // Uncontrolled mode: track the expand/collapse click as a nearby-stop event.
+                    internalExpanded = next
+                    onEvent(DeparturesUiEvent.NearbyStopDepartureBoardToggle(stopId, stopName, next))
+                }
             },
         )
 
@@ -160,6 +168,19 @@ fun DepartureBoardStopCard(
                 state = state,
                 onRetry = { if (isExpanded == null) onEvent(DeparturesUiEvent.Refresh) },
                 onLoadPreviousDepartures = { onEvent(DeparturesUiEvent.LoadPreviousDepartures(stopId)) },
+                onLineFilterChange = { lineNumber, transportMode, selected ->
+                    onEvent(
+                        DeparturesUiEvent.LineFilterChanged(
+                            stopId = stopId,
+                            selected = selected,
+                            lineNumber = lineNumber,
+                            transportMode = transportMode,
+                        ),
+                    )
+                },
+                onShowPreviousToggle = { show ->
+                    onEvent(DeparturesUiEvent.TogglePreviousDepartures(stopId, show))
+                },
                 maxItems = maxItems,
                 modifier = Modifier.padding(top = 4.dp),
             )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -40,6 +40,7 @@ import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardBody
 import xyz.ksharma.krail.trip.planner.ui.components.loading.AnimatedDots
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.StopDepartureBoardEntry
+import xyz.ksharma.krail.trip.planner.ui.state.departureboard.DepartureBoardUiEvent
 
 // ── LazyListScope extension ───────────────────────────────────────────────────
 
@@ -55,15 +56,21 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.StopDepartureBoardEntry
 fun LazyListScope.departureBoardAccordionSection(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
-    onExpandChange: (Boolean) -> Unit,
-    onLoadPreviousDepartures: (String) -> Unit = {},
-    onRefreshStop: (String) -> Unit = {},
+    onEvent: (DepartureBoardUiEvent) -> Unit,
 ) {
     stickyHeader(key = "${entry.stopId}_header", contentType = "stop_header") {
         DepartureBoardAccordionSectionHeader(
             entry = entry,
             isExpanded = isExpanded,
-            onExpandChange = onExpandChange,
+            onExpandChange = { expand ->
+                onEvent(
+                    if (expand) {
+                        DepartureBoardUiEvent.ExpandStop(entry.stopId)
+                    } else {
+                        DepartureBoardUiEvent.CollapseStop
+                    },
+                )
+            },
             modifier = Modifier.padding(bottom = 16.dp),
         )
     }
@@ -73,8 +80,21 @@ fun LazyListScope.departureBoardAccordionSection(
             DepartureBoardAccordionContent(
                 stopId = entry.stopId,
                 state = entry.state,
-                onLoadPreviousDepartures = onLoadPreviousDepartures,
-                onRefreshStop = onRefreshStop,
+                onLoadPreviousDepartures = { onEvent(DepartureBoardUiEvent.LoadPreviousDepartures(it)) },
+                onRefreshStop = { onEvent(DepartureBoardUiEvent.RefreshStop(it)) },
+                onLineFilterChange = { lineNumber, transportMode, selected ->
+                    onEvent(
+                        DepartureBoardUiEvent.LineFilterChanged(
+                            stopId = entry.stopId,
+                            selected = selected,
+                            lineNumber = lineNumber,
+                            transportMode = transportMode,
+                        ),
+                    )
+                },
+                onShowPreviousToggle = { show ->
+                    onEvent(DepartureBoardUiEvent.TogglePreviousDepartures(entry.stopId, show))
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -165,11 +185,15 @@ private fun DepartureBoardAccordionContent(
     onLoadPreviousDepartures: (String) -> Unit,
     onRefreshStop: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onLineFilterChange: ((lineNumber: String?, transportMode: String?, selected: Boolean) -> Unit)? = null,
+    onShowPreviousToggle: ((Boolean) -> Unit)? = null,
 ) {
     DepartureBoardBody(
         state = state,
         onRetry = { onRefreshStop(stopId) },
         onLoadPreviousDepartures = { onLoadPreviousDepartures(stopId) },
+        onLineFilterChange = onLineFilterChange,
+        onShowPreviousToggle = onShowPreviousToggle,
         modifier = modifier,
     )
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -124,10 +124,7 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
             onInviteFriendsTileDisplay = { viewModel.markInviteFriendsTileAsSeen() },
             departureBoardEntries = departureBoardEntries,
             expandedDepartureBoardStopId = expandedDepartureBoardStopId,
-            onDepartureBoardExpand = departureBoardViewModel::onCardExpand,
-            onDepartureBoardCollapse = departureBoardViewModel::onCardCollapse,
-            onLoadPreviousDepartures = departureBoardViewModel::onLoadPreviousDepartures,
-            onRefreshDepartureBoardStop = departureBoardViewModel::onRefreshStop,
+            onDepartureBoardEvent = departureBoardViewModel::onEvent,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModel.kt
@@ -16,8 +16,14 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
 import xyz.ksharma.krail.departures.ui.DepartureBoardRepository
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.trackDepartureBoardLineFilterClick
+import xyz.ksharma.krail.departures.ui.trackDepartureBoardShowPrevious
+import xyz.ksharma.krail.departures.ui.trackDepartureBoardStopClick
+import xyz.ksharma.krail.trip.planner.ui.state.departureboard.DepartureBoardUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 /**
@@ -46,6 +52,7 @@ data class StopDepartureBoardEntry(
  */
 class DepartureBoardViewModel(
     private val repository: DepartureBoardRepository,
+    private val analytics: Analytics,
 ) : ViewModel() {
 
     // Unique stops derived from the saved trips list (both from- and to-stops, deduplicated).
@@ -120,6 +127,30 @@ class DepartureBoardViewModel(
     }
 
     /**
+     * Single entry-point for all UI-initiated events.
+     * Delegates to the appropriate internal function so callers don't need
+     * separate function references for each action.
+     */
+    fun onEvent(event: DepartureBoardUiEvent) {
+        when (event) {
+            is DepartureBoardUiEvent.ExpandStop -> onCardExpand(event.stopId)
+            DepartureBoardUiEvent.CollapseStop -> onCardCollapse()
+            is DepartureBoardUiEvent.LoadPreviousDepartures -> onLoadPreviousDepartures(event.stopId)
+            is DepartureBoardUiEvent.RefreshStop -> onRefreshStop(event.stopId)
+            is DepartureBoardUiEvent.LineFilterChanged -> onLineFilterChanged(
+                stopId = event.stopId,
+                selected = event.selected,
+                lineNumber = event.lineNumber,
+                transportMode = event.transportMode,
+            )
+            is DepartureBoardUiEvent.TogglePreviousDepartures -> onTogglePreviousDepartures(
+                stopId = event.stopId,
+                show = event.show,
+            )
+        }
+    }
+
+    /**
      * Expands the card for [stopId].
      *
      * Setting [_expandedStopId] triggers [flatMapLatest] in [entries] which cancels the previous
@@ -129,10 +160,16 @@ class DepartureBoardViewModel(
     fun onCardExpand(stopId: String) {
         if (_expandedStopId.value == stopId) return
         _expandedStopId.value = stopId
+        val stopName = _stops.value.firstOrNull { it.first == stopId }?.second ?: ""
+        analytics.trackDepartureBoardStopClick(stopId = stopId, stopName = stopName, expand = true)
     }
 
     /** Collapses the currently open card. [flatMapLatest] cancels the polling loop. */
     fun onCardCollapse() {
+        _expandedStopId.value?.let { stopId ->
+            val stopName = _stops.value.firstOrNull { it.first == stopId }?.second ?: ""
+            analytics.trackDepartureBoardStopClick(stopId = stopId, stopName = stopName, expand = false)
+        }
         _expandedStopId.value = null
     }
 
@@ -148,5 +185,23 @@ class DepartureBoardViewModel(
      */
     fun onLoadPreviousDepartures(stopId: String) {
         viewModelScope.launch { repository.loadPreviousDepartures(stopId) }
+    }
+
+    private fun onTogglePreviousDepartures(stopId: String, show: Boolean) {
+        analytics.trackDepartureBoardShowPrevious(
+            stopId = stopId,
+            show = show,
+            source = DepartureBoardSource.SAVED_TRIPS,
+        )
+    }
+
+    private fun onLineFilterChanged(stopId: String, selected: Boolean, lineNumber: String?, transportMode: String?) {
+        analytics.trackDepartureBoardLineFilterClick(
+            stopId = stopId,
+            selected = selected,
+            lineNumber = lineNumber,
+            transportMode = transportMode,
+            source = DepartureBoardSource.SAVED_TRIPS,
+        )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -58,6 +58,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
 import xyz.ksharma.krail.trip.planner.ui.departureboard.departureBoardAccordionSection
+import xyz.ksharma.krail.trip.planner.ui.state.departureboard.DepartureBoardUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -77,10 +78,7 @@ fun SavedTripsScreen(
     onInviteFriendsTileDisplay: () -> Unit = {},
     departureBoardEntries: ImmutableList<StopDepartureBoardEntry> = persistentListOf(),
     expandedDepartureBoardStopId: String? = null,
-    onDepartureBoardExpand: (String) -> Unit = {},
-    onDepartureBoardCollapse: () -> Unit = {},
-    onLoadPreviousDepartures: (String) -> Unit = {},
-    onRefreshDepartureBoardStop: (String) -> Unit = {},
+    onDepartureBoardEvent: (DepartureBoardUiEvent) -> Unit = {},
 ) {
     val emptyStateTip = remember {
         buildList {
@@ -234,10 +232,7 @@ fun SavedTripsScreen(
                             expandedMap = expandedMap,
                             departureBoardEntries = departureBoardEntries,
                             expandedDepartureBoardStopId = expandedDepartureBoardStopId,
-                            onDepartureBoardExpand = onDepartureBoardExpand,
-                            onDepartureBoardCollapse = onDepartureBoardCollapse,
-                            onLoadPreviousDepartures = onLoadPreviousDepartures,
-                            onRefreshDepartureBoardStop = onRefreshDepartureBoardStop,
+                            onDepartureBoardEvent = onDepartureBoardEvent,
                         )
                     }
                 }
@@ -295,10 +290,7 @@ private fun LazyListScope.savedTripsContent(
     expandedMap: SnapshotStateMap<String, Boolean>,
     departureBoardEntries: ImmutableList<StopDepartureBoardEntry>,
     expandedDepartureBoardStopId: String?,
-    onDepartureBoardExpand: (String) -> Unit,
-    onDepartureBoardCollapse: () -> Unit,
-    onLoadPreviousDepartures: (String) -> Unit = {},
-    onRefreshDepartureBoardStop: (String) -> Unit = {},
+    onDepartureBoardEvent: (DepartureBoardUiEvent) -> Unit = {},
 ) {
     stickyHeader(key = "saved_trips_title") {
         SavedTripsTitle {
@@ -377,11 +369,7 @@ private fun LazyListScope.savedTripsContent(
             departureBoardAccordionSection(
                 entry = entry,
                 isExpanded = expandedDepartureBoardStopId == entry.stopId,
-                onExpandChange = { expand ->
-                    if (expand) onDepartureBoardExpand(entry.stopId) else onDepartureBoardCollapse()
-                },
-                onLoadPreviousDepartures = onLoadPreviousDepartures,
-                onRefreshStop = onRefreshDepartureBoardStop,
+                onEvent = onDepartureBoardEvent,
             )
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
@@ -53,6 +53,7 @@ fun StopDetailsBottomSheet(
         additionalInfo = {
             DepartureBoardStopCard(
                 stopId = stop.stopId,
+                stopName = stop.stopName,
                 state = departuresState,
                 onEvent = departuresViewModel::onEvent,
             )

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/DepartureBoardViewModelTest.kt
@@ -16,6 +16,8 @@ import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
 import xyz.ksharma.krail.departures.network.api.service.DeparturesService
 import xyz.ksharma.krail.departures.ui.DepartureBoardConfig
 import xyz.ksharma.krail.departures.ui.DepartureBoardRepository
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -58,7 +60,7 @@ class DepartureBoardViewModelTest {
             ioDispatcher = testDispatcher,
             config = testConfig,
         )
-        viewModel = DepartureBoardViewModel(repository = repository)
+        viewModel = DepartureBoardViewModel(repository = repository, analytics = NoOpAnalytics)
     }
 
     @AfterTest
@@ -407,6 +409,13 @@ class DepartureBoardViewModelTest {
             toStopName = "Stop C",
         )
     }
+}
+
+/** No-op [Analytics] for tests — discards all events. */
+private object NoOpAnalytics : Analytics {
+    override fun track(event: AnalyticsEvent) = Unit
+    override fun setUserId(userId: String) = Unit
+    override fun setUserProperty(name: String, value: String) = Unit
 }
 
 /**


### PR DESCRIPTION
### TL;DR

Adds analytics instrumentation to the Departure Board feature, covering screen views, line filter interactions, previous departures toggles, and stop card expand/collapse events.

### What changed?

- Introduced a new `DepartureBoard` analytics screen and four new `AnalyticsEvent` types: `DepartureBoardScreenViewEvent`, `DepartureBoardLineFilterClickEvent`, `DepartureBoardShowPreviousEvent`, and `DepartureBoardStopClickEvent`, each tagged with a `DepartureBoardSource` (`SAVED_TRIPS` or `STOP_SHEET`) to distinguish which surface fired the event.
- Added a `DeparturesAnalytics.kt` helper file with extension functions on `Analytics` to keep tracking calls concise and consistent across both ViewModels.
- Wired analytics into `DeparturesViewModel` (stop sheet surface) and `DepartureBoardViewModel` (saved trips accordion surface), injecting `Analytics` into both and tracking events at the appropriate call sites.
- Introduced a `DepartureBoardUiEvent` sealed interface with `ExpandStop`, `CollapseStop`, `LoadPreviousDepartures`, `RefreshStop`, and `LineFilterChanged` events, replacing the four separate callback lambdas previously threaded through `SavedTripsScreen` and `departureBoardAccordionSection`.
- Added a `LineFilterChanged` event to `DeparturesUiEvent` so the stop-sheet surface can also report filter changes to its ViewModel.
- Propagated `onLineFilterChange` through `DepartureBoardBody` and `DepartureBoardStopCard` so line filter selections bubble up to the ViewModel layer.
- Updated DI modules to supply `Analytics` to both ViewModels.
- Added a `NoOpAnalytics` test double in both ViewModel test files so existing tests compile and pass without real analytics.

### How to test?

1. Open the **Saved Trips** screen and expand a stop card — verify a `dep_board_stop_click` event fires with `expand = true`.
2. Collapse the card — verify the same event fires with `expand = false`.
3. Tap a line chip to filter departures — verify `dep_board_line_filter_click` fires with the correct `lineNumber`, `transportMode`, and `source = saved_trips`.
4. Clear the filter — verify the event fires with `lineNumber = null` and `transportMode = null`.
5. Tap "Show previous departures" — verify `dep_board_show_previous` fires with `show = true` and `source = saved_trips`.
6. Open the **Stop Sheet** bottom sheet — verify `dep_board_screen_view` and a Firebase `screen_view` event fire with `source = stop_sheet`.
7. Repeat the line filter and previous departures steps from the stop sheet and confirm `source = stop_sheet` on all events.
8. Run the unit test suites for `DeparturesViewModelTest` and `DepartureBoardViewModelTest` — all tests should pass.

### Why make this change?

The Departure Board surfaces had no analytics coverage, making it impossible to measure how often users check live departures, which stops and lines they care about most, and whether features like "Show previous departures" are actually used. This change closes that gap by instrumenting all key interactions across both the saved-trips accordion and the stop-sheet surfaces.