### PR TITLE
fix: align totalUniqueServiceAlerts count with parsed serviceAlertList

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -214,6 +214,7 @@ private fun RouteSummary(
     badgeColor: Color,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChip.kt
@@ -128,6 +128,7 @@ fun DiscoverChip(
 @Preview(group = "Discover Chip Previews - Barbie Pink", name = "Selected Light Mode")
 @Composable
 private fun DiscoverChipPreview_BarbiePink_Selected() {
+    val dim = KrailTheme.dimensions
     PreviewTheme(themeStyle = KrailThemeStyle.BarbiePink) {
         DiscoverChip(
             type = DiscoverCardType.Travel,
@@ -141,6 +142,7 @@ private fun DiscoverChipPreview_BarbiePink_Selected() {
 @Preview
 @Composable
 private fun DiscoverChipPreview_BarbiePink_Unselected() {
+    val dim = KrailTheme.dimensions
     PreviewTheme(themeStyle = KrailThemeStyle.BarbiePink) {
         DiscoverChip(
             type = DiscoverCardType.Travel,
@@ -154,6 +156,8 @@ private fun DiscoverChipPreview_BarbiePink_Unselected() {
 @Preview
 @Composable
 private fun DiscoverChipPreview_BarbiePink_Selected_DarkMode() {
+    val dim = KrailTheme.dimensions
+
     PreviewTheme(themeStyle = KrailThemeStyle.BarbiePink) {
         DiscoverChip(
             type = DiscoverCardType.Travel,
@@ -167,6 +171,8 @@ private fun DiscoverChipPreview_BarbiePink_Selected_DarkMode() {
 @Preview
 @Composable
 private fun DiscoverChipPreview_BarbiePink_Unselected_DarkMode() {
+    val dim = KrailTheme.dimensions
+
     PreviewTheme(themeStyle = KrailThemeStyle.BarbiePink) {
         DiscoverChip(
             type = DiscoverCardType.Travel,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -81,7 +81,11 @@ internal fun TripResponse.buildJourneyListWithRawData():
                 totalWalkTime = walkingDurationStr,
                 transportModeLines = transportModeLines,
                 legs = legsList,
-                totalUniqueServiceAlerts = legs.flatMap { leg -> leg.infos.orEmpty() }.toSet().size,
+                totalUniqueServiceAlerts = legsList
+                    .filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                    .flatMap { it.serviceAlertList.orEmpty() }
+                    .toSet()
+                    .size,
                 departureDeviation = firstPublicTransportLeg.getDepartureDeviation(),
                 scheduledOriginTime = firstPublicTransportLeg.getScheduledOriginTime(),
             ).also {

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
@@ -329,6 +329,130 @@ class TripResponseMapperTest {
 
     //endregion
 
+    //region totalUniqueServiceAlerts
+
+    @Test
+    fun `Given leg with no infos When buildJourneyList Then totalUniqueServiceAlerts is 0`() {
+        val response = TripResponse(
+            journeys = listOf(buildJourneyWithTransportLeg(productClass = 1L, infos = null)),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(0, journey?.totalUniqueServiceAlerts)
+    }
+
+    @Test
+    fun `Given leg with fully valid infos When buildJourneyList Then totalUniqueServiceAlerts matches`() {
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 1L,
+                    infos = listOf(
+                        TripResponse.Info(subtitle = "Delays", content = "Train delayed", priority = "high"),
+                        TripResponse.Info(subtitle = "Works", content = "Track works", priority = "normal"),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(2, journey?.totalUniqueServiceAlerts)
+    }
+
+    @Test
+    fun `Given leg with info missing subtitle When buildJourneyList Then that info is not counted`() {
+        // Regression: before the fix, totalUniqueServiceAlerts counted raw infos regardless of
+        // whether toAlert() could parse them. An info with null subtitle is dropped by toAlert()
+        // but was still included in the badge count, so the alert bottom sheet never opened.
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 1L,
+                    infos = listOf(
+                        TripResponse.Info(subtitle = null, content = "Some content", priority = "high"),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(0, journey?.totalUniqueServiceAlerts)
+    }
+
+    @Test
+    fun `Given leg with info missing content When buildJourneyList Then that info is not counted`() {
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 1L,
+                    infos = listOf(
+                        TripResponse.Info(subtitle = "Delays", content = null, priority = "normal"),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(0, journey?.totalUniqueServiceAlerts)
+    }
+
+    @Test
+    fun `Given leg with info with unrecognised priority When buildJourneyList Then that info is not counted`() {
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 1L,
+                    infos = listOf(
+                        TripResponse.Info(subtitle = "Notice", content = "Some notice", priority = "unknown"),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(0, journey?.totalUniqueServiceAlerts)
+    }
+
+    @Test
+    fun `Given mix of valid and invalid infos When buildJourneyList Then only valid ones are counted`() {
+        // Core regression: badge showed 3 alerts but serviceAlertList was empty (or fewer),
+        // so the bottom sheet guarded by alerts.isNotEmpty() never opened.
+        val response = TripResponse(
+            journeys = listOf(
+                buildJourneyWithTransportLeg(
+                    productClass = 1L,
+                    infos = listOf(
+                        TripResponse.Info(subtitle = "Delays", content = "Train delayed", priority = "high"),
+                        TripResponse.Info(subtitle = null, content = "Missing heading", priority = "normal"),
+                        TripResponse.Info(subtitle = "Works", content = null, priority = "low"),
+                        TripResponse.Info(subtitle = "Notice", content = "Info notice", priority = "unknown"),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+        val transportLeg = journey?.legs?.firstOrNull() as? TimeTableState.JourneyCardInfo.Leg.TransportLeg
+
+        assertEquals(
+            1,
+            journey?.totalUniqueServiceAlerts,
+            "Badge count must match the number of alerts serviceAlertList actually contains",
+        )
+        assertEquals(
+            journey?.totalUniqueServiceAlerts,
+            transportLeg?.serviceAlertList?.size,
+            "totalUniqueServiceAlerts must equal serviceAlertList size so the bottom sheet opens",
+        )
+    }
+
+    //endregion
+
     //region displayText on TransportLeg
 
     @Test
@@ -425,10 +549,12 @@ class TripResponseMapperTest {
         realtimeTripId: String = "defaultRtId",
         depTime: String = "2026-04-18T22:00:00Z",
         arrTime: String = "2026-04-18T22:30:00Z",
+        infos: List<TripResponse.Info>? = null,
     ) = TripResponse.Journey(
         legs = listOf(
             TripResponse.Leg(
                 duration = 1800L,
+                infos = infos,
                 origin = TripResponse.StopSequence(
                     name = "Origin Station",
                     disassembledName = "Origin Station, Platform 1",


### PR DESCRIPTION
### TL;DR

Fixes a bug where the service alerts badge count could show a non-zero number while the alerts bottom sheet remained empty and never opened.

### What changed?

`totalUniqueServiceAlerts` is now derived from the already-mapped `serviceAlertList` on each `TransportLeg` rather than from the raw `infos` list on the original API response legs. This ensures the badge count reflects only alerts that were successfully parsed (i.e. those with a valid subtitle, content, and recognised priority), keeping it in sync with what the bottom sheet actually displays.

Tests were added to cover:
- Legs with no infos (count = 0)
- Legs with fully valid infos (count matches)
- Infos missing a subtitle (not counted)
- Infos missing content (not counted)
- Infos with an unrecognised priority (not counted)
- A mix of valid and invalid infos (only valid ones counted, and badge count equals `serviceAlertList` size)

### How to test?

1. Find a journey that has service alerts attached to one or more legs.
2. Verify the badge on the journey card shows the correct alert count.
3. Tap the badge and confirm the alerts bottom sheet opens and displays the same number of alerts shown on the badge.
4. Run the `TripResponseMapperTest` suite and confirm all new and existing tests pass.

### Why make this change?

Previously, `totalUniqueServiceAlerts` was counted from the raw API `infos` list before any filtering or parsing. Infos that failed to map to a valid alert (e.g. missing subtitle, missing content, or unknown priority) were still included in the count, causing the badge to show a number greater than the actual parsed alerts. Because the bottom sheet is guarded by `alerts.isNotEmpty()`, it would never open when all raw infos were invalid, leaving users with a tappable badge that did nothing.