### PR TITLE
feat: Map toggle and Share buttons in TrackTripScreen title bar

### DIFF
--- a/feature/track/ui/build.gradle.kts
+++ b/feature/track/ui/build.gradle.kts
@@ -62,6 +62,7 @@ kotlin {
                 implementation(projects.core.festival)
                 implementation(projects.core.log)
                 implementation(projects.core.navigation)
+                implementation(projects.core.share)
                 implementation(projects.core.transport)
                 implementation(projects.core.uiTooling)
                 implementation(projects.feature.track.state)

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
@@ -8,6 +8,7 @@
 
 package xyz.ksharma.krail.feature.track.ui
 
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
@@ -34,6 +35,7 @@ import xyz.ksharma.krail.core.festival.model.greetingAndEmoji
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.share.ShareManager
 import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
 import xyz.ksharma.krail.feature.track.LegTrackingInfo
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
@@ -65,6 +67,7 @@ class TrackTripViewModel(
     private val festivalManager: FestivalManager,
     private val gtfsRealtimeRepository: GtfsRealtimeRepository,
     private val sandook: Sandook,
+    private val shareManager: ShareManager,
 ) : ViewModel() {
 
     private val loadingEmoji: String by lazy {
@@ -351,6 +354,13 @@ class TrackTripViewModel(
         lastPollInstant = null
         stopPolling()
         trackingManager.stop()
+    }
+
+    fun shareTrip(bitmap: ImageBitmap, text: String) {
+        viewModelScope.launch {
+            shareManager.shareImage(bitmap = bitmap, text = text)
+                .onFailure { error -> logError("error sharing track trip", error) }
+        }
     }
 
     private fun startClock() {

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/di/TrackUiModule.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/di/TrackUiModule.kt
@@ -16,6 +16,7 @@ val trackUiModule = module {
             festivalManager = get(),
             gtfsRealtimeRepository = get(),
             sandook = get(),
+            shareManager = get(),
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
@@ -270,6 +270,7 @@ internal fun TrackedLegView(
                 isPast = currentStopIndex != null && lastIdx <= currentStopIndex,
                 isApproaching = isLastApproaching,
                 isArrived = isArrived,
+                isDestination = true,
                 lineColor = lineColor,
                 approachingTimeText = if (isLastApproaching) approachingText(lastStop) else null,
                 modifier = Modifier
@@ -295,6 +296,7 @@ private fun TrackedStopRow(
     lineColor: Color,
     modifier: Modifier = Modifier,
     isArrived: Boolean = false,
+    isDestination: Boolean = false,
     approachingTimeText: String? = null,
     backgroundColor: Color = KrailTheme.colors.surface,
 ) {
@@ -302,18 +304,16 @@ private fun TrackedStopRow(
     val softLabel = KrailTheme.colors.softLabel
 
     val contentColor = when {
+        isArrived && isDestination -> lineColor.ensureMinimumContrast(backgroundColor)
         isArrived -> softLabel
         isApproaching -> lineColor.ensureMinimumContrast(backgroundColor)
         isPast -> onSurface
         else -> onSurface
     }
-    val timeStyle = when {
-        isPast || isApproaching -> KrailTheme.typography.bodyMedium
-        else -> KrailTheme.typography.bodyMedium
-    }
+    val timeStyle = KrailTheme.typography.bodyMedium
     val stopNameStyle = when {
+        isArrived && isDestination -> KrailTheme.typography.titleMedium
         isApproaching -> KrailTheme.typography.titleMedium
-        isPast -> KrailTheme.typography.bodyMedium
         else -> KrailTheme.typography.bodyMedium
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -53,11 +53,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import xyz.ksharma.krail.core.maps.state.LatLng
@@ -82,6 +80,7 @@ import xyz.ksharma.krail.info.tiles.ui.InfoTileDefaults.shape
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.components.TextButton
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.icons.rememberShareIconPainter
 import xyz.ksharma.krail.taj.preview.PreviewComponent
@@ -104,7 +103,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import app.krail.taj.resources.Res as TajRes
 
 @OptIn(ExperimentalTime::class)
 @Composable
@@ -148,16 +146,8 @@ fun TrackTripScreen(
                         AnimatedDots(modifier = Modifier.size(48.dp, 16.dp))
                     }
                     if (isJourneyActive) {
-                        ActionButton(
-                            onClick = { mapExpanded = !mapExpanded },
-                            contentDescription = if (mapExpanded) "Hide Map" else "Show Map",
-                        ) {
-                            Image(
-                                painter = painterResource(TajRes.drawable.ic_location),
-                                contentDescription = null,
-                                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(24.dp),
-                            )
+                        TextButton(onClick = { mapExpanded = !mapExpanded }) {
+                            Text(text = if (mapExpanded) "Hide Map" else "Map")
                         }
                         ActionButton(
                             onClick = { triggerShare = true },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -185,8 +185,12 @@ fun TrackTripScreen(
                     triggerShare = triggerShare,
                     onShareCapture = { bitmap ->
                         triggerShare = false
-                        val text = "${s.journey.fromStopName} to ${s.journey.toStopName}," +
-                            " departs ${s.journey.originTime}"
+                        val deepLinkUrl = encodedData
+                            ?.let { "\nhttps://ksharma-xyz.github.io/trip?d=$it" }
+                            .orEmpty()
+                        val text = "${countdownDisplay.first} ${countdownDisplay.second}" +
+                            "\n${s.journey.fromStopName} to ${s.journey.toStopName}" +
+                            deepLinkUrl
                         viewModel.shareTrip(bitmap = bitmap, text = text)
                     },
                 )
@@ -202,8 +206,8 @@ fun TrackTripScreen(
                     triggerShare = triggerShare,
                     onShareCapture = { bitmap ->
                         triggerShare = false
-                        val text = "${s.journey.fromStopName} to ${s.journey.toStopName}," +
-                            " departs ${s.journey.originTime}"
+                        val text = "Arrived at ${s.journey.toStopName}" +
+                            "\n${s.journey.fromStopName} to ${s.journey.toStopName}"
                         viewModel.shareTrip(bitmap = bitmap, text = text)
                     },
                 )
@@ -425,13 +429,7 @@ private fun JourneyContent(
         }
     }
 
-    Column(
-        modifier = modifier.fillMaxSize()
-            .drawWithContent {
-                graphicsLayer.record { this@drawWithContent.drawContent() }
-                drawLayer(graphicsLayer)
-            },
-    ) {
+    Column(modifier = modifier.fillMaxSize()) {
         AnimatedVisibility(
             visible = mapExpanded,
             enter = expandVertically(tween(400)),
@@ -453,7 +451,11 @@ private fun JourneyContent(
 
         LazyColumn(
             contentPadding = PaddingValues(top = 24.dp, bottom = 80.dp),
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize()
+                .drawWithContent {
+                    graphicsLayer.record { this@drawWithContent.drawContent() }
+                    drawLayer(graphicsLayer)
+                },
         ) {
             item(key = "origin-destination") {
                 OriginDestination(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -41,15 +42,26 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.share.withBrandingHeader
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.feature.track.DepartureDeviation
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
@@ -68,10 +80,10 @@ import xyz.ksharma.krail.info.tiles.ui.InfoTileDefaults.shadowRadius
 import xyz.ksharma.krail.info.tiles.ui.InfoTileDefaults.shadowSpread
 import xyz.ksharma.krail.info.tiles.ui.InfoTileDefaults.shape
 import xyz.ksharma.krail.taj.components.Button
-import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
+import xyz.ksharma.krail.taj.icons.rememberShareIconPainter
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
@@ -89,8 +101,10 @@ import xyz.ksharma.krail.trip.planner.ui.journeymap.LiveVehicleLayer
 import xyz.ksharma.krail.trip.planner.ui.journeymap.business.TrackedJourneyMapMapper.toJourneyMapState
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+import app.krail.taj.resources.Res as TajRes
 
 @OptIn(ExperimentalTime::class)
 @Composable
@@ -113,6 +127,8 @@ fun TrackTripScreen(
     }
 
     var mapExpanded by rememberSaveable { mutableStateOf(false) }
+    var triggerShare by remember { mutableStateOf(false) }
+    val isJourneyActive = state is TrackTripState.Tracking || state is TrackTripState.Arrived
 
     Box(
         modifier = modifier
@@ -130,6 +146,30 @@ fun TrackTripScreen(
                         exit = fadeOut(),
                     ) {
                         AnimatedDots(modifier = Modifier.size(48.dp, 16.dp))
+                    }
+                    if (isJourneyActive) {
+                        ActionButton(
+                            onClick = { mapExpanded = !mapExpanded },
+                            contentDescription = if (mapExpanded) "Hide Map" else "Show Map",
+                        ) {
+                            Image(
+                                painter = painterResource(TajRes.drawable.ic_location),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
+                        ActionButton(
+                            onClick = { triggerShare = true },
+                            contentDescription = "Share journey",
+                        ) {
+                            Image(
+                                painter = rememberShareIconPainter(),
+                                contentDescription = null,
+                                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                                modifier = Modifier.size(24.dp),
+                            )
+                        }
                     }
                 },
             )
@@ -150,9 +190,15 @@ fun TrackTripScreen(
                     countdownDisplay = countdownDisplay,
                     now = now,
                     mapExpanded = mapExpanded,
-                    onMapToggle = { mapExpanded = !mapExpanded },
                     stopCoordinates = stopCoordinates,
                     liveOverlay = liveOverlay,
+                    triggerShare = triggerShare,
+                    onShareCapture = { bitmap ->
+                        triggerShare = false
+                        val text = "${s.journey.fromStopName} to ${s.journey.toStopName}," +
+                            " departs ${s.journey.originTime}"
+                        viewModel.shareTrip(bitmap = bitmap, text = text)
+                    },
                 )
 
                 is TrackTripState.Arrived -> JourneyContent(
@@ -161,9 +207,15 @@ fun TrackTripScreen(
                     now = now,
                     isArrived = true,
                     mapExpanded = mapExpanded,
-                    onMapToggle = { mapExpanded = !mapExpanded },
                     stopCoordinates = stopCoordinates,
                     liveOverlay = liveOverlay,
+                    triggerShare = triggerShare,
+                    onShareCapture = { bitmap ->
+                        triggerShare = false
+                        val text = "${s.journey.fromStopName} to ${s.journey.toStopName}," +
+                            " departs ${s.journey.originTime}"
+                        viewModel.shareTrip(bitmap = bitmap, text = text)
+                    },
                 )
 
                 TrackTripState.NotFound -> Column(
@@ -351,9 +403,10 @@ private fun JourneyContent(
     modifier: Modifier = Modifier,
     isArrived: Boolean = false,
     mapExpanded: Boolean = false,
-    onMapToggle: () -> Unit = {},
     stopCoordinates: Map<String, LatLng> = emptyMap(),
     liveOverlay: LiveTrackingOverlay? = null,
+    triggerShare: Boolean = false,
+    onShareCapture: (ImageBitmap) -> Unit = {},
 ) {
     val journeyMapState = remember(stopCoordinates) {
         if (stopCoordinates.isNotEmpty()) {
@@ -363,7 +416,32 @@ private fun JourneyContent(
         }
     }
 
-    Column(modifier = modifier.fillMaxSize()) {
+    val graphicsLayer = rememberGraphicsLayer()
+    val cardBackground = KrailTheme.colors.surface
+    val onSurfaceColor = KrailTheme.colors.onSurface
+    val screenDensity = LocalDensity.current.density
+
+    LaunchedEffect(triggerShare) {
+        if (triggerShare) {
+            val raw = graphicsLayer.toImageBitmap()
+            val branded = withContext(Dispatchers.Default) {
+                raw.withBrandingHeader(
+                    backgroundColor = cardBackground,
+                    textColor = onSurfaceColor,
+                    density = screenDensity,
+                )
+            }
+            onShareCapture(branded)
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize()
+            .drawWithContent {
+                graphicsLayer.record { this@drawWithContent.drawContent() }
+                drawLayer(graphicsLayer)
+            },
+    ) {
         AnimatedVisibility(
             visible = mapExpanded,
             enter = expandVertically(tween(400)),
@@ -401,26 +479,6 @@ private fun JourneyContent(
                         .padding(horizontal = 16.dp, vertical = 8.dp)
                         .background(color = KrailTheme.colors.surface),
                 )
-            }
-
-            item(key = "actions") {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 4.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Button(
-                        onClick = onMapToggle,
-                        dimensions = ButtonDefaults.smallButtonSize(),
-                        colors = ButtonDefaults.buttonColors(
-                            customContainerColor = KrailTheme.colors.onSurface,
-                            customContentColor = KrailTheme.colors.surface,
-                        ),
-                    ) {
-                        Text(if (mapExpanded) "Hide Map" else "Map")
-                    }
-                }
             }
 
             stickyHeader(key = "arrival-info") {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TitleBar.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TitleBar.kt
@@ -71,6 +71,7 @@ fun TitleBar(
             Row(
                 modifier = Modifier.padding(start = SpacingTokens.XL),
                 horizontalArrangement = Arrangement.spacedBy(SpacingTokens.M),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 CompositionLocalProvider(
                     LocalContainerColor provides KrailTheme.colors.onSurface,


### PR DESCRIPTION
## Summary

Stacked on #1513.

- Adds "Map"/"Hide Map" `TextButton` and a share icon `ActionButton` to the `TitleBar` actions in `TrackTripScreen`
- Both are only shown when the journey is active (`Tracking` or `Arrived` state)
- Map button toggles the live map panel inline
- Share button captures `JourneyContent` via `rememberGraphicsLayer`, applies the KRAIL branding header via `withBrandingHeader`, then delegates to `TrackTripViewModel.shareTrip`
- `ShareManager` injected into `TrackTripViewModel`; `core:share` added to `feature/track/ui` dependencies
- Removed the old in-list map/share action row from `JourneyContent`

## Test plan

- [x] Detekt clean
- [ ] Visual: "Map" and share icon appear in title bar when trip is active
- [ ] Tapping "Map"/"Hide Map" toggles the live map panel
- [ ] Tapping share triggers the OS share sheet with a branded screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)