### PR TITLE
fix: clear all journey caches when transport mode filter changes

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -288,6 +288,12 @@ class TimeTableViewModel(
             this.unselectedModes.clear()
             this.unselectedModes.addAll(unselectedModes)
 
+            // Pagination caches were built under the old filter — discard them so journeys
+            // fetched for deselected modes do not bleed into the re-fetched list.
+            loadMoreJourneys.clear()
+            previousJourneysCache.clear()
+            loadMoreCount = 0
+
             // call api
             rateLimiter.triggerEvent()
             updateUiState {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -288,8 +288,12 @@ class TimeTableViewModel(
             this.unselectedModes.clear()
             this.unselectedModes.addAll(unselectedModes)
 
-            // Pagination caches were built under the old filter — discard them so journeys
-            // fetched for deselected modes do not bleed into the re-fetched list.
+            // All three caches were built under the old filter. Clear them so no
+            // old-mode journeys survive into the re-fetched list. journeys must also
+            // be cleared here (not just in updateTripsCache) because startedJourneyList
+            // is derived from journeys before the clear, and would re-introduce
+            // old-mode trips into the new results otherwise.
+            journeys.clear()
             loadMoreJourneys.clear()
             previousJourneysCache.clear()
             loadMoreCount = 0

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -53,9 +53,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import xyz.ksharma.krail.core.maps.state.LatLng
@@ -103,6 +105,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
+import app.krail.taj.resources.Res as TajRes
 
 @OptIn(ExperimentalTime::class)
 @Composable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -53,11 +53,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
 import xyz.ksharma.krail.core.maps.state.LatLng
@@ -105,7 +103,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
-import app.krail.taj.resources.Res as TajRes
 
 @OptIn(ExperimentalTime::class)
 @Composable


### PR DESCRIPTION
## Summary

Stacked on #1514.

**Bug**: when the user changes the transport mode filter, `loadMoreJourneys` and `previousJourneysCache` were not cleared immediately. Journeys fetched for deselected modes persisted in the merged list after the re-fetch.

Additionally, the main `journeys` map was not cleared until `updateTripsCache` ran. Because `startedJourneyList` is derived from `journeys` before the clear inside `updateTripsCache`, old-mode trips were being re-introduced into the new mode's results via the started-journey preservation path.

**Fix**: clear `journeys`, `loadMoreJourneys`, `previousJourneysCache`, and reset `loadMoreCount` eagerly in `onModeSelectionChanged` — matching what `onDateTimeSelectionChanged` already does.

## Test plan

- [x] All existing TimeTable ViewModel tests pass
- [x] Detekt clean
- [ ] Manual: select a filter, load more, change filter — old-mode journeys no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)