### PR TITLE
docs: add PR guidelines (Graphite, stacking, 500-line limit) to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,16 @@ Key rules:
 - When the same data appears twice in the same list (e.g. previous journeys + main journeys),
   prefix keys to keep them unique: `"prev_$journeyId"` vs plain `journeyId`
 
+## Pull Requests
+
+**Always use Graphite (`gt submit`) to raise PRs — never `gh pr create` directly.**
+
+We stack PRs. Break work into focused, layered branches and submit the full stack with `gt submit --stack --publish`.
+
+**Max 500 lines of change per PR.** If a branch exceeds this, split it before submitting:
+- Use `gt branch split --by-commit` or carve out a new child branch
+- Each PR should have a single clear concern (ViewModel logic, UI layer, bug fix, etc.)
+
 ## Build
 
 Never run build/compile commands (assembleDebug, etc.) — ask the user to run them and share output.


### PR DESCRIPTION
### TL;DR

Adds PR submission guidelines to CLAUDE.md, enforcing the use of Graphite, stacked PRs, and a 500-line change limit.

### What changed?

A new "Pull Requests" section has been added to CLAUDE.md with the following rules:
- PRs must be raised using `gt submit`, not `gh pr create`
- Work should be broken into focused, stacked branches submitted with `gt submit --stack --publish`
- PRs are capped at 500 lines of change; branches exceeding this must be split using `gt branch split --by-commit` or by carving out a child branch
- Each PR should address a single concern (e.g. ViewModel logic, UI layer, bug fix)

### How to test?

Review the updated CLAUDE.md to confirm the new section appears correctly and the guidance is clear and consistent with existing conventions.

### Why make this change?

To ensure Claude follows the team's established PR workflow — using Graphite for stacking and keeping PRs small and focused — reducing review overhead and maintaining a clean, navigable commit history.