### PR TITLE
fix: encode excluded product classes in deep link and auto-switch trips on new deep link tap

### DIFF
--- a/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLink.kt
+++ b/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLink.kt
@@ -13,6 +13,14 @@ data class TripDeepLink(
     @SerialName("dep") val departureUtcDateTime: String,
     /** One entry per TransportLeg in the shared journey */
     @SerialName("legs") val legs: List<DeepLinkLeg>,
+    /**
+     * TfNSW product classes excluded when this journey was planned (e.g. [1] when the user
+     * filtered to bus-only). The TrackTrip API call must apply the same exclusion so it returns
+     * bus journeys instead of defaulting to trains.
+     *
+     * Absent from old deep links → decoded as [emptyList] (no exclusions applied).
+     */
+    @SerialName("excl") val excludedProductClasses: List<Int> = emptyList(),
 ) {
     @Serializable
     data class DeepLinkLeg(

--- a/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLinkEncoder.kt
+++ b/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLinkEncoder.kt
@@ -18,6 +18,7 @@ object TripDeepLinkEncoder {
         toStopName: String,
         departureUtcDateTime: String,
         legs: List<TimeTableState.JourneyCardInfo.Leg>,
+        excludedProductClasses: Set<Int> = emptySet(),
     ): String? {
         val deepLinkLegs = legs
             .filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
@@ -38,6 +39,7 @@ object TripDeepLinkEncoder {
             toStopName = toStopName,
             departureUtcDateTime = departureUtcDateTime,
             legs = deepLinkLegs,
+            excludedProductClasses = excludedProductClasses.toList(),
         )
 
         val json = Json.encodeToString(deepLink)

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
@@ -246,18 +246,16 @@ class TrackTripViewModel(
                 _uiState.value = TrackTripState.Prompt(newDeepLink)
             }
 
-            // New deep link + actively tracking a DIFFERENT trip → enforce MAX_TRACKED_TRIPS limit
+            // New deep link + actively tracking a DIFFERENT trip → clear old and prompt for new.
+            // A deep link tap is explicit user intent to switch trips, so we don't need confirmation.
             newDeepLink != null && existingTracked != null && existingTracked.deepLink != newDeepLink -> {
                 log(
-                    "[TRACK_RESOLVE] → AlreadyTracking — " +
-                        "currently tracking ${existingTracked.deepLink.fromStopName} → " +
-                        "${existingTracked.deepLink.toStopName}, " +
+                    "[TRACK_RESOLVE] → Prompt (different trip requested, clearing previous: " +
+                        "${existingTracked.deepLink.fromStopName} → ${existingTracked.deepLink.toStopName}), " +
                         "new trip ${newDeepLink.fromStopName} → ${newDeepLink.toStopName}",
                 )
-                _uiState.value = TrackTripState.AlreadyTracking(
-                    currentDeepLink = existingTracked.deepLink,
-                    requestedDeepLink = newDeepLink,
-                )
+                trackingManager.stop()
+                _uiState.value = TrackTripState.Prompt(newDeepLink)
             }
 
             // Resume existing tracking (same trip or opened from SavedTrips card with no encoded data)
@@ -449,7 +447,7 @@ class TrackTripViewModel(
                     destinationStopId = deepLink.toStopId,
                     date = date,
                     time = time,
-                    excludeProductClassSet = emptySet(),
+                    excludeProductClassSet = deepLink.excludedProductClasses.toSet(),
                 )
             }
             val journeyCount = response.journeys?.size ?: 0

--- a/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
+++ b/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
@@ -145,9 +145,9 @@ class TrackTripViewModelTest {
         }
 
     @Test
-    fun `GIVEN new deep link AND different trip already tracking WHEN ViewModel created THEN state is AlreadyTracking`() =
+    fun `GIVEN new deep link AND different trip already tracking WHEN ViewModel created THEN old tracking cleared and state is Prompt`() =
         runTest {
-            // Enforces MAX_TRACKED_TRIPS = 1 limit
+            // Deep link tap is explicit user intent to switch trips — old tracking is cleared automatically.
             val existing = makeTripDeepLink(
                 transportationId = "existing-trip",
                 departureUtcDateTime = futureIso(30.minutes),
@@ -163,10 +163,11 @@ class TrackTripViewModelTest {
             vm.uiState.test {
                 skipItems(1)
                 val state = awaitItem()
-                assertIs<TrackTripState.AlreadyTracking>(state)
-                assertEquals(existing.fromStopName, state.currentDeepLink.fromStopName)
+                assertIs<TrackTripState.Prompt>(state)
+                assertEquals(requested.fromStopName, state.deepLink.fromStopName)
                 cancelAndIgnoreRemainingEvents()
             }
+            assertNull(trackingManager.tracked.value, "Old tracking should be cleared")
         }
 
     @Test

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -463,6 +463,7 @@ class TimeTableViewModel(
                     toStopName = trip.toStopName,
                     departureUtcDateTime = journey.originUtcDateTime,
                     legs = journey.legs,
+                    excludedProductClasses = unselectedModes,
                 ) ?: return@mapNotNull null
                 journey.journeyId to url
             }.toMap().toImmutableMap()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -215,14 +215,7 @@ fun TrackTripScreen(
                     }
                 }
 
-                is TrackTripState.AlreadyTracking -> AlreadyTrackingContent(
-                    currentDeepLink = s.currentDeepLink,
-                    requestedDeepLink = s.requestedDeepLink,
-                    onStopCurrentAndTrackNew = {
-                        viewModel.onStopTracking()
-                        viewModel.onStartTracking(s.requestedDeepLink)
-                    },
-                )
+                is TrackTripState.AlreadyTracking -> Unit // unreachable — deep link tap clears old tracking
             }
         }
     }
@@ -264,47 +257,6 @@ private fun PromptContent(
                 Text("Start Tracking")
             }
         }
-    }
-}
-
-@Composable
-private fun AlreadyTrackingContent(
-    currentDeepLink: TripDeepLink,
-    requestedDeepLink: TripDeepLink,
-    onStopCurrentAndTrackNew: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier.fillMaxSize()) {
-        OriginDestination(
-            trip = Trip(
-                fromStopId = requestedDeepLink.fromStopId,
-                fromStopName = requestedDeepLink.fromStopName,
-                toStopId = requestedDeepLink.toStopId,
-                toStopName = requestedDeepLink.toStopName,
-            ),
-            timeLineColor = KrailTheme.colors.onSurface,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp)
-                .background(color = KrailTheme.colors.surface),
-        )
-
-        ErrorMessage(
-            emoji = "\uD83D\uDEA6",
-            title = "Already on another trip",
-            message = "Currently tracking ${
-                currentDeepLink.fromStopName
-                    .split(" ")
-                    .joinToString("\u00A0")
-            } to\u00A0${
-                currentDeepLink.toStopName
-                    .split(" ")
-                    .joinToString("\u00A0")
-            }.",
-            actionData = ActionData("Stop & Track New", onStopCurrentAndTrackNew),
-            filledButton = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
     }
 }
 
@@ -646,11 +598,7 @@ private fun TrackTripScreenPreview(state: TrackTripState) {
                     }
                 }
 
-                is TrackTripState.AlreadyTracking -> AlreadyTrackingContent(
-                    currentDeepLink = state.currentDeepLink,
-                    requestedDeepLink = state.requestedDeepLink,
-                    onStopCurrentAndTrackNew = {},
-                )
+                is TrackTripState.AlreadyTracking -> Unit // unreachable — deep link tap clears old tracking
 
                 TrackTripState.Initial -> LoadingContent(deepLink = null)
                 TrackTripState.ArrivedAndFinished -> Unit
@@ -821,17 +769,6 @@ private fun TrackTripScreenArrivedPreview() {
 @Composable
 private fun TrackTripScreenArrivedDelayedPreview() {
     TrackTripScreenPreview(state = TrackTripState.Arrived(sampleDelayedJourney))
-}
-
-@PreviewComponent
-@Composable
-private fun TrackTripScreenAlreadyTrackingPreview() {
-    TrackTripScreenPreview(
-        state = TrackTripState.AlreadyTracking(
-            currentDeepLink = sampleDeepLink,
-            requestedDeepLink = sampleDeepLink.copy(fromStopName = "Strathfield"),
-        ),
-    )
 }
 
 @OptIn(ExperimentalTime::class)


### PR DESCRIPTION
### TL;DR

Tapping a deep link to a different trip now automatically clears the previous tracking session and starts the new one, instead of showing an "Already Tracking" interstitial screen.

### What changed?

- When a deep link is tapped for a different trip while one is already being tracked, the old tracking session is stopped immediately and the new trip's `Prompt` state is shown — no confirmation dialog required.
- The `AlreadyTracking` UI state and its associated composable (`AlreadyTrackingContent`) have been removed as they are now unreachable.
- `excludedProductClasses` is now encoded into the deep link so that when a tracked trip is refreshed via the TrackTrip API, the same transport mode filters that were active when the journey was planned are re-applied. This prevents, for example, a bus-only journey from returning train results.
- Old deep links without the `excl` field decode gracefully with an empty list (no exclusions applied).

### How to test?

1. Open the timetable for a bus-only route (deselect all modes except bus), tap **Track** on a journey, and confirm tracking starts.
2. While tracking that bus journey, tap a deep link for a different trip. Verify the old tracking is cleared automatically and the new trip's prompt screen is shown — no "Already on another trip" screen should appear.
3. Confirm that the TrackTrip refresh correctly returns bus journeys (not trains) for a bus-only tracked trip.
4. Decode an old deep link (without the `excl` field) and verify it loads without errors, applying no product class exclusions.

### Why make this change?

Tapping a deep link is an explicit user action to switch trips — forcing users through a confirmation screen adds unnecessary friction. Automatically clearing the old session and starting the new one is the more intuitive behaviour. Additionally, without encoding the excluded product classes into the deep link, the TrackTrip API would default to returning train journeys even when the user had filtered to a different mode, causing incorrect results during trip tracking.