### PR TITLE
chore: add fullQualityChecks script for Android + iOS compile and Detekt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,21 @@ We stack PRs. Break work into focused, layered branches and submit the full stac
 
 Never run build/compile commands (assembleDebug, etc.) — ask the user to run them and share output.
 
+## Full Quality Checks
+
+To verify a branch compiles on both platforms and passes static analysis, ask the user to run:
+
+```
+./scripts/fullQualityChecks.sh
+```
+
+This runs, in order:
+1. `compileDebugSources` — Android compile
+2. `compileKotlinIosSimulatorArm64` — iOS Simulator compile
+3. `detekt --continue` — static analysis (auto-corrects imports and trailing commas)
+
+Stops on first compile failure. Detekt continues on rule violations so all issues are reported at once.
+
 ## Gradle Dependencies
 
 Always use **type-safe project accessors** — never the string form.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ maintainability across platforms. Key modules include:
 - **Run App**:  
   Use Android Studio or Xcode to deploy on simulators or real devices.
 
+- **Full quality checks** (`fullQualityChecks`):  
+  Compiles Android + iOS and runs Detekt in one command.
+  ```bash
+  ./scripts/fullQualityChecks.sh
+  ```
+
 ---
 
 ## Contributing

--- a/scripts/fullQualityChecks.sh
+++ b/scripts/fullQualityChecks.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# fullQualityChecks — compile Android + iOS, run Detekt.
+# Usage: ./scripts/fullQualityChecks.sh
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "▶ Android compile..."
+./gradlew compileDebugSources
+
+echo ""
+echo "▶ iOS compile (Simulator arm64)..."
+./gradlew compileKotlinIosSimulatorArm64
+
+echo ""
+echo "▶ Detekt..."
+./gradlew detekt --continue
+
+echo ""
+echo "✓ All quality checks passed."


### PR DESCRIPTION
Adds scripts/fullQualityChecks.sh that runs compileDebugSources,
compileKotlinIosSimulatorArm64, and detekt in sequence. Documented
in README under Building & Running and in CLAUDE.md under Build.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>