### PR TITLE
test: ViewModel tests for label event handlers

### DIFF
--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelLabelHandlersTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelLabelHandlersTest.kt
@@ -1,0 +1,394 @@
+package xyz.ksharma.core.test.viewmodels
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.core.test.fakes.FakeAnalytics
+import xyz.ksharma.core.test.fakes.FakeFlag
+import xyz.ksharma.core.test.fakes.FakeNearbyStopsManagerForMap
+import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.core.test.fakes.FakeSandookPreferences
+import xyz.ksharma.core.test.fakes.FakeStopResultsManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the label-event handlers on [SearchStopViewModel] — the slice of `onEvent`
+ * that mutates `stopLabels` (assign, create, clear, delete, reorder) plus the lifetime
+ * `observeStopLabels` flow.
+ *
+ * These complement the pure-function tests in `SearchStopRulesTest` (which lock down
+ * "what should the UI render?") and the Compose tests in
+ * `SearchStopScreenInteractionTest` (which lock down "did the rules actually drive
+ * what got rendered?"). The VM tests here lock down "did the handler write the right
+ * thing to state and to the DB?".
+ *
+ * Each handler is asserted on three axes where applicable:
+ * - **Optimistic state update** — `_uiState` reflects the change before any IO.
+ * - **DB persistence** — the right rows land in [FakeSandook] so a process restart
+ *   would replay the same UI state.
+ * - **Side effects** — recents pinning for AssignLabelStop, no-op guards on protected
+ *   labels for DeleteLabel.
+ *
+ * Pattern: each test subscribes to `uiState` via Turbine so the underlying
+ * `WhileSubscribed` flow stays hot, fires the event, advances the virtual clock so
+ * background coroutines settle, then asserts on `expectMostRecentItem()`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchStopViewModelLabelHandlersTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val fakeAnalytics = FakeAnalytics()
+    private val fakeStopResultsManager = FakeStopResultsManager()
+    private val fakeFlag = FakeFlag()
+    private val fakeNearbyStopsManager = FakeNearbyStopsManagerForMap()
+    private val fakePreferences = FakeSandookPreferences()
+    private val fakeSandook = FakeSandook()
+
+    private lateinit var viewModel: SearchStopViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        // Pre-seed Home + Work into the fake DB. Without this, the VM's
+        // observeStopLabels() empty-rows branch would seed defaults on its own
+        // schedule and tests would race against that initial write.
+        fakeSandook.upsertStopLabel("Home", "🏠", null, null, 0L)
+        fakeSandook.upsertStopLabel("Work", "💼", null, null, 1L)
+
+        viewModel = SearchStopViewModel(
+            analytics = fakeAnalytics,
+            stopResultsManager = fakeStopResultsManager,
+            flag = fakeFlag,
+            nearbyStopsManager = fakeNearbyStopsManager,
+            ioDispatcher = testDispatcher,
+            preferences = fakePreferences,
+            sandook = fakeSandook,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // region AssignLabelStop
+
+    @Test
+    fun `Given unset label When AssignLabelStop fires Then state and sandook reflect attached stop`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                val central = StopItem(stopId = "stop_central", stopName = "Central Station")
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                val home = state.stopLabels.first { it.label == "Home" }
+                assertEquals("stop_central", home.stopId)
+                assertEquals("Central Station", home.stopName)
+
+                // DB was also written — a fresh VM with the same fakeSandook would
+                // recover the same state.
+                val rows = fakeSandook.observeStopLabels().first()
+                val dbHome = rows.first { it.label == "Home" }
+                assertEquals("stop_central", dbHome.stop_id)
+                assertEquals("Central Station", dbHome.stop_name)
+            }
+        }
+
+    @Test
+    fun `Given AssignLabelStop When handler runs Then stop is also pinned to recents`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                val central = StopItem(stopId = "stop_central", stopName = "Central Station")
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                advanceUntilIdle()
+
+                // Pinning to recents is the contract that means tapping a saved pill
+                // also lights up that stop in Recents next time the screen opens, so
+                // the user can still get to it after removing the label.
+                val recents = fakeSandook.selectRecentSearchStops()
+                assertTrue(recents.any { it.stopId == "stop_central" }) {
+                    "expected stop_central in recents, got ${recents.map { it.stopId }}"
+                }
+            }
+        }
+
+    // endregion
+
+    // region CreateLabel
+
+    @Test
+    fun `Given new label name When CreateLabel fires Then label is appended in state and DB`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "Gym", emoji = "🏋"))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                val gym = state.stopLabels.first { it.label == "Gym" }
+                assertEquals("🏋", gym.emoji)
+                assertNull(gym.stopId)
+                assertNull(gym.stopName)
+
+                val rows = fakeSandook.observeStopLabels().first()
+                assertTrue(rows.any { it.label == "Gym" })
+            }
+        }
+
+    @Test
+    fun `Given duplicate name with different case When CreateLabel fires Then label is not added`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                // "home" should match seeded "Home" case-insensitively after
+                // normaliseLabelName — duplicate must silently no-op.
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "home", emoji = "🏠"))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                val homes = state.stopLabels.count { it.label.equals("home", ignoreCase = true) }
+                assertEquals(1, homes, "expected exactly one Home label, got $homes")
+            }
+        }
+
+    @Test
+    fun `Given blank name When CreateLabel fires Then nothing changes`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+            val before = expectMostRecentItem().stopLabels.size
+
+            viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "   ", emoji = "🌀"))
+            advanceUntilIdle()
+
+            // Blank input is treated like no input — count is unchanged.
+            assertEquals(before, expectMostRecentItem().stopLabels.size)
+        }
+    }
+
+    @Test
+    fun `Given name with surrounding emoji When CreateLabel fires Then name is normalised`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                // The save-sheet text field allows free typing; the VM is the
+                // canonicaliser. "🚗 Garage 🚗" should land as "Garage" in the DB.
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "🚗 Garage 🚗", emoji = "🚗"))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertNotNull(state.stopLabels.firstOrNull { it.label == "Garage" })
+            }
+        }
+
+    // endregion
+
+    // region ClearLabelStop
+
+    @Test
+    fun `Given label with stop When ClearLabelStop fires Then stop is detached`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            // Set Home first so there's something to clear.
+            val central = StopItem(stopId = "stop_central", stopName = "Central Station")
+            viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+            advanceUntilIdle()
+
+            viewModel.onEvent(SearchStopUiEvent.ClearLabelStop("Home"))
+            advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            val home = state.stopLabels.first { it.label == "Home" }
+            assertNull(home.stopId)
+            assertNull(home.stopName)
+
+            // DB was also cleared.
+            val rows = fakeSandook.observeStopLabels().first()
+            val dbHome = rows.first { it.label == "Home" }
+            assertNull(dbHome.stop_id)
+            assertNull(dbHome.stop_name)
+        }
+    }
+
+    // endregion
+
+    // region DeleteLabel
+
+    @Test
+    fun `Given non-protected label When DeleteLabel fires Then label is removed`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            viewModel.onEvent(SearchStopUiEvent.DeleteLabel("Work"))
+            advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            assertTrue(state.stopLabels.none { it.label == "Work" })
+
+            // DB row was deleted too.
+            val rows = fakeSandook.observeStopLabels().first()
+            assertTrue(rows.none { it.label == "Work" })
+        }
+    }
+
+    @Test
+    fun `Given protected Home label When DeleteLabel fires Then label is preserved`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            viewModel.onEvent(SearchStopUiEvent.DeleteLabel(StopLabel.PROTECTED_LABEL))
+            advanceUntilIdle()
+
+            // Handler early-returns; existing state still contains Home. Defence in
+            // depth — the UI also hides ✕ on Home.
+            val state = expectMostRecentItem()
+            assertTrue(state.stopLabels.any { it.label == "Home" })
+
+            // DB row also preserved.
+            val rows = fakeSandook.observeStopLabels().first()
+            assertTrue(rows.any { it.label == "Home" })
+        }
+    }
+
+    @Test
+    fun `Given home key with mixed case When DeleteLabel fires Then label is preserved`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            // Defensive: the UI should never send "home" (lowercase) because the label
+            // value is fixed, but the handler must still treat it as protected.
+            viewModel.onEvent(SearchStopUiEvent.DeleteLabel("home"))
+            advanceUntilIdle()
+
+            assertTrue(expectMostRecentItem().stopLabels.any { it.label == "Home" })
+        }
+    }
+
+    // endregion
+
+    // region MoveLabelToIndex
+
+    @Test
+    fun `Given two labels When MoveLabelToIndex moves Home to position 1 Then Work comes first`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("Home", 1))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals("Work", state.stopLabels[0].label)
+                assertEquals("Home", state.stopLabels[1].label)
+
+                // The handler also re-numbers sort_order across the whole list. Walk
+                // the DB rows by label and assert the new order is reflected there
+                // too — otherwise next process start would reset to the old order.
+                val rows = fakeSandook.observeStopLabels().first()
+                val byLabel = rows.associateBy { it.label }
+                val workOrder = byLabel["Work"]?.sort_order ?: error("Work missing")
+                val homeOrder = byLabel["Home"]?.sort_order ?: error("Home missing")
+                assertTrue(workOrder < homeOrder, "expected Work($workOrder) before Home($homeOrder)")
+            }
+        }
+
+    @Test
+    fun `Given target equal to source When MoveLabelToIndex fires Then order is unchanged`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            // No-op path: dragging onto the same slot should not re-emit or re-write.
+            viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("Home", 0))
+            advanceUntilIdle()
+
+            assertEquals("Home", expectMostRecentItem().stopLabels[0].label)
+        }
+    }
+
+    @Test
+    fun `Given unknown label key When MoveLabelToIndex fires Then order is unchanged`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            // Defensive: a stale label key (e.g. one deleted between the drag start
+            // and drag end) should be a no-op rather than crash.
+            viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("DoesNotExist", 0))
+            advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            assertEquals("Home", state.stopLabels[0].label)
+            assertEquals("Work", state.stopLabels[1].label)
+        }
+    }
+
+    // endregion
+
+    // region observeStopLabels
+
+    @Test
+    fun `Given empty DB When VM is created Then defaults are seeded into sandook`() = runTest {
+        // Brand new sandook so observeStopLabels' empty-rows branch fires.
+        val freshSandook = FakeSandook()
+        val freshVm = SearchStopViewModel(
+            analytics = FakeAnalytics(),
+            stopResultsManager = FakeStopResultsManager(),
+            flag = FakeFlag(),
+            nearbyStopsManager = FakeNearbyStopsManagerForMap(),
+            ioDispatcher = testDispatcher,
+            preferences = FakeSandookPreferences(),
+            sandook = freshSandook,
+        )
+        // Subscribe so the VM scope's observer collects.
+        freshVm.uiState.test {
+            advanceUntilIdle()
+
+            val rows = freshSandook.observeStopLabels().first()
+            val labels = rows.map { it.label }.toSet()
+            // Defaults from StopLabel.defaults: Home + Work, no other rows.
+            assertEquals(StopLabel.defaults.map { it.label }.toSet(), labels)
+        }
+    }
+
+    @Test
+    fun `Given labels in DB When sandook emits Then state mirrors DB rows`() = runTest {
+        viewModel.uiState.test {
+            advanceUntilIdle()
+
+            // Externally update the DB (simulating another VM or a process-level
+            // change) and assert the VM reflects the new shape on the next
+            // observer tick.
+            fakeSandook.upsertStopLabel("Gym", "🏋", null, null, 5L)
+            advanceUntilIdle()
+
+            val state = expectMostRecentItem()
+            assertEquals(3, state.stopLabels.size)
+            assertTrue(state.stopLabels.any { it.label == "Gym" })
+        }
+    }
+
+    // endregion
+}

--- a/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenInteractionTest.kt
+++ b/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenInteractionTest.kt
@@ -206,6 +206,111 @@ class SearchStopScreenInteractionTest {
         }
     }
 
+    @Test
+    fun recentHeader_isHidden_onFreshInstall() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.freshInstall(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // No recents -> no Recent / Clear all header. The whole list is empty so the
+        // user falls through to "Select on map" / public-transport note.
+        composeRule.onNodeWithText("Recent").assertDoesNotExist()
+        composeRule.onNodeWithText("Clear all").assertDoesNotExist()
+    }
+
+    // endregion
+
+    // region Assigning mode banner
+
+    @Test
+    fun tappingUnsetPill_showsAssigningBanner() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // Both Home and Work are unset. Tapping Home should flip the screen into
+        // assigning mode and the banner copy from `pillRowBannerText` should appear.
+        composeRule.onNodeWithText("Home").performClick()
+
+        composeRule
+            .onNodeWithText("Tap the ⭐ next to a stop to save it as Home")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun tappingUnsetPillTwice_togglesAssigningModeOff() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // First tap -> assigning. Second tap on the same pill -> idle. The banner
+        // should disappear once we toggle out, otherwise users can't dismiss
+        // assigning mode without picking a stop.
+        composeRule.onNodeWithText("Home").performClick()
+        composeRule.onNodeWithText("Home").performClick()
+
+        composeRule
+            .onNodeWithText("Tap the ⭐ next to a stop to save it as Home")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun tappingUnsetPill_doesNotInvokeOnStopSelect() {
+        var selected: StopItem? = null
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onStopSelect = { selected = it },
+                    onEvent = {},
+                )
+            }
+        }
+
+        // Tapping an unset pill enters assigning mode — it must NOT navigate the
+        // search field back with a stop, because there is no stop attached yet.
+        composeRule.onNodeWithText("Home").performClick()
+
+        assert(selected == null) {
+            "expected onStopSelect not to fire for an unset pill, got $selected"
+        }
+    }
+
+    // endregion
+
+    // region Add label affordance
+
+    @Test
+    fun addLabelPill_isVisible_inIdleMode() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // The "+ Add" trailing chip is the entry point to AddLabelBottomSheet. It
+        // must be present whenever the pill row renders and we're not editing.
+        composeRule.onNodeWithText("+ Add").assertIsDisplayed()
+    }
+
     // endregion
 }
 

--- a/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenInteractionTest.kt
+++ b/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenInteractionTest.kt
@@ -1,0 +1,219 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Compose UI tests for [SearchStopScreen]. These are deliberately scoped to behaviors
+ * that ARE NOT covered by the pure-function tests in `SearchStopRulesTest` /
+ * `LabelNameNormalizerTest` — the rules tests cover the math; these tests cover that
+ * the rules actually drive the rendering.
+ *
+ * What's intentionally NOT tested here:
+ * - Drag-to-reorder (gesture coordination with reorderable lib is brittle in
+ *   Robolectric; covered by snapshot tests visually instead).
+ * - Long-press timing-based assertions (Compose's clock advancement makes them
+ *   flaky in CI). Long-press is exercised at the pure-function layer
+ *   (`pillRowBannerText` editing branch) so the rule is locked in regardless.
+ * - The save / add-label sheet flows that require ModalBottomSheet animation
+ *   completion — those are ViewModel-side and covered by the upcoming VM tests
+ *   in a sibling branch.
+ *
+ * What IS covered: visibility of the pill row + Home/Work pills under different
+ * SearchStopState shapes, the protection-from-deletion invariant on Home, the
+ * star-icon state on stop rows, and direct-tap callbacks (`onStopSelect` for set
+ * pills, `ClearLabelStop` for filled-star taps).
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [34],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+class SearchStopScreenInteractionTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // region Pill row visibility
+
+    @Test
+    fun pillRow_isHidden_onFreshInstallWithNoRecents() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.freshInstall(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // Home + Work pills should NOT be in the tree because there are no
+        // recents below to interact with — see shouldShowPillRow().
+        composeRule.onNodeWithText("Home").assertDoesNotExist()
+        composeRule.onNodeWithText("Work").assertDoesNotExist()
+    }
+
+    @Test
+    fun pillRow_isShown_whenAtLeastOneRecentExists() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // The pill row should be visible because we have recent stops.
+        composeRule.onNodeWithText("Home").assertIsDisplayed()
+        composeRule.onNodeWithText("Work").assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region Star icon state on stop rows
+
+    @Test
+    fun savedStop_showsRemoveFromLabelsStar() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithHomeSet(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        // Central Station is saved as Home (homeSet stopId == stop_central), so
+        // its star should advertise "Remove from labels" rather than "Save as
+        // label". onAllNodes is used because Town Hall's star advertises the
+        // "Save as label" variant — we only want to assert at least one of each.
+        composeRule.onAllNodesWithContentDescription("Remove from labels")
+            .assertCountAtLeast(1)
+        composeRule.onAllNodesWithContentDescription("Save as label")
+            .assertCountAtLeast(1)
+    }
+
+    // endregion
+
+    // region Direct-action callbacks
+
+    @Test
+    fun tappingFilledStar_firesClearLabelStopWithMatchingLabel() {
+        val captured = mutableListOf<SearchStopUiEvent>()
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithHomeSet(),
+                    onEvent = { captured += it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Remove from labels").performClick()
+
+        // Tapping the filled star should clear the matching label directly — no
+        // sheet opens, no SaveStopAsLabelSheet detour.
+        val cleared = captured.filterIsInstance<SearchStopUiEvent.ClearLabelStop>()
+        assert(cleared.isNotEmpty()) {
+            "expected at least one ClearLabelStop event, got: $captured"
+        }
+        assert(cleared.first().labelKey == "Home") {
+            "expected ClearLabelStop for Home, got ${cleared.first().labelKey}"
+        }
+    }
+
+    @Test
+    fun tappingSetPill_invokesOnStopSelectWithUnderlyingStop() {
+        var selected: StopItem? = null
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithHomeSet(),
+                    onStopSelect = { selected = it },
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Home").performClick()
+
+        // Tapping the set Home pill is the fast-path for "use this saved stop as
+        // From/To" — onStopSelect should fire with Home's underlying stop.
+        assert(selected != null) { "expected onStopSelect to fire" }
+        assert(selected!!.stopId == "stop_central") {
+            "expected stop_central, got ${selected?.stopId}"
+        }
+        assert(selected!!.stopName == "Central Station")
+    }
+
+    // endregion
+
+    // region Recent header
+
+    @Test
+    fun recentHeader_showsRecentAndClearAllLabelsWhenRecentsExist() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Recent").assertIsDisplayed()
+        composeRule.onNodeWithText("Clear all").assertIsDisplayed()
+    }
+
+    @Test
+    fun clearAllButton_firesClearRecentSearchStopsEventWithCount() {
+        val captured = mutableListOf<SearchStopUiEvent>()
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = { captured += it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Clear all").performClick()
+
+        val clears = captured.filterIsInstance<SearchStopUiEvent.ClearRecentSearchStops>()
+        assert(clears.isNotEmpty()) {
+            "expected ClearRecentSearchStops event, got: $captured"
+        }
+        // Two recents in the fixture (centralStop, townHallStop).
+        assert(clears.first().recentSearchCount == 2) {
+            "expected count 2, got ${clears.first().recentSearchCount}"
+        }
+    }
+
+    // endregion
+}
+
+private fun androidx.compose.ui.test.SemanticsNodeInteractionCollection.assertCountAtLeast(
+    minimum: Int,
+) {
+    val actual = fetchSemanticsNodes().size
+    assert(actual >= minimum) {
+        "expected at least $minimum nodes, found $actual"
+    }
+}

--- a/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenTestFixtures.kt
+++ b/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenTestFixtures.kt
@@ -1,0 +1,58 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+
+/**
+ * Shared fixtures for SearchStopScreen Compose UI tests. Keep stops + labels here so
+ * each test can build its specific scenario via copy() rather than hand-rolling
+ * SearchStopState every time.
+ */
+internal object SearchStopFixtures {
+
+    val centralStop = SearchStopState.StopResult(
+        "Central Station",
+        "stop_central",
+        persistentListOf(TransportMode.Train),
+    )
+
+    val townHallStop = SearchStopState.StopResult(
+        "Town Hall",
+        "stop_town_hall",
+        persistentListOf(TransportMode.Train, TransportMode.LightRail),
+    )
+
+    val homeUnset = StopLabel(emoji = "🏠", label = "Home")
+    val homeSet = StopLabel(
+        emoji = "🏠",
+        label = "Home",
+        stopId = "stop_central",
+        stopName = "Central Station",
+    )
+    val workUnset = StopLabel(emoji = "💼", label = "Work")
+    val gymUnset = StopLabel(emoji = "🏋", label = "Gym")
+
+    /** Idle Recent state with one recent stop and the seeded Home/Work labels. */
+    fun recentWithDefaults(): SearchStopState = SearchStopState(
+        listState = ListState.Recent,
+        recentStops = persistentListOf(centralStop, townHallStop),
+        stopLabels = persistentListOf(homeUnset, workUnset),
+    )
+
+    /** Recent state with Home already set — used for "tap set pill" navigation tests. */
+    fun recentWithHomeSet(): SearchStopState = SearchStopState(
+        listState = ListState.Recent,
+        recentStops = persistentListOf(centralStop, townHallStop),
+        stopLabels = persistentListOf(homeSet, workUnset),
+    )
+
+    /** Fresh-install state — no recents, defaults seeded. Pill row should be hidden. */
+    fun freshInstall(): SearchStopState = SearchStopState(
+        listState = ListState.Recent,
+        recentStops = persistentListOf(),
+        stopLabels = persistentListOf(homeUnset, workUnset),
+    )
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/StopLabelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/StopLabelTest.kt
@@ -1,0 +1,171 @@
+package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
+
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [StopLabel] — a small data class with three load-bearing derived
+ * properties that the rest of the feature reads aggressively:
+ *
+ * - `isSet` decides star fill vs outline on every stop result row and whether the
+ *   pill is tappable as a save shortcut.
+ * - `isProtected` keeps Home undeletable everywhere (UI hides ✕, VM handler
+ *   early-returns).
+ * - `defaults` is the seed list used when the DB is empty on first install — its
+ *   shape determines what the user sees out-of-the-box.
+ *
+ * Lives under feature/trip-planner/ui/src/commonTest because the state module
+ * doesn't have its own test infra wired up yet; the assertions don't depend on
+ * anything ui-specific so they're agnostic to that placement.
+ */
+class StopLabelTest {
+
+    // region isSet
+
+    @Test
+    fun `isSet is false when neither stopId nor stopName provided`() {
+        val label = StopLabel(emoji = "🏠", label = "Home")
+        assertFalse(label.isSet, "default-constructed label should be unset")
+    }
+
+    @Test
+    fun `isSet is true when both stopId and stopName provided`() {
+        val label = StopLabel(
+            emoji = "🏠",
+            label = "Home",
+            stopId = "stop_central",
+            stopName = "Central Station",
+        )
+        assertTrue(label.isSet)
+    }
+
+    @Test
+    fun `isSet is false when only stopId provided`() {
+        // Defensive: if migration ever leaves a row half-populated, isSet must
+        // refuse to treat it as a clickable shortcut.
+        val label = StopLabel(emoji = "🏠", label = "Home", stopId = "stop_central")
+        assertFalse(label.isSet)
+    }
+
+    @Test
+    fun `isSet is false when only stopName provided`() {
+        val label = StopLabel(emoji = "🏠", label = "Home", stopName = "Central Station")
+        assertFalse(label.isSet)
+    }
+
+    // endregion
+
+    // region isProtected
+
+    @Test
+    fun `isProtected is true for Home`() {
+        val home = StopLabel(emoji = "🏠", label = StopLabel.PROTECTED_LABEL)
+        assertTrue(home.isProtected)
+    }
+
+    @Test
+    fun `isProtected matches case-insensitively`() {
+        // Defensive: even if the DB ever contains a lowercase variant, the protection
+        // must hold so the user never lands on a deletable Home.
+        val home = StopLabel(emoji = "🏠", label = "home")
+        assertTrue(home.isProtected)
+    }
+
+    @Test
+    fun `isProtected is false for Work`() {
+        val work = StopLabel(emoji = "💼", label = "Work")
+        assertFalse(work.isProtected)
+    }
+
+    @Test
+    fun `isProtected is false for arbitrary user label`() {
+        val gym = StopLabel(emoji = "🏋", label = "Gym")
+        assertFalse(gym.isProtected)
+    }
+
+    // endregion
+
+    // region toStopItem
+
+    @Test
+    fun `toStopItem returns null when label is unset`() {
+        val unset = StopLabel(emoji = "🏠", label = "Home")
+        assertNull(unset.toStopItem(), "unset labels can't navigate to a stop")
+    }
+
+    @Test
+    fun `toStopItem returns StopItem with same id and name when set`() {
+        val home = StopLabel(
+            emoji = "🏠",
+            label = "Home",
+            stopId = "stop_central",
+            stopName = "Central Station",
+        )
+        val expected = StopItem(stopId = "stop_central", stopName = "Central Station")
+        assertEquals(expected, home.toStopItem())
+    }
+
+    // endregion
+
+    // region defaults
+
+    @Test
+    fun `defaults contains Home and Work both unset`() {
+        // First-install contract: UI must render two unset pills without ✕ on Home.
+        // Anything else here would change the freshInstall snapshot.
+        assertEquals(2, StopLabel.defaults.size)
+
+        val home = StopLabel.defaults[0]
+        assertEquals(StopLabel.PROTECTED_LABEL, home.label)
+        assertFalse(home.isSet)
+        assertTrue(home.isProtected)
+
+        val work = StopLabel.defaults[1]
+        assertEquals("Work", work.label)
+        assertFalse(work.isSet)
+        assertFalse(work.isProtected)
+    }
+
+    @Test
+    fun `PROTECTED_LABEL constant is exactly Home`() {
+        // Pinned because RealSandook + ViewModel + UI all check
+        // .equals(PROTECTED_LABEL, ignoreCase = true) — renaming this without
+        // updating callers would silently break the protection.
+        assertEquals("Home", StopLabel.PROTECTED_LABEL)
+    }
+
+    // endregion
+
+    // region copy semantics
+
+    @Test
+    fun `copy with stopId and stopName makes label set`() {
+        // The VM uses copy() to optimistically attach a stop in AssignLabelStop —
+        // make sure that actually flips isSet to true.
+        val unset = StopLabel(emoji = "🏠", label = "Home")
+        val set = unset.copy(stopId = "stop_central", stopName = "Central Station")
+        assertTrue(set.isSet)
+        assertNotNull(set.toStopItem())
+    }
+
+    @Test
+    fun `copy with null stopId clears the assignment`() {
+        // ClearLabelStop is implemented as copy(stopId = null, stopName = null).
+        val set = StopLabel(
+            emoji = "🏠",
+            label = "Home",
+            stopId = "stop_central",
+            stopName = "Central Station",
+        )
+        val cleared = set.copy(stopId = null, stopName = null)
+        assertFalse(cleared.isSet)
+        assertNull(cleared.toStopItem())
+    }
+
+    // endregion
+}


### PR DESCRIPTION
test: ViewModel tests for label event handlers

Cover the slice of SearchStopViewModel.onEvent that mutates stopLabels:
AssignLabelStop, CreateLabel, ClearLabelStop, DeleteLabel,
MoveLabelToIndex, plus the lifetime observeStopLabels flow. Each handler
is asserted on three axes where applicable: optimistic state update, DB
persistence via FakeSandook, and side effects (recents pinning,
protected-Home no-op, sort_order resync).

Pairs with SearchStopRulesTest (pure rules) and
SearchStopScreenInteractionTest (Compose) — the rules say what should
render, the Compose tests say it does, and these say the data behind
the render lands correctly in state and DB.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

test: pin StopLabel derived properties and defaults

Cover isSet, isProtected (incl. case-insensitive matching), toStopItem,
the StopLabel.defaults seed list and the PROTECTED_LABEL constant.

These are read all over the feature (star fill, pill clickability,
delete-overlay visibility, VM handler short-circuit on Home) so a
regression in any of them is hard to debug from the symptom — pin them
at the type level instead.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>