### PR TITLE
refactor: migrate AddLabelPill to taj OutlinedButton

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -1562,9 +1562,13 @@ private fun UnsetLabelPill(
 
 @Composable
 private fun AddLabelPill(onClick: () -> Unit) {
+    // chipButtonSize matches the hand-rolled Set/Unset/Done pill geometry
+    // (chipHorizontal/Vertical padding, no min-height) so the row stays
+    // visually aligned. smallButtonSize was making "+ Add" noticeably shorter
+    // and narrower than its neighbours.
     OutlinedButton(
         onClick = onClick,
-        dimensions = ButtonDefaults.smallButtonSize(),
+        dimensions = ButtonDefaults.chipButtonSize(),
     ) {
         Text(text = "+ Add", style = KrailTheme.typography.labelLarge)
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -93,7 +93,9 @@ import xyz.ksharma.krail.core.permission.PermissionStatus
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.backgroundColorOf
+import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Divider
+import xyz.ksharma.krail.taj.components.OutlinedButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
@@ -1560,25 +1562,11 @@ private fun UnsetLabelPill(
 
 @Composable
 private fun AddLabelPill(onClick: () -> Unit) {
-    val dim = KrailTheme.dimensions
-    val shape = RoundedCornerShape(dim.radiusFull)
-    Row(
-        modifier = Modifier
-            .clip(shape)
-            .border(
-                width = dim.strokeThin,
-                color = KrailTheme.colors.label,
-                shape = shape,
-            )
-            .klickable(onClick = onClick)
-            .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
-        verticalAlignment = Alignment.CenterVertically,
+    OutlinedButton(
+        onClick = onClick,
+        dimensions = ButtonDefaults.smallButtonSize(),
     ) {
-        Text(
-            text = "+ Add",
-            style = KrailTheme.typography.labelLarge,
-            color = KrailTheme.colors.label,
-        )
+        Text(text = "+ Add", style = KrailTheme.typography.labelLarge)
     }
 }
 


### PR DESCRIPTION
The "+ Add" pill in SearchStopScreen's label row was a hand-rolled Row
with clip/border/klickable/padding. Replace with OutlinedButton from
taj — same visual treatment (transparent fill, label-coloured border +
content) but routed through the design-system token, so any future
change to outlined-action affordances (focus state, ripple, padding,
disabled treatment) propagates here for free.

UnsetLabelPill stays as a decorative Row because the parent
LabelShortcutsRow handles its taps via awaitEachGesture — wrapping it
in OutlinedButton would create a competing click source.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>