### PR TITLE
refactor: extract TripPoller from TrackTripViewModel

### DIFF
--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
@@ -2,7 +2,6 @@
     "LongMethod",
     "TooManyFunctions",
     "CyclomaticComplexMethod",
-    "LoopWithTooManyJumpStatements",
     "ForbiddenComment",
 )
 
@@ -12,23 +11,15 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
-import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
 import xyz.ksharma.krail.core.festival.FestivalManager
 import xyz.ksharma.krail.core.festival.model.NoFestival
 import xyz.ksharma.krail.core.festival.model.greetingAndEmoji
@@ -37,23 +28,13 @@ import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.share.ShareManager
 import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
-import xyz.ksharma.krail.feature.track.LegTrackingInfo
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
 import xyz.ksharma.krail.feature.track.TrackTripState
-import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
-import xyz.ksharma.krail.feature.track.TrackedLeg
-import xyz.ksharma.krail.feature.track.TrackingConfig
 import xyz.ksharma.krail.feature.track.TrackingManager
 import xyz.ksharma.krail.feature.track.TripDeepLink
 import xyz.ksharma.krail.feature.track.TripDeepLinkDecoder
-import xyz.ksharma.krail.feature.track.ui.TripResponseMapper.findMatchingJourney
-import xyz.ksharma.krail.feature.track.ui.TripResponseMapper.toTrackedJourneyDisplay
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -61,12 +42,12 @@ import kotlin.time.Instant
 @OptIn(ExperimentalTime::class)
 class TrackTripViewModel(
     private val encodedData: String?,
-    private val tripPlanningService: TripPlanningService,
+    tripPlanningService: TripPlanningService,
     private val trackingManager: TrackingManager,
-    private val ioDispatcher: CoroutineDispatcher,
+    ioDispatcher: CoroutineDispatcher,
     private val festivalManager: FestivalManager,
-    private val gtfsRealtimeRepository: GtfsRealtimeRepository,
-    private val sandook: Sandook,
+    gtfsRealtimeRepository: GtfsRealtimeRepository,
+    sandook: Sandook,
     private val shareManager: ShareManager,
 ) : ViewModel() {
 
@@ -75,35 +56,33 @@ class TrackTripViewModel(
     }
 
     private val _uiState = MutableStateFlow<TrackTripState>(TrackTripState.Initial)
-    private val _clock = MutableStateFlow(Clock.System.now())
-    private var clockJob: Job? = null
+
+    private val tripPoller = TripPoller(
+        scope = viewModelScope,
+        ioDispatcher = ioDispatcher,
+        tripPlanningService = tripPlanningService,
+        trackingManager = trackingManager,
+        gtfsRealtimeRepository = gtfsRealtimeRepository,
+        sandook = sandook,
+        state = _uiState,
+    )
 
     /** Current time, ticking every second while a trip is being tracked. */
-    val clock: StateFlow<Instant> = _clock
+    val clock: StateFlow<Instant> = tripPoller.clock
 
     /**
-     * Countdown split into (label, value) so the UI can animate only the changing value.
-     * e.g. ("Arriving in", "4m 32s"), ("Departed", "just now").
+     * Countdown split into (label, value) so the UI can animate only the changing
+     * value. e.g. ("Arriving in", "4m 32s"), ("Arrived", "just now").
      */
-    val countdownDisplay: StateFlow<Pair<String, String>> =
-        combine(_uiState, _clock) { state, now ->
-            when (state) {
-                is TrackTripState.Tracking -> computeCountdown(state.journey, now)
-                is TrackTripState.Arrived -> computeCountdown(state.journey, now)
-                else -> "" to ""
-            }
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = "" to "",
-        )
+    val countdownDisplay: StateFlow<Pair<String, String>> = tripPoller.countdownDisplay
 
     /**
      * Polling and the countdown clock are tied to this flow's subscriber lifecycle:
      * - [onStart]: resumes polling when the UI (re)subscribes after a navigation return.
      * - [onCompletion]: stops polling and the clock when the last subscriber disconnects
-     *   (screen leaves, app backgrounds). [lastPollInstant] is kept so the next resume
-     *   can smart-delay: no API call if within the [TrackingConfig.POLL_INTERVAL_MS] window.
+     *   (screen leaves, app backgrounds). The poller's `lastPollInstant` is kept so the
+     *   next resume can smart-delay: no API call if within
+     *   [xyz.ksharma.krail.feature.track.TrackingConfig.POLL_INTERVAL_MS].
      * - [SharingStarted.WhileSubscribed] with a 5 s stop timeout tolerates quick config
      *   changes (rotation) without an unnecessary stop/restart cycle.
      */
@@ -115,86 +94,40 @@ class TrackTripViewModel(
             log(
                 "TrackTrip: uiState.onStart — state=${current::class.simpleName}, " +
                     "trackedTrip=${deepLink?.fromStopName ?: "none"} → ${deepLink?.toStopName ?: "none"}, " +
-                    "pollingActive=${pollingJob?.isActive}, " +
-                    "vmEncodedData=${encodedData?.take(20)?.plus("…") ?: "null"}",
+                    "pollingActive=${tripPoller.isPollingActive}, " +
+                    "vmEncodedData=${encodedData?.take(VM_LOG_PREFIX_LEN)?.plus("…") ?: "null"}",
             )
-            if (current is TrackTripState.Tracking && deepLink != null && pollingJob?.isActive != true) {
+            if (current is TrackTripState.Tracking && deepLink != null && !tripPoller.isPollingActive) {
                 log("TrackTrip: uiState.onStart — resuming poll (WhileSubscribed)")
-                startPolling(deepLink)
+                tripPoller.startPolling(deepLink)
             }
         }
         .onCompletion {
-            // UI subscribers gone (screen left or app backgrounded) — pause polling and clock
-            // until the next subscriber arrives. lastPollInstant is preserved so we can
-            // calculate the remaining interval on resume.
+            // UI subscribers gone (screen left or app backgrounded) — pause polling and
+            // clock until the next subscriber arrives. The poller's `lastPollInstant`
+            // is preserved so we can calculate the remaining interval on resume.
             log("TrackTrip: uiState.onCompletion — pausing poll (no UI subscribers)")
-            stopPolling()
+            tripPoller.stopPolling()
         }
         .stateIn(
             scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
+            started = SharingStarted.WhileSubscribed(WHILE_SUBSCRIBED_TIMEOUT_MS),
             initialValue = TrackTripState.Loading(),
         )
 
-    private var pollingJob: Job? = null
-    private var livePositionJob: Job? = null
+    val liveOverlay: StateFlow<LiveTrackingOverlay?> = tripPoller.liveOverlay
 
-    private var cachedStopCoordinates: Map<String, LatLng> = emptyMap()
-
-    private val _liveOverlay = MutableStateFlow<LiveTrackingOverlay?>(null)
-
-    /**
-     * Live vehicle positions and stop delays. Collected only while the map panel is visible.
-     * [SharingStarted.WhileSubscribed] pauses GTFS-RT polling when no UI is collecting —
-     * same pattern as [uiState].
-     */
-    val liveOverlay: StateFlow<LiveTrackingOverlay?> = _liveOverlay
-        .onStart {
-            log("[LIVETRACK] liveOverlay.onStart — subscriber attached, starting live position polling")
-            startLivePositionPolling()
-        }
-        .onCompletion {
-            log("[LIVETRACK] liveOverlay.onCompletion — last subscriber gone, stopping live position polling")
-            stopLivePositionPolling()
-        }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = null,
-        )
-
-    private val _stopCoordinates = MutableStateFlow<Map<String, LatLng>>(emptyMap())
-
-    /**
-     * stopId → LatLng, fetched once when journey display is first available.
-     * feature/trip-planner/ui uses this to build JourneyMapUiState via TrackedJourneyMapMapper
-     * (keeping the mapper in the UI layer where JourneyMap lives, avoiding a circular dep).
-     */
-    val stopCoordinates: StateFlow<Map<String, LatLng>> = _stopCoordinates
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5_000),
-            initialValue = emptyMap(),
-        )
-
-    private var lastPollInstant: Instant? = null
-
-    // TODO: Evaluate whether this should instead be driven by a "minimum shown departure deviation"
-    //  threshold — e.g. if real-time data says the train is > 2 min late AND we haven't started
-    //  yet, allow the countdown to reappear. For now the latch is the safest UX default.
-    private var hasPassedArrivalMoment = false
+    val stopCoordinates: StateFlow<Map<String, LatLng>> = tripPoller.stopCoordinates
 
     init {
-        @Suppress("MagicNumber")
         log(
             "[TRACK_RESOLVE] ViewModel created — " +
                 "vmHash=${hashCode()}, " +
-                "encodedData=${encodedData?.take(20)?.plus("…") ?: "null"}",
+                "encodedData=${encodedData?.take(VM_LOG_PREFIX_LEN)?.plus("…") ?: "null"}",
         )
         resolveInitialState()
     }
 
-    @Suppress("MagicNumber")
     private fun resolveInitialState() {
         val existingTracked = trackingManager.tracked.value
         val newDeepLink = encodedData?.let {
@@ -205,7 +138,7 @@ class TrackTripViewModel(
                             "depUtc=${decoded.departureUtcDateTime}, legs=${decoded.legs.size}",
                     )
                 } else {
-                    logError("[TRACK_RESOLVE] failed to decode encodedData=${it.take(30)}…")
+                    logError("[TRACK_RESOLVE] failed to decode encodedData=${it.take(DECODE_LOG_PREFIX_LEN)}…")
                 }
             }
         }
@@ -223,25 +156,21 @@ class TrackTripViewModel(
         )
 
         // Expire any stale existing trip before evaluating the new deep link.
-        if (existingTracked != null && isTripExpired(existingTracked.deepLink)) {
-            log(
-                "[TRACK_RESOLVE] existing trip expired " +
-                    "(departure > ${TrackingConfig.DEPARTURE_EXPIRED_HOURS}h ago) → " +
-                    "ArrivedAndFinished",
-            )
-            transitionToArrivedAndFinished()
+        if (existingTracked != null && tripPoller.isTripExpired(existingTracked.deepLink)) {
+            log("[TRACK_RESOLVE] existing trip expired → ArrivedAndFinished")
+            tripPoller.transitionToArrivedAndFinished()
             return
         }
 
         when {
-            // New expired deep link → nothing to show, clean up and go back immediately
-            newDeepLink != null && isTripExpired(newDeepLink) -> {
+            // New expired deep link → nothing to show, clean up and go back immediately.
+            newDeepLink != null && tripPoller.isTripExpired(newDeepLink) -> {
                 log("[TRACK_RESOLVE] new deep link expired → ArrivedAndFinished")
-                transitionToArrivedAndFinished()
+                tripPoller.transitionToArrivedAndFinished()
             }
 
-            // Existing trip already finished AND new trip requested → auto-clear and show Prompt.
-            // No need to ask the user; the old trip is done.
+            // Existing trip already finished AND new trip requested → auto-clear and
+            // show Prompt. No need to ask the user; the old trip is done.
             newDeepLink != null && existingTracked != null &&
                 existingTracked.deepLink != newDeepLink && existingTracked.isArrived -> {
                 log("[TRACK_RESOLVE] existing trip already arrived, clearing → Prompt for new trip")
@@ -249,8 +178,9 @@ class TrackTripViewModel(
                 _uiState.value = TrackTripState.Prompt(newDeepLink)
             }
 
-            // New deep link + actively tracking a DIFFERENT trip → clear old and prompt for new.
-            // A deep link tap is explicit user intent to switch trips, so we don't need confirmation.
+            // New deep link + actively tracking a DIFFERENT trip → clear old and prompt
+            // for new. A deep link tap is explicit user intent to switch trips, so we
+            // don't need confirmation.
             newDeepLink != null && existingTracked != null && existingTracked.deepLink != newDeepLink -> {
                 log(
                     "[TRACK_RESOLVE] → Prompt (different trip requested, clearing previous: " +
@@ -261,7 +191,8 @@ class TrackTripViewModel(
                 _uiState.value = TrackTripState.Prompt(newDeepLink)
             }
 
-            // Resume existing tracking (same trip or opened from SavedTrips card with no encoded data)
+            // Resume existing tracking (same trip or opened from SavedTrips card with no
+            // encoded data).
             existingTracked != null -> {
                 existingTracked.display?.let { display ->
                     if (existingTracked.isArrived) {
@@ -274,7 +205,7 @@ class TrackTripViewModel(
                                 "${existingTracked.deepLink.toStopName}",
                         )
                         _uiState.value = TrackTripState.Tracking(display)
-                        startPolling(existingTracked.deepLink)
+                        tripPoller.startPolling(existingTracked.deepLink)
                     }
                 } ?: run {
                     log(
@@ -282,11 +213,11 @@ class TrackTripViewModel(
                             "${existingTracked.deepLink.fromStopName})",
                     )
                     _uiState.value = TrackTripState.Loading(existingTracked.deepLink, loadingEmoji)
-                    startPolling(existingTracked.deepLink)
+                    tripPoller.startPolling(existingTracked.deepLink)
                 }
             }
 
-            // New deep link, nothing tracked yet → show prompt
+            // New deep link, nothing tracked yet → show prompt.
             newDeepLink != null -> {
                 log("[TRACK_RESOLVE] → Prompt (${newDeepLink.fromStopName} → ${newDeepLink.toStopName})")
                 _uiState.value = TrackTripState.Prompt(newDeepLink)
@@ -299,48 +230,24 @@ class TrackTripViewModel(
         }
     }
 
-    /** True when [TrackingConfig.DEPARTURE_EXPIRED_HOURS] have elapsed since the scheduled departure. */
-    private fun isTripExpired(deepLink: TripDeepLink): Boolean {
-        val depInstant = runCatching { Instant.parse(deepLink.departureUtcDateTime) }.getOrNull()
-            ?: return false
-        return Clock.System.now() > depInstant + TrackingConfig.DEPARTURE_EXPIRED_HOURS.hours
-    }
-
-    /**
-     * Transitions to [TrackTripState.ArrivedAndFinished]: stops polling, resets state,
-     * removes the trip from the tracking manager. The screen observes this state and
-     * navigates back automatically.
-     */
-    private fun transitionToArrivedAndFinished() {
-        log("TrackTrip: → ArrivedAndFinished")
-        stopPolling()
-        hasPassedArrivalMoment = false
-        lastPollInstant = null
-        trackingManager.stop()
-        _uiState.value = TrackTripState.ArrivedAndFinished
-    }
-
     fun retry() {
         log("TrackTrip: retry() — re-resolving state")
-        stopPolling()
-        lastPollInstant = null
+        tripPoller.stopPolling()
+        tripPoller.reset()
         resolveInitialState()
     }
 
     fun onStartTracking(deepLink: TripDeepLink) {
         log("TrackTrip: onStartTracking — ${deepLink.fromStopName} → ${deepLink.toStopName}")
-        log("[LIVETRACK] onStartTracking — livePositionJob active=${livePositionJob?.isActive}")
-        hasPassedArrivalMoment = false
-        lastPollInstant = null
-        gtfsRealtimeRepository.clearCache()
+        tripPoller.reset()
         trackingManager.start(deepLink)
         _uiState.value = TrackTripState.Loading(deepLink, loadingEmoji)
-        startPolling(deepLink)
-        // Re-kick live-position polling so the first GTFS-RT call happens immediately after
-        // tracking starts, rather than waiting out the current retry-delay cycle.
-        if (livePositionJob?.isActive != true) {
+        tripPoller.startPolling(deepLink)
+        // Re-kick live-position polling so the first GTFS-RT call happens immediately
+        // after tracking starts, rather than waiting out the current retry-delay cycle.
+        if (!tripPoller.isLivePositionPollingActive) {
             log("[LIVETRACK] onStartTracking — livePositionJob was dead, restarting")
-            startLivePositionPolling()
+            tripPoller.startLivePositionPolling()
         } else {
             log("[LIVETRACK] onStartTracking — livePositionJob already active, no restart needed")
         }
@@ -348,9 +255,7 @@ class TrackTripViewModel(
 
     fun onStopTracking() {
         log("TrackTrip: onStopTracking")
-        hasPassedArrivalMoment = false
-        lastPollInstant = null
-        stopPolling()
+        tripPoller.stopPolling()
         trackingManager.stop()
     }
 
@@ -361,371 +266,14 @@ class TrackTripViewModel(
         }
     }
 
-    private fun startClock() {
-        clockJob?.cancel()
-        clockJob = viewModelScope.launch {
-            while (isActive) {
-                _clock.value = Clock.System.now()
-                delay(1.seconds)
-            }
-        }
-    }
-
-    private fun startPolling(deepLink: TripDeepLink) {
-        stopPolling()
-        if (isTripExpired(deepLink)) {
-            log("TrackTrip: startPolling — trip already expired, skipping")
-            transitionToArrivedAndFinished()
-            return
-        }
-        startClock()
-        log(
-            "TrackTrip: startPolling — ${deepLink.fromStopName} → ${deepLink.toStopName}, " +
-                "interval=${TrackingConfig.POLL_INTERVAL_MS}ms, vmHash=${hashCode()}",
-        )
-        pollingJob = viewModelScope.launch {
-            while (isActive) {
-                // Guard before each API call — trip may expire between polls
-                if (isTripExpired(deepLink)) {
-                    log(
-                        "TrackTrip: poll loop — departure expired " +
-                            "(>${TrackingConfig.DEPARTURE_EXPIRED_HOURS}h ago)",
-                    )
-                    transitionToArrivedAndFinished()
-                    break
-                }
-
-                // Smart delay: if we polled recently (e.g. user returned to this screen),
-                // wait out the remaining interval instead of hitting the API immediately.
-                // lastPollInstant == null means first poll — go straight through.
-                val elapsedMs =
-                    lastPollInstant?.let { (Clock.System.now() - it).inWholeMilliseconds }
-                        ?: Long.MAX_VALUE
-                val remainingWaitMs =
-                    (TrackingConfig.POLL_INTERVAL_MS - elapsedMs).coerceAtLeast(0L)
-                if (remainingWaitMs > 0L) {
-                    log("TrackTrip: poll — polled ${elapsedMs}ms ago, waiting ${remainingWaitMs}ms before next call")
-                    delay(remainingWaitMs)
-                    continue
-                }
-
-                setRefreshing(true)
-                fetchAndUpdate(deepLink)
-                lastPollInstant = Clock.System.now()
-                setRefreshing(false)
-                val current = _uiState.value
-                when {
-                    current is TrackTripState.Arrived -> {
-                        log("TrackTrip: poll loop exit — Arrived")
-                        break
-                    }
-
-                    current is TrackTripState.ArrivedAndFinished -> {
-                        log("TrackTrip: poll loop exit — ArrivedAndFinished")
-                        break
-                    }
-
-                    current !is TrackTripState.Tracking -> {
-                        log("TrackTrip: poll loop exit — state=${current::class.simpleName}")
-                        break
-                    }
-
-                    else -> delay(TrackingConfig.POLL_INTERVAL_MS)
-                }
-            }
-        }
-    }
-
-    private fun setRefreshing(refreshing: Boolean) {
-        val current = _uiState.value
-        if (current is TrackTripState.Tracking) {
-            _uiState.value = current.copy(isRefreshing = refreshing)
-        }
-    }
-
-    private suspend fun fetchAndUpdate(deepLink: TripDeepLink) {
-        log("TrackTrip: fetchAndUpdate — ${deepLink.fromStopName} → ${deepLink.toStopName}")
-        runCatching {
-            val depInstant = Instant.parse(deepLink.departureUtcDateTime)
-            val date = depInstant.toApiDateString()
-            val time = depInstant.toApiTimeString()
-            log("TrackTrip: fetchAndUpdate — calling API date=$date time=$time")
-
-            val response = withContext(ioDispatcher) {
-                tripPlanningService.trip(
-                    originStopId = deepLink.fromStopId,
-                    destinationStopId = deepLink.toStopId,
-                    date = date,
-                    time = time,
-                    excludeProductClassSet = deepLink.excludedProductClasses.toSet(),
-                )
-            }
-            val journeyCount = response.journeys?.size ?: 0
-            val deepLinkLegIds = deepLink.legs.map { it.transportationId }
-            log(
-                "TrackTrip: fetchAndUpdate — response received — $journeyCount journeys, " +
-                    "seeking legs=$deepLinkLegIds",
-            )
-
-            val matchedJourney = response.findMatchingJourney(deepLink)
-            if (matchedJourney == null) {
-                logError(
-                    "TrackTrip: fetchAndUpdate — NotFound: no journey matched deep link legs " +
-                        "(deepLink legs=${deepLink.legs.map { it.transportationId }}). " +
-                        "Possible causes: trip cancelled, schedule changed, or departure >2h ago",
-                )
-                _uiState.value = TrackTripState.NotFound
-                return
-            }
-            log("TrackTrip: fetchAndUpdate — journey matched, building display")
-
-            val display = matchedJourney.toTrackedJourneyDisplay(deepLink) ?: run {
-                logError("TrackTrip: fetchAndUpdate — Error: failed to build TrackedJourneyDisplay")
-                _uiState.value = TrackTripState.Error
-                return
-            }
-
-            trackingManager.update(display)
-            fetchStopCoordinatesIfNeeded(display)
-
-            val now = Clock.System.now()
-            val arrivalInstant = Instant.parse(display.destinationUtcDateTime)
-            val arrivalFinishedAt = arrivalInstant + TrackingConfig.ARRIVAL_FINISHED_MINUTES.minutes
-            when {
-                now > arrivalFinishedAt -> {
-                    log(
-                        "TrackTrip: fetchAndUpdate — ArrivedAndFinished " +
-                            "(>${TrackingConfig.ARRIVAL_FINISHED_MINUTES}min past arrival)",
-                    )
-                    transitionToArrivedAndFinished()
-                }
-
-                now > arrivalInstant -> {
-                    log(
-                        "TrackTrip: fetchAndUpdate — Arrived " +
-                            "(departs ${display.originTime}, arrives ${display.destinationTime})",
-                    )
-                    trackingManager.markArrived()
-                    _uiState.value = TrackTripState.Arrived(display)
-                    scheduleAutoRemoval(arrivalInstant)
-                }
-
-                else -> {
-                    log(
-                        "TrackTrip: fetchAndUpdate — Tracking " +
-                            "(departs ${display.originTime}, arrives ${display.destinationTime})",
-                    )
-                    _uiState.value = TrackTripState.Tracking(journey = display)
-                }
-            }
-        }.onFailure { error ->
-            logError("TrackTrip: fetchAndUpdate — exception during fetch/parse", error)
-            val cachedDisplay = trackingManager.tracked.value?.display
-            if (cachedDisplay != null) {
-                log("TrackTrip: fetchAndUpdate — falling back to cached display")
-                _uiState.value = TrackTripState.Tracking(journey = cachedDisplay)
-            } else {
-                logError("TrackTrip: fetchAndUpdate — no cached display, showing Error state")
-                _uiState.value = TrackTripState.Error
-            }
-        }
-    }
-
-    private fun scheduleAutoRemoval(arrivalInstant: Instant) {
-        viewModelScope.launch {
-            val removeAt = arrivalInstant + TrackingConfig.ARRIVAL_FINISHED_MINUTES.minutes
-            val delayMs = (removeAt - Clock.System.now()).inWholeMilliseconds.coerceAtLeast(0)
-            log("TrackTrip: scheduleAutoRemoval — ArrivedAndFinished in ${delayMs}ms")
-            delay(delayMs)
-            transitionToArrivedAndFinished()
-        }
-    }
-
-    private fun stopPolling() {
-        pollingJob?.cancel()
-        pollingJob = null
-        clockJob?.cancel()
-        clockJob = null
-    }
-
-    private fun startLivePositionPolling() {
-        log("[LIVETRACK] startLivePositionPolling — starting job (prev active=${livePositionJob?.isActive})")
-        livePositionJob?.cancel()
-        livePositionJob = viewModelScope.launch {
-            log("[LIVETRACK] livePositionJob launched")
-            while (isActive) {
-                val tracked = trackingManager.tracked.value
-                if (tracked == null) {
-                    // Not tracking yet (e.g. Prompt state) — wait and retry instead of breaking,
-                    // so the loop is still alive when tracking starts.
-                    log("[LIVETRACK] tracked=null, waiting ${TrackingConfig.GTFS_RT_POLL_INTERVAL_MS}ms before retry")
-                    delay(TrackingConfig.GTFS_RT_POLL_INTERVAL_MS)
-                    continue
-                }
-                if (tracked.isArrived) {
-                    log("[LIVETRACK] tracked.isArrived=true — stopping live position polling")
-                    break
-                }
-                val display = tracked.display
-                if (display == null) {
-                    // Trip API hasn't returned yet — retry quickly so the first GTFS-RT poll
-                    // fires immediately after trip data lands rather than waiting a full 30s cycle.
-                    log("[LIVETRACK] tracked.display=null (trip API not yet returned), retrying in 2s")
-                    delay(GTFS_RT_RETRY_DELAY_MS)
-                    continue
-                }
-                val transportLegCount = display.legs.filterIsInstance<TrackedLeg.Transport>().size
-                log("[LIVETRACK] pollLivePositions — legs=${display.legs.size}, transport legs=$transportLegCount")
-                pollLivePositions(display)
-                log("[LIVETRACK] pollLivePositions complete — sleeping ${TrackingConfig.GTFS_RT_POLL_INTERVAL_MS}ms")
-                delay(TrackingConfig.GTFS_RT_POLL_INTERVAL_MS)
-            }
-            log("[LIVETRACK] livePositionJob loop exited")
-        }
-    }
-
-    private fun stopLivePositionPolling() {
-        log("[LIVETRACK] stopLivePositionPolling — cancelling job (active=${livePositionJob?.isActive})")
-        livePositionJob?.cancel()
-        livePositionJob = null
-    }
-
-    private suspend fun pollLivePositions(display: TrackedJourneyDisplay) {
-        val legInfos = display.legs.mapIndexedNotNull { index, leg ->
-            if (leg !is TrackedLeg.Transport) return@mapIndexedNotNull null
-            LegTrackingInfo(
-                legIndex = index,
-                transportMode = leg.transportMode,
-                lineName = leg.lineName,
-                realtimeTripId = leg.realtimeTripId,
-            )
-        }
-        if (legInfos.isEmpty()) {
-            log("[LIVETRACK] pollLivePositions — no transport legs, skipping")
-            return
-        }
-        log("[LIVETRACK] pollLivePositions — ${legInfos.size} legs, originUtc=${display.originUtcDateTime}")
-        val overlay = gtfsRealtimeRepository.pollLiveTracking(
-            legs = legInfos,
-            originUtcDateTime = display.originUtcDateTime,
-        )
-        log(
-            "[LIVETRACK] pollLivePositions done — " +
-                "positions=${overlay.vehiclePositions.size} delays=${overlay.stopDelays.size}",
-        )
-        _liveOverlay.value = overlay
-    }
-
-    private fun fetchStopCoordinatesIfNeeded(display: TrackedJourneyDisplay) {
-        if (cachedStopCoordinates.isNotEmpty()) return
-
-        // Primary path: use coordinates embedded in the API response (StopSequence.coord).
-        // This avoids a DB lookup and works even when the GTFS-static DB has no record for
-        // a platform-level stop id.
-        val apiCoords = display.legs
-            .filterIsInstance<TrackedLeg.Transport>()
-            .flatMap { it.stops }
-            .filter { it.stopId.isNotBlank() && it.lat != null && it.lon != null }
-            .associate { it.stopId to LatLng(latitude = it.lat!!, longitude = it.lon!!) }
-
-        if (apiCoords.isNotEmpty()) {
-            cachedStopCoordinates = apiCoords
-            _stopCoordinates.value = apiCoords
-            log("[LIVETRACK] stop coordinates from API response — ${apiCoords.size} stops")
-            return
-        }
-
-        // Fallback: DB lookup (for cached/restored journeys that pre-date the lat/lon fields).
-        log("[LIVETRACK] stop coordinates not in API response, falling back to DB lookup")
-        viewModelScope.launch(ioDispatcher) {
-            val allStopIds = display.legs
-                .asSequence()
-                .filterIsInstance<TrackedLeg.Transport>()
-                .flatMap { it.stops }
-                .map { it.stopId }
-                .filter { it.isNotBlank() }
-                .distinct()
-                .toList()
-
-            if (allStopIds.isEmpty()) {
-                log("[LIVETRACK] stop coordinates DB fallback — no stop IDs, map will stay loading")
-                return@launch
-            }
-
-            cachedStopCoordinates = sandook.selectStopCoordinatesBatch(allStopIds)
-                .mapValues { (_, pair) -> LatLng(latitude = pair.first, longitude = pair.second) }
-
-            log("TrackTrip: stop coordinates loaded — ${cachedStopCoordinates.size}/${allStopIds.size} found")
-            _stopCoordinates.value = cachedStopCoordinates
-        }
-    }
-
     override fun onCleared() {
         super.onCleared()
-        stopPolling()
-    }
-
-    @Suppress("MagicNumber")
-    private fun computeCountdown(
-        journey: TrackedJourneyDisplay,
-        now: Instant,
-    ): Pair<String, String> {
-        val originInstant = runCatching { Instant.parse(journey.originUtcDateTime) }.getOrNull()
-            ?: return "" to ""
-        // Use the last transport stop's utcTime as destination — identical source to what
-        // TrackedLegView uses, so CountdownCard and the timeline always agree.
-        val lastStopUtc =
-            (journey.legs.lastOrNull { it is TrackedLeg.Transport } as? TrackedLeg.Transport)
-                ?.stops
-                ?.lastOrNull()
-                ?.utcTime
-        val destinationInstant = lastStopUtc
-            ?.let { runCatching { Instant.parse(it) }.getOrNull() }
-            ?: runCatching { Instant.parse(journey.destinationUtcDateTime) }.getOrNull()
-            ?: return "" to ""
-        return if (now < originInstant) {
-            val secs = (originInstant - now).inWholeSeconds
-            val value = when {
-                secs < SECONDS_PER_MINUTE -> "${secs}s"
-                secs < SECONDS_PER_HOUR -> {
-                    val mins = secs / SECONDS_PER_MINUTE
-                    val rem = secs % SECONDS_PER_MINUTE
-                    if (rem > 0L) "${mins}m ${rem}s" else "${mins}m"
-                }
-
-                else -> (originInstant - now).toGenericFormattedTimeString()
-            }
-            LABEL_DEPARTING_IN to value
-        } else {
-            val duration = destinationInstant - now
-            val totalSeconds = duration.inWholeSeconds
-
-            // One-way latch: once we've crossed into arrived territory, never go back.
-            if (totalSeconds <= 0L) hasPassedArrivalMoment = true
-
-            when {
-                hasPassedArrivalMoment && totalSeconds > 0L -> LABEL_ARRIVED to LABEL_JUST_NOW
-                totalSeconds <= -SECONDS_PER_MINUTE -> LABEL_ARRIVED to duration.toGenericFormattedTimeString()
-                totalSeconds < 0L -> LABEL_ARRIVED to LABEL_JUST_NOW
-                totalSeconds < SECONDS_PER_MINUTE -> LABEL_ARRIVING_IN to "${totalSeconds}s"
-                totalSeconds < SECONDS_PER_HOUR -> {
-                    val mins = totalSeconds / SECONDS_PER_MINUTE
-                    val secs = totalSeconds % SECONDS_PER_MINUTE
-                    LABEL_ARRIVING_IN to if (secs > 0L) "${mins}m ${secs}s" else "${mins}m"
-                }
-
-                else -> LABEL_ARRIVING_IN to duration.toGenericFormattedTimeString()
-            }
-        }
+        tripPoller.stopPolling()
     }
 
     companion object {
-        private const val SECONDS_PER_MINUTE = 60L
-        private const val SECONDS_PER_HOUR = 3600L
-        private const val LABEL_ARRIVED = "Arrived"
-        private const val LABEL_JUST_NOW = "just now"
-        private const val LABEL_ARRIVING_IN = "Arriving in"
-        private const val LABEL_DEPARTING_IN = "Departing in"
-        private const val GTFS_RT_RETRY_DELAY_MS = 2_000L
+        private const val WHILE_SUBSCRIBED_TIMEOUT_MS = 5_000L
+        private const val VM_LOG_PREFIX_LEN = 20
+        private const val DECODE_LOG_PREFIX_LEN = 30
     }
 }

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
@@ -1,0 +1,551 @@
+@file:Suppress(
+    "TooManyFunctions",
+    "LongParameterList",
+    "LongMethod",
+    "CyclomaticComplexMethod",
+    "LoopWithTooManyJumpStatements",
+    "ForbiddenComment",
+)
+
+package xyz.ksharma.krail.feature.track.ui
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiTimeString
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toGenericFormattedTimeString
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
+import xyz.ksharma.krail.feature.track.LegTrackingInfo
+import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
+import xyz.ksharma.krail.feature.track.TrackTripState
+import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
+import xyz.ksharma.krail.feature.track.TrackedLeg
+import xyz.ksharma.krail.feature.track.TrackingConfig
+import xyz.ksharma.krail.feature.track.TrackingManager
+import xyz.ksharma.krail.feature.track.TripDeepLink
+import xyz.ksharma.krail.feature.track.ui.TripResponseMapper.findMatchingJourney
+import xyz.ksharma.krail.feature.track.ui.TripResponseMapper.toTrackedJourneyDisplay
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Owns all long-running coroutine work behind the track-trip screen — the trip-API
+ * poll loop, the GTFS-RT live-positions poll loop, and the 1 Hz countdown clock —
+ * plus the derived state those loops produce ([clock], [liveOverlay],
+ * [stopCoordinates], [countdownDisplay]).
+ *
+ * Extracted from [TrackTripViewModel] so the polling logic can be tested directly
+ * with `runTest { TripPoller(backgroundScope, …) }` — `backgroundScope` is auto-
+ * cancelled when the test ends, so the three `while (isActive)` loops don't leak
+ * past the test body. The ViewModel had no testable seam for that previously.
+ *
+ * The poller mutates the [state] StateFlow it is constructed with — the same
+ * `_uiState` the ViewModel exposes — so transitions discovered during a poll
+ * (Arrived, ArrivedAndFinished, NotFound, Error) become visible to the UI without
+ * a separate event channel.
+ */
+@OptIn(ExperimentalTime::class)
+internal class TripPoller(
+    private val scope: CoroutineScope,
+    private val ioDispatcher: CoroutineDispatcher,
+    private val tripPlanningService: TripPlanningService,
+    private val trackingManager: TrackingManager,
+    private val gtfsRealtimeRepository: GtfsRealtimeRepository,
+    private val sandook: Sandook,
+    private val state: MutableStateFlow<TrackTripState>,
+) {
+
+    private val _clock = MutableStateFlow(Clock.System.now())
+
+    /** Current time, ticking every second while polling is active. */
+    val clock: StateFlow<Instant> = _clock
+
+    private val _liveOverlay = MutableStateFlow<LiveTrackingOverlay?>(null)
+
+    /**
+     * Live vehicle positions and stop delays. Collected only while the map panel is
+     * visible — [SharingStarted.WhileSubscribed] pauses GTFS-RT polling when no UI
+     * is collecting.
+     */
+    val liveOverlay: StateFlow<LiveTrackingOverlay?> = _liveOverlay
+        .onStart {
+            log("[LIVETRACK] liveOverlay.onStart — subscriber attached, starting live position polling")
+            startLivePositionPolling()
+        }
+        .onCompletion {
+            log("[LIVETRACK] liveOverlay.onCompletion — last subscriber gone, stopping live position polling")
+            stopLivePositionPolling()
+        }
+        .stateIn(
+            scope = scope,
+            started = SharingStarted.WhileSubscribed(WHILE_SUBSCRIBED_TIMEOUT_MS),
+            initialValue = null,
+        )
+
+    private val _stopCoordinates = MutableStateFlow<Map<String, LatLng>>(emptyMap())
+
+    /**
+     * stopId → LatLng, fetched once when journey display is first available.
+     * feature/trip-planner/ui uses this to build JourneyMapUiState via
+     * TrackedJourneyMapMapper (keeping the mapper in the UI layer where JourneyMap
+     * lives, avoiding a circular dep).
+     */
+    val stopCoordinates: StateFlow<Map<String, LatLng>> = _stopCoordinates
+        .stateIn(
+            scope = scope,
+            started = SharingStarted.WhileSubscribed(WHILE_SUBSCRIBED_TIMEOUT_MS),
+            initialValue = emptyMap(),
+        )
+
+    /**
+     * Countdown split into (label, value) so the UI can animate only the changing
+     * value. e.g. ("Arriving in", "4m 32s"), ("Arrived", "just now").
+     */
+    val countdownDisplay: StateFlow<Pair<String, String>> =
+        combine(state, _clock) { trackTripState, now ->
+            when (trackTripState) {
+                is TrackTripState.Tracking -> computeCountdown(trackTripState.journey, now)
+                is TrackTripState.Arrived -> computeCountdown(trackTripState.journey, now)
+                else -> "" to ""
+            }
+        }.stateIn(
+            scope = scope,
+            started = SharingStarted.WhileSubscribed(WHILE_SUBSCRIBED_TIMEOUT_MS),
+            initialValue = "" to "",
+        )
+
+    private var pollingJob: Job? = null
+    private var livePositionJob: Job? = null
+    private var clockJob: Job? = null
+    private var lastPollInstant: Instant? = null
+    private var cachedStopCoordinates: Map<String, LatLng> = emptyMap()
+
+    // TODO: Evaluate whether this should instead be driven by a "minimum shown
+    //  departure deviation" threshold — e.g. if real-time data says the train is
+    //  > 2 min late AND we haven't started yet, allow the countdown to reappear.
+    //  For now the latch is the safest UX default.
+    private var hasPassedArrivalMoment = false
+
+    val isPollingActive: Boolean
+        get() = pollingJob?.isActive == true
+
+    val isLivePositionPollingActive: Boolean
+        get() = livePositionJob?.isActive == true
+
+    /** True when [TrackingConfig.DEPARTURE_EXPIRED_HOURS] have elapsed since the scheduled departure. */
+    fun isTripExpired(deepLink: TripDeepLink): Boolean {
+        val depInstant = runCatching { Instant.parse(deepLink.departureUtcDateTime) }.getOrNull()
+            ?: return false
+        return Clock.System.now() > depInstant + TrackingConfig.DEPARTURE_EXPIRED_HOURS.hours
+    }
+
+    /**
+     * Resets per-trip state so the next [startPolling] call behaves like a fresh
+     * start — clears the smart-delay anchor, the arrival latch, and the GTFS-RT
+     * cache so live positions for the new trip aren't shadowed by the old one.
+     */
+    fun reset() {
+        lastPollInstant = null
+        hasPassedArrivalMoment = false
+        gtfsRealtimeRepository.clearCache()
+    }
+
+    /**
+     * Transitions to [TrackTripState.ArrivedAndFinished]: stops polling, clears
+     * tracking, sets state. The screen observes this state and navigates back
+     * automatically.
+     */
+    fun transitionToArrivedAndFinished() {
+        log("TrackTrip: → ArrivedAndFinished")
+        stopPolling()
+        hasPassedArrivalMoment = false
+        lastPollInstant = null
+        trackingManager.stop()
+        state.value = TrackTripState.ArrivedAndFinished
+    }
+
+    fun startPolling(deepLink: TripDeepLink) {
+        stopPolling()
+        if (isTripExpired(deepLink)) {
+            log("TrackTrip: startPolling — trip already expired, skipping")
+            transitionToArrivedAndFinished()
+            return
+        }
+        startClock()
+        log(
+            "TrackTrip: startPolling — ${deepLink.fromStopName} → ${deepLink.toStopName}, " +
+                "interval=${TrackingConfig.POLL_INTERVAL_MS}ms",
+        )
+        pollingJob = scope.launch {
+            while (isActive) {
+                // Guard before each API call — trip may expire between polls.
+                if (isTripExpired(deepLink)) {
+                    log(
+                        "TrackTrip: poll loop — departure expired " +
+                            "(>${TrackingConfig.DEPARTURE_EXPIRED_HOURS}h ago)",
+                    )
+                    transitionToArrivedAndFinished()
+                    break
+                }
+
+                // Smart delay: if we polled recently (e.g. user returned to this screen),
+                // wait out the remaining interval instead of hitting the API immediately.
+                // lastPollInstant == null means first poll — go straight through.
+                val elapsedMs =
+                    lastPollInstant?.let { (Clock.System.now() - it).inWholeMilliseconds }
+                        ?: Long.MAX_VALUE
+                val remainingWaitMs =
+                    (TrackingConfig.POLL_INTERVAL_MS - elapsedMs).coerceAtLeast(0L)
+                if (remainingWaitMs > 0L) {
+                    log("TrackTrip: poll — polled ${elapsedMs}ms ago, waiting ${remainingWaitMs}ms before next call")
+                    delay(remainingWaitMs)
+                    continue
+                }
+
+                setRefreshing(true)
+                fetchAndUpdate(deepLink)
+                lastPollInstant = Clock.System.now()
+                setRefreshing(false)
+                val current = state.value
+                when {
+                    current is TrackTripState.Arrived -> {
+                        log("TrackTrip: poll loop exit — Arrived")
+                        break
+                    }
+
+                    current is TrackTripState.ArrivedAndFinished -> {
+                        log("TrackTrip: poll loop exit — ArrivedAndFinished")
+                        break
+                    }
+
+                    current !is TrackTripState.Tracking -> {
+                        log("TrackTrip: poll loop exit — state=${current::class.simpleName}")
+                        break
+                    }
+
+                    else -> delay(TrackingConfig.POLL_INTERVAL_MS)
+                }
+            }
+        }
+    }
+
+    fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+        clockJob?.cancel()
+        clockJob = null
+    }
+
+    fun startLivePositionPolling() {
+        log("[LIVETRACK] startLivePositionPolling — starting job (prev active=${livePositionJob?.isActive})")
+        livePositionJob?.cancel()
+        livePositionJob = scope.launch {
+            log("[LIVETRACK] livePositionJob launched")
+            while (isActive) {
+                val tracked = trackingManager.tracked.value
+                if (tracked == null) {
+                    // Not tracking yet (e.g. Prompt state) — wait and retry instead of breaking,
+                    // so the loop is still alive when tracking starts.
+                    log("[LIVETRACK] tracked=null, waiting ${TrackingConfig.GTFS_RT_POLL_INTERVAL_MS}ms before retry")
+                    delay(TrackingConfig.GTFS_RT_POLL_INTERVAL_MS)
+                    continue
+                }
+                if (tracked.isArrived) {
+                    log("[LIVETRACK] tracked.isArrived=true — stopping live position polling")
+                    break
+                }
+                val display = tracked.display
+                if (display == null) {
+                    // Trip API hasn't returned yet — retry quickly so the first GTFS-RT poll
+                    // fires immediately after trip data lands rather than waiting a full 30s cycle.
+                    log("[LIVETRACK] tracked.display=null (trip API not yet returned), retrying in 2s")
+                    delay(GTFS_RT_RETRY_DELAY_MS)
+                    continue
+                }
+                val transportLegCount = display.legs.filterIsInstance<TrackedLeg.Transport>().size
+                log("[LIVETRACK] pollLivePositions — legs=${display.legs.size}, transport legs=$transportLegCount")
+                pollLivePositions(display)
+                log("[LIVETRACK] pollLivePositions complete — sleeping ${TrackingConfig.GTFS_RT_POLL_INTERVAL_MS}ms")
+                delay(TrackingConfig.GTFS_RT_POLL_INTERVAL_MS)
+            }
+            log("[LIVETRACK] livePositionJob loop exited")
+        }
+    }
+
+    fun stopLivePositionPolling() {
+        log("[LIVETRACK] stopLivePositionPolling — cancelling job (active=${livePositionJob?.isActive})")
+        livePositionJob?.cancel()
+        livePositionJob = null
+    }
+
+    private fun startClock() {
+        clockJob?.cancel()
+        clockJob = scope.launch {
+            while (isActive) {
+                _clock.value = Clock.System.now()
+                delay(1.seconds)
+            }
+        }
+    }
+
+    private fun setRefreshing(refreshing: Boolean) {
+        val current = state.value
+        if (current is TrackTripState.Tracking) {
+            state.value = current.copy(isRefreshing = refreshing)
+        }
+    }
+
+    private suspend fun fetchAndUpdate(deepLink: TripDeepLink) {
+        log("TrackTrip: fetchAndUpdate — ${deepLink.fromStopName} → ${deepLink.toStopName}")
+        runCatching {
+            val depInstant = Instant.parse(deepLink.departureUtcDateTime)
+            val date = depInstant.toApiDateString()
+            val time = depInstant.toApiTimeString()
+            log("TrackTrip: fetchAndUpdate — calling API date=$date time=$time")
+
+            val response = withContext(ioDispatcher) {
+                tripPlanningService.trip(
+                    originStopId = deepLink.fromStopId,
+                    destinationStopId = deepLink.toStopId,
+                    date = date,
+                    time = time,
+                    excludeProductClassSet = deepLink.excludedProductClasses.toSet(),
+                )
+            }
+            val journeyCount = response.journeys?.size ?: 0
+            val deepLinkLegIds = deepLink.legs.map { it.transportationId }
+            log(
+                "TrackTrip: fetchAndUpdate — response received — $journeyCount journeys, " +
+                    "seeking legs=$deepLinkLegIds",
+            )
+
+            val matchedJourney = response.findMatchingJourney(deepLink)
+            if (matchedJourney == null) {
+                logError(
+                    "TrackTrip: fetchAndUpdate — NotFound: no journey matched deep link legs " +
+                        "(deepLink legs=${deepLink.legs.map { it.transportationId }}). " +
+                        "Possible causes: trip cancelled, schedule changed, or departure >2h ago",
+                )
+                state.value = TrackTripState.NotFound
+                return
+            }
+            log("TrackTrip: fetchAndUpdate — journey matched, building display")
+
+            val display = matchedJourney.toTrackedJourneyDisplay(deepLink) ?: run {
+                logError("TrackTrip: fetchAndUpdate — Error: failed to build TrackedJourneyDisplay")
+                state.value = TrackTripState.Error
+                return
+            }
+
+            trackingManager.update(display)
+            fetchStopCoordinatesIfNeeded(display)
+
+            val now = Clock.System.now()
+            val arrivalInstant = Instant.parse(display.destinationUtcDateTime)
+            val arrivalFinishedAt = arrivalInstant + TrackingConfig.ARRIVAL_FINISHED_MINUTES.minutes
+            when {
+                now > arrivalFinishedAt -> {
+                    log(
+                        "TrackTrip: fetchAndUpdate — ArrivedAndFinished " +
+                            "(>${TrackingConfig.ARRIVAL_FINISHED_MINUTES}min past arrival)",
+                    )
+                    transitionToArrivedAndFinished()
+                }
+
+                now > arrivalInstant -> {
+                    log(
+                        "TrackTrip: fetchAndUpdate — Arrived " +
+                            "(departs ${display.originTime}, arrives ${display.destinationTime})",
+                    )
+                    trackingManager.markArrived()
+                    state.value = TrackTripState.Arrived(display)
+                    scheduleAutoRemoval(arrivalInstant)
+                }
+
+                else -> {
+                    log(
+                        "TrackTrip: fetchAndUpdate — Tracking " +
+                            "(departs ${display.originTime}, arrives ${display.destinationTime})",
+                    )
+                    state.value = TrackTripState.Tracking(journey = display)
+                }
+            }
+        }.onFailure { error ->
+            logError("TrackTrip: fetchAndUpdate — exception during fetch/parse", error)
+            val cachedDisplay = trackingManager.tracked.value?.display
+            if (cachedDisplay != null) {
+                log("TrackTrip: fetchAndUpdate — falling back to cached display")
+                state.value = TrackTripState.Tracking(journey = cachedDisplay)
+            } else {
+                logError("TrackTrip: fetchAndUpdate — no cached display, showing Error state")
+                state.value = TrackTripState.Error
+            }
+        }
+    }
+
+    private suspend fun pollLivePositions(display: TrackedJourneyDisplay) {
+        val legInfos = display.legs.mapIndexedNotNull { index, leg ->
+            if (leg !is TrackedLeg.Transport) return@mapIndexedNotNull null
+            LegTrackingInfo(
+                legIndex = index,
+                transportMode = leg.transportMode,
+                lineName = leg.lineName,
+                realtimeTripId = leg.realtimeTripId,
+            )
+        }
+        if (legInfos.isEmpty()) {
+            log("[LIVETRACK] pollLivePositions — no transport legs, skipping")
+            return
+        }
+        log("[LIVETRACK] pollLivePositions — ${legInfos.size} legs, originUtc=${display.originUtcDateTime}")
+        val overlay = gtfsRealtimeRepository.pollLiveTracking(
+            legs = legInfos,
+            originUtcDateTime = display.originUtcDateTime,
+        )
+        log(
+            "[LIVETRACK] pollLivePositions done — " +
+                "positions=${overlay.vehiclePositions.size} delays=${overlay.stopDelays.size}",
+        )
+        _liveOverlay.value = overlay
+    }
+
+    private fun fetchStopCoordinatesIfNeeded(display: TrackedJourneyDisplay) {
+        if (cachedStopCoordinates.isNotEmpty()) return
+
+        // Primary path: use coordinates embedded in the API response (StopSequence.coord).
+        // This avoids a DB lookup and works even when the GTFS-static DB has no record for
+        // a platform-level stop id.
+        val apiCoords = display.legs
+            .filterIsInstance<TrackedLeg.Transport>()
+            .flatMap { it.stops }
+            .filter { it.stopId.isNotBlank() && it.lat != null && it.lon != null }
+            .associate { it.stopId to LatLng(latitude = it.lat!!, longitude = it.lon!!) }
+
+        if (apiCoords.isNotEmpty()) {
+            cachedStopCoordinates = apiCoords
+            _stopCoordinates.value = apiCoords
+            log("[LIVETRACK] stop coordinates from API response — ${apiCoords.size} stops")
+            return
+        }
+
+        // Fallback: DB lookup (for cached/restored journeys that pre-date the lat/lon fields).
+        log("[LIVETRACK] stop coordinates not in API response, falling back to DB lookup")
+        scope.launch(ioDispatcher) {
+            val allStopIds = display.legs
+                .asSequence()
+                .filterIsInstance<TrackedLeg.Transport>()
+                .flatMap { it.stops }
+                .map { it.stopId }
+                .filter { it.isNotBlank() }
+                .distinct()
+                .toList()
+
+            if (allStopIds.isEmpty()) {
+                log("[LIVETRACK] stop coordinates DB fallback — no stop IDs, map will stay loading")
+                return@launch
+            }
+
+            cachedStopCoordinates = sandook.selectStopCoordinatesBatch(allStopIds)
+                .mapValues { (_, pair) -> LatLng(latitude = pair.first, longitude = pair.second) }
+
+            log("TrackTrip: stop coordinates loaded — ${cachedStopCoordinates.size}/${allStopIds.size} found")
+            _stopCoordinates.value = cachedStopCoordinates
+        }
+    }
+
+    private fun scheduleAutoRemoval(arrivalInstant: Instant) {
+        scope.launch {
+            val removeAt = arrivalInstant + TrackingConfig.ARRIVAL_FINISHED_MINUTES.minutes
+            val delayMs = (removeAt - Clock.System.now()).inWholeMilliseconds.coerceAtLeast(0)
+            log("TrackTrip: scheduleAutoRemoval — ArrivedAndFinished in ${delayMs}ms")
+            delay(delayMs)
+            transitionToArrivedAndFinished()
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun computeCountdown(
+        journey: TrackedJourneyDisplay,
+        now: Instant,
+    ): Pair<String, String> {
+        val originInstant = runCatching { Instant.parse(journey.originUtcDateTime) }.getOrNull()
+            ?: return "" to ""
+        // Use the last transport stop's utcTime as destination — identical source to what
+        // TrackedLegView uses, so CountdownCard and the timeline always agree.
+        val lastStopUtc =
+            (journey.legs.lastOrNull { it is TrackedLeg.Transport } as? TrackedLeg.Transport)
+                ?.stops
+                ?.lastOrNull()
+                ?.utcTime
+        val destinationInstant = lastStopUtc
+            ?.let { runCatching { Instant.parse(it) }.getOrNull() }
+            ?: runCatching { Instant.parse(journey.destinationUtcDateTime) }.getOrNull()
+            ?: return "" to ""
+        return if (now < originInstant) {
+            val secs = (originInstant - now).inWholeSeconds
+            val value = when {
+                secs < SECONDS_PER_MINUTE -> "${secs}s"
+                secs < SECONDS_PER_HOUR -> {
+                    val mins = secs / SECONDS_PER_MINUTE
+                    val rem = secs % SECONDS_PER_MINUTE
+                    if (rem > 0L) "${mins}m ${rem}s" else "${mins}m"
+                }
+
+                else -> (originInstant - now).toGenericFormattedTimeString()
+            }
+            LABEL_DEPARTING_IN to value
+        } else {
+            val duration = destinationInstant - now
+            val totalSeconds = duration.inWholeSeconds
+
+            // One-way latch: once we've crossed into arrived territory, never go back.
+            if (totalSeconds <= 0L) hasPassedArrivalMoment = true
+
+            when {
+                hasPassedArrivalMoment && totalSeconds > 0L -> LABEL_ARRIVED to LABEL_JUST_NOW
+                totalSeconds <= -SECONDS_PER_MINUTE -> LABEL_ARRIVED to duration.toGenericFormattedTimeString()
+                totalSeconds < 0L -> LABEL_ARRIVED to LABEL_JUST_NOW
+                totalSeconds < SECONDS_PER_MINUTE -> LABEL_ARRIVING_IN to "${totalSeconds}s"
+                totalSeconds < SECONDS_PER_HOUR -> {
+                    val mins = totalSeconds / SECONDS_PER_MINUTE
+                    val secs = totalSeconds % SECONDS_PER_MINUTE
+                    LABEL_ARRIVING_IN to if (secs > 0L) "${mins}m ${secs}s" else "${mins}m"
+                }
+
+                else -> LABEL_ARRIVING_IN to duration.toGenericFormattedTimeString()
+            }
+        }
+    }
+
+    companion object {
+        private const val SECONDS_PER_MINUTE = 60L
+        private const val SECONDS_PER_HOUR = 3600L
+        private const val LABEL_ARRIVED = "Arrived"
+        private const val LABEL_JUST_NOW = "just now"
+        private const val LABEL_ARRIVING_IN = "Arriving in"
+        private const val LABEL_DEPARTING_IN = "Departing in"
+        private const val GTFS_RT_RETRY_DELAY_MS = 2_000L
+        private const val WHILE_SUBSCRIBED_TIMEOUT_MS = 5_000L
+    }
+}

--- a/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
+++ b/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
@@ -76,12 +76,13 @@ class TrackTripViewModelTest {
 
     /**
      * Wraps [runTest] with a finally that cancels the ViewModel's [viewModelScope]
-     * before the test body returns. Required because [TrackTripViewModel] launches
-     * three `while (isActive)` loops (poll job, GTFS-RT live-positions job, clock job)
-     * that only exit on Arrived/Error/etc. transitions. After the body completes,
-     * `runTest` calls `advanceUntilIdle()` to drain pending tasks — without this
-     * cancellation, those infinite loops keep re-scheduling delays and the drain
-     * runs until the 60s real-time test timeout, spamming logs the entire time.
+     * before the test body returns. The poll/live-positions/clock loops live in
+     * [TripPoller] but the poller is constructed with `viewModelScope` here, so the
+     * three `while (isActive)` loops still run on the test scheduler and never exit
+     * naturally in Tracking state. Without this cancellation, `runTest`'s end-of-body
+     * `advanceUntilIdle()` would re-schedule delays forever until the 60 s real-time
+     * timeout. See [TripPollerTest] for the cleaner, scope-injected pattern that
+     * exercises the polling logic directly via `runTest { TripPoller(backgroundScope) }`.
      */
     private fun runTrackingTest(
         body: suspend TestScope.() -> Unit,

--- a/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TripPollerTest.kt
+++ b/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TripPollerTest.kt
@@ -1,0 +1,397 @@
+@file:Suppress("LongMethod")
+
+package xyz.ksharma.krail.feature.track.ui
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
+import xyz.ksharma.krail.feature.track.LegTrackingInfo
+import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
+import xyz.ksharma.krail.feature.track.TrackTripState
+import xyz.ksharma.krail.feature.track.TrackingManager
+import xyz.ksharma.krail.feature.track.TripDeepLink
+import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
+import xyz.ksharma.krail.trip.planner.network.api.model.StopType
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
+import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+
+/**
+ * Direct unit tests for [TripPoller].
+ *
+ * The poller takes a [kotlinx.coroutines.CoroutineScope] in its constructor, so tests
+ * pass [kotlinx.coroutines.test.TestScope.backgroundScope] — which `runTest` auto-
+ * cancels at end-of-body. The three `while (isActive)` polling loops therefore stop
+ * cleanly when the test returns; no helper wrapper, no manual cleanup, no risk of the
+ * trailing `advanceUntilIdle` looping forever (contrast with [TrackTripViewModelTest],
+ * which uses `viewModelScope` and needs a cleanup wrapper for exactly that reason).
+ *
+ * That's the whole point of the [TrackTripViewModel] → [TripPoller] split: the poller
+ * accepts its lifecycle scope, so the lifecycle is whatever the caller wants.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+class TripPollerTest {
+
+    @Test
+    fun `GIVEN startPolling WHEN API returns future arrival THEN state becomes Tracking`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(5.minutes))
+        val tripService = ConfigurableTripService().apply {
+            responseProvider = { matchingResponse(deepLink, arrivalUtcDateTime = futureIso(30.minutes)) }
+        }
+        val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+        val poller = makePoller(tripService = tripService, state = state)
+
+        poller.startPolling(deepLink)
+        runCurrent()
+
+        assertIs<TrackTripState.Tracking>(state.value)
+        assertEquals(1, tripService.callCount)
+    }
+
+    @Test
+    fun `GIVEN startPolling WHEN API returns past arrival within 30min THEN state becomes Arrived`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = pastIso(40.minutes))
+        val tripService = ConfigurableTripService().apply {
+            responseProvider = { matchingResponse(deepLink, arrivalUtcDateTime = pastIso(10.minutes)) }
+        }
+        val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+        val poller = makePoller(tripService = tripService, state = state)
+
+        poller.startPolling(deepLink)
+        runCurrent()
+
+        assertIs<TrackTripState.Arrived>(state.value)
+    }
+
+    @Test
+    fun `GIVEN startPolling WHEN API returns past arrival over 30min ago THEN state becomes ArrivedAndFinished`() =
+        runTest {
+            val deepLink = makeDeepLink(departureUtcDateTime = pastIso(2.hours))
+            val tripService = ConfigurableTripService().apply {
+                responseProvider = { matchingResponse(deepLink, arrivalUtcDateTime = pastIso(40.minutes)) }
+            }
+            val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+            val trackingManager = TrackingManager().apply { start(deepLink) }
+            val poller = makePoller(
+                tripService = tripService,
+                state = state,
+                trackingManager = trackingManager,
+            )
+
+            poller.startPolling(deepLink)
+            runCurrent()
+
+            assertEquals(TrackTripState.ArrivedAndFinished, state.value)
+            assertNull(trackingManager.tracked.value, "tracking should be cleared on finish")
+            assertFalse(poller.isPollingActive, "polling job should have stopped")
+        }
+
+    @Test
+    fun `GIVEN startPolling WHEN API throws AND no cached display THEN state becomes Error`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val tripService = ConfigurableTripService().apply { shouldThrow = true }
+        val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+        val poller = makePoller(tripService = tripService, state = state)
+
+        poller.startPolling(deepLink)
+        runCurrent()
+
+        assertEquals(TrackTripState.Error, state.value)
+    }
+
+    @Test
+    fun `GIVEN startPolling WHEN API throws AND cached display exists THEN state stays Tracking with cache`() =
+        runTest {
+            val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+            val tripService = ConfigurableTripService().apply { shouldThrow = true }
+            val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+            val trackingManager = TrackingManager().apply {
+                start(deepLink)
+                update(makeDisplay(deepLink, arrivalUtcDateTime = futureIso(1.hours)))
+            }
+            val poller = makePoller(
+                tripService = tripService,
+                state = state,
+                trackingManager = trackingManager,
+            )
+
+            poller.startPolling(deepLink)
+            runCurrent()
+
+            val current = state.value
+            assertIs<TrackTripState.Tracking>(current)
+            assertEquals(deepLink.fromStopName, current.journey.fromStopName)
+        }
+
+    @Test
+    fun `GIVEN startPolling WHEN response has no matching journey THEN state becomes NotFound`() = runTest {
+        val deepLink = makeDeepLink(
+            transportationId = "expected",
+            departureUtcDateTime = futureIso(30.minutes),
+        )
+        val mismatch = deepLink.copy(legs = listOf(TripDeepLink.DeepLinkLeg("other", 1)))
+        val tripService = ConfigurableTripService().apply {
+            responseProvider = { matchingResponse(mismatch, arrivalUtcDateTime = futureIso(1.hours)) }
+        }
+        val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+        val poller = makePoller(tripService = tripService, state = state)
+
+        poller.startPolling(deepLink)
+        runCurrent()
+
+        assertEquals(TrackTripState.NotFound, state.value)
+    }
+
+    @Test
+    fun `GIVEN expired trip WHEN startPolling fires THEN goes straight to ArrivedAndFinished without API call`() =
+        runTest {
+            val deepLink = makeDeepLink(departureUtcDateTime = pastIso(3.hours))
+            val tripService = ConfigurableTripService()
+            val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+            val poller = makePoller(tripService = tripService, state = state)
+
+            poller.startPolling(deepLink)
+            runCurrent()
+
+            assertEquals(TrackTripState.ArrivedAndFinished, state.value)
+            assertEquals(0, tripService.callCount, "expired trip must not hit the API")
+        }
+
+    @Test
+    fun `GIVEN transitionToArrivedAndFinished WHEN called directly THEN polling stops and state is set`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val tripService = ConfigurableTripService().apply {
+            responseProvider = { matchingResponse(deepLink, arrivalUtcDateTime = futureIso(1.hours)) }
+        }
+        val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+        val trackingManager = TrackingManager().apply { start(deepLink) }
+        val poller = makePoller(
+            tripService = tripService,
+            state = state,
+            trackingManager = trackingManager,
+        )
+
+        poller.startPolling(deepLink)
+        runCurrent()
+        assertTrue(poller.isPollingActive)
+
+        poller.transitionToArrivedAndFinished()
+        runCurrent()
+
+        assertEquals(TrackTripState.ArrivedAndFinished, state.value)
+        assertFalse(poller.isPollingActive)
+        assertNull(trackingManager.tracked.value)
+    }
+
+    @Test
+    fun `GIVEN isTripExpired WHEN departure is past expiry hours THEN returns true`() = runTest {
+        val expired = makeDeepLink(departureUtcDateTime = pastIso(3.hours))
+        val fresh = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val poller = makePoller()
+
+        assertTrue(poller.isTripExpired(expired))
+        assertFalse(poller.isTripExpired(fresh))
+    }
+
+    @Test
+    fun `GIVEN startPolling WHEN successful THEN polling job is active`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val tripService = ConfigurableTripService().apply {
+            responseProvider = { matchingResponse(deepLink, arrivalUtcDateTime = futureIso(1.hours)) }
+        }
+        val state = MutableStateFlow<TrackTripState>(TrackTripState.Loading())
+        val poller = makePoller(tripService = tripService, state = state)
+
+        assertFalse(poller.isPollingActive, "poller starts idle")
+        poller.startPolling(deepLink)
+        runCurrent()
+        // First poll completed and state is Tracking — loop is parked on its
+        // POLL_INTERVAL_MS delay, still active.
+        assertTrue(poller.isPollingActive, "poller should be running after a successful first poll")
+        assertIs<TrackTripState.Tracking>(state.value)
+    }
+
+    // region helpers
+
+    private fun TestScope.makePoller(
+        tripService: TripPlanningService = ConfigurableTripService(),
+        state: MutableStateFlow<TrackTripState> = MutableStateFlow(TrackTripState.Loading()),
+        trackingManager: TrackingManager = TrackingManager(),
+    ): TripPoller = TripPoller(
+        scope = backgroundScope,
+        // Share the test scheduler so withContext(ioDispatcher) advances under the
+        // same virtual clock as runCurrent().
+        ioDispatcher = StandardTestDispatcher(testScheduler),
+        tripPlanningService = tripService,
+        trackingManager = trackingManager,
+        gtfsRealtimeRepository = NoopGtfsRealtimeRepository,
+        sandook = NoopSandook,
+        state = state,
+    )
+
+    private fun futureIso(duration: kotlin.time.Duration) =
+        (Clock.System.now() + duration).toString()
+
+    private fun pastIso(duration: kotlin.time.Duration) =
+        (Clock.System.now() - duration).toString()
+
+    private fun makeDeepLink(
+        transportationId: String = "test-transport-id",
+        departureUtcDateTime: String = futureIso(1.hours),
+    ) = TripDeepLink(
+        fromStopId = "from-stop",
+        toStopId = "to-stop",
+        fromStopName = "Origin Station",
+        toStopName = "Destination Station",
+        departureUtcDateTime = departureUtcDateTime,
+        legs = listOf(TripDeepLink.DeepLinkLeg(transportationId = transportationId, productClass = 1)),
+    )
+
+    private fun makeDisplay(
+        deepLink: TripDeepLink,
+        arrivalUtcDateTime: String,
+    ) = xyz.ksharma.krail.feature.track.TrackedJourneyDisplay(
+        fromStopId = deepLink.fromStopId,
+        toStopId = deepLink.toStopId,
+        fromStopName = deepLink.fromStopName,
+        toStopName = deepLink.toStopName,
+        originTime = "08:00",
+        scheduledOriginTime = null,
+        destinationTime = "08:30",
+        originUtcDateTime = deepLink.departureUtcDateTime,
+        destinationUtcDateTime = arrivalUtcDateTime,
+        travelTime = "30 mins",
+        legs = kotlinx.collections.immutable.persistentListOf(),
+    )
+
+    private fun matchingResponse(
+        deepLink: TripDeepLink,
+        arrivalUtcDateTime: String,
+    ): TripResponse {
+        val origin = stopSeq(deepLink.departureUtcDateTime)
+        val destination = stopSeq(arrivalUtcDateTime)
+        val leg = TripResponse.Leg(
+            origin = origin,
+            destination = destination,
+            stopSequence = listOf(origin, destination),
+            transportation = TripResponse.Transportation(
+                id = deepLink.legs.first().transportationId,
+                disassembledName = "T1",
+                product = TripResponse.Product(productClass = 1L, name = "Train"),
+                destination = TripResponse.OperatorClass(name = "City Circle", id = "cc"),
+                name = "T1 Northern",
+                description = "Train",
+            ),
+            duration = SECONDS_PER_HALF_HOUR,
+        )
+        return TripResponse(journeys = listOf(TripResponse.Journey(legs = listOf(leg))))
+    }
+
+    private fun stopSeq(utcDateTime: String) = TripResponse.StopSequence(
+        arrivalTimePlanned = utcDateTime,
+        arrivalTimeEstimated = utcDateTime,
+        departureTimePlanned = utcDateTime,
+        departureTimeEstimated = utcDateTime,
+        name = "Stop",
+        disassembledName = "Stop",
+        id = "stop_id",
+        type = StopType.STOP.type,
+    )
+
+    // endregion
+
+    companion object {
+        private const val SECONDS_PER_HALF_HOUR = 1800L
+    }
+}
+
+// region Local fakes
+
+private class ConfigurableTripService : TripPlanningService {
+    var callCount = 0
+    var shouldThrow = false
+    var responseProvider: () -> TripResponse = { TripResponse(journeys = emptyList()) }
+
+    override suspend fun trip(
+        originStopId: String,
+        destinationStopId: String,
+        depArr: DepArr,
+        date: String?,
+        time: String?,
+        excludeProductClassSet: Set<Int>,
+    ): TripResponse {
+        callCount++
+        if (shouldThrow) throw IllegalStateException("Simulated network error")
+        return responseProvider()
+    }
+
+    override suspend fun stopFinder(
+        stopSearchQuery: String,
+        stopType: StopType,
+    ): StopFinderResponse = StopFinderResponse()
+}
+
+private object NoopGtfsRealtimeRepository : GtfsRealtimeRepository {
+    override suspend fun pollLiveTracking(
+        legs: List<LegTrackingInfo>,
+        originUtcDateTime: String,
+    ): LiveTrackingOverlay = LiveTrackingOverlay(
+        vehiclePositions = emptyMap(),
+        stopDelays = emptyMap(),
+        lastModified = null,
+    )
+
+    override fun clearCache() = Unit
+}
+
+private object NoopSandook : xyz.ksharma.krail.sandook.Sandook {
+    override fun observeStopLabels(): Flow<List<xyz.ksharma.krail.sandook.StopLabels>> = flowOf(emptyList())
+    override fun upsertStopLabel(label: String, emoji: String, stopId: String?, stopName: String?, sortOrder: Long) = Unit
+    override fun updateStopLabelStop(label: String, stopId: String?, stopName: String?) = Unit
+    override fun deleteStopLabel(label: String) = Unit
+    override fun clearStopLabels() = Unit
+    override fun insertOrReplaceTheme(productClass: Long) = Unit
+    override fun getProductClass(): Long? = null
+    override fun clearTheme() = Unit
+    override fun insertOrReplaceTrip(tripId: String, fromStopId: String, fromStopName: String, toStopId: String, toStopName: String) = Unit
+    override fun deleteTrip(tripId: String) = Unit
+    override fun selectAllTrips(): List<xyz.ksharma.krail.sandook.SavedTrip> = emptyList()
+    override fun observeAllTrips(): Flow<List<xyz.ksharma.krail.sandook.SavedTrip>> = flowOf(emptyList())
+    override fun selectTripById(tripId: String): xyz.ksharma.krail.sandook.SavedTrip? = null
+    override fun clearSavedTrips() = Unit
+    override fun getAlerts(journeyId: String): List<xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId> = emptyList()
+    override fun clearAlerts() = Unit
+    override fun insertAlerts(journeyId: String, alerts: List<xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId>) = Unit
+    override fun insertNswStop(stopId: String, stopName: String, stopLat: Double, stopLon: Double, isParent: Boolean?) = Unit
+    override fun stopsCount(): Int = 0
+    override fun productClassCount(): Int = 0
+    override fun insertNswStopProductClass(stopId: String, productClass: Int) = Unit
+    override fun <R> insertTransaction(block: () -> R): R = block()
+    override fun clearNswStopsTable() = Unit
+    override fun clearNswProductClassTable() = Unit
+    override fun selectStops(stopName: String, excludeProductClassList: List<Int>): List<xyz.ksharma.krail.sandook.SelectProductClassesForStop> = emptyList()
+    override fun selectStopCoordinatesBatch(stopIds: List<String>): Map<String, Pair<Double, Double>> = emptyMap()
+    override fun insertOrReplaceRecentSearchStop(stopId: String) = Unit
+    override fun selectRecentSearchStops(): List<xyz.ksharma.krail.sandook.SelectRecentSearchStops> = emptyList()
+    override fun clearRecentSearchStops() = Unit
+    override fun cleanupOrphanedRecentSearchStops() = Unit
+    override fun cleanupOldRecentSearchStops() = Unit
+}
+
+// endregion


### PR DESCRIPTION
The ViewModel owned three while(isActive) loops (poll job, GTFS-RT
live-positions job, clock job) plus the smart-delay anchor and
fetchAndUpdate IO. They were untestable in isolation: the only seam
into them was viewModelScope, which has no public cancellation hook,
so VM tests had to wrap runTest in a helper that cancelled
viewModelScope in a finally block to stop the loops before runTest's
end-of-body advanceUntilIdle drained them forever.

Moves all of that into a new TripPoller class that takes its
CoroutineScope in the constructor:
- TrackTripViewModel constructs TripPoller(viewModelScope, …) and
  delegates lifecycle (startPolling, startLivePositionPolling,
  transitionToArrivedAndFinished, isTripExpired, reset)
- TripPoller owns clock, liveOverlay, stopCoordinates, countdownDisplay
  StateFlows; the VM just re-exposes them so the public API of
  TrackTripViewModel is unchanged (TrackTripScreen and the Koin module
  don't move)
- Public/internal split: TripPoller is internal — it's an
  implementation detail of the track:ui module

The new TripPollerTest exercises the polling logic directly via
runTest { TripPoller(backgroundScope, …) }. backgroundScope is auto-
cancelled when the test ends so the loops stop without manual cleanup.
TrackTripViewModelTest still uses the runTrackingTest wrapper because
it constructs the VM (which still binds the poller to viewModelScope);
the docstring on the wrapper now points at TripPollerTest as the
cleaner alternative.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>