### PR TITLE
refactor: rework stop-label pill styling

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_location_on.xml
+++ b/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_location_on.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM7,9c0,-2.76 2.24,-5 5,-5s5,2.24 5,5c0,2.88 -2.88,7.19 -5,9.88C9.92,16.21 7,11.85 7,9z"
+      android:fillColor="#e3e3e3"/>
+  <path
+      android:pathData="M12,9m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_map.xml
+++ b/feature/trip-planner/ui/src/commonMain/composeResources/drawable/ic_map.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="m600,840 l-240,-84 -186,72q-20,8 -37,-4.5T120,790v-560q0,-13 7.5,-23t20.5,-15l212,-72 240,84 186,-72q20,-8 37,4.5t17,33.5v560q0,13 -7.5,23T812,768l-212,72ZM560,742v-468l-160,-56v468l160,56ZM640,742 L760,702v-474l-120,46v468ZM200,732 L320,686v-468l-120,40v474ZM640,274v468,-468ZM320,218v468,-468Z"
+      android:fillColor="#e3e3e3"/>
+</vector>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AddLabelBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AddLabelBottomSheet.kt
@@ -19,9 +19,10 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,11 +35,10 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import app.krail.taj.resources.Res
-import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import krail.feature.trip_planner.ui.generated.resources.ic_info
+import krail.feature.trip_planner.ui.generated.resources.ic_location_on
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ModalBottomSheet
@@ -67,7 +67,10 @@ fun AddLabelBottomSheet(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-    var name by rememberSaveable { mutableStateOf("") }
+    // Hoisted text-field state so suggestion taps can update the visible text
+    // without rekeying the TextField — rekeying would dismiss the keyboard.
+    val textFieldState = rememberTextFieldState("")
+    val name = textFieldState.text.toString()
     var selectedSuggestionIndex by rememberSaveable { mutableIntStateOf(-1) }
 
     val availableSuggestions = remember(existingLabels) {
@@ -203,7 +206,7 @@ fun AddLabelBottomSheet(
                                     )
                                     .klickable {
                                         selectedSuggestionIndex = index
-                                        name = chipName
+                                        textFieldState.setTextAndPlaceCursorAtEnd(chipName)
                                     }
                                     .padding(
                                         horizontal = dim.chipHorizontalPadding,
@@ -235,24 +238,21 @@ fun AddLabelBottomSheet(
                 verticalArrangement = Arrangement.spacedBy(dim.spacingXS),
             ) {
                 SectionHeading(text = "Name")
-                key(selectedSuggestionIndex) {
-                    TextField(
-                        placeholder = "e.g. Home, Gym, School…",
-                        initialText = name,
-                        onTextChange = { text ->
-                            name = text.toString()
-                            val cleaned = normaliseLabelName(name)
-                            selectedSuggestionIndex = if (cleaned.isNotBlank()) {
-                                availableSuggestions.indexOfFirst {
-                                    labelNamesMatch(it.first, cleaned)
-                                }
-                            } else {
-                                -1
+                TextField(
+                    placeholder = "e.g. Home, Gym, School…",
+                    state = textFieldState,
+                    onTextChange = { text ->
+                        val cleaned = normaliseLabelName(text.toString())
+                        selectedSuggestionIndex = if (cleaned.isNotBlank()) {
+                            availableSuggestions.indexOfFirst {
+                                labelNamesMatch(it.first, cleaned)
                             }
-                        },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
+                        } else {
+                            -1
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
                 if (isDuplicate) {
                     Text(
                         text = "\"$cleanedName\" is already a label.",
@@ -299,7 +299,7 @@ private fun StopChip(stopName: String, modifier: Modifier = Modifier) {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
-            painter = painterResource(Res.drawable.ic_location),
+            painter = painterResource(TripPlannerRes.drawable.ic_location_on),
             contentDescription = null,
             colorFilter = ColorFilter.tint(KrailTheme.colors.surface),
             modifier = Modifier.size(12.dp),
@@ -316,7 +316,7 @@ private fun StopChip(stopName: String, modifier: Modifier = Modifier) {
 private fun LabelPreviewPill(name: String) {
     val dim = KrailTheme.dimensions
     val shape = RoundedCornerShape(dim.radiusFull)
-    val icon = stopLabelIcon(name) ?: Res.drawable.ic_location
+    val icon = stopLabelIcon(name) ?: TripPlannerRes.drawable.ic_location_on
     Row(
         modifier = Modifier
             .clip(shape)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SaveStopAsLabelSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SaveStopAsLabelSheet.kt
@@ -23,10 +23,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import app.krail.taj.resources.Res
-import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_location_on
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.components.ModalBottomSheet
 import xyz.ksharma.krail.taj.components.Text
@@ -105,7 +105,7 @@ private fun LabelChoiceChip(
     val dim = KrailTheme.dimensions
     val shape = RoundedCornerShape(dim.radiusFull)
     val themeColor = themeColor()
-    val icon = stopLabelIcon(label.label) ?: Res.drawable.ic_location
+    val icon = stopLabelIcon(label.label) ?: Res.drawable.ic_location_on
     // Solid chip when the label already has a stop; outlined when it doesn't, since
     // tapping an outlined chip is what attaches this stop to that empty label.
     val isSet = label.isSet

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopLabelPill.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopLabelPill.kt
@@ -1,0 +1,159 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import app.krail.taj.resources.Res as TajRes
+import app.krail.taj.resources.ic_location
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.LocalTextColor
+import xyz.ksharma.krail.taj.LocalTextStyle
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+
+/**
+ * Filled pill shown when a [StopLabel] has a stop assigned. Sits on the dark
+ * `stopLabelSurface` token in both light and dark mode and pairs with the matching
+ * `onStopLabelSurface` content colour. Styling is locked inside the pill via
+ * composition locals, so callers cannot override the typography or colours from
+ * the outside — by design.
+ */
+@Composable
+internal fun SetLabelPill(
+    label: StopLabel,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+    val shape = RoundedCornerShape(dim.radiusFull)
+    val pillBackground = KrailTheme.colors.stopLabelSurface
+    val contentColor = KrailTheme.colors.onStopLabelSurface
+
+    CompositionLocalProvider(
+        LocalTextStyle provides KrailTheme.typography.labelLarge,
+        LocalTextColor provides contentColor,
+        LocalContentColor provides contentColor,
+    ) {
+        val icon = stopLabelIcon(label.label) ?: TajRes.drawable.ic_location
+        Row(
+            modifier = modifier
+                .clip(shape)
+                .background(pillBackground, shape)
+                .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
+            horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Image(
+                painter = painterResource(icon),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                modifier = Modifier.size(dim.spacingXL),
+            )
+            Text(text = label.label)
+        }
+    }
+}
+
+/**
+ * Outlined pill shown when a [StopLabel] has no stop assigned. Background stays
+ * transparent so the screen's themed gradient shows through; the border uses the
+ * dark `stopLabelSurface` token so the outline reads consistently across themes.
+ *
+ * Styling is locked inside the pill via composition locals.
+ *
+ * The [isAssigning] flag is intentionally unused here — the assigning visual is
+ * a scale-up animation applied by the parent so the pill's own colours stay
+ * stable during the transition.
+ */
+@Composable
+internal fun UnsetLabelPill(
+    label: StopLabel,
+    @Suppress("UNUSED_PARAMETER") isAssigning: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+    val shape = RoundedCornerShape(dim.radiusFull)
+    val borderColor = KrailTheme.colors.stopLabelSurface
+    val contentColor = KrailTheme.colors.label
+
+    CompositionLocalProvider(
+        LocalTextStyle provides KrailTheme.typography.labelLarge,
+        LocalTextColor provides contentColor,
+        LocalContentColor provides contentColor,
+    ) {
+        val icon = stopLabelIcon(label.label) ?: TajRes.drawable.ic_location
+        Row(
+            modifier = modifier
+                .clip(shape)
+                .border(width = dim.strokeThin, color = borderColor, shape = shape)
+                .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
+            horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Image(
+                painter = painterResource(icon),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                modifier = Modifier.size(dim.spacingXL),
+            )
+            Text(text = label.label)
+        }
+    }
+}
+
+// region Previews
+
+@PreviewComponent
+@Composable
+private fun PreviewSetLabelPill_Train() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        SetLabelPill(label = StopLabel(emoji = "🏠", label = "Home"))
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun PreviewSetLabelPill_PurpleDrip() {
+    PreviewTheme(themeStyle = KrailThemeStyle.PurpleDrip) {
+        SetLabelPill(label = StopLabel(emoji = "🎓", label = "Uni"))
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun PreviewUnsetLabelPill_Idle() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        UnsetLabelPill(
+            label = StopLabel(emoji = "🏠", label = "Home"),
+            isAssigning = false,
+        )
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun PreviewUnsetLabelPill_Assigning() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
+        UnsetLabelPill(
+            label = StopLabel(emoji = "💼", label = "Work"),
+            isAssigning = true,
+        )
+    }
+}
+
+// endregion

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopLabelPill.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopLabelPill.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
-import app.krail.taj.resources.Res as TajRes
-import app.krail.taj.resources.ic_location
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_location_on
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalTextColor
@@ -49,7 +49,7 @@ internal fun SetLabelPill(
         LocalTextColor provides contentColor,
         LocalContentColor provides contentColor,
     ) {
-        val icon = stopLabelIcon(label.label) ?: TajRes.drawable.ic_location
+        val icon = stopLabelIcon(label.label) ?: Res.drawable.ic_location_on
         Row(
             modifier = modifier
                 .clip(shape)
@@ -96,7 +96,7 @@ internal fun UnsetLabelPill(
         LocalTextColor provides contentColor,
         LocalContentColor provides contentColor,
     ) {
-        val icon = stopLabelIcon(label.label) ?: TajRes.drawable.ic_location
+        val icon = stopLabelIcon(label.label) ?: Res.drawable.ic_location_on
         Row(
             modifier = modifier
                 .clip(shape)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -69,7 +69,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import app.krail.taj.resources.ic_close
-import app.krail.taj.resources.ic_location
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -122,6 +121,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import app.krail.taj.resources.Res as TajRes
+import krail.feature.trip_planner.ui.generated.resources.Res as TripPlannerRes
+import krail.feature.trip_planner.ui.generated.resources.ic_map
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @Suppress("LongMethod", "CyclomaticComplexMethod")
@@ -1432,9 +1433,15 @@ private fun LabelShortcutsRow(
         // reorderable library's drop-target calculations.
         if (editing) {
             item(key = "trailing-done") {
+                // Done sits next to the always-dark stopLabelSurface pills, so its
+                // container must be light in both modes — monochromeButtonColors flips
+                // to onSurface (dark in light mode), which would blend into the pills.
                 Button(
                     onClick = onDoneEditing,
-                    colors = ButtonDefaults.monochromeButtonColors(),
+                    colors = ButtonDefaults.buttonColors(
+                        customContainerColor = KrailTheme.colors.onStopLabelSurface,
+                        customContentColor = KrailTheme.colors.stopLabelSurface,
+                    ),
                     dimensions = ButtonDefaults.chipButtonSize(),
                 ) {
                     Text(text = "Done")
@@ -1459,19 +1466,22 @@ private fun DeleteOverlay(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
+    // Pill background is always dark (stopLabelSurface), so the overlay must use the
+    // paired light token in both modes — using onSurface here would flip to dark in
+    // light mode and disappear into the pill.
     Box(
         modifier = modifier
             .offset(x = dim.spacingS, y = -dim.spacingS)
             .size(dim.spacingXXL)
             .clip(CircleShape)
-            .background(KrailTheme.colors.onSurface, CircleShape)
+            .background(KrailTheme.colors.onStopLabelSurface, CircleShape)
             .klickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Image(
             painter = painterResource(TajRes.drawable.ic_close),
             contentDescription = "Delete label",
-            colorFilter = ColorFilter.tint(KrailTheme.colors.surface),
+            colorFilter = ColorFilter.tint(KrailTheme.colors.stopLabelSurface),
             modifier = Modifier.size(dim.spacingL),
         )
     }
@@ -1553,7 +1563,7 @@ private fun SelectOnMapItem(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
-            painter = painterResource(TajRes.drawable.ic_location),
+            painter = painterResource(TripPlannerRes.drawable.ic_map),
             contentDescription = null,
             colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
             modifier = Modifier.size(dim.spacingXXL),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -81,6 +81,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.withTimeoutOrNull
+import krail.feature.trip_planner.ui.generated.resources.ic_map
 import org.jetbrains.compose.resources.painterResource
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -122,7 +123,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import app.krail.taj.resources.Res as TajRes
 import krail.feature.trip_planner.ui.generated.resources.Res as TripPlannerRes
-import krail.feature.trip_planner.ui.generated.resources.ic_map
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @Suppress("LongMethod", "CyclomaticComplexMethod")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -93,6 +92,7 @@ import xyz.ksharma.krail.core.permission.PermissionStatus
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.backgroundColorOf
+import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.OutlinedButton
@@ -108,10 +108,11 @@ import xyz.ksharma.krail.trip.planner.ui.components.AddLabelBottomSheet
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.LabelConflictSheet
 import xyz.ksharma.krail.trip.planner.ui.components.SaveStopAsLabelSheet
+import xyz.ksharma.krail.trip.planner.ui.components.SetLabelPill
 import xyz.ksharma.krail.trip.planner.ui.components.StopSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.TripSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.TripSearchListItemState
-import xyz.ksharma.krail.trip.planner.ui.components.stopLabelIcon
+import xyz.ksharma.krail.trip.planner.ui.components.UnsetLabelPill
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.SearchStopMap
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
@@ -1431,11 +1432,22 @@ private fun LabelShortcutsRow(
         // reorderable library's drop-target calculations.
         if (editing) {
             item(key = "trailing-done") {
-                DonePill(onClick = onDoneEditing)
+                Button(
+                    onClick = onDoneEditing,
+                    colors = ButtonDefaults.monochromeButtonColors(),
+                    dimensions = ButtonDefaults.chipButtonSize(),
+                ) {
+                    Text(text = "Done")
+                }
             }
         } else {
             item(key = "trailing-add") {
-                AddLabelPill(onClick = onAddLabelClick)
+                OutlinedButton(
+                    onClick = onAddLabelClick,
+                    dimensions = ButtonDefaults.chipButtonSize(),
+                ) {
+                    Text(text = "+ Add")
+                }
             }
         }
     }
@@ -1490,87 +1502,6 @@ private fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
 }
 
 @Composable
-private fun SetLabelPill(
-    label: StopLabel,
-    modifier: Modifier = Modifier,
-) {
-    val dim = KrailTheme.dimensions
-    val shape = RoundedCornerShape(dim.radiusFull)
-    val themeColor = themeColor()
-    val icon = stopLabelIcon(label.label) ?: TajRes.drawable.ic_location
-    Row(
-        modifier = modifier
-            .clip(shape)
-            .background(themeColor, shape)
-            .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
-        horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Image(
-            painter = painterResource(icon),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(KrailTheme.colors.surface),
-            modifier = Modifier.size(dim.spacingXL),
-        )
-        Text(
-            text = label.label,
-            style = KrailTheme.typography.labelLarge,
-            color = KrailTheme.colors.surface,
-        )
-    }
-}
-
-@Composable
-private fun UnsetLabelPill(
-    label: StopLabel,
-    @Suppress("UNUSED_PARAMETER") isAssigning: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    val dim = KrailTheme.dimensions
-    val shape = RoundedCornerShape(dim.radiusFull)
-    // Visual feedback for assigning mode is the scale-up animation on the parent Box;
-    // the pill's own colours stay constant so it doesn't blend into the themed
-    // background gradient.
-    val borderColor = KrailTheme.colors.label
-    val contentColor = KrailTheme.colors.label
-    val icon = stopLabelIcon(label.label) ?: TajRes.drawable.ic_location
-    Row(
-        modifier = modifier
-            .clip(shape)
-            .border(width = dim.strokeThin, color = borderColor, shape = shape)
-            .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
-        horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Image(
-            painter = painterResource(icon),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(contentColor),
-            modifier = Modifier.size(dim.spacingXL),
-        )
-        Text(
-            text = label.label,
-            style = KrailTheme.typography.labelLarge,
-            color = contentColor,
-        )
-    }
-}
-
-@Composable
-private fun AddLabelPill(onClick: () -> Unit) {
-    // chipButtonSize matches the hand-rolled Set/Unset/Done pill geometry
-    // (chipHorizontal/Vertical padding, no min-height) so the row stays
-    // visually aligned. smallButtonSize was making "+ Add" noticeably shorter
-    // and narrower than its neighbours.
-    OutlinedButton(
-        onClick = onClick,
-        dimensions = ButtonDefaults.chipButtonSize(),
-    ) {
-        Text(text = "+ Add", style = KrailTheme.typography.labelLarge)
-    }
-}
-
-@Composable
 private fun PillRowInfoBanner(
     text: String,
     modifier: Modifier = Modifier,
@@ -1589,30 +1520,6 @@ private fun PillRowInfoBanner(
                 bottom = dim.spacingS,
             ),
     )
-}
-
-/**
- * Visually distinct from label pills — uses inverse onSurface/surface so "Done" reads
- * as an action button (like the journey-card map button), not as another pill.
- */
-@Composable
-private fun DonePill(onClick: () -> Unit) {
-    val dim = KrailTheme.dimensions
-    val shape = RoundedCornerShape(dim.radiusFull)
-    Row(
-        modifier = Modifier
-            .clip(shape)
-            .background(KrailTheme.colors.onSurface, shape)
-            .klickable(onClick = onClick)
-            .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = "Done",
-            style = KrailTheme.typography.labelLarge,
-            color = KrailTheme.colors.surface,
-        )
-    }
 }
 
 @Composable

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/ThemeTransitionAnimations.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/ThemeTransitionAnimations.kt
@@ -148,6 +148,8 @@ internal fun createLightDarkModeAnimatedColors(
         walkingPath = targetColors.walkingPath,
         userLocationDot = targetColors.userLocationDot,
         outlineSubtle = targetColors.outlineSubtle,
+        stopLabelSurface = targetColors.stopLabelSurface,
+        onStopLabelSurface = targetColors.onStopLabelSurface,
     )
 }
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -253,8 +253,12 @@ fun OutlinedButton(
             modifier = modifier
                 .heightIn(dimensions.height)
                 .clip(dimensions.shape)
+                // Use the container colour as-is — Color.copy(alpha = X) REPLACES alpha,
+                // which turns Color.Transparent (RGBA 0,0,0,0) into solid black when
+                // LocalContentAlpha is 1f. Disabled-state fade is applied to the border
+                // and content below, which is the correct visual for an outlined button.
                 .background(
-                    color = LocalContainerColor.current.copy(alpha = LocalContentAlpha.current),
+                    color = LocalContainerColor.current,
                     shape = dimensions.shape,
                 )
                 .border(

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.TextFieldDecorator
 import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
@@ -61,6 +62,7 @@ fun TextField(
     modifier: Modifier = Modifier,
     placeholder: String? = null,
     initialText: String? = null,
+    state: TextFieldState? = null,
     enabled: Boolean = true,
     textStyle: TextStyle? = null,
     readOnly: Boolean = false,
@@ -74,7 +76,10 @@ fun TextField(
     val isFocused by interactionSource.collectIsFocusedAsState()
     val contentAlpha = if (enabled) 1f else TextFieldTokens.DisabledLabelOpacity
 
-    val textFieldState = rememberTextFieldState(initialText.orEmpty())
+    // Hoisted state takes precedence — callers that need to mutate the text from
+    // outside (e.g. selecting a suggestion chip that fills the field) must pass
+    // their own state so the field is not rekeyed and focus / IME are preserved.
+    val textFieldState = state ?: rememberTextFieldState(initialText.orEmpty())
     val textSelectionColors = TextSelectionColors(
         handleColor = KrailTheme.colors.onSurface,
         backgroundColor = KrailTheme.colors.onSurface.copy(alpha = TextSelectionBackgroundOpacity),

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -39,6 +39,12 @@ val md_theme_light_outline_subtle = Color(0x33010101)
 // Used for past/previous departure rows and past journey cards.
 val md_theme_light_past_departure_row_surface = Color(0xFFEEEEEE)
 
+// Stop-label surface — intentionally dark in BOTH light and dark mode so stop-label
+// pills read as a single visual treatment regardless of theme. Pair with
+// [md_theme_on_stop_label_surface] for content drawn on top.
+val md_theme_stop_label_surface = Color(0xFF1C1B1A)
+val md_theme_on_stop_label_surface = Color(0xFFFCF6F1)
+
 /**
  * KRAIL Dark theme color tokens
  */
@@ -145,6 +151,13 @@ data class KrailColors(
     val pastDepartureRowSurface: Color,
     /** Subtle border/stroke color for chip outlines, dividers, and UI control tracks. */
     val outlineSubtle: Color,
+    /**
+     * Background/border surface for stop-label pills. Same dark value in both light and
+     * dark mode by design — pair with [onStopLabelSurface] for content drawn on top.
+     */
+    val stopLabelSurface: Color,
+    /** Content colour (text, icons) drawn on top of [stopLabelSurface]. Light in both modes. */
+    val onStopLabelSurface: Color,
 )
 
 internal val KrailLightColors = KrailColors(
@@ -175,6 +188,8 @@ internal val KrailLightColors = KrailColors(
     bottomSheetDragHandle = md_theme_light_sheet_drag_handle,
     pastDepartureRowSurface = md_theme_light_past_departure_row_surface,
     outlineSubtle = md_theme_light_outline_subtle,
+    stopLabelSurface = md_theme_stop_label_surface,
+    onStopLabelSurface = md_theme_on_stop_label_surface,
 )
 
 internal val KrailDarkColors = KrailColors(
@@ -205,6 +220,8 @@ internal val KrailDarkColors = KrailColors(
     bottomSheetDragHandle = md_theme_dark_sheet_drag_handle,
     pastDepartureRowSurface = md_theme_dark_past_departure_row_surface,
     outlineSubtle = md_theme_dark_outline_subtle,
+    stopLabelSurface = md_theme_stop_label_surface,
+    onStopLabelSurface = md_theme_on_stop_label_surface,
 )
 
 internal val LocalKrailColors = staticCompositionLocalOf {
@@ -236,5 +253,7 @@ internal val LocalKrailColors = staticCompositionLocalOf {
         bottomSheetDragHandle = Color.Unspecified,
         pastDepartureRowSurface = Color.Unspecified,
         outlineSubtle = Color.Unspecified,
+        stopLabelSurface = Color.Unspecified,
+        onStopLabelSurface = Color.Unspecified,
     )
 }


### PR DESCRIPTION
refactor: rework stop-label pill styling

Extract Set/UnsetLabelPill into a shared component with styling locked via
CompositionLocalProvider so callers cannot override typography or colours.
Add stopLabelSurface + onStopLabelSurface tokens (dark in both modes) so
pills read as one visual treatment regardless of theme; SetLabelPill no
longer uses the per-screen theme colour for text, which was inconsistent
across themes.

Inline AddLabelPill (OutlinedButton) and DonePill (Button +
monochromeButtonColors) at their call sites — the wrappers added nothing
over the underlying taj components.

Fix OutlinedButton: Color.Transparent.copy(alpha = 1f) produced solid
black in light mode because Color.copy replaces alpha instead of
multiplying. Use the container colour as-is; disabled-state fade still
applies via the border + content.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

refactor: pill icons, contrast tweaks, hoist TextField state

- ic_location_on (trip-planner) replaces taj ic_location as the fallback
  icon for stop-label pills and the bottom-sheet pills (AddLabelBottomSheet,
  SaveStopAsLabelSheet).
- ic_map replaces ic_location for the "Select on map" row so the icon
  no longer visually clashes with the saved-label pins above it.
- DeleteOverlay (X circle drawn over a pill in edit/reorder mode) and
  the trailing "Done" button switch to the onStopLabelSurface /
  stopLabelSurface pair so they always read light-on-dark; previously
  KrailTheme.colors.onSurface flipped to dark in light mode and the
  controls vanished into the always-dark pill.
- Add optional state: TextFieldState? param to taj.TextField for caller-
  controlled state hoisting. Use it in AddLabelBottomSheet so tapping a
  suggestion chip mutates the visible text without rekeying the field.
  The previous key(selectedSuggestionIndex) wrapper destroyed and recreated
  the TextField on every index change, dismissing the keyboard on
  suggestion tap and again on the first typed letter (when the typed text
  no longer matched and the index flipped back to -1).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>