### PR TITLE
fix(savedtrips): widen pill condition to include 1 trip + park & ride

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -102,10 +102,15 @@ fun SavedTripsScreen(
         }.random()
     }
 
-    // Pill only shown when content is rich enough that a collapsed state adds value.
-    val showPill = savedTripsState.savedTrips.size >= 2 &&
-        savedTripsState.parkRideUiState.isNotEmpty() &&
-        departureBoardEntries.size >= 2
+    // Pill only shown when there's enough saved content above to justify collapsing
+    // the search row out of the way:
+    //   • 2+ saved trips, OR
+    //   • 1 saved trip + at least one Park & Ride entry.
+    // Anything less and the expanded row stays — first-time and lightly-used
+    // accounts still get the full search affordance front-and-centre.
+    val savedTripsCount = savedTripsState.savedTrips.size
+    val hasParkRide = savedTripsState.parkRideUiState.isNotEmpty()
+    val showPill = savedTripsCount >= 2 || (savedTripsCount >= 1 && hasParkRide)
 
     // Search row expand / from-highlight state — rememberSaveable survives rotation.
     var isSearchExpanded by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
Previously the collapsed pill only appeared when the user had 2+ saved
trips AND any park & ride AND 2+ departure-board entries. The dep-board
gate meant accounts with sparse boards never collapsed the row even when
their saved-content list was visually crowded.

New rule:
  • 2+ saved trips, OR
  • 1 saved trip + at least one Park & Ride entry → pill
  • otherwise → expanded row

Drops the departure-board gate, which was a proxy for "is there enough
content above to justify a collapsed row" but didn't actually correlate
with that perception.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>