### PR TITLE
feat(timetable): show stop labels in OriginDestination + tap to open details

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -9,6 +9,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.persistentSetOf
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -38,6 +39,13 @@ data class TimeTableState(
     val canLoadMore: Boolean = false,
     /** Whether the Show Previous / Load More pagination UI is enabled. */
     val paginationEnabled: Boolean = true,
+    /**
+     * User-defined stop labels observed from the DB. UI converts trip stops to
+     * [xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay]s using
+     * `Trip.fromStopDisplay(stopLabels)` / `Trip.toStopDisplay(stopLabels)` so
+     * the timetable header shows the user's nickname for a stop when set.
+     */
+    val stopLabels: ImmutableList<StopLabel> = persistentListOf(),
 ) {
     @OptIn(ExperimentalTime::class)
     @Stable

--- a/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestinationTest.kt
+++ b/feature/trip-planner/ui/src/androidUnitTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestinationTest.kt
@@ -1,0 +1,186 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
+
+/**
+ * Compose UI tests for [OriginDestination].
+ *
+ * These cover the two rendering modes (labelled / unlabelled) and the click
+ * callback contract. Animation and shadow rendering are covered by the snapshot
+ * suite via [TripPlannerUiSnapshotTest]; they are intentionally not asserted here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [34],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+class OriginDestinationTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // region Text rendering
+
+    @Test
+    fun unlabelled_stopNamesAreDisplayed() {
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = central,
+                    destination = townHall,
+                    timeLineColor = Color.Black,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Central Station").assertIsDisplayed()
+        composeRule.onNodeWithText("Town Hall Station").assertIsDisplayed()
+    }
+
+    @Test
+    fun labelled_showsLabelAndNameInParentheses() {
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = centralLabelled,
+                    destination = townHallLabelled,
+                    timeLineColor = Color.Black,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Home (Central Station)").assertIsDisplayed()
+        composeRule.onNodeWithText("Work (Town Hall Station)").assertIsDisplayed()
+    }
+
+    @Test
+    fun partialLabel_labelledStopShowsFormat_unlabelledShowsNameOnly() {
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = centralLabelled,
+                    destination = townHall,
+                    timeLineColor = Color.Black,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Home (Central Station)").assertIsDisplayed()
+        composeRule.onNodeWithText("Town Hall Station").assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region Click callbacks
+
+    @Test
+    fun tappingOriginRow_invokesOnOriginClick_withCorrectDisplay() {
+        var clicked: StopDisplay? = null
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = central,
+                    destination = townHall,
+                    timeLineColor = Color.Black,
+                    onOriginClick = { clicked = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Central Station").performClick()
+
+        assert(clicked != null) { "expected onOriginClick to fire" }
+        assert(clicked!!.stopId == "200060") {
+            "expected stopId 200060, got ${clicked?.stopId}"
+        }
+        assert(clicked!!.name == "Central Station") {
+            "expected name Central Station, got ${clicked?.name}"
+        }
+    }
+
+    @Test
+    fun tappingDestinationRow_invokesOnDestinationClick_withCorrectDisplay() {
+        var clicked: StopDisplay? = null
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = central,
+                    destination = townHall,
+                    timeLineColor = Color.Black,
+                    onDestinationClick = { clicked = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Town Hall Station").performClick()
+
+        assert(clicked != null) { "expected onDestinationClick to fire" }
+        assert(clicked!!.stopId == "200070") {
+            "expected stopId 200070, got ${clicked?.stopId}"
+        }
+        assert(clicked!!.name == "Town Hall Station") {
+            "expected name Town Hall Station, got ${clicked?.name}"
+        }
+    }
+
+    @Test
+    fun tappingOriginRow_doesNotFireDestinationCallback() {
+        var destinationClicked = false
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = central,
+                    destination = townHall,
+                    timeLineColor = Color.Black,
+                    onDestinationClick = { destinationClicked = true },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Central Station").performClick()
+
+        assert(!destinationClicked) { "destination callback fired when origin was tapped" }
+    }
+
+    @Test
+    fun noClickHandlers_rendersWithoutError() {
+        composeRule.setContent {
+            PreviewTheme {
+                OriginDestination(
+                    origin = central,
+                    destination = townHall,
+                    timeLineColor = Color.Black,
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Central Station").assertIsDisplayed()
+        composeRule.onNodeWithText("Town Hall Station").assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region fixtures
+
+    private val central = StopDisplay(stopId = "200060", name = "Central Station")
+    private val townHall = StopDisplay(stopId = "200070", name = "Town Hall Station")
+    private val centralLabelled = StopDisplay(stopId = "200060", name = "Central Station", label = "Home")
+    private val townHallLabelled = StopDisplay(stopId = "200070", name = "Town Hall Station", label = "Work")
+
+    // endregion
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -27,6 +29,8 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
 private val TIMELINE_CIRCLE_RADIUS = 5.dp
 private const val LABELLED_NAME_CAPTION_ALPHA = 0.65f
+private val CLICKABLE_CORNER_RADIUS = 8.dp
+private val CLICKABLE_VERTICAL_PADDING = 6.dp
 
 /**
  * Vertical timeline showing the origin and destination of a trip. Each stop
@@ -114,8 +118,15 @@ private fun StopColumn(
     } else {
         KrailTheme.typography.titleLarge
     }
+    // When clickable, give the touch target some breathing room and round its
+    // corners so the ripple reads as a tappable affordance rather than bleeding
+    // into adjacent content. Non-clickable surfaces (TrackTrip, intro) keep
+    // today's exact layout — no clip, no padding.
     val clickModifier = onClick?.let { handler ->
-        Modifier.klickable { handler(display) }
+        Modifier
+            .clip(RoundedCornerShape(CLICKABLE_CORNER_RADIUS))
+            .klickable { handler(display) }
+            .padding(vertical = CLICKABLE_VERTICAL_PADDING)
     } ?: Modifier
 
     Column(modifier = modifier.then(clickModifier)) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -18,20 +18,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
 private val TIMELINE_CIRCLE_RADIUS = 5.dp
+private const val LABELLED_NAME_CAPTION_ALPHA = 0.65f
 
+/**
+ * Vertical timeline showing the origin and destination of a trip. Each stop
+ * renders the user's label as primary text when set, with the raw stop name
+ * as a smaller caption underneath; unlabelled stops keep the existing
+ * single-line treatment.
+ *
+ * Optional click handlers light up only when the caller passes them — the
+ * timetable screen wires them to a stop-details sheet, while TrackTrip and
+ * the intro screen leave them null and stay non-interactive.
+ */
 @Composable
 internal fun OriginDestination(
-    trip: Trip,
+    origin: StopDisplay,
+    destination: StopDisplay,
     timeLineColor: Color,
     modifier: Modifier = Modifier,
-    originSubtitle: String? = null,
-    destinationSubtitle: String? = null,
+    onOriginClick: ((StopDisplay) -> Unit)? = null,
+    onDestinationClick: ((StopDisplay) -> Unit)? = null,
 ) {
     val dim = KrailTheme.dimensions
     Column(
@@ -47,45 +61,15 @@ internal fun OriginDestination(
                     circleRadius = TIMELINE_CIRCLE_RADIUS,
                 ),
         ) {
-            Column(modifier = Modifier.padding(start = 16.dp).fillMaxWidth()) {
-                AnimatedContent(
-                    targetState = trip.fromStopName,
-                    transitionSpec = {
-                        (
-                            fadeIn(
-                                animationSpec = tween(200),
-                            ) + slideInVertically(
-                                initialOffsetY = { it / 2 },
-                                animationSpec = tween(500, easing = EaseOutBounce),
-                            )
-                            ) togetherWith (
-                            fadeOut(
-                                animationSpec = tween(200),
-                            ) + slideOutVertically(
-                                targetOffsetY = { -it / 2 },
-                                animationSpec = tween(500),
-                            )
-                            )
-                    },
-                    contentAlignment = Alignment.CenterStart,
-                    label = "originStopName",
-                ) { targetText ->
-                    Text(
-                        text = targetText,
-                        color = timeLineColor,
-                        style = KrailTheme.typography.titleLarge,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                }
-                originSubtitle?.let {
-                    Text(
-                        text = it,
-                        color = timeLineColor.copy(alpha = 0.7f),
-                        style = KrailTheme.typography.bodySmall,
-                        modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),
-                    )
-                }
-            }
+            StopColumn(
+                display = origin,
+                timeLineColor = timeLineColor,
+                onClick = onOriginClick,
+                animationLabel = "originStopName",
+                modifier = Modifier
+                    .padding(start = 16.dp)
+                    .fillMaxWidth(),
+            )
         }
 
         Spacer(
@@ -102,45 +86,73 @@ internal fun OriginDestination(
                     circleRadius = 5.dp,
                 ),
         ) {
-            Column(modifier = Modifier.padding(start = 16.dp).fillMaxWidth()) {
-                AnimatedContent(
-                    targetState = trip.toStopName,
-                    transitionSpec = {
-                        (
-                            fadeIn(
-                                animationSpec = tween(200),
-                            ) + slideInVertically(
-                                initialOffsetY = { -it / 2 },
-                                animationSpec = tween(500, easing = EaseOutBounce),
-                            )
-                            ) togetherWith (
-                            fadeOut(
-                                animationSpec = tween(200),
-                            ) + slideOutVertically(
-                                targetOffsetY = { it / 2 },
-                                animationSpec = tween(500),
-                            )
-                            )
-                    },
-                    contentAlignment = Alignment.CenterStart,
-                    label = "destinationStopName",
-                ) { targetText ->
-                    Text(
-                        text = targetText,
-                        color = timeLineColor,
-                        style = KrailTheme.typography.titleLarge,
-                        modifier = Modifier.fillMaxWidth(),
+            StopColumn(
+                display = destination,
+                timeLineColor = timeLineColor,
+                onClick = onDestinationClick,
+                animationLabel = "destinationStopName",
+                modifier = Modifier
+                    .padding(start = 16.dp)
+                    .fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun StopColumn(
+    display: StopDisplay,
+    timeLineColor: Color,
+    onClick: ((StopDisplay) -> Unit)?,
+    animationLabel: String,
+    modifier: Modifier = Modifier,
+) {
+    val labelled = display.label != null
+    val primaryText = display.label ?: display.name
+    val primaryStyle = if (labelled) {
+        KrailTheme.typography.headlineSmall.copy(fontWeight = FontWeight.SemiBold)
+    } else {
+        KrailTheme.typography.titleLarge
+    }
+    val clickModifier = onClick?.let { handler ->
+        Modifier.klickable { handler(display) }
+    } ?: Modifier
+
+    Column(modifier = modifier.then(clickModifier)) {
+        AnimatedContent(
+            targetState = primaryText,
+            transitionSpec = {
+                (
+                    fadeIn(animationSpec = tween(200)) +
+                        slideInVertically(
+                            initialOffsetY = { it / 2 },
+                            animationSpec = tween(500, easing = EaseOutBounce),
+                        )
+                    ) togetherWith (
+                    fadeOut(animationSpec = tween(200)) +
+                        slideOutVertically(
+                            targetOffsetY = { -it / 2 },
+                            animationSpec = tween(500),
+                        )
                     )
-                }
-                destinationSubtitle?.let {
-                    Text(
-                        text = it,
-                        color = timeLineColor.copy(alpha = 0.7f),
-                        style = KrailTheme.typography.bodySmall,
-                        modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),
-                    )
-                }
-            }
+            },
+            contentAlignment = Alignment.CenterStart,
+            label = animationLabel,
+        ) { targetText ->
+            Text(
+                text = targetText,
+                color = timeLineColor,
+                style = primaryStyle,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (labelled) {
+            Text(
+                text = display.name,
+                color = timeLineColor.copy(alpha = LABELLED_NAME_CAPTION_ALPHA),
+                style = KrailTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),
+            )
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -8,40 +8,50 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_location_on
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.core.snapshot.ScreenshotTest
+import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.CardShape
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.themeBackgroundColor
+import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
-private val TIMELINE_CIRCLE_RADIUS = 5.dp
-private const val LABELLED_NAME_CAPTION_ALPHA = 0.65f
-private val CLICKABLE_CORNER_RADIUS = 8.dp
-private val CLICKABLE_VERTICAL_PADDING = 6.dp
+private val SHADOW_RADIUS = 12.dp
+private val SHADOW_SPREAD = 2.dp
+private const val SHADOW_ALPHA = 1f
+private val ORIGIN_CIRCLE_SIZE = 10.dp
+private val STOP_ROW_VERTICAL_PADDING = 12.dp
 
-/**
- * Vertical timeline showing the origin and destination of a trip. Each stop
- * renders the user's label as primary text when set, with the raw stop name
- * as a smaller caption underneath; unlabelled stops keep the existing
- * single-line treatment.
- *
- * Optional click handlers light up only when the caller passes them — the
- * timetable screen wires them to a stop-details sheet, while TrackTrip and
- * the intro screen leave them null and stay non-interactive.
- */
 @Composable
 internal fun OriginDestination(
     origin: StopDisplay,
@@ -52,86 +62,92 @@ internal fun OriginDestination(
     onDestinationClick: ((StopDisplay) -> Unit)? = null,
 ) {
     val dim = KrailTheme.dimensions
+    val cardShape = CardShape
+
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = dim.spacingXL),
+            .dropShadow(
+                shape = cardShape,
+                shadow = Shadow(
+                    radius = SHADOW_RADIUS,
+                    color = themeBackgroundColor(),
+                    spread = SHADOW_SPREAD,
+                    alpha = SHADOW_ALPHA,
+                ),
+            )
+            .clip(cardShape)
+            .border(
+                width = dim.strokeThin,
+                color = themeBackgroundColor(),
+                shape = cardShape,
+            )
+            .background(color = KrailTheme.colors.surface, shape = cardShape),
     ) {
-        Row(
-            modifier = Modifier.fillMaxWidth()
-                .timeLineTop(
-                    color = timeLineColor,
-                    strokeWidth = dim.strokeMedium,
-                    circleRadius = TIMELINE_CIRCLE_RADIUS,
-                ),
-        ) {
-            StopColumn(
-                display = origin,
-                timeLineColor = timeLineColor,
-                onClick = onOriginClick,
-                animationLabel = "originStopName",
-                modifier = Modifier
-                    .padding(start = 16.dp)
-                    .fillMaxWidth(),
-            )
-        }
-
-        Spacer(
-            modifier = Modifier.fillMaxWidth()
-                .height(12.dp)
-                .timeLineCenter(color = timeLineColor, strokeWidth = 3.dp),
+        StopRow(
+            display = origin,
+            isOrigin = true,
+            timeLineColor = timeLineColor,
+            onClick = onOriginClick,
         )
-
-        Row(
-            modifier = Modifier.fillMaxWidth()
-                .timeLineBottom(
-                    color = timeLineColor,
-                    strokeWidth = 3.dp,
-                    circleRadius = 5.dp,
-                ),
-        ) {
-            StopColumn(
-                display = destination,
-                timeLineColor = timeLineColor,
-                onClick = onDestinationClick,
-                animationLabel = "destinationStopName",
-                modifier = Modifier
-                    .padding(start = 16.dp)
-                    .fillMaxWidth(),
-            )
-        }
+        Divider(modifier = Modifier.padding(start = dim.spacingXL, end = dim.spacingM))
+        StopRow(
+            display = destination,
+            isOrigin = false,
+            timeLineColor = timeLineColor,
+            onClick = onDestinationClick,
+        )
     }
 }
 
 @Composable
-private fun StopColumn(
+private fun StopRow(
     display: StopDisplay,
+    isOrigin: Boolean,
     timeLineColor: Color,
     onClick: ((StopDisplay) -> Unit)?,
-    animationLabel: String,
     modifier: Modifier = Modifier,
 ) {
-    val labelled = display.label != null
-    val primaryText = display.label ?: display.name
-    val primaryStyle = if (labelled) {
-        KrailTheme.typography.headlineSmall.copy(fontWeight = FontWeight.SemiBold)
-    } else {
-        KrailTheme.typography.titleLarge
-    }
-    // When clickable, give the touch target some breathing room and round its
-    // corners so the ripple reads as a tappable affordance rather than bleeding
-    // into adjacent content. Non-clickable surfaces (TrackTrip, intro) keep
-    // today's exact layout — no clip, no padding.
+    val dim = KrailTheme.dimensions
     val clickModifier = onClick?.let { handler ->
-        Modifier
-            .clip(RoundedCornerShape(CLICKABLE_CORNER_RADIUS))
-            .klickable { handler(display) }
-            .padding(vertical = CLICKABLE_VERTICAL_PADDING)
+        Modifier.klickable { handler(display) }
     } ?: Modifier
+    val displayText = if (display.label != null) {
+        "${display.label} (${display.name})"
+    } else {
+        display.name
+    }
 
-    Column(modifier = modifier.then(clickModifier)) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(clickModifier)
+            .padding(horizontal = dim.spacingXL, vertical = STOP_ROW_VERTICAL_PADDING),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
+    ) {
+        Box(
+            modifier = Modifier.size(dim.iconSmall),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (isOrigin) {
+                Box(
+                    modifier = Modifier
+                        .size(ORIGIN_CIRCLE_SIZE)
+                        .background(timeLineColor, CircleShape),
+                )
+            } else {
+                Image(
+                    painter = painterResource(Res.drawable.ic_location_on),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(timeLineColor),
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+        }
+
         AnimatedContent(
-            targetState = primaryText,
+            targetState = displayText,
             transitionSpec = {
                 (
                     fadeIn(animationSpec = tween(200)) +
@@ -148,22 +164,56 @@ private fun StopColumn(
                     )
             },
             contentAlignment = Alignment.CenterStart,
-            label = animationLabel,
+            label = if (isOrigin) "originStopName" else "destinationStopName",
         ) { targetText ->
             Text(
                 text = targetText,
-                color = timeLineColor,
-                style = primaryStyle,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-        if (labelled) {
-            Text(
-                text = display.name,
-                color = timeLineColor.copy(alpha = LABELLED_NAME_CAPTION_ALPHA),
-                style = KrailTheme.typography.bodyMedium,
-                modifier = Modifier.padding(top = 2.dp, bottom = 4.dp),
+                style = KrailTheme.typography.titleMedium,
+                color = KrailTheme.colors.onSurface,
             )
         }
     }
 }
+
+// region Previews
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewOriginDestination_Unlabelled() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        OriginDestination(
+            origin = StopDisplay(stopId = "1", name = "Central Station"),
+            destination = StopDisplay(stopId = "2", name = "Town Hall Station"),
+            timeLineColor = themeColor(),
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewOriginDestination_BothLabelled() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
+        OriginDestination(
+            origin = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
+            destination = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
+            timeLineColor = themeColor(),
+        )
+    }
+}
+
+@ScreenshotTest
+@Preview(name = "Origin labelled only — Ferry")
+@Composable
+private fun PreviewOriginDestination_OriginLabelledOnly() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Ferry) {
+        OriginDestination(
+            origin = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
+            destination = StopDisplay(stopId = "2", name = "Circular Quay Wharf"),
+            timeLineColor = themeColor(),
+        )
+    }
+}
+
+// endregion

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
@@ -42,7 +42,7 @@ import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.OriginDestination
-import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
 @Composable
 fun IntroContentSaveTrips(
@@ -57,7 +57,8 @@ fun IntroContentSaveTrips(
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             OriginDestination(
-                trip = trip,
+                origin = demoOrigin,
+                destination = demoDestination,
                 timeLineColor = KrailTheme.colors.onSurface,
             )
 
@@ -141,9 +142,5 @@ fun IntroContentSaveTrips(
     }
 }
 
-private val trip = Trip(
-    fromStopName = "Wynyard Station",
-    toStopName = "Central Station",
-    fromStopId = "1",
-    toStopId = "2",
-)
+private val demoOrigin = StopDisplay(stopId = "1", name = "Wynyard Station")
+private val demoDestination = StopDisplay(stopId = "2", name = "Central Station")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -54,11 +55,13 @@ import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_star
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
+import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.TransportModeSortOrder
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
+import xyz.ksharma.krail.departures.ui.DeparturesViewModel
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.AnimatedDots
 import xyz.ksharma.krail.taj.components.Button
@@ -74,6 +77,7 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.ActionData
+import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardStopCard
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCard
 import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
@@ -380,15 +384,28 @@ fun TimeTableScreen(
 
         selectedStop?.let { stop ->
             // Stop-details sheet — opened by tapping a stop in the timetable
-            // header. transportModes is left empty for v1; the shared sheet
-            // gracefully hides the section when the list is empty. Future
-            // iteration can enrich this (see SAVED_TRIPS_NAMING_PLAN.md /
-            // LABEL_DISPLAY_PLAN.md follow-ups).
+            // header. Mirrors the SearchStopMap wrapper's contents minus the
+            // map-only bits (LatLng, parkAndRide indicator, "Select stop"
+            // action button) since this sheet is opened from inside a trip,
+            // not from a search picker. transportModes left empty until we
+            // have a per-stop modes lookup wired in.
+            val departuresViewModel = koinViewModel<DeparturesViewModel>()
+            val departuresState by departuresViewModel.uiState
+                .collectAsStateWithLifecycle()
             StopDetailsBottomSheet(
                 stopId = stop.stopId,
                 stopName = stop.name,
                 transportModes = persistentListOf(),
                 onDismiss = { selectedStop = null },
+                additionalInfo = {
+                    DepartureBoardStopCard(
+                        stopId = stop.stopId,
+                        stopName = stop.name,
+                        state = departuresState,
+                        onEvent = departuresViewModel::onEvent,
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                },
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -80,8 +80,12 @@ import xyz.ksharma.krail.trip.planner.ui.components.JourneyCardState
 import xyz.ksharma.krail.trip.planner.ui.components.OriginDestination
 import xyz.ksharma.krail.trip.planner.ui.components.TransportModeChip
 import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiAnim
+import xyz.ksharma.krail.trip.planner.ui.components.map.StopDetailsBottomSheet
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.fromStopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.toStopDisplay
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
@@ -109,6 +113,9 @@ fun TimeTableScreen(
         mutableStateListOf(*timeTableState.unselectedModes.toTypedArray())
     }
     var isReverseButtonRotated by rememberSaveable { mutableStateOf(false) }
+    // Tracks which stop's details sheet is open. Tap on a stop in the
+    // OriginDestination header sets this; the sheet is dismissed back to null.
+    var selectedStop by remember { mutableStateOf<StopDisplay?>(null) }
 
     Column(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
@@ -190,8 +197,11 @@ fun TimeTableScreen(
             item(key = "Origin-Destination") {
                 timeTableState.trip?.let { trip ->
                     OriginDestination(
-                        trip = trip,
+                        origin = trip.fromStopDisplay(timeTableState.stopLabels),
+                        destination = trip.toStopDisplay(timeTableState.stopLabels),
                         timeLineColor = KrailTheme.colors.onSurface,
+                        onOriginClick = { display -> selectedStop = display },
+                        onDestinationClick = { display -> selectedStop = display },
                         modifier = Modifier.fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp)
                             .background(color = KrailTheme.colors.surface),
@@ -366,6 +376,20 @@ fun TimeTableScreen(
                     modifier = Modifier.height(96.dp).systemBarsPadding(),
                 )
             }
+        }
+
+        selectedStop?.let { stop ->
+            // Stop-details sheet — opened by tapping a stop in the timetable
+            // header. transportModes is left empty for v1; the shared sheet
+            // gracefully hides the section when the list is empty. Future
+            // iteration can enrich this (see SAVED_TRIPS_NAMING_PLAN.md /
+            // LABEL_DISPLAY_PLAN.md follow-ups).
+            StopDetailsBottomSheet(
+                stopId = stop.stopId,
+                stopName = stop.name,
+                transportModes = persistentListOf(),
+                onDismiss = { selectedStop = null },
+            )
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -41,6 +42,7 @@ import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 import xyz.ksharma.krail.core.share.ShareManager
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.feature.track.TripDeepLinkEncoder
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
@@ -51,6 +53,7 @@ import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
@@ -181,6 +184,14 @@ class TimeTableViewModel(
             .asBoolean(fallback = false)
     }
 
+    init {
+        // Single VM-lifetime observer so DB updates always reach the UI even if
+        // the screen briefly unsubscribes across config changes. Mirrors
+        // SearchStopViewModel's pattern; we deliberately skip the seed-on-empty
+        // branch since SearchStopViewModel owns label seeding.
+        observeStopLabels()
+    }
+
     /**
      * Get raw journey data by ID for map visualization.
      */
@@ -270,6 +281,24 @@ class TimeTableViewModel(
             TimeTableUiEvent.LoadMoreTrips -> onLoadMoreTrips()
 
             TimeTableUiEvent.LoadPreviousTrips -> onLoadPreviousTrips()
+        }
+    }
+
+    private fun observeStopLabels() {
+        viewModelScope.launchWithExceptionHandler<TimeTableViewModel>(ioDispatcher) {
+            sandook.observeStopLabels()
+                .distinctUntilChanged()
+                .collectLatest { rows ->
+                    val labels = rows.map { row ->
+                        StopLabel(
+                            emoji = row.emoji,
+                            label = row.label,
+                            stopId = row.stop_id,
+                            stopName = row.stop_name,
+                        )
+                    }.toImmutableList()
+                    updateUiState { copy(stopLabels = labels) }
+                }
         }
     }
 
@@ -433,6 +462,7 @@ class TimeTableViewModel(
         pruneStaleLoadMoreEntries()
     }
 
+    @OptIn(ExperimentalTime::class)
     @VisibleForTesting
     fun pruneStaleLoadMoreEntries() {
         val latestFreshInstant = journeys.values

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -99,7 +99,7 @@ import xyz.ksharma.krail.trip.planner.ui.journeymap.JourneyMap
 import xyz.ksharma.krail.trip.planner.ui.journeymap.LiveVehicleLayer
 import xyz.ksharma.krail.trip.planner.ui.journeymap.business.TrackedJourneyMapMapper.toJourneyMapState
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
-import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 import xyz.ksharma.krail.trip.planner.ui.timetable.ActionButton
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -275,12 +275,8 @@ private fun PromptContent(
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         OriginDestination(
-            trip = Trip(
-                fromStopId = deepLink.fromStopId,
-                fromStopName = deepLink.fromStopName,
-                toStopId = deepLink.toStopId,
-                toStopName = deepLink.toStopName,
-            ),
+            origin = StopDisplay(stopId = deepLink.fromStopId, name = deepLink.fromStopName),
+            destination = StopDisplay(stopId = deepLink.toStopId, name = deepLink.toStopName),
             timeLineColor = KrailTheme.colors.onSurface,
             modifier = Modifier
                 .fillMaxWidth()
@@ -315,12 +311,8 @@ private fun LoadingContent(
     Column(modifier = modifier.fillMaxSize()) {
         deepLink?.let { dl ->
             OriginDestination(
-                trip = Trip(
-                    fromStopId = dl.fromStopId,
-                    fromStopName = dl.fromStopName,
-                    toStopId = dl.toStopId,
-                    toStopName = dl.toStopName,
-                ),
+                origin = StopDisplay(stopId = dl.fromStopId, name = dl.fromStopName),
+                destination = StopDisplay(stopId = dl.toStopId, name = dl.toStopName),
                 timeLineColor = KrailTheme.colors.onSurface,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -411,12 +403,8 @@ private fun JourneyContent(
         ) {
             item(key = "origin-destination") {
                 OriginDestination(
-                    trip = Trip(
-                        fromStopId = journey.fromStopId,
-                        fromStopName = journey.fromStopName,
-                        toStopId = journey.toStopId,
-                        toStopName = journey.toStopName,
-                    ),
+                    origin = StopDisplay(stopId = journey.fromStopId, name = journey.fromStopName),
+                    destination = StopDisplay(stopId = journey.toStopId, name = journey.toStopName),
                     timeLineColor = KrailTheme.colors.onSurface,
                     modifier = Modifier
                         .fillMaxWidth()


### PR DESCRIPTION
OriginDestination now takes two StopDisplays instead of a Trip and renders
the user's nickname for a stop as primary text (slightly larger,
SemiBold), with the raw stop name as a smaller muted caption underneath.
Unlabelled stops keep today's single-line treatment so first-time and
unlabelled-stop users see no regression.

Optional click handlers (StopDisplay -> Unit) on each stop's column.
TimeTableScreen wires them to the existing shared StopDetailsBottomSheet
(same sheet shown when tapping a nearby stop on the map), but without
the "Select stop" action button — the user is already inside a trip,
not picking from search.

TrackTripScreen (3 sites) and IntroContentSaveTrips pass unlabelled
StopDisplays and null click handlers; their behaviour is unchanged.

TimeTableState gains a stopLabels: ImmutableList<StopLabel> field, fed
by a single VM-lifetime sandook.observeStopLabels() in TimeTableViewModel
(mirrors SearchStopViewModel; skips the seed-on-empty branch since
SearchStopVM owns label seeding).

Stacks on top of karan/stop-display-model — uses the StopDisplay model
+ Trip.fromStopDisplay/toStopDisplay extensions added there.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>