### PR TITLE
fix(search-stop): match UnsetLabelPill border weight to OutlinedButton

### DIFF
--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/components/TrackingCard.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/components/TrackingCard.kt
@@ -4,15 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.feature.track.TrackedJourney
-import xyz.ksharma.krail.taj.components.RoundIconButton
+import xyz.ksharma.krail.taj.components.OutlinedButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.modifier.cardBackground
 import xyz.ksharma.krail.taj.modifier.klickable
@@ -40,16 +37,10 @@ fun TrackingCard(
             Text(text = tracked.deepLink.toStopName, style = KrailTheme.typography.bodyMedium)
         }
 
-        RoundIconButton(
+        OutlinedButton(
             onClick = onStopTracking,
-            color = KrailTheme.colors.onSurface,
-            onClickLabel = "Stop tracking",
         ) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = null,
-                tint = KrailTheme.colors.surface,
-            )
+            Text("Stop")
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopLabelPill.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/StopLabelPill.kt
@@ -71,8 +71,8 @@ internal fun SetLabelPill(
 
 /**
  * Outlined pill shown when a [StopLabel] has no stop assigned. Background stays
- * transparent so the screen's themed gradient shows through; the border uses the
- * dark `stopLabelSurface` token so the outline reads consistently across themes.
+ * transparent so the screen's themed gradient shows through; the border uses
+ * `onSurface` (full opacity) to match the weight of the OutlinedButton "+ Add" chip.
  *
  * Styling is locked inside the pill via composition locals.
  *
@@ -88,7 +88,7 @@ internal fun UnsetLabelPill(
 ) {
     val dim = KrailTheme.dimensions
     val shape = RoundedCornerShape(dim.radiusFull)
-    val borderColor = KrailTheme.colors.stopLabelSurface
+    val borderColor = KrailTheme.colors.onSurface
     val contentColor = KrailTheme.colors.label
 
     CompositionLocalProvider(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -95,7 +95,6 @@ import xyz.ksharma.krail.taj.backgroundColorOf
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Divider
-import xyz.ksharma.krail.taj.components.OutlinedButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
@@ -1313,6 +1312,10 @@ private fun LabelShortcutsRow(
         val key = from.key as? String ?: return@rememberReorderableLazyListState
         onMoveLabel(key, to.index)
     }
+    val pillButtonColors = ButtonDefaults.buttonColors(
+        customContainerColor = KrailTheme.colors.onStopLabelSurface,
+        customContentColor = KrailTheme.colors.stopLabelSurface,
+    )
 
     LazyRow(
         state = lazyListState,
@@ -1431,27 +1434,26 @@ private fun LabelShortcutsRow(
         // the END (not the front) keeps the reorder UX smooth — front-anchored Done
         // shifted layout when items dragged toward index 0, which fought the
         // reorderable library's drop-target calculations.
+        // Both Done and + Add share the same solid pill colors and asymmetric padding
+        // (double start to create visual breathing room from the label pills).
         if (editing) {
             item(key = "trailing-done") {
-                // Done sits next to the always-dark stopLabelSurface pills, so its
-                // container must be light in both modes — monochromeButtonColors flips
-                // to onSurface (dark in light mode), which would blend into the pills.
                 Button(
                     onClick = onDoneEditing,
-                    colors = ButtonDefaults.buttonColors(
-                        customContainerColor = KrailTheme.colors.onStopLabelSurface,
-                        customContentColor = KrailTheme.colors.stopLabelSurface,
-                    ),
+                    colors = pillButtonColors,
                     dimensions = ButtonDefaults.chipButtonSize(),
+                    modifier = Modifier.padding(start = dim.spacingM),
                 ) {
                     Text(text = "Done")
                 }
             }
         } else {
             item(key = "trailing-add") {
-                OutlinedButton(
+                Button(
                     onClick = onAddLabelClick,
+                    colors = pillButtonColors,
                     dimensions = ButtonDefaults.chipButtonSize(),
+                    modifier = Modifier.padding(start = dim.spacingM),
                 ) {
                     Text(text = "+ Add")
                 }


### PR DESCRIPTION
fix(search-stop): match UnsetLabelPill border weight to OutlinedButton

Swap stopLabelSurface (always-dark, invisible in dark mode) for onSurface
(full opacity, theme-aware) so the unset pill outline matches the visual
weight of the solid + Add / OutlinedButton chips beside it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(search-stop): solid + Add / Done buttons with extra leading gap

Replace the outlined + Add chip with a solid button using the same
onStopLabelSurface/stopLabelSurface colours as Done, so both trailing
slots share a consistent pill treatment. Adds an extra spacingM of
leading margin on both buttons to visually separate them from the label
pills.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

fix(track): use krail OutlinedButton in TrackingCard, drop material3 import

Replace androidx.compose.material3.OutlinedButton with the project's
own taj OutlinedButton, and remove unused Icons/Icon/RoundIconButton
imports left over from the icon-to-text-button swap.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>