### PR TITLE
feat(savedtrips): show stop label icon and name in SavedTripCard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,17 @@ implementation(project(":core:log"))
 `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` is active in `settings.gradle.kts`.
 The accessor name mirrors the directory path with dots (`core/log` → `projects.core.log`).
 
+## Preview Annotations
+
+Always use the project's custom preview annotations — never bare `@Preview`.
+
+| Annotation | Use for |
+|---|---|
+| `@PreviewComponent` | Individual components / composables |
+| `@ScreenPreview` | Full screens |
+
+Both are defined in `xyz.ksharma.krail.taj.preview`. They expand to multiple device/theme combinations automatically. Using `@Preview` directly produces a single-config preview and misses dark mode, font scale, etc.
+
 ## Per-feature UX rule docs
 
 Some features have a markdown file capturing their UX invariants and outstanding test

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -22,4 +22,5 @@ data class SavedTripsState(
     val fromStop: StopItem? = null,
     val toStop: StopItem? = null,
     val hasSeenInviteFriendsTile: Boolean = false,
+    val stopLabels: ImmutableList<StopLabel> = persistentListOf(),
 )

--- a/feature/trip-planner/ui/LABEL_DISPLAY_PLAN.md
+++ b/feature/trip-planner/ui/LABEL_DISPLAY_PLAN.md
@@ -1,0 +1,471 @@
+# Stop Labels — Display Across Surfaces
+
+Plan for showing user-labelled stops everywhere a stop name is rendered: timetable header, recents,
+search results, and the search-stop "From" / "To" pill.
+
+> **Sibling doc:** [`SAVED_TRIPS_NAMING_PLAN.md`](SAVED_TRIPS_NAMING_PLAN.md) covers the parallel
+> epic (trip-level naming + ✕-instead-of-star on the saved-trip card). The two epics touch different
+> files and ship independently.
+
+This document is the source of truth before review. UX, UI components, and tech changes each get
+their own section. Decisions and open questions are at the end.
+
+---
+
+## Goals & non-goals
+
+### Goals (current scope)
+
+- A user who has labelled a stop sees that label, not the raw stop name, in: timetable header,
+  recent searches list, search results list, and the search stop row's "From"/"To" pill once a stop
+  is selected.
+- The label resolution is **one pure function**, not duplicated per surface.
+- `OriginDestination` becomes a clean component that takes a display model and is ready to be made
+  click-to-details (timetable only) in a later PR.
+- Park & Ride card and the saved-trip card are **not touched** in this stack.
+
+### Non-goals (current scope)
+
+- Saved-trip card redesign (deferred — see Future epic 1).
+- Reordering saved trips (deferred — see Future epic 2).
+- Trip-level sort (deferred — see "Parked"; only if reorder turns out insufficient).
+- Wiring stop-details bottom sheet to clicks on the timetable header (deferred — separate follow-up
+  PR after this stack).
+
+---
+
+## UX
+
+### Surface matrix
+
+| Surface                                      | Primary                      | Subtitle                             | Click                           |
+|----------------------------------------------|------------------------------|--------------------------------------|---------------------------------|
+| Search row "From" / "To" — stop selected     | label if set, else stop name | (none — tight space)                 | already opens search            |
+| **Recents list — labelled**                  | **stop name**                | **label, small + muted** (with icon) | already selects stop for search |
+| Recents list — unlabelled                    | stop name                    | (none — unchanged)                   | already selects stop for search |
+| Search results — labelled                    | stop name                    | label, small + muted (with icon)     | already selects stop for search |
+| Search results — unlabelled                  | stop name                    | (none — unchanged)                   | already selects stop for search |
+| **Timetable `OriginDestination` — labelled** | **label (with icon)**        | **stop name, small + muted**         | future: open stop-details sheet |
+| Timetable `OriginDestination` — unlabelled   | stop name                    | (none — unchanged)                   | future: open stop-details sheet |
+| TrackTrip's 3× `OriginDestination`           | stop name                    | (none — unchanged)                   | none planned                    |
+| Intro `OriginDestination`                    | stop name (demo data)        | (none — unchanged)                   | none                            |
+| **Saved trip card**                          | **untouched in this stack**  | —                                    | —                               |
+| **Park & Ride card**                         | **untouched**                | —                                    | —                               |
+
+Recents reads honestly: "you searched for Central — by the way you've labelled it Home". Timetable
+reads as routine: "you're going Home, which is Central Station".
+
+### Mockups
+
+#### `OriginDestination` — both stops labelled
+
+```
+●   [home icon]  Home              ← titleLarge, themed timeline color
+│                Central Station   ← bodySmall, alpha 0.7
+│
+●   [work icon]  Work
+                 Town Hall Station
+```
+
+#### `OriginDestination` — only "from" labelled
+
+```
+●   [home icon]  Home
+│                Central Station   ← subtitle
+│
+●   Town Hall Station              ← titleLarge, single line, no subtitle
+```
+
+#### `OriginDestination` — unknown label name (e.g. "Mom's")
+
+Falls back to `ic_location_on`:
+
+```
+●   [location icon]  Mom's
+│                    Bondi Junction
+```
+
+Same fallback `SetLabelPill` and the bottom sheets already use.
+
+#### `OriginDestination` — neither labelled
+
+Identical to today. No regression.
+
+#### Recents list — mixed
+
+```
+🕒  Central Station
+    [home icon] Home              ← small, alpha 0.65, with icon
+🕒  Town Hall Station
+    [work icon] Work
+🕒  Wynyard                        ← unchanged (no label)
+```
+
+#### Search results — mixed
+
+```
+📍  Central Station
+    [home icon] Home              ← small, alpha
+📍  Central Park                   ← unchanged
+📍  Centennial Park                ← unchanged
+```
+
+#### Search row "From" / "To" pills — stop selected
+
+```
+[ Starting from: [home icon] Home ]
+[ Destination:   [work icon] Work ]
+```
+
+No subtitle — tight space, the user just picked the stop, context isn't lost.
+
+### Per-surface rules
+
+- **Subtitle alpha**: `LocalContentColor.current.copy(alpha = 0.7f)` on `OriginDestination`, `0.65f`
+  on recents/search rows. Tweak on-device after first paint.
+- **Subtitle style**: `bodySmall` everywhere it appears.
+- **Icon source**: `stopLabelIcon(label)` (existing helper in `components/StopLabelIcons.kt`), with
+  `ic_location_on` (trip-planner module) as fallback when no match.
+- **Icon tint**: matches the same `LocalContentColor` / themed timeline color the surrounding text
+  uses. Reads as part of the same line, not as a separate pip.
+- **Whitespace / casing**: label text rendered verbatim — we display what the user stored.
+
+### What stays unchanged
+
+- `SetLabelPill` and `UnsetLabelPill` themselves (they already render the label correctly).
+- Park & Ride card.
+- Saved-trip card (deferred; see future epic).
+- All click semantics on existing surfaces (recents, search row, etc.). Only new addition is
+  *optional* click handlers on `OriginDestination`, defaulted to `null` (no-op).
+
+---
+
+## UI / components
+
+### `StopDisplay` — boundary type
+
+The single representation of "a stop, possibly labelled" that crosses VM ↔ UI:
+
+```kotlin
+@Stable
+data class StopDisplay(
+    val stopId: String,
+    val name: String,
+    val label: String? = null,
+)
+```
+
+- Pure data, no UX policy (no `primary`/`secondary` getters).
+- `stopId` carried so future click-to-details handlers can use it.
+- No `emoji` field — drawables are the visual vocabulary; emojis are only used by `StopLabel` itself
+  in the bottom-sheet pickers.
+
+### `OriginDestination` — refactored API
+
+Today:
+`OriginDestination(trip: Trip, timeLineColor: Color, originSubtitle: String?, destinationSubtitle: String?)`.
+
+After:
+
+```kotlin
+@Composable
+internal fun OriginDestination(
+    origin: StopDisplay,
+    destination: StopDisplay,
+    timeLineColor: Color,
+    modifier: Modifier = Modifier,
+    onOriginClick: ((StopDisplay) -> Unit)? = null,       // wired later, timetable only
+    onDestinationClick: ((StopDisplay) -> Unit)? = null,  // wired later, timetable only
+)
+```
+
+- Subtitle is now implicit — when `display.label != null`, label is primary and `display.name` is
+  the subtitle. The two `originSubtitle`/`destinationSubtitle` params disappear.
+- Icon (`stopLabelIcon(label) ?: ic_location_on`) is rendered inline next to the label, tinted with
+  `timeLineColor`.
+- Click handlers default to null. When non-null, that stop's `Column` wraps in `klickable` with a
+  subtle ripple. No visible affordance at rest — matches the "less dramatic" preference.
+- Existing animation behaviour (`AnimatedContent` slide+bounce on stop-name change) is preserved by
+  switching the keyed value from `trip.fromStopName` to `origin.label ?: origin.name` (or the
+  equivalent display string).
+
+### `LabelTextWithIcon` — optional helper, deferred
+
+If recents/search rows and `OriginDestination` end up with nearly-identical "icon + label text"
+rendering, extract a small helper. Until then, render inline. **YAGNI**.
+
+### What to keep dumb
+
+- `StopSearchListItem` keeps its current `stopName: String` (and gains a `labelSubtitle: String?`) —
+  it doesn't need to know about `StopDisplay`. Caller resolves and passes strings + a drawable.
+- Composables under `OriginDestination` (the column with icon + label + subtitle) are inline — no
+  top-level reusable yet.
+
+---
+
+## Tech / code changes
+
+### File layout
+
+New:
+
+-
+`feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/StopDisplay.kt`
+    - `data class StopDisplay`
+    - `fun StopItem.toDisplay(labels: List<StopLabel>): StopDisplay`
+    - `fun Trip.fromDisplay(labels: List<StopLabel>): StopDisplay`
+    - `fun Trip.toDisplay(labels: List<StopLabel>): StopDisplay`
+    - `private fun List<StopLabel>.findLabelFor(stopId): String?`
+- `feature/trip-planner/ui/src/commonTest/.../state/savedtrip/StopDisplayTest.kt`
+
+Modified (across PRs):
+
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../components/OriginDestination.kt` — API
+  refactor, icon + subtitle render.
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../timetable/TimeTableScreen.kt` — pass
+  `StopDisplay`s.
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../tracktrip/TrackTripScreen.kt` — 3 call sites
+  pass unlabelled `StopDisplay`s.
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../intro/IntroContentSaveTrips.kt` — 1 call site
+  passes unlabelled `StopDisplay`s.
+- `feature/trip-planner/state/src/commonMain/.../timetable/TimeTableState.kt` — add
+  `stopLabels: ImmutableList<StopLabel>` (or pre-built `from`/`to` `StopDisplay`s — see "Decision:
+  state shape", below).
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../timetable/TimeTableViewModel.kt` — observe
+  `sandook.observeStopLabels()`, fold into state.
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../components/StopSearchListItem.kt` — add
+  optional `labelSubtitle: String?` and `labelIcon: DrawableResource?`; render second line when
+  present.
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../searchstop/SearchStopScreen.kt` — at the
+  recents/search-results call sites, look up the label per row from `searchStopState.stopLabels` and
+  pass to `StopSearchListItem`.
+- `feature/trip-planner/ui/src/commonMain/kotlin/.../components/SearchStopRow.kt` —
+  `fromStopItem.displayName` and `toStopItem.displayName` swap in. Component gains
+  `labels: List<StopLabel>` param (or pre-built display) — see "Decision: state shape".
+
+Untouched:
+
+- `SavedTripsScreen.kt`, `SavedTripCard.kt`, `ParkRideCard.kt`.
+
+### Resolver — pure function
+
+```kotlin
+fun StopItem.toDisplay(labels: List<StopLabel>): StopDisplay =
+    StopDisplay(
+        stopId = stopId,
+        name = stopName,
+        label = labels.findLabelFor(stopId),
+    )
+
+fun Trip.fromDisplay(labels: List<StopLabel>): StopDisplay =
+    StopDisplay(stopId = fromStopId, name = fromStopName, label = labels.findLabelFor(fromStopId))
+
+fun Trip.toDisplay(labels: List<StopLabel>): StopDisplay =
+    StopDisplay(stopId = toStopId, name = toStopName, label = labels.findLabelFor(toStopId))
+
+private fun List<StopLabel>.findLabelFor(stopId: String): String? =
+    firstOrNull { it.isSet && it.stopId == stopId }?.label
+```
+
+Mirrors the `stopLabelIcon` precedent — stateless, case-sensitive lookup. `isSet` filter is
+essential (a label without a stop assigned is irrelevant).
+
+### State shape — VM produces display models, UI doesn't see labels list
+
+| State                        | Holds today                | After                                                                                                                                                                                                                                   |
+|------------------------------|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `SearchStopState.stopLabels` | `ImmutableList<StopLabel>` | unchanged — that screen *also* renders the labels themselves (pill row), so the list belongs there. UI computes `StopDisplay` at render time from the same list.                                                                        |
+| `TimeTableState`             | Trip data, no labels       | observe `sandook.observeStopLabels()` and either (a) hold a `stopLabels` list and let UI resolve, or (b) pre-compute `from: StopDisplay` and `to: StopDisplay` in state. **(b) is preferred** — UI doesn't see labels, cohesion higher. |
+| `SavedTripsState`            | trips, no labels           | unchanged in this stack.                                                                                                                                                                                                                |
+
+**Decision: state shape — pre-built `StopDisplay`s, not raw labels.**
+
+For screens whose UI does not directly render the labels list, expose pre-built `StopDisplay`s.
+Cleaner separation: VM does the lookup once per emission; UI is purely presentational. Saves rework
+if the resolver later gets more complex (per-stop fallbacks, case-insensitive matching, etc.).
+
+For `SearchStopScreen`, labels are already in state (the screen renders the pill row). Compute
+display models inline at the recents/search-results call sites — no new state field.
+
+### Per-PR breakdown
+
+Stacked on `karan/savedtrips-pill-condition` (current top of stack).
+
+#### PR 1 — `karan/stop-display-model`
+
+- Add `StopDisplay.kt` with the data class + extension resolvers.
+- Add unit tests `StopDisplayTest.kt`.
+- **No call-site changes.** Pure addition.
+- **Estimated**: ~80 LOC.
+
+Tests:
+
+- empty `labels` → returns `StopDisplay(stopId, name, label = null)`
+- label exists but `isSet == false` → label = null
+- label `isSet` and `stopId` matches → label populated
+- multiple labels, one matches → first matching label
+- two labels match same `stopId` (data corruption case) → first wins; document contract
+- whitespace / case in label string → preserved verbatim
+
+#### PR 2 — `karan/origin-destination-display-model`
+
+- Refactor `OriginDestination` to take two `StopDisplay`s, drop the two subtitle params.
+- Inline render of icon + label (when present) + name subtitle (when label set).
+- Add nullable `onOriginClick` / `onDestinationClick` params, defaulted null.
+- Add `stopLabels` observation to `TimeTableViewModel`, expose `from: StopDisplay` /
+  `to: StopDisplay` in `TimeTableState`.
+- Update 5 call sites: timetable (passes labelled displays), 3× TrackTrip (unlabelled), intro (
+  unlabelled).
+- Snapshot tests: `OriginDestination` labelled / unlabelled / mixed.
+- **Estimated**: ~150 LOC.
+
+#### PR 3 — `karan/recents-and-search-labels`
+
+- `StopSearchListItem`: add optional `labelSubtitle: String?` + `labelIcon: DrawableResource?`
+  params. When both provided, render a small second line below the stop name with icon + label,
+  alpha 0.65.
+- `SearchStopScreen` recents call site (~`:1261`) and results call site (~`:1147`): look up label
+  per row from `searchStopState.stopLabels`, pass icon + subtitle.
+- `SearchStopRow` already-selected From/To: swap display string from `stopName` to label-or-name. (
+  No subtitle here.)
+- Snapshot tests: `StopSearchListItem` labelled / unlabelled.
+- **Estimated**: ~80 LOC.
+
+### Testing strategy
+
+- **Unit (state module)**: `StopDisplayTest` — exhaustive table of label / no-label / multi-match /
+  `isSet=false` cases. Pure functions, fast, no Compose.
+- **Behavioural (VM)**: extend `TimeTableViewModelTest` to assert that an emitted `StopLabel`
+  matching the trip's `fromStopId` is reflected in `state.from.label`. We don't unit-test the
+  resolver from the VM — that has its own tests.
+- **Snapshot (Roborazzi)**: extend `TripPlannerUiSnapshotTest` with new variants for
+  `OriginDestination` (labelled / mixed / unlabelled) and `StopSearchListItem` (labelled /
+  unlabelled). Existing variants unchanged stay green.
+
+---
+
+## Future epics
+
+These are NOT in the current 3-PR stack. Sketches only — flesh out in follow-up plans.
+
+### Future epic 1 — Trip labels
+
+Saved-trip cards aren't well-served by stop labels: a routine's identity is its *purpose* ("Morning
+Commute"), not its *places* ("Home → Work"). Two Home→Work variants should be distinguishable; stop
+labels alone can't.
+
+#### UX
+
+- Each saved trip can have an optional `name: String?` ("Morning Commute", "Gym Run", "Saturday
+  Coffee").
+- Saved-trip card primary becomes the trip name when set; otherwise today's stop-name treatment.
+- Subtitle (small, alpha): `From → To` stop names. If both stops are also labelled, subtitle uses
+  stop labels (`🏠 Home → 💼 Work`); composes cleanly with the stop-label feature.
+- Edit affordance: pencil icon on the card → bottom sheet to enter name. Sheet mirrors the
+  stop-label suggestion sheet — pre-canned chips (Morning Commute, Gym Run, etc.) plus a free-text
+  field.
+- **Suggestions based on context**: when the user saves a new trip, default suggestions consider
+  time-of-day + day-of-week. Mon-Fri 8am → "Morning Commute". Sat morning → "Saturday Coffee". User
+  can override or pick free text.
+
+#### UI
+
+- New: `EditTripNameSheet.kt` — mirrors `AddLabelBottomSheet` shape (suggestions chips + name
+  field + save).
+- `SavedTripCard.kt` gains a primary-line slot (trip name when set) and the subtitle treatment.
+- Pencil icon inline on the card or in a long-press menu — TBD.
+
+#### Tech
+
+- Migration: add `name: String?` to the Trip table. Existing trips have null name → render today's
+  UX (no regression).
+- ViewModel: trip-name edits flow through `SavedTripUiEvent.RenameTrip(tripId, name)` →
+  `sandook.updateTripName(...)`.
+- No interaction with the stop-label feature at the VM layer — entirely separate data.
+
+### Future epic 2 — Reorder saved trips
+
+Same long-press-then-drag pattern as label pills on `SearchStopScreen`. Same reorderable library.
+
+#### UX
+
+- Long-press a saved-trip card → enters reorder mode (cards wiggle, optional ✕ if we want
+  delete-while-reordering, otherwise just drag handle).
+- Drag to reorder.
+- Persists `position: Int` per trip.
+- Should land **after** trip labels — reordering identical-looking "Home → Work" cards is hard;
+  named cards are draggable-friendly.
+
+#### UI
+
+- Reuse the existing reorderable LazyColumn pattern from `SearchStopScreen`. The pill version proved
+  the gestures.
+
+#### Tech
+
+- DB migration: add `position: Int` column to the trip table.
+- `MoveSavedTripToIndex` event. Sandook update: write new positions.
+- UI: `LongPressDraggableHandle` on each card.
+
+### Parked
+
+- **Sort menu**. Only if reorder turns out insufficient (e.g. users grow many trips and manual
+  ordering gets tedious). Implicit options: alphabetical by trip name, last-used, manual (=
+  reorder). Tiny menu in the trailing icon slot of the saved-trips title row. Wait for signal before
+  building.
+- **Stop-details sheet**. Only on timetable's `OriginDestination`. Wires the `onOriginClick` /
+  `onDestinationClick` hooks added in PR 2 to a new `StopDetailsSheet`. Independent PR after the
+  stop-label stack lands.
+
+---
+
+## Decisions log
+
+- **VM produces display models, not raw labels list.** Cohesion: VM owns "look up label for this
+  stop"; UI owns "render this `StopDisplay`". One screen exception (`SearchStopState`) keeps
+  `stopLabels` because it *renders* the labels themselves.
+- **`StopDisplay` is pure data — no `primary` / `secondary` getters.** Recents wants name primary,
+  label subtitle. Timetable wants the inverse. Encoding either policy on the model breaks the other
+  call site.
+- **No `LabelledStopText` shared composable.** Each surface composes inline. Extract only when a
+  second surface needs an identical layout (YAGNI).
+- **No `emoji` field on `StopDisplay`.** Drawables (`stopLabelIcon`) are the visual vocabulary; the
+  emoji on `StopLabel` is only used by the bottom-sheet pickers.
+- **`OriginDestination` API takes two `StopDisplay`s, not `Trip`.** Cleaner cap on the component's
+  domain dependencies and unblocks the future click-to-details wiring.
+- **Click affordance on `OriginDestination` is invisible at rest.** No icon, no border, no chevron
+  until usage shows it's needed.
+- **Saved-trip card untouched in this stack.** Trip labels are the right tool for that surface;
+  stop-label rendering would be throwaway work if shipped first.
+- **Park & Ride card untouched.** Out of scope.
+- **Click-to-details only on timetable's `OriginDestination`.** TrackTrip and intro pass null; same
+  component, different opt-in per call site.
+- **No filter button.** Saved trips lists are small (3-8 typical, ~15 power user); filter UI is
+  overhead at that scale. Reorder + trip names give the user enough organisation. Out of scope,
+  not "parked".
+
+---
+
+## Open questions
+
+1. **`SearchStopRow` in selected state — does it need the icon next to the label?** Tight space;
+   current sketch shows `[home icon] Home`. If the icon hurts readability inside the pill, drop it
+   and show label text only.
+2. **Subtitle alpha — `0.65f` (recents) vs `0.7f` (`OriginDestination`).** Pick one or keep them
+   surface-tuned? Eyeballing on-device after PR 2 will decide.
+3. **`SavedTripsViewModel` change later for trip labels.** Worth preparing the `Trip` row migration
+   in advance, or wait until the trip-labels epic starts?
+4. **Reorder + click-to-details on the timetable header.** If both eventually land, which gesture
+   goes where? Reorder is unlikely on the timetable header (it's two specific stops, not a list), so
+   probably no conflict. Flagging in case the rule changes.
+5. **Where does `LabelTextWithIcon` (if it ever exists) live — `taj` or feature `components/`?**
+   Default: feature first; promote to taj only when a second feature wants it.
+
+---
+
+## TODO / future work
+
+- After PR 1-3 land, schedule a follow-up to wire stop-details bottom sheet from timetable's
+  `OriginDestination` clicks.
+- Trip-labels epic plan (`TRIP_LABELS_PLAN.md`) once we're ready to start it.
+- Reorder-saved-trips PR (sibling to trip labels).

--- a/feature/trip-planner/ui/SAVED_TRIPS_NAMING_PLAN.md
+++ b/feature/trip-planner/ui/SAVED_TRIPS_NAMING_PLAN.md
@@ -1,0 +1,461 @@
+# Saved Trips — Naming & Unfavourite UX
+
+Design proposal for two related changes on the saved-trip card:
+
+1. **Trip naming** — let users give each saved trip a name ("Morning Commute", "Gym Run") so
+   routines are identifiable beyond their stop pair.
+2. **Unfavourite UX** — replace the easy-to-mistap star with a more deliberate gesture, since
+   accidental tap currently removes the trip from favourites.
+
+> **Sibling doc:** [`LABEL_DISPLAY_PLAN.md`](LABEL_DISPLAY_PLAN.md) covers the parallel epic (
+> stop-level labels showing across timetable, recents, search). The two epics touch different files
+> and ship independently — they can develop in parallel.
+
+---
+
+## Problem
+
+Two real, related complaints:
+
+- **"Home → Work" doesn't scale.** Multiple Home→Work variants (different times, different changes)
+  all render identically. Users can't tell which card is which without tapping in.
+- **Mistap on the star.** Star is the only unfavourite affordance. It's small, lives in the corner
+  of every card, and a passing tap removes the trip — the user often doesn't even notice. Recovery
+  requires re-saving from scratch.
+
+These problems share an opportunity: a more visible "this is *my* trip — Morning Commute" affordance
+can also be the deliberate destructive-action target. One UI element, two jobs.
+
+## Goals
+
+- Each saved trip can carry an optional **name** (free text, with suggested templates).
+- Every card surfaces a clear, deliberate way to **remove the trip from saved**, distinct from
+  accidental taps.
+- Card UX stays composable with the stop-label feature already in flight (so a card can show a trip
+  name + still benefit from `🏠 Home → 💼 Work` as a subtitle).
+- Card layout degrades gracefully when no name is set — no regression for users who never engage
+  with naming.
+
+## Non-goals (this epic)
+
+- Reorder of saved trips (separate sibling epic, lands after this).
+- Trip-name search/filter (out of scope per `LABEL_DISPLAY_PLAN.md` — list is small).
+- Per-stop click → details sheet (different surface, separate PR after the stop-label stack).
+
+---
+
+## Approach A — Inline name pill (preferred)
+
+Each card grows a small pill at the top. Mirrors the stop-label pill vocabulary already shipped on
+`SearchStopScreen`.
+
+### Mockups
+
+**Unnamed (rest mode):**
+
+```
+┌────────────────────────────────────────────┐
+│  🚆     ╭──────────────────────╮           │
+│         │ + Name this trip      │           │
+│         ╰──────────────────────╯           │
+│                                            │
+│  Central Station                           │
+│        ↓                                   │
+│  Town Hall Station                         │
+│  [Park & Ride row — UNCHANGED]             │
+└────────────────────────────────────────────┘
+```
+
+- Placeholder pill is `OutlinedButton`-style (matches `+ Add` on the search-stop pill row):
+  low-emphasis, low-contrast text.
+- **No ✕ in rest mode.** The card has no visible destructive affordance — that lives behind a
+  long-press gesture (see Edit mode below).
+
+**Named (rest mode):**
+
+```
+┌────────────────────────────────────────────┐
+│  🚆     ╭──────────────────────╮           │
+│         │ Morning Commute       │           │
+│         ╰──────────────────────╯           │
+│                                            │
+│  Central Station                           │
+│        ↓                                   │
+│  Town Hall Station                         │
+│  [Park & Ride row]                         │
+└────────────────────────────────────────────┘
+```
+
+- Pill is filled (themed dark surface, like `SetLabelPill`). Reuses the same component family, same
+  colour vocabulary.
+- Tap pill body → swaps in-place to inline `TextField` (see "Editing", below).
+
+**Edit mode (entered via long-press on any saved-trip card):**
+
+```
+┌────────────────────────────────────────────┐
+│  🚆     ╭──────────────────────╮       ✕  │  ← ✕ overlay appears
+│         │ Morning Commute       │  (wiggling)│
+│         ╰──────────────────────╯           │
+│                                            │
+│  Central Station                           │
+│  ...                                       │
+└────────────────────────────────────────────┘
+```
+
+- Long-press *anywhere on the card body* enters edit mode for **the whole list** (every card
+  wiggles, every card shows ✕ at top-right).
+- Tap ✕ → unfavourites that trip immediately. **No snackbar, no confirmation** — the long-press was
+  the deliberate gesture, and ✕ is invisible at rest, so accidental removal is structurally
+  impossible.
+- Drag a card while in edit mode → reorder (lands later as a sibling epic; the gesture is reserved
+  here).
+- A `Done` affordance exits edit mode. Same pattern as `SearchStopScreen`'s label-pill edit mode.
+  Placement TBD — see open questions.
+
+This is the same idiom shipped in PR #1527 / #1528 for label-pill editing. Reuse the gesture model
+and the wiggle animation directly.
+
+**Editing (inline — tap the pill body):**
+
+```
+┌────────────────────────────────────────────┐
+│  🚆     ╭──────────────────────╮       ✕  │
+│         │ Morning Commute│      │           │  ← TextField focused, IME up
+│         ╰──────────────────────╯           │
+│  ...                                       │
+└────────────────────────────────────────────┘
+```
+
+The pill body swaps in-place to a `BasicTextField` with the existing name pre-filled (or empty when
+starting from the placeholder). IME action `Done` saves and the pill returns to its read-only state.
+Tapping outside the pill (anywhere on the screen, including elsewhere on the card) commits the
+current value and dismisses the keyboard.
+
+### Interaction model
+
+**Rest mode:**
+
+| User action                                 | Result                                                                                |
+|---------------------------------------------|---------------------------------------------------------------------------------------|
+| Tap unnamed pill (`+ Name this trip`)       | Pill swaps to inline `TextField` with focus + IME up                                  |
+| Tap named pill                              | Pill swaps to inline `TextField` pre-filled with current name                         |
+| IME `Done` while editing                    | Commits current text; non-empty saves the name, empty clears it (back to placeholder) |
+| Tap anywhere outside the pill while editing | Same commit-and-dismiss as IME `Done`                                                 |
+| Tap card body (outside pill, not editing)   | Opens timetable for the trip (today's behaviour, unchanged)                           |
+| Long-press card body                        | Enters **edit mode for the whole saved-trips list**                                   |
+
+**Edit mode (after long-press):**
+
+| User action               | Result                                                                                                        |
+|---------------------------|---------------------------------------------------------------------------------------------------------------|
+| Tap ✕ on any card         | Unfavourites that trip immediately. No snackbar, no confirmation.                                             |
+| Drag a card               | Reserved for future reorder (lands as separate epic).                                                         |
+| Tap card body (outside ✕) | Same as rest mode — opens timetable. (Mirrors the search-stop label pill rule: tap is always primary action.) |
+| Tap pill body             | Same as rest mode — swaps to inline `TextField`. Editing inside edit mode is fine.                            |
+| Tap **Done**              | Exits edit mode.                                                                                              |
+
+### Inline TextField (in place of a bottom sheet)
+
+The pill itself hosts the editing UI — no separate component, no modal:
+
+- **Implementation**: when the pill is tapped, swap its `Text` for the existing `taj.TextField` (
+  using the hoisted-state pattern). The TextField sits inside the same pill shape, so the visual
+  transition is essentially text → text-with-cursor.
+- **Focus & IME**: tap requests focus on the TextField; soft keyboard opens automatically. IME
+  action set to `ImeAction.Done`.
+- **Commit**: IME `Done` or any tap outside the pill commits the current value. Non-empty text →
+  save name. Empty → clear (revert to placeholder).
+- **Cancel**: hardware back button dismisses without saving (text rolls back to the previous
+  committed value).
+- **Validation**: trim whitespace; max 30 chars (fits on the pill); duplicate names across trips are
+  allowed — it's per-trip, not per-stop, and "Morning Commute (slow)" vs "Morning Commute" is the
+  user's call.
+- **Card tap-through guard**: while the TextField has focus, the card body's click handler must be
+  disabled — a stray tap inside the card while editing should not navigate to the timetable.
+  Re-enable on focus loss.
+
+**Suggestions row** — deliberately deferred. Inline `TextField` doesn't have a clean place for
+suggestion chips without growing the card height awkwardly. If users want suggestions, they go in a
+follow-up PR (e.g. as a Gboard-style auto-complete or a small chip row that shows only while
+focused). For v1, the placeholder text (`+ Name this trip`) is the only hint.
+
+### Pros
+
+- **Discoverable**. Every card displays a naming prompt; no hidden gestures.
+- **Consistent vocabulary**. Pills, ✕, long-press edit mode are the language of `SearchStopScreen`.
+  Users who learned stop labels need to learn nothing new here.
+- **Mistap resistance**. ✕ is small and lives where the user has to deliberately reach. Star is
+  gone.
+- **Composes with stop labels**. When stops are also labelled, card subtitle reads
+  `🏠 Home → 💼 Work`. Independent rendering.
+- **Edit mode reuses gestures.** The same long-press → wiggle → ✕ idiom from search-stop label
+  pills.
+
+### Cons
+
+- **Vertical space cost**. Every card grows ~40dp at the top, even when unnamed.
+- **Visual noise on unlabelled cards**. The "+ Name this trip" placeholder shows on every unnamed
+  trip — could feel pushy if user doesn't engage with naming.
+    - Mitigation: very low-contrast placeholder; once dismissed, doesn't re-appear (a
+      `hasSeenNamingPrompt` flag, dismissed by tapping anywhere or by a tiny ✕ on the placeholder
+      itself). Becomes silent until user long-presses the card.
+- **Long-press conflict with future reorder**. Long-press is already overloaded for label pills (
+  enter edit mode) and will be for reorder of saved trips later.
+    - Resolution: long-press *on the name pill* enters name-edit mode; long-press *on the card body*
+      enters reorder mode (drag the whole card). Two distinct gesture targets; same gesture, no
+      overlap because they're on different regions.
+
+### Tech sketch
+
+**Data**:
+
+- Add `name: String?` column to the saved-trips table (Sandook). Migration: existing rows have null.
+- New event: `SavedTripUiEvent.RenameTrip(tripId: String, name: String?)`. Null clears the name.
+- New event: `SavedTripUiEvent.RemoveSavedTrip(tripId: String)` — replaces what star toggle did. (
+  Star is gone from this surface.)
+
+**State**:
+
+- `Trip` data class gains `val name: String? = null`. Add nullable to keep existing call sites
+  compiling.
+- `SavedTripsState` unchanged structurally; existing `savedTrips: ImmutableList<Trip>` carries
+  names.
+
+**UI**:
+
+- `SavedTripCard.kt`: add the name pill at the top, remove the star. Reuse `SetLabelPill` for the
+  named-and-not-editing state, an `OutlinedButton` (chip-sized) for the unnamed placeholder. The
+  editing state is the same pill shape with a `taj.TextField` inside.
+- Card-internal state: `var nameEditing: Boolean` +
+  `val textFieldState = rememberTextFieldState(initialName.orEmpty())`. On focus loss / IME `Done`,
+  fire `RenameTrip(tripId, textFieldState.text.toString().trim().ifBlank { null })`.
+- **Edit mode** (list-level): `SavedTripsScreen` owns `var editing: Boolean`. Long-press on any card
+  toggles it on; tapping the Done affordance toggles it off. While `editing`, every card shows the ✕
+  overlay at top-right and applies the wiggle animation. Tap ✕ fires `RemoveSavedTrip(tripId)`
+  directly — no confirmation sheet, no snackbar (the long-press was the deliberate gesture).
+- Reuse the wiggle animation + ✕ overlay components from `SearchStopScreen` if they're extracted;
+  otherwise, mirror their implementation 1:1 to keep visual parity.
+- **No bottom-sheet component**, **no snackbar host**.
+
+**PRs (estimated):**
+
+1. **`karan/trip-name-data`** — Trip table migration, `name: String?` on Trip, repository
+   `RenameTrip` and `RemoveSavedTrip` methods + events. ~120 LOC.
+2. **`karan/saved-trip-card-naming`** — card UI: name pill with inline `TextField` editing. Star
+   untouched in this PR. ~180 LOC.
+3. **`karan/saved-trips-edit-mode`** — list-level edit mode: long-press to enter, wiggle + ✕
+   overlay, tap ✕ removes, Done exits. Star removed in this PR. ~180 LOC.
+
+Total ~480 LOC. Splitting card-naming and edit-mode into separate PRs because the latter touches
+list-level state and removes the existing star (higher review attention warranted).
+
+---
+
+## Approach B — Long-press menu (alternative)
+
+Card stays close to today; all naming + favourite actions live behind a long-press context menu.
+
+### Mockups
+
+**Card (named or unnamed) — visually almost the same as today:**
+
+```
+┌────────────────────────────────────────────┐
+│  🚆                                    ⭐  │
+│                                            │
+│  Morning Commute                           │  ← when named, header line
+│  Central Station                           │
+│        ↓                                   │
+│  Town Hall Station                         │
+│  [Park & Ride row]                         │
+└────────────────────────────────────────────┘
+```
+
+(When unnamed, header line absent — exactly like today.)
+
+**Long-press → context menu (modal sheet or popover):**
+
+```
+   ╭───────────────────────────╮
+   │ Rename trip               │
+   │ ─────────────────────────  │
+   │ Remove from saved         │
+   ╰───────────────────────────╯
+```
+
+(Reorder will be added here later as a third item.)
+
+### Interaction model
+
+| User action                | Result                                                                |
+|----------------------------|-----------------------------------------------------------------------|
+| Tap card                   | Opens timetable (unchanged)                                           |
+| Tap star                   | Removes from saved + shows undo snackbar (with mitigation; see below) |
+| Long-press card            | Opens context menu sheet                                              |
+| Menu → "Rename trip"       | Opens `EditTripNameSheet`                                             |
+| Menu → "Remove from saved" | Removes + undo snackbar                                               |
+
+### Star mistap mitigation (without removing the star)
+
+Snackbar-based undo is forbidden by the design system (no snackbars rule). Mitigation options:
+
+- **Confirm `ModalBottomSheet`**: tap star → a sheet asks "Remove Morning Commute from
+  saved? [Cancel] [Remove]". Adds friction but prevents mistaps fully. Same pattern as
+  `LabelConflictSheet`.
+- **Two-tap with hint**: first tap shows "Tap again to remove" inline near the star; second tap
+  within 1.5s removes. No modal but extra logic.
+
+### Pros
+
+- **Card layout barely changes**. Today's design stays. Lower risk of regressing the visual.
+- **Long-press menu scales naturally**. Adding "Reorder" later is a one-line addition.
+- **Less visual clutter**. Cards aren't paying for naming UI on every render; only named cards add a
+  header.
+- **Smaller blast radius**. Less code touched.
+
+### Cons
+
+- **Naming is hidden**. New users won't discover the feature unless prompted (onboarding tile, info
+  tile, etc).
+- **Star stays — mistap risk persists**. Mitigated by undo, but undo is a safety net, not a fix.
+  Users who don't read snackbars in time still feel the friction.
+- **Different vocabulary from stop-labels**. Saved-trips uses long-press menu; search-stop uses
+  inline pills + long-press to enter edit mode. Two patterns for "edit a labelled thing".
+- **More taps to name a trip**. Long-press → menu → tap → sheet. Inline placeholder in A is 1-tap.
+
+### Tech sketch
+
+- Same data layer (Trip gains `name: String?`).
+- New: `SavedTripContextMenu.kt` (small modal sheet listing Rename / Remove).
+- `EditTripNameSheet` (bottom sheet for name edit — Approach B does not use inline editing).
+- `SavedTripCard.kt`: add long-press handler that opens the menu; add named-header row.
+- Star handler: wrap existing logic with **confirm `ModalBottomSheet`** OR two-tap detector. (
+  Snackbars not allowed.)
+
+**PRs (estimated):**
+
+1. **`karan/trip-name-data`** — same as A. ~120 LOC.
+2. **`karan/trip-name-edit-sheet`** — bottom-sheet name editor with suggestion chips + ViewModel
+   events. ~180 LOC.
+3. **`karan/saved-trip-card-context-menu`** — long-press menu, named header on card, confirm-sheet
+   for star tap. ~180 LOC.
+
+Total ~480 LOC.
+
+---
+
+## Comparison
+
+| Concern                                | A — Inline pill + edit-mode ✕                         | B — Long-press menu + confirm sheet                           |
+|----------------------------------------|-------------------------------------------------------|---------------------------------------------------------------|
+| Naming discoverability                 | high — visible prompt on every card                   | low — must long-press to find Rename                          |
+| Mistap risk for unfavourite            | **none structurally** — ✕ invisible at rest           | medium — star stays, mitigated only by confirm-sheet friction |
+| Vertical space per card                | +40dp always (the name pill row)                      | +20dp when named only                                         |
+| Visual noise on unnamed cards          | medium (low-contrast placeholder)                     | none                                                          |
+| Visual consistency w/ stop-label pills | high — same edit-mode + ✕ + Done idiom                | low — context menu is a new pattern in the app                |
+| Tap count to name a trip               | 1 tap → type → IME `Done`                             | 2 taps + sheet → save                                         |
+| Tap count to unfavourite               | long-press → 1 tap on ✕ → done                        | 1 tap on star → confirm sheet → confirm                       |
+| Future reorder integration             | folds into existing edit mode (drag inside edit mode) | needs separate "Reorder" menu item or distinct gesture        |
+| Implementation surface area            | medium (~480 LOC, 3 PRs, mostly UI)                   | medium (~480 LOC, 3 PRs, sheet + menu + confirm)              |
+| Risk of visual regression              | medium (card layout reflows)                          | low (card stays close to today)                               |
+| Snackbar dependency                    | none                                                  | none (confirm sheet replaces snackbar)                        |
+
+---
+
+## Recommendation
+
+**Approach A**, with two qualifiers below.
+
+Why A:
+
+1. **The two problems are deeply linked.** The user's report ("easy to mistap star") and ("can't
+   tell my trips apart") share the same root cause: the card has no deliberate identity and no
+   deliberate destructive action. Approach A solves both: the named pill is the identity, the
+   long-press → ✕ pattern is the deliberate destructive action. Mistaps are *structurally*
+   impossible because ✕ is invisible at rest.
+2. **Consistency.** We already ship `SearchStopScreen`'s pill + edit-mode + ✕ idiom for label-pill
+   management. Saved-trip cards adopting the exact same gesture vocabulary keeps the user's mental
+   model intact across the app. Approach B introduces a context menu — a third pattern with no other
+   home in the codebase.
+3. **Discoverability.** Naming trips is a *core* feature of this epic; if users don't find it, the
+   work is wasted. Approach A makes the prompt visible-but-low-contrast — present enough to
+   discover, quiet enough to ignore. Approach B requires content marketing (info tile, intro screen)
+   to be discovered.
+4. **No snackbars needed.** Approach A's edit-mode gating means we never need an undo affordance —
+   accidental removal can't happen, so there's nothing to undo. Approach B sidesteps the snackbar
+   ban with confirm sheets, but that adds friction on every legitimate removal.
+
+Qualifiers:
+
+- The placeholder on unnamed cards must be **genuinely low-contrast** (alpha 0.4–0.5 of `softLabel`)
+  so it doesn't dominate. If user testing shows it still feels pushy, add a per-card "✕ this prompt"
+  affordance that hides the placeholder permanently for that trip (one tap, persisted).
+- Inline `TextField` requires the card-body click handler to be disabled while the field has focus,
+  otherwise a stray tap inside the card during editing would navigate to the timetable. Critical to
+  get right; mirror the keyboard-handling pattern from `AddLabelBottomSheet` (post-fix, hoisted
+  state).
+
+If A turns out wrong (e.g. on-device review reveals the cards feel bloated, or inline editing is
+fiddly), B is a graceful fallback — the data layer is the same, only the UI changes.
+
+---
+
+## Open questions
+
+1. **Where does the `Done` affordance go for exiting edit mode?** Options: (a) replace the screen's
+   title with a "Done" text button while editing; (b) a floating button at the bottom of the
+   screen; (c) an "always-visible" Done button on top-right of the screen header. `SearchStopScreen`
+   puts Done in the trailing slot of the pill row — saved-trips list doesn't have an equivalent.
+   Lean (a) for minimum new chrome, but worth seeing on-device.
+2. **Should the placeholder pill on unnamed cards be dismissable?** A user who never wants to name
+   their trips might find the constant prompt noisy. Two choices: (a) always show — the prompt is
+   the discovery mechanism; (b) per-card "✕ this prompt" persistence. Lean (a) for v1; revisit if
+   feedback says it's pushy.
+3. **Where does the trip name come from on a brand-new save?** Two choices: (a) trip is saved as
+   unnamed, user names later; (b) save flow auto-focuses the inline `TextField` on the new card.
+   Lean (a) — don't shove a keyboard at the user immediately after save.
+4. **Suggestions for trip names** (Approach A). Deferred. Inline TextField doesn't have a clean
+   place for suggestion chips without growing the card height. If we want them later: (a)
+   Gboard-style auto-complete row above the keyboard, (b) a small chip row that appears only while
+   the TextField has focus. Decide when usage shows the need.
+5. **Card-tap-through guard during inline editing.** While the TextField inside the pill has focus,
+   the card-body click handler must be disabled — a stray tap inside the card while editing should
+   not navigate to the timetable. Critical to get right. Plan: gate the `klickable` on
+   `!nameEditing`.
+
+---
+
+## Decisions (locked)
+
+- **Approach A** (inline pill + edit-mode ✕) is the chosen direction.
+- **Named pill at top of saved-trip card.** Reuses `SetLabelPill` visual vocabulary for the
+  read-only state.
+- **Star is removed** from the saved-trip card. Unfavourite happens via edit-mode ✕.
+- **✕ at card top-right is visible only in edit mode**, never at rest. Position: top-right corner of
+  the card.
+- **Inline `TextField` for naming** — no bottom sheet, no separate component. Tap pill → field gains
+  focus → IME up → IME `Done` or outside-tap commits.
+- **Long-press card body** enters list-level **edit mode**: every card wiggles, ✕ appears at
+  top-right of every card. Mirrors `SearchStopScreen` label-pill edit mode.
+- **Tap ✕ in edit mode** → unfavourite immediately. **No confirmation, no snackbar.** The long-press
+  is the deliberate gesture; edit-mode-only ✕ makes mistaps structurally impossible.
+- **Done** affordance exits edit mode (placement TBD — see open question 1).
+- **Reorder gesture lives inside the same edit mode** as a future addition (drag a card while in
+  edit mode). Not in this epic, but the gesture region is reserved.
+- **Tap card body** (outside pill / ✕, in either mode) → opens timetable, unchanged.
+- **No snackbars anywhere in this feature.** Per the taj design system rule.
+- **Stop-label rendering on the saved-trip card is still deferred** — it lands inside the name
+  pill's subtitle if / when we decide to compose the two features. Not in scope for this epic's
+  first PR.
+
+---
+
+## TODO / future work
+
+- Confirm naming sheet copy and suggestion list (esp. day-of-week heuristics).
+- Confirm undo snackbar copy and timeout.
+- Decide: dismissable placeholder (per open question 1)?
+- Add user-research/testing pass after PR 3 merges and before adding reorder.
+- Reorder epic plan (`SAVED_TRIPS_REORDER_PLAN.md`) — sibling document; depends on the data layer
+  this epic establishes.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -79,6 +80,7 @@ fun DepartureBoardStopCard(
     state: DeparturesState,
     onEvent: (DeparturesUiEvent) -> Unit,
     modifier: Modifier = Modifier,
+    iconColor: Color = KrailTheme.colors.onSurface,
     stopName: String = "",
     isExpanded: Boolean? = null,
     onExpandChange: ((Boolean) -> Unit)? = null,
@@ -147,6 +149,7 @@ fun DepartureBoardStopCard(
             expanded = expanded,
             silentLoading = state.silentLoading,
             arrowRotation = arrowRotation,
+            iconColor = iconColor,
             onClick = {
                 val next = !expanded
                 if (onExpandChange != null) {
@@ -197,6 +200,7 @@ private fun CardHeader(
     expanded: Boolean,
     silentLoading: Boolean,
     arrowRotation: Float,
+    iconColor: Color,
     onClick: () -> Unit,
 ) {
     val dim = KrailTheme.dimensions
@@ -227,7 +231,7 @@ private fun CardHeader(
                 Image(
                     painter = painterResource(Res.drawable.ic_arrow_down),
                     contentDescription = if (expanded) "Collapse" else "Expand",
-                    colorFilter = ColorFilter.tint(KrailTheme.colors.softLabel),
+                    colorFilter = ColorFilter.tint(iconColor),
                     modifier = Modifier.size(ArrowIconSize).rotate(arrowRotation),
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.tooling.preview.Preview
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
@@ -28,16 +27,18 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.cardBackground
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
-import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
 @Composable
 fun SavedTripCard(
-    trip: Trip,
+    fromDisplay: StopDisplay,
+    toDisplay: StopDisplay,
     primaryTransportMode: TransportMode?,
     onStarClick: () -> Unit,
     onCardClick: () -> Unit,
@@ -59,12 +60,11 @@ fun SavedTripCard(
         }
 
         Column(
-            modifier = Modifier
-                .weight(1f),
+            modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(dim.cardInternalSpacing),
         ) {
-            Text(text = trip.fromStopName, style = KrailTheme.typography.bodyMedium)
-            Text(text = trip.toStopName, style = KrailTheme.typography.bodyMedium)
+            StopDisplayRow(display = fromDisplay)
+            StopDisplayRow(display = toDisplay)
         }
 
         Box(
@@ -98,19 +98,46 @@ fun SavedTripCard(
     }
 }
 
+@Composable
+private fun StopDisplayRow(
+    display: StopDisplay,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+    val displayText = if (display.label != null) {
+        "${display.label} (${display.name})"
+    } else {
+        display.name
+    }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+    ) {
+        display.label?.let { label ->
+            stopLabelIcon(label)?.let { icon ->
+                Image(
+                    painter = painterResource(icon),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                    modifier = Modifier.size(dim.spacingL),
+                )
+            }
+        }
+        Text(text = displayText, style = KrailTheme.typography.bodyMedium)
+    }
+}
+
 // region Previews
 
-@Preview
+@PreviewComponent
 @Composable
 private fun SavedTripCardPreview() {
     PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
         SavedTripCard(
-            trip = Trip(
-                fromStopId = "1",
-                fromStopName = "Edmondson Park Station",
-                toStopId = "2",
-                toStopName = "Harris Park Station",
-            ),
+            fromDisplay = StopDisplay(stopId = "1", name = "Edmondson Park Station"),
+            toDisplay = StopDisplay(stopId = "2", name = "Harris Park Station"),
             primaryTransportMode = TransportMode.Train,
             onCardClick = {},
             onStarClick = {},
@@ -118,7 +145,21 @@ private fun SavedTripCardPreview() {
     }
 }
 
-@Preview
+@PreviewComponent
+@Composable
+private fun SavedTripCardLabelledPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        SavedTripCard(
+            fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
+            toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
+            primaryTransportMode = TransportMode.Train,
+            onCardClick = {},
+            onStarClick = {},
+        )
+    }
+}
+
+@PreviewComponent
 @Composable
 private fun SavedTripCardListPreview() {
     PreviewTheme {
@@ -128,48 +169,32 @@ private fun SavedTripCardListPreview() {
             verticalArrangement = Arrangement.spacedBy(dim.spacingXL),
         ) {
             SavedTripCard(
-                trip = Trip(
-                    fromStopId = "1",
-                    fromStopName = "Edmondson Park Station",
-                    toStopId = "2",
-                    toStopName = "Harris Park Station",
-                ),
+                fromDisplay = StopDisplay(stopId = "1", name = "Edmondson Park Station"),
+                toDisplay = StopDisplay(stopId = "2", name = "Harris Park Station"),
                 primaryTransportMode = TransportMode.Train,
                 onCardClick = {},
                 onStarClick = {},
             )
 
             SavedTripCard(
-                trip = Trip(
-                    fromStopId = "1",
-                    fromStopName = "Harrington Street, Stand D",
-                    toStopId = "2",
-                    toStopName = "Albert Rd, Stand A",
-                ),
+                fromDisplay = StopDisplay(stopId = "1", name = "Harrington Street, Stand D"),
+                toDisplay = StopDisplay(stopId = "2", name = "Albert Rd, Stand A"),
                 primaryTransportMode = TransportMode.Bus,
                 onCardClick = {},
                 onStarClick = {},
             )
 
             SavedTripCard(
-                trip = Trip(
-                    fromStopId = "1",
-                    fromStopName = "Manly Wharf",
-                    toStopId = "2",
-                    toStopName = "Circular Quay Wharf",
-                ),
+                fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
+                toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf", label = "Work"),
                 primaryTransportMode = TransportMode.Ferry,
                 onCardClick = {},
                 onStarClick = {},
             )
 
             SavedTripCard(
-                trip = Trip(
-                    fromStopId = "1",
-                    fromStopName = "Central Station",
-                    toStopId = "2",
-                    toStopName = "Town Hall Station",
-                ),
+                fromDisplay = StopDisplay(stopId = "1", name = "Central Station"),
+                toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
                 primaryTransportMode = TransportMode.Metro,
                 onCardClick = {},
                 onStarClick = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -58,6 +59,7 @@ fun SavedTripCard(
     } else {
         KrailTheme.colors.onSurface
     }
+    val bothLabelled = fromDisplay.label != null && toDisplay.label != null
 
     Row(
         modifier = modifier
@@ -70,43 +72,108 @@ fun SavedTripCard(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
-        // Stop names
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(dim.spacingL),
-        ) {
-            StopDisplayRow(display = fromDisplay)
-            StopDisplayRow(display = toDisplay)
+        // Stop content — two layouts depending on whether both stops are labelled
+        if (bothLabelled) {
+            BothLabelledContent(
+                fromDisplay = fromDisplay,
+                toDisplay = toDisplay,
+                modifier = Modifier.weight(1f),
+            )
+        } else {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(dim.spacingL),
+            ) {
+                StopDisplayRow(display = fromDisplay)
+                StopDisplayRow(display = toDisplay)
+            }
         }
 
-        // Right side: mode pill (if available) + star
-        Column(
-            horizontalAlignment = Alignment.End,
-            verticalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxHeight(),
+        // Star button
+        Box(
+            modifier = Modifier
+                .size(dim.savedTripIconButtonSize)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClickLabel = "Remove Saved Trip",
+                    role = Role.Button,
+                    onClick = onStarClick,
+                )
+                .semantics(mergeDescendants = true) {},
+            contentAlignment = Alignment.Center,
         ) {
-            // Star button
-            Box(
-                modifier = Modifier
-                    .size(dim.savedTripIconButtonSize)
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClickLabel = "Remove Saved Trip",
-                        role = Role.Button,
-                        onClick = onStarClick,
+            Image(
+                painter = painterResource(Res.drawable.ic_star_filled),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(starColor),
+                modifier = Modifier.size(dim.iconSmall),
+            )
+        }
+    }
+}
+
+/**
+ * Side-by-side two-column layout used when both stops carry a user label.
+ * Labels are the primary text; stop names render as secondary below them.
+ * A thin vertical divider separates the columns.
+ */
+@Composable
+private fun BothLabelledContent(
+    fromDisplay: StopDisplay,
+    toDisplay: StopDisplay,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+    Row(
+        modifier = modifier.height(IntrinsicSize.Min),
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        LabelledStopColumn(display = fromDisplay, modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier
+                .width(dim.strokeThin)
+                .fillMaxHeight()
+                .background(KrailTheme.colors.outlineSubtle),
+        )
+        LabelledStopColumn(display = toDisplay, modifier = Modifier.weight(1f))
+    }
+}
+
+@Composable
+private fun LabelledStopColumn(
+    display: StopDisplay,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
+    ) {
+        Row(
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+        ) {
+            display.label?.let { label ->
+                stopLabelIcon(label)?.let { icon ->
+                    Image(
+                        painter = painterResource(icon),
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                        modifier = Modifier.size(dim.spacingXL),
                     )
-                    .semantics(mergeDescendants = true) {},
-                contentAlignment = Alignment.Center,
-            ) {
-                Image(
-                    painter = painterResource(Res.drawable.ic_star_filled),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(starColor),
-                    modifier = Modifier.size(dim.iconSmall),
+                }
+                Text(
+                    text = label,
+                    style = KrailTheme.typography.titleMedium,
                 )
             }
         }
+        Text(
+            text = display.name,
+            style = KrailTheme.typography.bodyMedium,
+        )
     }
 }
 
@@ -116,7 +183,6 @@ private fun StopDisplayRow(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
@@ -126,6 +192,14 @@ private fun StopDisplayRow(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
             ) {
+                stopLabelIcon(label)?.let { icon ->
+                    Image(
+                        painter = painterResource(icon),
+                        contentDescription = null,
+                        colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                        modifier = Modifier.size(dim.spacingXL),
+                    )
+                }
                 Text(
                     text = label,
                     style = KrailTheme.typography.titleMedium,
@@ -134,7 +208,7 @@ private fun StopDisplayRow(
         }
         Text(
             text = display.name,
-            style =  KrailTheme.typography.bodyMedium,
+            style = KrailTheme.typography.bodyMedium,
         )
     }
 }
@@ -157,7 +231,7 @@ private fun PreviewSavedTripCard_Unlabelled() {
 
 @PreviewComponent
 @Composable
-private fun PreviewSavedTripCard_Labelled() {
+private fun PreviewSavedTripCard_BothLabelled() {
     PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
@@ -171,7 +245,7 @@ private fun PreviewSavedTripCard_Labelled() {
 
 @PreviewComponent
 @Composable
-private fun PreviewSavedTripCard_NoMode() {
+private fun PreviewSavedTripCard_OneLabelled() {
     PreviewTheme(themeStyle = KrailThemeStyle.Ferry) {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
@@ -208,7 +282,7 @@ private fun PreviewSavedTripCardList() {
             )
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
-                toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
+                toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
                 primaryTransportMode = TransportMode.Metro,
                 onCardClick = {},
                 onStarClick = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -1,15 +1,19 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -25,13 +29,14 @@ import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
-import xyz.ksharma.krail.taj.modifier.cardBackground
+import xyz.ksharma.krail.taj.modifier.CardShape
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.isAppInDarkMode
+import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
@@ -45,55 +50,62 @@ fun SavedTripCard(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
+    val cardShape = CardShape
+    val themeColor = themeColor()
+    val modeHexColor = primaryTransportMode?.let { NswTransportConfig.colorFor(it) }
+    val starColor = if (isAppInDarkMode().not()) {
+        modeHexColor?.hexToComposeColor() ?: themeColor
+    } else {
+        KrailTheme.colors.onSurface
+    }
+
     Row(
         modifier = modifier
-            .cardBackground()
+            .fillMaxWidth()
+            .clip(cardShape)
+            .background(color = themeBackgroundColor(), shape = cardShape)
             .klickable(onClick = onCardClick)
-            .padding(vertical = dim.spacingXL, horizontal = dim.spacingXL),
+            .padding(horizontal = dim.spacingXL, vertical = dim.spacingXL)
+            .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
-        primaryTransportMode?.let {
-            TransportModeIcon(
-                transportMode = primaryTransportMode,
-                modifier = Modifier.padding(end = dim.cardInternalSpacing),
-            )
-        }
-
+        // Stop names
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(dim.cardInternalSpacing),
+            verticalArrangement = Arrangement.spacedBy(dim.spacingL),
         ) {
             StopDisplayRow(display = fromDisplay)
             StopDisplayRow(display = toDisplay)
         }
 
-        Box(
-            modifier = Modifier
-                .size(dim.savedTripIconButtonSize)
-                .clip(CircleShape)
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClickLabel = "Remove Saved Trip",
-                    role = Role.Button,
-                    onClick = onStarClick,
-                )
-                .semantics(mergeDescendants = true) {},
-            contentAlignment = Alignment.Center,
+        // Right side: mode pill (if available) + star
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxHeight(),
         ) {
-            Image(
-                painter = painterResource(Res.drawable.ic_star_filled),
-                contentDescription = "Save Trip",
-                colorFilter = ColorFilter.tint(
-                    if (isAppInDarkMode().not()) {
-                        primaryTransportMode?.let { NswTransportConfig.colorFor(it) }
-                            ?.hexToComposeColor()
-                            ?: themeColor()
-                    } else {
-                        KrailTheme.colors.onSurface
-                    },
-                ),
-            )
+            // Star button
+            Box(
+                modifier = Modifier
+                    .size(dim.savedTripIconButtonSize)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClickLabel = "Remove Saved Trip",
+                        role = Role.Button,
+                        onClick = onStarClick,
+                    )
+                    .semantics(mergeDescendants = true) {},
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    painter = painterResource(Res.drawable.ic_star_filled),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(starColor),
+                    modifier = Modifier.size(dim.iconSmall),
+                )
+            }
         }
     }
 }
@@ -104,28 +116,26 @@ private fun StopDisplayRow(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-    val displayText = if (display.label != null) {
-        "${display.label} (${display.name})"
-    } else {
-        display.name
-    }
 
-    Row(
+    Column(
         modifier = modifier,
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
     ) {
         display.label?.let { label ->
-            stopLabelIcon(label)?.let { icon ->
-                Image(
-                    painter = painterResource(icon),
-                    contentDescription = null,
-                    colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                    modifier = Modifier.size(dim.spacingL),
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+            ) {
+                Text(
+                    text = label,
+                    style = KrailTheme.typography.titleMedium,
                 )
             }
         }
-        Text(text = displayText, style = KrailTheme.typography.bodyMedium)
+        Text(
+            text = display.name,
+            style =  KrailTheme.typography.bodyMedium,
+        )
     }
 }
 
@@ -133,11 +143,11 @@ private fun StopDisplayRow(
 
 @PreviewComponent
 @Composable
-private fun SavedTripCardPreview() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
+private fun PreviewSavedTripCard_Unlabelled() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
         SavedTripCard(
-            fromDisplay = StopDisplay(stopId = "1", name = "Edmondson Park Station"),
-            toDisplay = StopDisplay(stopId = "2", name = "Harris Park Station"),
+            fromDisplay = StopDisplay(stopId = "1", name = "Central Station"),
+            toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
             primaryTransportMode = TransportMode.Train,
             onCardClick = {},
             onStarClick = {},
@@ -147,12 +157,12 @@ private fun SavedTripCardPreview() {
 
 @PreviewComponent
 @Composable
-private fun SavedTripCardLabelledPreview() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+private fun PreviewSavedTripCard_Labelled() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
             toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
-            primaryTransportMode = TransportMode.Train,
+            primaryTransportMode = TransportMode.Bus,
             onCardClick = {},
             onStarClick = {},
         )
@@ -161,7 +171,21 @@ private fun SavedTripCardLabelledPreview() {
 
 @PreviewComponent
 @Composable
-private fun SavedTripCardListPreview() {
+private fun PreviewSavedTripCard_NoMode() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Ferry) {
+        SavedTripCard(
+            fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
+            toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf"),
+            primaryTransportMode = null,
+            onCardClick = {},
+            onStarClick = {},
+        )
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun PreviewSavedTripCardList() {
     PreviewTheme {
         val dim = KrailTheme.dimensions
         Column(
@@ -175,15 +199,6 @@ private fun SavedTripCardListPreview() {
                 onCardClick = {},
                 onStarClick = {},
             )
-
-            SavedTripCard(
-                fromDisplay = StopDisplay(stopId = "1", name = "Harrington Street, Stand D"),
-                toDisplay = StopDisplay(stopId = "2", name = "Albert Rd, Stand A"),
-                primaryTransportMode = TransportMode.Bus,
-                onCardClick = {},
-                onStarClick = {},
-            )
-
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
                 toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf", label = "Work"),
@@ -191,10 +206,9 @@ private fun SavedTripCardListPreview() {
                 onCardClick = {},
                 onStarClick = {},
             )
-
             SavedTripCard(
-                fromDisplay = StopDisplay(stopId = "1", name = "Central Station"),
-                toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
+                fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
+                toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
                 primaryTransportMode = TransportMode.Metro,
                 onCardClick = {},
                 onStarClick = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -20,45 +20,34 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.core.transport.TransportMode
-import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.CardShape
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
-import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeBackgroundColor
-import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
 @Composable
 fun SavedTripCard(
     fromDisplay: StopDisplay,
     toDisplay: StopDisplay,
-    primaryTransportMode: TransportMode?,
     onStarClick: () -> Unit,
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
+    favouriteIconColor: Color = KrailTheme.colors.onSurface,
 ) {
     val dim = KrailTheme.dimensions
     val cardShape = CardShape
-    val themeColor = themeColor()
-    val modeHexColor = primaryTransportMode?.let { NswTransportConfig.colorFor(it) }
-    val starColor = if (isAppInDarkMode().not()) {
-        modeHexColor?.hexToComposeColor() ?: themeColor
-    } else {
-        KrailTheme.colors.onSurface
-    }
     val bothLabelled = fromDisplay.label != null && toDisplay.label != null
 
     Row(
@@ -106,7 +95,7 @@ fun SavedTripCard(
             Image(
                 painter = painterResource(Res.drawable.ic_star_filled),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(starColor),
+                colorFilter = ColorFilter.tint(favouriteIconColor),
                 modifier = Modifier.size(dim.iconSmall),
             )
         }
@@ -222,7 +211,6 @@ private fun PreviewSavedTripCard_Unlabelled() {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Central Station"),
             toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
-            primaryTransportMode = TransportMode.Train,
             onCardClick = {},
             onStarClick = {},
         )
@@ -236,7 +224,6 @@ private fun PreviewSavedTripCard_BothLabelled() {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
             toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
-            primaryTransportMode = TransportMode.Bus,
             onCardClick = {},
             onStarClick = {},
         )
@@ -250,7 +237,6 @@ private fun PreviewSavedTripCard_OneLabelled() {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
             toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf"),
-            primaryTransportMode = null,
             onCardClick = {},
             onStarClick = {},
         )
@@ -269,21 +255,18 @@ private fun PreviewSavedTripCardList() {
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Edmondson Park Station"),
                 toDisplay = StopDisplay(stopId = "2", name = "Harris Park Station"),
-                primaryTransportMode = TransportMode.Train,
                 onCardClick = {},
                 onStarClick = {},
             )
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
                 toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf", label = "Work"),
-                primaryTransportMode = TransportMode.Ferry,
                 onCardClick = {},
                 onStarClick = {},
             )
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
                 toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
-                primaryTransportMode = TransportMode.Metro,
                 onCardClick = {},
                 onStarClick = {},
             )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -1,4 +1,4 @@
-@file:Suppress("MagicNumber", "TooManyFunctions")
+@file:Suppress("MagicNumber")
 
 package xyz.ksharma.krail.trip.planner.ui.departureboard
 
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -22,22 +21,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_arrow_down
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
-import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
 import xyz.ksharma.krail.taj.components.AnimatedDots
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.modifier.klickable
-import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.theme.KrailThemeStyle
-import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardBody
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.StopDepartureBoardEntry
@@ -106,10 +98,7 @@ fun LazyListScope.departureBoardAccordionSection(
 
 // ── Header card composable ────────────────────────────────────────────────────
 
-/**
- * The tappable header card for a stop section.
- * Shared by [departureBoardAccordionSection] (lazy use) and [DepartureBoardAccordionSection] (preview use).
- */
+/** Tappable header card for a stop section. */
 @Composable
 internal fun DepartureBoardAccordionSectionHeader(
     entry: StopDepartureBoardEntry,
@@ -203,158 +192,7 @@ private fun DepartureBoardAccordionContent(
     )
 }
 
-// ── Standalone composable (previews only) ────────────────────────────────────
-
-/**
- * Accordion section for a single stop. Uses a plain [Column] layout.
- * Intended for standalone Compose Previews — the production saved trips screen uses
- * [departureBoardAccordionSection] instead for per-item lazy list keys.
- */
-@Composable
-fun DepartureBoardAccordionSection(
-    entry: StopDepartureBoardEntry,
-    isExpanded: Boolean,
-    onExpandChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
-    onLoadPreviousDepartures: (String) -> Unit = {},
-    onRefreshStop: (String) -> Unit = {},
-) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        DepartureBoardAccordionSectionHeader(
-            entry = entry,
-            isExpanded = isExpanded,
-            onExpandChange = onExpandChange,
-        )
-
-        if (isExpanded) {
-            Column(modifier = Modifier.background(KrailTheme.colors.surface)) {
-                DepartureBoardAccordionContent(
-                    stopId = entry.stopId,
-                    state = entry.state,
-                    onLoadPreviousDepartures = onLoadPreviousDepartures,
-                    onRefreshStop = onRefreshStop,
-                )
-            }
-        }
-    }
-}
-
-// ── Previews ──────────────────────────────────────────────────────────────────
-
 private val SECTION_HEADER_BOTTOM_PADDING = 16.dp
 private val ARROW_ICON_SIZE = 18.dp
 private val DOTS_WIDTH = 32.dp
 private val DOTS_HEIGHT = 16.dp
-
-private const val TRANSPORT_MODE_TRAIN = "Train"
-private const val TRANSPORT_MODE_BUS = "Bus"
-
-private val previewTrainDepartures: ImmutableList<StopDeparture> = persistentListOf(
-    StopDeparture(
-        lineNumber = "T1",
-        lineColorCode = "#F99D1C",
-        transportModeName = TRANSPORT_MODE_TRAIN,
-        destinationName = "Liverpool via Strathfield",
-        departureTimeText = "11:30 AM",
-        departureUtcDateTime = "2026-04-08T01:30:00Z",
-        platformText = "Platform 4",
-        isRealTime = true,
-    ),
-    StopDeparture(
-        lineNumber = "T2",
-        lineColorCode = "#0098CD",
-        transportModeName = TRANSPORT_MODE_TRAIN,
-        destinationName = "Bondi Junction",
-        departureTimeText = "11:33 AM",
-        departureUtcDateTime = "2026-04-08T01:33:00Z",
-        platformText = "Platform 7",
-        isRealTime = false,
-    ),
-)
-
-private val previewMixedDepartures: ImmutableList<StopDeparture> = persistentListOf(
-    StopDeparture(
-        lineNumber = "T1",
-        lineColorCode = "#F99D1C",
-        transportModeName = TRANSPORT_MODE_TRAIN,
-        destinationName = "Liverpool via Strathfield",
-        departureTimeText = "11:30 AM",
-        departureUtcDateTime = "2026-04-08T01:30:00Z",
-        platformText = "Platform 4",
-        isRealTime = true,
-    ),
-    StopDeparture(
-        lineNumber = "333",
-        lineColorCode = "#00B5EF",
-        transportModeName = TRANSPORT_MODE_BUS,
-        destinationName = "Parramatta",
-        departureTimeText = "11:35 AM",
-        departureUtcDateTime = "2026-04-08T01:35:00Z",
-        platformText = "Stand A",
-        isRealTime = false,
-    ),
-)
-
-@PreviewComponent
-@Composable
-private fun DepartureBoardStopSectionCollapsedPreview() {
-    PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardAccordionSection(
-            entry = StopDepartureBoardEntry(
-                stopId = "10111010",
-                stopName = "Toongabbie Station",
-                state = DeparturesState(isLoading = false, departures = previewTrainDepartures),
-            ),
-            isExpanded = false,
-            onExpandChange = {},
-        )
-    }
-}
-
-@PreviewComponent
-@Composable
-private fun DepartureBoardStopSectionExpandedTrainPreview() {
-    PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardAccordionSection(
-            entry = StopDepartureBoardEntry(
-                stopId = "10111010",
-                stopName = "Toongabbie Station",
-                state = DeparturesState(isLoading = false, departures = previewTrainDepartures),
-            ),
-            isExpanded = true,
-            onExpandChange = {},
-        )
-    }
-}
-
-@Preview(name = "Expanded — mixed modes")
-@Composable
-private fun DepartureBoardStopSectionMixedPreview() {
-    PreviewTheme(KrailThemeStyle.Bus) {
-        DepartureBoardAccordionSection(
-            entry = StopDepartureBoardEntry(
-                stopId = "10111010",
-                stopName = "Central Station",
-                state = DeparturesState(isLoading = false, departures = previewMixedDepartures),
-            ),
-            isExpanded = true,
-            onExpandChange = {},
-        )
-    }
-}
-
-@Preview(name = "Loading state")
-@Composable
-private fun DepartureBoardStopSectionLoadingPreview() {
-    PreviewTheme(KrailThemeStyle.Train) {
-        DepartureBoardAccordionSection(
-            entry = StopDepartureBoardEntry(
-                stopId = "10111010",
-                stopName = "Toongabbie Station",
-                state = DeparturesState(isLoading = true),
-            ),
-            isExpanded = true,
-            onExpandChange = {},
-        )
-    }
-}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -56,12 +57,14 @@ import xyz.ksharma.krail.trip.planner.ui.state.departureboard.DepartureBoardUiEv
 fun LazyListScope.departureBoardAccordionSection(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
+    iconColor: Color,
     onEvent: (DepartureBoardUiEvent) -> Unit,
 ) {
     stickyHeader(key = "${entry.stopId}_header", contentType = "stop_header") {
         DepartureBoardAccordionSectionHeader(
             entry = entry,
             isExpanded = isExpanded,
+            iconColor = iconColor,
             onExpandChange = { expand ->
                 onEvent(
                     if (expand) {
@@ -111,6 +114,7 @@ fun LazyListScope.departureBoardAccordionSection(
 internal fun DepartureBoardAccordionSectionHeader(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
+    iconColor: Color,
     onExpandChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -164,7 +168,7 @@ internal fun DepartureBoardAccordionSectionHeader(
             Image(
                 painter = painterResource(Res.drawable.ic_arrow_down),
                 contentDescription = if (isExpanded) "Collapse" else "Expand",
-                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                colorFilter = ColorFilter.tint(iconColor),
                 modifier = Modifier.size(ARROW_ICON_SIZE).rotate(arrowRotation),
             )
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -70,6 +70,8 @@ import xyz.ksharma.krail.trip.planner.ui.departureboard.departureBoardAccordionS
 import xyz.ksharma.krail.trip.planner.ui.state.departureboard.DepartureBoardUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.fromStopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.toStopDisplay
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 private const val LAZY_COLUMN_BOTTOM_PADDING = 300
@@ -395,7 +397,8 @@ private fun LazyListScope.savedTripsContent(
     ) { trip ->
         val dim = KrailTheme.dimensions
         SavedTripCard(
-            trip = trip,
+            fromDisplay = trip.fromStopDisplay(savedTripsState.stopLabels),
+            toDisplay = trip.toStopDisplay(savedTripsState.stopLabels),
             onStarClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
             onCardClick = {
                 onSavedTripCardClick(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -60,6 +61,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
@@ -96,6 +98,7 @@ fun SavedTripsScreen(
     onDepartureBoardEvent: (DepartureBoardUiEvent) -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
+    val iconColor = if (isAppInDarkMode().not()) themeColor() else KrailTheme.colors.onSurface
     val emptyStateTip = remember {
         buildList {
             add("Tap ★ on a trip to save it here.")
@@ -259,6 +262,7 @@ fun SavedTripsScreen(
                         savedTripsContent(
                             savedTripsState = savedTripsState,
                             trackedJourney = trackedJourney,
+                            iconColor = iconColor,
                             onEvent = onEvent,
                             onSavedTripCardClick = onSavedTripCardClick,
                             onTrackingCardClick = onTrackingCardClick,
@@ -358,6 +362,7 @@ private fun LazyListScope.infoTiles(
 private fun LazyListScope.savedTripsContent(
     savedTripsState: SavedTripsState,
     trackedJourney: TrackedJourney?,
+    iconColor: Color,
     onEvent: (SavedTripUiEvent) -> Unit,
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     onTrackingCardClick: () -> Unit = {},
@@ -412,9 +417,9 @@ private fun LazyListScope.savedTripsContent(
                     ),
                 )
             },
-            primaryTransportMode = null, // TODO
             modifier = Modifier
                 .padding(horizontal = dim.pageHorizontalPadding),
+            favouriteIconColor = iconColor,
         )
 
         Spacer(modifier = Modifier.height(dim.spacingXL))
@@ -465,6 +470,7 @@ private fun LazyListScope.savedTripsContent(
             departureBoardAccordionSection(
                 entry = entry,
                 isExpanded = expandedDepartureBoardStopId == entry.stopId,
+                iconColor = iconColor,
                 onEvent = onDepartureBoardEvent,
             )
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -277,8 +277,16 @@ class SavedTripsViewModel(
         viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
             sandook.observeStopLabels()
                 .distinctUntilChanged()
-                .collect { labels ->
-                    updateUiState { copy(stopLabels = labels.toImmutableList()) }
+                .collect { rows ->
+                    val labels = rows.map { row ->
+                        StopLabel(
+                            emoji = row.emoji,
+                            label = row.label,
+                            stopId = row.stop_id,
+                            stopName = row.stop_name,
+                        )
+                    }.toImmutableList()
+                    updateUiState { copy(stopLabels = labels) }
                 }
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -118,6 +118,7 @@ class SavedTripsViewModel(
         .onStart {
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.SavedTrips)
             observeSavedTrips()
+            observeStopLabels()
             seedDefaultLabelsIfEmpty()
             observeFacilityDetailsFromDb()
             refreshFacilityDetails()
@@ -269,6 +270,16 @@ class SavedTripsViewModel(
                     }.toImmutableList(),
                 )
             }
+        }
+    }
+
+    private fun observeStopLabels() {
+        viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+            sandook.observeStopLabels()
+                .distinctUntilChanged()
+                .collect { labels ->
+                    updateUiState { copy(stopLabels = labels.toImmutableList()) }
+                }
         }
     }
 


### PR DESCRIPTION
feat(savedtrips): show stop label icon and name in SavedTripCard

- Add stopLabels to SavedTripsState; observe and emit from ViewModel
- Replace trip: Trip with fromDisplay/toDisplay: StopDisplay in
  SavedTripCard — label resolution stays at screen boundary, matching
  the TimeTableScreen pattern
- New StopDisplayRow renders stopLabelIcon + "Label (Stop name)" inline

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

docs(claude): document PreviewComponent/ScreenPreview annotation rule

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

fix(savedtrips): map StopLabels DB rows to StopLabel domain model

observeStopLabels() was passing the SQLDelight-generated StopLabels type
directly into state instead of mapping to the StopLabel domain model.
Aligns with the identical mapping in TimeTableViewModel.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(savedtrips): two-column layout when both stops have labels

Side-by-side LabelledStopColumn layout with a thin vertical divider when
both stops carry a user label, giving the card a richer visual hierarchy.
Single/unlabelled stops keep the existing stacked StopDisplayRow layout.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>