### PR TITLE
feat(departures): match expand arrow color to star — themeColor in light, onSurface in dark

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -48,8 +49,6 @@ import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
-import xyz.ksharma.krail.taj.theme.isAppInDarkMode
-import xyz.ksharma.krail.taj.themeColor
 
 private val ArrowIconSize = 18.dp // no token equivalent
 
@@ -81,6 +80,7 @@ fun DepartureBoardStopCard(
     state: DeparturesState,
     onEvent: (DeparturesUiEvent) -> Unit,
     modifier: Modifier = Modifier,
+    iconColor: Color = KrailTheme.colors.onSurface,
     stopName: String = "",
     isExpanded: Boolean? = null,
     onExpandChange: ((Boolean) -> Unit)? = null,
@@ -149,6 +149,7 @@ fun DepartureBoardStopCard(
             expanded = expanded,
             silentLoading = state.silentLoading,
             arrowRotation = arrowRotation,
+            iconColor = iconColor,
             onClick = {
                 val next = !expanded
                 if (onExpandChange != null) {
@@ -199,10 +200,10 @@ private fun CardHeader(
     expanded: Boolean,
     silentLoading: Boolean,
     arrowRotation: Float,
+    iconColor: Color,
     onClick: () -> Unit,
 ) {
     val dim = KrailTheme.dimensions
-    val arrowColor = if (isAppInDarkMode().not()) themeColor() else KrailTheme.colors.onSurface
     SubtleButton(
         onClick = onClick,
         dimensions = ButtonDefaults.largeButtonSize(),
@@ -230,7 +231,7 @@ private fun CardHeader(
                 Image(
                     painter = painterResource(Res.drawable.ic_arrow_down),
                     contentDescription = if (expanded) "Collapse" else "Expand",
-                    colorFilter = ColorFilter.tint(arrowColor),
+                    colorFilter = ColorFilter.tint(iconColor),
                     modifier = Modifier.size(ArrowIconSize).rotate(arrowRotation),
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardStopCard.kt
@@ -48,6 +48,8 @@ import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
+import xyz.ksharma.krail.taj.themeColor
 
 private val ArrowIconSize = 18.dp // no token equivalent
 
@@ -200,6 +202,7 @@ private fun CardHeader(
     onClick: () -> Unit,
 ) {
     val dim = KrailTheme.dimensions
+    val arrowColor = if (isAppInDarkMode().not()) themeColor() else KrailTheme.colors.onSurface
     SubtleButton(
         onClick = onClick,
         dimensions = ButtonDefaults.largeButtonSize(),
@@ -227,7 +230,7 @@ private fun CardHeader(
                 Image(
                     painter = painterResource(Res.drawable.ic_arrow_down),
                     contentDescription = if (expanded) "Collapse" else "Expand",
-                    colorFilter = ColorFilter.tint(KrailTheme.colors.softLabel),
+                    colorFilter = ColorFilter.tint(arrowColor),
                     modifier = Modifier.size(ArrowIconSize).rotate(arrowRotation),
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -20,45 +20,34 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.core.transport.TransportMode
-import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.CardShape
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
-import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeBackgroundColor
-import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
 @Composable
 fun SavedTripCard(
     fromDisplay: StopDisplay,
     toDisplay: StopDisplay,
-    primaryTransportMode: TransportMode?,
     onStarClick: () -> Unit,
     onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
+    favouriteIconColor: Color = KrailTheme.colors.onSurface,
 ) {
     val dim = KrailTheme.dimensions
     val cardShape = CardShape
-    val themeColor = themeColor()
-    val modeHexColor = primaryTransportMode?.let { NswTransportConfig.colorFor(it) }
-    val starColor = if (isAppInDarkMode().not()) {
-        modeHexColor?.hexToComposeColor() ?: themeColor
-    } else {
-        KrailTheme.colors.onSurface
-    }
     val bothLabelled = fromDisplay.label != null && toDisplay.label != null
 
     Row(
@@ -106,7 +95,7 @@ fun SavedTripCard(
             Image(
                 painter = painterResource(Res.drawable.ic_star_filled),
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(starColor),
+                colorFilter = ColorFilter.tint(favouriteIconColor),
                 modifier = Modifier.size(dim.iconSmall),
             )
         }
@@ -222,7 +211,6 @@ private fun PreviewSavedTripCard_Unlabelled() {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Central Station"),
             toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
-            primaryTransportMode = TransportMode.Train,
             onCardClick = {},
             onStarClick = {},
         )
@@ -236,7 +224,6 @@ private fun PreviewSavedTripCard_BothLabelled() {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
             toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station", label = "Work"),
-            primaryTransportMode = TransportMode.Bus,
             onCardClick = {},
             onStarClick = {},
         )
@@ -250,7 +237,6 @@ private fun PreviewSavedTripCard_OneLabelled() {
         SavedTripCard(
             fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
             toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf"),
-            primaryTransportMode = null,
             onCardClick = {},
             onStarClick = {},
         )
@@ -269,21 +255,18 @@ private fun PreviewSavedTripCardList() {
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Edmondson Park Station"),
                 toDisplay = StopDisplay(stopId = "2", name = "Harris Park Station"),
-                primaryTransportMode = TransportMode.Train,
                 onCardClick = {},
                 onStarClick = {},
             )
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Manly Wharf", label = "Home"),
                 toDisplay = StopDisplay(stopId = "2", name = "Circular Quay Wharf", label = "Work"),
-                primaryTransportMode = TransportMode.Ferry,
                 onCardClick = {},
                 onStarClick = {},
             )
             SavedTripCard(
                 fromDisplay = StopDisplay(stopId = "1", name = "Central Station", label = "Home"),
                 toDisplay = StopDisplay(stopId = "2", name = "Town Hall Station"),
-                primaryTransportMode = TransportMode.Metro,
                 onCardClick = {},
                 onStarClick = {},
             )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -56,12 +57,14 @@ import xyz.ksharma.krail.trip.planner.ui.state.departureboard.DepartureBoardUiEv
 fun LazyListScope.departureBoardAccordionSection(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
+    iconColor: Color,
     onEvent: (DepartureBoardUiEvent) -> Unit,
 ) {
     stickyHeader(key = "${entry.stopId}_header", contentType = "stop_header") {
         DepartureBoardAccordionSectionHeader(
             entry = entry,
             isExpanded = isExpanded,
+            iconColor = iconColor,
             onExpandChange = { expand ->
                 onEvent(
                     if (expand) {
@@ -111,6 +114,7 @@ fun LazyListScope.departureBoardAccordionSection(
 internal fun DepartureBoardAccordionSectionHeader(
     entry: StopDepartureBoardEntry,
     isExpanded: Boolean,
+    iconColor: Color,
     onExpandChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -164,7 +168,7 @@ internal fun DepartureBoardAccordionSectionHeader(
             Image(
                 painter = painterResource(Res.drawable.ic_arrow_down),
                 contentDescription = if (isExpanded) "Collapse" else "Expand",
-                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                colorFilter = ColorFilter.tint(iconColor),
                 modifier = Modifier.size(ARROW_ICON_SIZE).rotate(arrowRotation),
             )
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -60,6 +61,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
@@ -96,6 +98,7 @@ fun SavedTripsScreen(
     onDepartureBoardEvent: (DepartureBoardUiEvent) -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
+    val iconColor = if (isAppInDarkMode().not()) themeColor() else KrailTheme.colors.onSurface
     val emptyStateTip = remember {
         buildList {
             add("Tap ★ on a trip to save it here.")
@@ -259,6 +262,7 @@ fun SavedTripsScreen(
                         savedTripsContent(
                             savedTripsState = savedTripsState,
                             trackedJourney = trackedJourney,
+                            iconColor = iconColor,
                             onEvent = onEvent,
                             onSavedTripCardClick = onSavedTripCardClick,
                             onTrackingCardClick = onTrackingCardClick,
@@ -358,6 +362,7 @@ private fun LazyListScope.infoTiles(
 private fun LazyListScope.savedTripsContent(
     savedTripsState: SavedTripsState,
     trackedJourney: TrackedJourney?,
+    iconColor: Color,
     onEvent: (SavedTripUiEvent) -> Unit,
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     onTrackingCardClick: () -> Unit = {},
@@ -412,9 +417,9 @@ private fun LazyListScope.savedTripsContent(
                     ),
                 )
             },
-            primaryTransportMode = null, // TODO
             modifier = Modifier
                 .padding(horizontal = dim.pageHorizontalPadding),
+            favouriteIconColor = iconColor,
         )
 
         Spacer(modifier = Modifier.height(dim.spacingXL))
@@ -465,6 +470,7 @@ private fun LazyListScope.savedTripsContent(
             departureBoardAccordionSection(
                 entry = entry,
                 isExpanded = expandedDepartureBoardStopId == entry.stopId,
+                iconColor = iconColor,
                 onEvent = onDepartureBoardEvent,
             )
         }


### PR DESCRIPTION
Same light/dark treatment as the saved-trip star: theme accent in light mode
so the arrow reads as interactive, onSurface (cream) in dark mode for
visibility against the dark card surface.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>