### PR TITLE
fix(ci): grant contents:write permission for create-github-release workflow

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -24,15 +24,16 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # Skip RC tags when triggered by a push (release-2-deploy-rc pushes v*-RC* tags).
     # workflow_call / workflow_dispatch always run — callers are responsible for filtering.
     if: ${{ github.event_name != 'push' || !contains(github.ref_name, '-RC') }}
     steps:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT_KRAIL_GITHUB }}
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           generate_release_notes: true
           draft: true


### PR DESCRIPTION
The generate_release_notes API call was failing with "Resource not
accessible by integration" because the job had no permissions block,
leaving it with the default read-only GITHUB_TOKEN. Adding
permissions: contents: write and switching to with.token (the idiomatic
approach for softprops/action-gh-release) fixes it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>