### PR TITLE
feat(savedtrips): show label-to-label layout when both stops are labelled

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -56,8 +56,11 @@ fun SavedTripCard(
             .klickable(onClick = onCardClick)
             .padding(
                 horizontal = dim.spacingXL,
-                vertical = if (fromDisplay.label != null && toDisplay.label != null)
-                    dim.spacingS else dim.spacingXL
+                vertical = if (fromDisplay.label != null && toDisplay.label != null) {
+                    dim.spacingS
+                } else {
+                    dim.spacingXL
+                },
             )
             .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically,
@@ -120,7 +123,7 @@ private fun LabelledSavedTripContent(
     FlowRow(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
-        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS)
+        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
     ) {
         Text(
             text = fromLabel,
@@ -155,8 +158,11 @@ private fun StopDisplayRow(
         }
         Text(
             text = display.name,
-            style = if (display.label != null) KrailTheme.typography.bodySmall
-            else KrailTheme.typography.bodyLarge,
+            style = if (display.label != null) {
+                KrailTheme.typography.bodySmall
+            } else {
+                KrailTheme.typography.bodyLarge
+            },
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -46,7 +46,6 @@ fun SavedTripCard(
 ) {
     val dim = KrailTheme.dimensions
     val cardShape = CardShape
-    val bothLabelled = fromDisplay.label != null && toDisplay.label != null
 
     Row(
         modifier = modifier
@@ -60,10 +59,12 @@ fun SavedTripCard(
         horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
         // Stop content — two layouts depending on whether both stops are labelled
-        if (bothLabelled) {
+        val fromLabel = fromDisplay.label
+        val toLabel = toDisplay.label
+        if (fromLabel != null && toLabel != null) {
             LabelledSavedTripContent(
-                fromLabel = fromDisplay.label!!,
-                toLabel = toDisplay.label!!,
+                fromLabel = fromLabel,
+                toLabel = toLabel,
                 modifier = Modifier.weight(1f),
             )
         } else {
@@ -122,7 +123,6 @@ private fun LabelledSavedTripContent(
         Text(
             text = "to",
             style = KrailTheme.typography.bodySmall,
-            color = KrailTheme.colors.softLabel,
         )
         Text(
             text = toLabel,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -9,12 +9,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -63,9 +61,9 @@ fun SavedTripCard(
     ) {
         // Stop content — two layouts depending on whether both stops are labelled
         if (bothLabelled) {
-            BothLabelledContent(
-                fromDisplay = fromDisplay,
-                toDisplay = toDisplay,
+            LabelledSavedTripContent(
+                fromLabel = fromDisplay.label!!,
+                toLabel = toDisplay.label!!,
                 modifier = Modifier.weight(1f),
             )
         } else {
@@ -103,36 +101,13 @@ fun SavedTripCard(
 }
 
 /**
- * Side-by-side two-column layout used when both stops carry a user label.
- * Labels are the primary text; stop names render as secondary below them.
- * A thin vertical divider separates the columns.
+ * Shown when both stops carry a user label. Presents labels as the sole content:
+ * fromLabel (bold), "to" (muted small), toLabel (bold). No stop names or icons.
  */
 @Composable
-private fun BothLabelledContent(
-    fromDisplay: StopDisplay,
-    toDisplay: StopDisplay,
-    modifier: Modifier = Modifier,
-) {
-    val dim = KrailTheme.dimensions
-    Row(
-        modifier = modifier.height(IntrinsicSize.Min),
-        horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        LabelledStopColumn(display = fromDisplay, modifier = Modifier.weight(1f))
-        Box(
-            modifier = Modifier
-                .width(dim.strokeThin)
-                .fillMaxHeight()
-                .background(KrailTheme.colors.outlineSubtle),
-        )
-        LabelledStopColumn(display = toDisplay, modifier = Modifier.weight(1f))
-    }
-}
-
-@Composable
-private fun LabelledStopColumn(
-    display: StopDisplay,
+private fun LabelledSavedTripContent(
+    fromLabel: String,
+    toLabel: String,
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
@@ -140,28 +115,18 @@ private fun LabelledStopColumn(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
     ) {
-        Row(
-            verticalAlignment = Alignment.Top,
-            horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
-        ) {
-            display.label?.let { label ->
-                stopLabelIcon(label)?.let { icon ->
-                    Image(
-                        painter = painterResource(icon),
-                        contentDescription = null,
-                        colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                        modifier = Modifier.size(dim.spacingXL),
-                    )
-                }
-                Text(
-                    text = label,
-                    style = KrailTheme.typography.titleMedium,
-                )
-            }
-        }
         Text(
-            text = display.name,
-            style = KrailTheme.typography.bodyMedium,
+            text = fromLabel,
+            style = KrailTheme.typography.titleMedium,
+        )
+        Text(
+            text = "to",
+            style = KrailTheme.typography.bodySmall,
+            color = KrailTheme.colors.softLabel,
+        )
+        Text(
+            text = toLabel,
+            style = KrailTheme.typography.titleMedium,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SavedTripCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,7 +54,11 @@ fun SavedTripCard(
             .clip(cardShape)
             .background(color = themeBackgroundColor(), shape = cardShape)
             .klickable(onClick = onCardClick)
-            .padding(horizontal = dim.spacingXL, vertical = dim.spacingXL)
+            .padding(
+                horizontal = dim.spacingXL,
+                vertical = if (fromDisplay.label != null && toDisplay.label != null)
+                    dim.spacingS else dim.spacingXL
+            )
             .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
@@ -112,9 +117,10 @@ private fun LabelledSavedTripContent(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-    Column(
+    FlowRow(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS)
     ) {
         Text(
             text = fromLabel,
@@ -142,27 +148,15 @@ private fun StopDisplayRow(
         verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
     ) {
         display.label?.let { label ->
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
-            ) {
-                stopLabelIcon(label)?.let { icon ->
-                    Image(
-                        painter = painterResource(icon),
-                        contentDescription = null,
-                        colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                        modifier = Modifier.size(dim.spacingXL),
-                    )
-                }
-                Text(
-                    text = label,
-                    style = KrailTheme.typography.titleMedium,
-                )
-            }
+            Text(
+                text = label,
+                style = KrailTheme.typography.titleMedium,
+            )
         }
         Text(
             text = display.name,
-            style = KrailTheme.typography.bodyMedium,
+            style = if (display.label != null) KrailTheme.typography.bodySmall
+            else KrailTheme.typography.bodyLarge,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -51,6 +51,8 @@ import krail.feature.trip_planner.ui.generated.resources.ic_search
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalThemeColor
+import xyz.ksharma.krail.taj.components.Button
+import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextFieldButton
@@ -110,13 +112,13 @@ fun SearchStopRow(
                     initialOffsetY = { it },
                     animationSpec = tween(durationMillis = 600, easing = FastOutSlowInEasing),
                 ) + fadeIn(animationSpec = tween(400)) togetherWith
-                    fadeOut(animationSpec = tween(150))
+                        fadeOut(animationSpec = tween(150))
             } else {
                 fadeIn(animationSpec = tween(100)) togetherWith
-                    slideOutVertically(
-                        targetOffsetY = { it },
-                        animationSpec = tween(350, easing = FastOutSlowInEasing),
-                    ) + fadeOut(animationSpec = tween(250))
+                        slideOutVertically(
+                            targetOffsetY = { it },
+                            animationSpec = tween(350, easing = FastOutSlowInEasing),
+                        ) + fadeOut(animationSpec = tween(250))
             }
         },
         modifier = modifier,
@@ -166,22 +168,13 @@ private fun CollapsedPill(
             ),
         contentAlignment = Alignment.Center,
     ) {
-        Row(
-            modifier = Modifier
-                .wrapContentWidth()
-                .background(color = themeColorHex.hexToComposeColor(), shape = shape)
-                .klickable(onClick = onClick)
-                .padding(
-                    horizontal = dim.buttonLargeHorizontalPadding,
-                    vertical = dim.spacingML,
-                ),
-            horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
-            verticalAlignment = Alignment.CenterVertically,
+
+        Button(
+            dimensions = ButtonDefaults.mediumButtonSize(),
+            onClick = onClick
         ) {
             Text(
-                text = "+ Plan a trip",
-                style = KrailTheme.typography.titleSmall,
-                color = KrailTheme.colors.surface,
+                text = "Plan a trip",
             )
         }
     }
@@ -262,14 +255,14 @@ private fun ExpandedSearchRow(
                         targetState = fromStopItem?.stopName ?: "Starting from",
                         transitionSpec = {
                             fadeIn(animationSpec = tween(200)) +
-                                slideInVertically(
-                                    initialOffsetY = { it / 2 },
-                                    animationSpec = tween(500, easing = FastOutSlowInEasing),
-                                ) togetherWith fadeOut(animationSpec = tween(200)) +
-                                slideOutVertically(
-                                    targetOffsetY = { -it / 2 },
-                                    animationSpec = tween(500),
-                                )
+                                    slideInVertically(
+                                        initialOffsetY = { it / 2 },
+                                        animationSpec = tween(500, easing = FastOutSlowInEasing),
+                                    ) togetherWith fadeOut(animationSpec = tween(200)) +
+                                    slideOutVertically(
+                                        targetOffsetY = { -it / 2 },
+                                        animationSpec = tween(500),
+                                    )
                         },
                         contentAlignment = Alignment.CenterStart,
                         label = "startingFromText",
@@ -294,14 +287,14 @@ private fun ExpandedSearchRow(
                     targetState = toStopItem?.stopName ?: "Destination",
                     transitionSpec = {
                         fadeIn(animationSpec = tween(200)) +
-                            slideInVertically(
-                                initialOffsetY = { -it / 2 },
-                                animationSpec = tween(500, easing = FastOutSlowInEasing),
-                            ) togetherWith fadeOut(animationSpec = tween(200)) +
-                            slideOutVertically(
-                                targetOffsetY = { it / 2 },
-                                animationSpec = tween(500),
-                            )
+                                slideInVertically(
+                                    initialOffsetY = { -it / 2 },
+                                    animationSpec = tween(500, easing = FastOutSlowInEasing),
+                                ) togetherWith fadeOut(animationSpec = tween(200)) +
+                                slideOutVertically(
+                                    targetOffsetY = { it / 2 },
+                                    animationSpec = tween(500),
+                                )
                     },
                     contentAlignment = Alignment.CenterStart,
                     label = "destinationText",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,7 +57,6 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextFieldButton
 import xyz.ksharma.krail.taj.components.ThemeTextFieldPlaceholderText
 import xyz.ksharma.krail.taj.hexToComposeColor
-import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
@@ -81,7 +79,6 @@ fun SearchStopRow(
     onReverseButtonClick: () -> Unit = {},
     onSearchButtonClick: () -> Unit = {},
 ) {
-    val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
     val navBarPadding = with(LocalDensity.current) {
         WindowInsets.navigationBars.getBottom(this).toDp()
@@ -112,13 +109,13 @@ fun SearchStopRow(
                     initialOffsetY = { it },
                     animationSpec = tween(durationMillis = 600, easing = FastOutSlowInEasing),
                 ) + fadeIn(animationSpec = tween(400)) togetherWith
-                        fadeOut(animationSpec = tween(150))
+                    fadeOut(animationSpec = tween(150))
             } else {
                 fadeIn(animationSpec = tween(100)) togetherWith
-                        slideOutVertically(
-                            targetOffsetY = { it },
-                            animationSpec = tween(350, easing = FastOutSlowInEasing),
-                        ) + fadeOut(animationSpec = tween(250))
+                    slideOutVertically(
+                        targetOffsetY = { it },
+                        animationSpec = tween(350, easing = FastOutSlowInEasing),
+                    ) + fadeOut(animationSpec = tween(250))
             }
         },
         modifier = modifier,
@@ -140,7 +137,6 @@ fun SearchStopRow(
             )
         } else {
             CollapsedPill(
-                themeColorHex = themeColorHex,
                 navBarPadding = navBarPadding.value,
                 onClick = onExpandRequest,
             )
@@ -150,13 +146,11 @@ fun SearchStopRow(
 
 @Composable
 private fun CollapsedPill(
-    themeColorHex: String,
     navBarPadding: Float,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-    val shape = RoundedCornerShape(dim.radiusFull)
 
     Box(
         modifier = modifier
@@ -168,10 +162,9 @@ private fun CollapsedPill(
             ),
         contentAlignment = Alignment.Center,
     ) {
-
         Button(
             dimensions = ButtonDefaults.mediumButtonSize(),
-            onClick = onClick
+            onClick = onClick,
         ) {
             Text(
                 text = "Plan a trip",
@@ -255,14 +248,14 @@ private fun ExpandedSearchRow(
                         targetState = fromStopItem?.stopName ?: "Starting from",
                         transitionSpec = {
                             fadeIn(animationSpec = tween(200)) +
-                                    slideInVertically(
-                                        initialOffsetY = { it / 2 },
-                                        animationSpec = tween(500, easing = FastOutSlowInEasing),
-                                    ) togetherWith fadeOut(animationSpec = tween(200)) +
-                                    slideOutVertically(
-                                        targetOffsetY = { -it / 2 },
-                                        animationSpec = tween(500),
-                                    )
+                                slideInVertically(
+                                    initialOffsetY = { it / 2 },
+                                    animationSpec = tween(500, easing = FastOutSlowInEasing),
+                                ) togetherWith fadeOut(animationSpec = tween(200)) +
+                                slideOutVertically(
+                                    targetOffsetY = { -it / 2 },
+                                    animationSpec = tween(500),
+                                )
                         },
                         contentAlignment = Alignment.CenterStart,
                         label = "startingFromText",
@@ -287,14 +280,14 @@ private fun ExpandedSearchRow(
                     targetState = toStopItem?.stopName ?: "Destination",
                     transitionSpec = {
                         fadeIn(animationSpec = tween(200)) +
-                                slideInVertically(
-                                    initialOffsetY = { -it / 2 },
-                                    animationSpec = tween(500, easing = FastOutSlowInEasing),
-                                ) togetherWith fadeOut(animationSpec = tween(200)) +
-                                slideOutVertically(
-                                    targetOffsetY = { it / 2 },
-                                    animationSpec = tween(500),
-                                )
+                            slideInVertically(
+                                initialOffsetY = { -it / 2 },
+                                animationSpec = tween(500, easing = FastOutSlowInEasing),
+                            ) togetherWith fadeOut(animationSpec = tween(200)) +
+                            slideOutVertically(
+                                targetOffsetY = { it / 2 },
+                                animationSpec = tween(500),
+                            )
                     },
                     contentAlignment = Alignment.CenterStart,
                     label = "destinationText",


### PR DESCRIPTION
feat(savedtrips): show label-to-label layout when both stops are labelled

When a saved trip's origin and destination both have user labels, the card
now shows only the label names (titleMedium) with a small muted "to"
connector in between — no stop names or icons. The full stop-name layout is
unchanged when only one or neither stop has a label.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

refactor(savedtrips): replace !! with null-safe smart-cast in SavedTripCard

Use local vals + null check instead of !! to unwrap labels safely.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(savedtrips): polish label-to-label card layout

- Switch LabelledSavedTripContent from Column to FlowRow so labels and
  "to" connector sit inline horizontally
- Reduce vertical padding on the card when both stops are labelled
- In the single-label fallback (StopDisplayRow): show name in bodyLarge
  when unlabelled, bodySmall when a label is present above it; remove
  icons (label text alone is sufficient)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

refactor(search): replace CollapsedPill custom Row with Button component

Simplifies the collapsed pill by using the app's Button composable
instead of a manually styled Row. Text updated from "+ Plan a trip"
to "Plan a trip".

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>