### PR TITLE
feat(search-stop): keep label shortcuts visible after clearing recents

### DIFF
--- a/feature/trip-planner/ui/SEARCH_STOP_UX.md
+++ b/feature/trip-planner/ui/SEARCH_STOP_UX.md
@@ -30,21 +30,28 @@ The screen is built around three ideas: **search for a stop**, **save stops as l
 
 ### Pill row visibility (`shouldShowPillRow`)
 
-The whole pill row + assigning banner only render when there's something below for
-the user to act on:
+The whole pill row + assigning banner only render when there's something for the
+user to act on:
 
 | List state | Pill row |
 |---|---|
-| Recent, no recents yet | hidden |
+| Recent, no recents, no labels set | hidden |
+| Recent, no recents, ≥ 1 label set | visible |
 | Recent, ≥ 1 recent stop | visible |
 | Results loading (no results yet) | hidden |
 | Results with ≥ 1 result | visible |
 | NoMatch | hidden |
 | Error | hidden |
 
-Reasoning: tapping an unset Home pill enters assigning mode, which expects at least
-one stop with a star button below. Showing pills against an empty canvas would let
-users tap into a dead-end state.
+Reasoning: tapping an **unset** pill enters assigning mode, which requires at least
+one stop with a star button below — showing it on an empty canvas is a dead-end.
+Tapping a **set** pill navigates directly to that stop (From / To), so it is always
+safe to show when a label is configured, even after the user clears their recents.
+
+First-launch progression:
+1. No labels set, no recents → pill row hidden (nothing useful to show yet).
+2. User makes a few searches → recents appear → pill row shows (labels can now be assigned).
+3. User assigns a label → label row stays visible even if recents are later cleared.
 
 ---
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRules.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRules.kt
@@ -94,15 +94,18 @@ internal fun conflictForAssign(
  * with stars to tap — otherwise tapping an unset Home pill enters assigning mode
  * with nothing to act on, which feels broken to the user.
  *
- * - In Recent mode: show iff the user has at least one recent stop.
+ * - In Recent mode: show if the user has at least one recent stop OR at least one
+ *   label is already configured. Set labels navigate directly to a stop (no dead-end),
+ *   so they remain useful even after the user clears their recent searches.
  * - In Results mode: show iff the search returned at least one result. Loading,
  *   NoMatch and Error states all hide the row.
  */
 internal fun shouldShowPillRow(
     listState: ListState,
     recentStops: List<SearchStopState.StopResult>,
+    stopLabels: List<StopLabel> = emptyList(),
 ): Boolean = when (listState) {
-    ListState.Recent -> recentStops.isNotEmpty()
+    ListState.Recent -> recentStops.isNotEmpty() || stopLabels.any { it.isSet }
     is ListState.Results -> listState.results.isNotEmpty()
     ListState.NoMatch, ListState.Error -> false
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -932,8 +932,8 @@ private fun SearchStopListContent(
         searchStopState.stopLabels.mapNotNull { it.stopId }.toSet()
     }
     val isLoading = listState is ListState.Results && listState.isLoading
-    val showPillRow = remember(listState, searchStopState.recentStops) {
-        shouldShowPillRow(listState, searchStopState.recentStops)
+    val showPillRow = remember(listState, searchStopState.recentStops, searchStopState.stopLabels) {
+        shouldShowPillRow(listState, searchStopState.recentStops, searchStopState.stopLabels)
     }
     when (listState) {
         ListState.Recent -> {

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRulesTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRulesTest.kt
@@ -223,5 +223,46 @@ class SearchStopRulesTest {
         assertFalse(shouldShowPillRow(ListState.Error, recentStops = listOf(centralRecent)))
     }
 
+    @Test
+    fun `pill row visible in Recent state when a label is set even with no recents`() {
+        assertTrue(
+            shouldShowPillRow(
+                listState = ListState.Recent,
+                recentStops = emptyList(),
+                stopLabels = listOf(homeSet),
+            ),
+        )
+    }
+
+    @Test
+    fun `pill row hidden in Recent state when no recents and no labels are set`() {
+        assertFalse(
+            shouldShowPillRow(
+                listState = ListState.Recent,
+                recentStops = emptyList(),
+                stopLabels = listOf(home, gym),
+            ),
+        )
+    }
+
+    @Test
+    fun `pill row visible after clear-all when at least one label remains set`() {
+        // Simulates: user clears recents (recentStops empty) but Home is already configured.
+        assertTrue(
+            shouldShowPillRow(
+                listState = ListState.Recent,
+                recentStops = emptyList(),
+                stopLabels = listOf(homeSet, gym),
+            ),
+        )
+    }
+
+    @Test
+    fun `set labels do not affect Results or NoMatch states`() {
+        val labelsWithSet = listOf(homeSet, workSet)
+        assertFalse(shouldShowPillRow(ListState.NoMatch, emptyList(), labelsWithSet))
+        assertFalse(shouldShowPillRow(ListState.Error, emptyList(), labelsWithSet))
+    }
+
     // endregion
 }


### PR DESCRIPTION
When the user clears recent searches, set labels now remain visible in
the pill row. Previously the row was hidden whenever recentStops was
empty, which felt broken for users who had already configured Home/Work.

Rule: in Recent mode, show the pill row if recents exist OR any label is
set. Unset-only labels still hide the row on a fresh install (no
dead-end assigning mode on an empty canvas).

Updates shouldShowPillRow, its call site, tests, and SEARCH_STOP_UX.md.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>