### PR TITLE
feat(remote-config): add TRIP_TRACKING_ENABLED flag (default off)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     implementation(projects.composeApp)
     implementation(projects.core.deeplink)
     implementation(projects.core.log)
+    implementation(projects.core.remoteConfig)
 
     // Android-specific dependencies
     implementation(libs.activity.compose)

--- a/androidApp/src/main/kotlin/xyz/ksharma/krail/KrailApplication.kt
+++ b/androidApp/src/main/kotlin/xyz/ksharma/krail/KrailApplication.kt
@@ -27,5 +27,5 @@ class KrailApplication : Application() {
 
 /** Android-platform bindings that can't live in the shared composeApp module. */
 private val androidAppModule = module {
-    single<AppDeepLinkHandler> { RealAppDeepLinkHandler(pendingDeepLinkManager = get()) }
+    single<AppDeepLinkHandler> { RealAppDeepLinkHandler(pendingDeepLinkManager = get(), flag = get()) }
 }

--- a/androidApp/src/main/kotlin/xyz/ksharma/krail/deeplink/RealAppDeepLinkHandler.kt
+++ b/androidApp/src/main/kotlin/xyz/ksharma/krail/deeplink/RealAppDeepLinkHandler.kt
@@ -3,13 +3,24 @@ package xyz.ksharma.krail.deeplink
 import android.net.Uri
 import xyz.ksharma.krail.core.deeplink.PendingDeepLinkManager
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 
 internal class RealAppDeepLinkHandler(
     private val pendingDeepLinkManager: PendingDeepLinkManager,
+    private val flag: Flag,
 ) : AppDeepLinkHandler {
+
+    private val trackingEnabled: Boolean
+        get() = flag.getFlagValue(FlagKeys.TRIP_TRACKING_ENABLED.key).asBoolean(false)
 
     override fun handleColdStart(uri: Uri?) {
         log("[DEEPLINK] handleColdStart — uri=$uri")
+        if (!trackingEnabled) {
+            log("[DEEPLINK] cold start — trip tracking disabled, ignoring deep link")
+            return
+        }
         val encodedData = uri?.extractEncodedData()
         if (encodedData != null) {
             log("[DEEPLINK] cold start — storing pending, encodedData=${encodedData.take(20)}…")
@@ -21,6 +32,10 @@ internal class RealAppDeepLinkHandler(
 
     override fun handleHotIntent(uri: Uri?) {
         log("[DEEPLINK] handleHotIntent — uri=$uri")
+        if (!trackingEnabled) {
+            log("[DEEPLINK] hot intent — trip tracking disabled, ignoring deep link")
+            return
+        }
         val encodedData = uri?.extractEncodedData()
         if (encodedData != null) {
             log("[DEEPLINK] hot intent — dispatching, encodedData=${encodedData.take(20)}…")

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/IOSDeepLinkHandler.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/IOSDeepLinkHandler.kt
@@ -3,6 +3,9 @@ package xyz.ksharma.krail
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import xyz.ksharma.krail.core.deeplink.PendingDeepLinkManager
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 
 /**
  * iOS entry point for deep link handling.
@@ -22,12 +25,17 @@ import xyz.ksharma.krail.core.deeplink.PendingDeepLinkManager
 class IOSDeepLinkHandler : KoinComponent {
 
     private val pendingDeepLinkManager: PendingDeepLinkManager by inject()
+    private val flag: Flag by inject()
 
     /**
      * Handle a URL string delivered by the OS (Universal Link or custom scheme).
      * Pass `url.absoluteString` from Swift.
+     *
+     * Silently ignored when [FlagKeys.TRIP_TRACKING_ENABLED] is off so deep links
+     * land on the website instead of opening the track-trip screen.
      */
     fun handle(urlString: String?) {
+        if (!flag.getFlagValue(FlagKeys.TRIP_TRACKING_ENABLED.key).asBoolean(false)) return
         urlString
             ?.extractEncodedData()
             ?.let { pendingDeepLinkManager.dispatchHot(it) }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -133,6 +133,10 @@ object RemoteConfigDefaults {
                 first = FlagKeys.SEARCH_STOP_MAPS_AVAILABLE.key,
                 second = false,
             ),
+            Pair(
+                first = FlagKeys.TRIP_TRACKING_ENABLED.key,
+                second = false,
+            ),
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -30,4 +30,6 @@ enum class FlagKeys(val key: String) {
 
     SEARCH_STOP_MAPS_AVAILABLE("maps_stop_search"),
     JOURNEY_MAPS_AVAILABLE("maps_journey"),
+
+    TRIP_TRACKING_ENABLED("trip_tracking_enabled"),
 }

--- a/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLinkEncoder.kt
+++ b/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLinkEncoder.kt
@@ -7,6 +7,7 @@ import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 const val TRACK_DEEP_LINK_BASE_URL = "https://ksharma-xyz.github.io/trip"
+const val KRAIL_WEBSITE_URL = "https://krail.app"
 
 object TripDeepLinkEncoder {
 

--- a/feature/track/ui/build.gradle.kts
+++ b/feature/track/ui/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.core.coroutinesExt)
+                implementation(projects.core.remoteConfig)
                 implementation(projects.core.maps.state)
                 implementation(projects.core.dateTime)
                 implementation(projects.core.di)

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModel.kt
@@ -26,6 +26,9 @@ import xyz.ksharma.krail.core.festival.model.greetingAndEmoji
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 import xyz.ksharma.krail.core.share.ShareManager
 import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
@@ -49,7 +52,11 @@ class TrackTripViewModel(
     gtfsRealtimeRepository: GtfsRealtimeRepository,
     sandook: Sandook,
     private val shareManager: ShareManager,
+    flag: Flag,
 ) : ViewModel() {
+
+    val isTripTrackingEnabled: Boolean =
+        flag.getFlagValue(FlagKeys.TRIP_TRACKING_ENABLED.key).asBoolean(false)
 
     private val loadingEmoji: String by lazy {
         (festivalManager.festivalOnDate() ?: NoFestival()).greetingAndEmoji.second

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/di/TrackUiModule.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/di/TrackUiModule.kt
@@ -17,6 +17,7 @@ val trackUiModule = module {
             gtfsRealtimeRepository = get(),
             sandook = get(),
             shareManager = get(),
+            flag = get(),
         )
     }
 }

--- a/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
+++ b/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import xyz.ksharma.krail.core.festival.FestivalManager
 import xyz.ksharma.krail.core.festival.model.Festival
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
 import xyz.ksharma.krail.feature.track.LegTrackingInfo
@@ -430,9 +432,30 @@ class TrackTripViewModelTest {
 
     // endregion
 
+    // region ── Trip tracking flag ────────────────────────────────────────────
+
+    @Test
+    fun `GIVEN flag is false WHEN ViewModel created THEN isTripTrackingEnabled is false`() =
+        runTrackingTest {
+            val vm = makeViewModel(encodedData = null, flag = FakeFlag(trackingEnabled = false))
+            assertTrue(!vm.isTripTrackingEnabled)
+        }
+
+    @Test
+    fun `GIVEN flag is true WHEN ViewModel created THEN isTripTrackingEnabled is true`() =
+        runTrackingTest {
+            val vm = makeViewModel(encodedData = null, flag = FakeFlag(trackingEnabled = true))
+            assertTrue(vm.isTripTrackingEnabled)
+        }
+
+    // endregion
+
     // region ── Helpers ───────────────────────────────────────────────────────
 
-    private fun makeViewModel(encodedData: String?) = TrackTripViewModel(
+    private fun makeViewModel(
+        encodedData: String?,
+        flag: Flag = FakeFlag(trackingEnabled = false),
+    ) = TrackTripViewModel(
         encodedData = encodedData,
         tripPlanningService = tripService,
         trackingManager = trackingManager,
@@ -441,6 +464,7 @@ class TrackTripViewModelTest {
         gtfsRealtimeRepository = FakeGtfsRealtimeRepository(),
         sandook = FakeSandook(),
         shareManager = NoopShareManager,
+        flag = flag,
     ).also { currentVm = it }
 
     private fun futureIso(duration: kotlin.time.Duration) =
@@ -604,4 +628,9 @@ private object NoopShareManager : xyz.ksharma.krail.core.share.ShareManager {
         title: String,
         text: String?,
     ): Result<Unit> = Result.success(Unit)
+}
+
+private class FakeFlag(private val trackingEnabled: Boolean) : Flag {
+    override fun getFlagValue(key: String): FlagValue =
+        FlagValue.BooleanValue(trackingEnabled)
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -43,6 +43,7 @@ import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 import xyz.ksharma.krail.core.share.ShareManager
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
+import xyz.ksharma.krail.feature.track.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.feature.track.TripDeepLinkEncoder
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
@@ -494,17 +495,22 @@ class TimeTableViewModel(
             .sortedBy { it.originUtcDateTime.utcToLocalDateTimeAEST() }
             .toImmutableList()
 
+        val trackingEnabled = flag.getFlagValue(FlagKeys.TRIP_TRACKING_ENABLED.key).asBoolean(false)
         val deepLinkUrls = tripInfo?.let { trip ->
             journeyList.mapNotNull { journey ->
-                val url = TripDeepLinkEncoder.encode(
-                    fromStopId = trip.fromStopId,
-                    fromStopName = trip.fromStopName,
-                    toStopId = trip.toStopId,
-                    toStopName = trip.toStopName,
-                    departureUtcDateTime = journey.originUtcDateTime,
-                    legs = journey.legs,
-                    excludedProductClasses = unselectedModes,
-                ) ?: return@mapNotNull null
+                val url = if (trackingEnabled) {
+                    TripDeepLinkEncoder.encode(
+                        fromStopId = trip.fromStopId,
+                        fromStopName = trip.fromStopName,
+                        toStopId = trip.toStopId,
+                        toStopName = trip.toStopName,
+                        departureUtcDateTime = journey.originUtcDateTime,
+                        legs = journey.legs,
+                        excludedProductClasses = unselectedModes,
+                    ) ?: return@mapNotNull null
+                } else {
+                    KRAIL_WEBSITE_URL
+                }
                 journey.journeyId to url
             }.toMap().toImmutableMap()
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -62,6 +62,7 @@ import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.share.withBrandingHeader
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.feature.track.DepartureDeviation
+import xyz.ksharma.krail.feature.track.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
 import xyz.ksharma.krail.feature.track.TrackTripState
 import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
@@ -185,9 +186,11 @@ fun TrackTripScreen(
                     triggerShare = triggerShare,
                     onShareCapture = { bitmap ->
                         triggerShare = false
-                        val deepLinkUrl = encodedData
-                            ?.let { "\nhttps://ksharma-xyz.github.io/trip?d=$it" }
-                            .orEmpty()
+                        val deepLinkUrl = if (viewModel.isTripTrackingEnabled) {
+                            encodedData?.let { "\nhttps://ksharma-xyz.github.io/trip?d=$it" }.orEmpty()
+                        } else {
+                            "\n$KRAIL_WEBSITE_URL"
+                        }
                         val text = "${countdownDisplay.first} ${countdownDisplay.second}" +
                             "\n${s.journey.fromStopName} to ${s.journey.toStopName}" +
                             deepLinkUrl


### PR DESCRIPTION
feat(remote-config): add TRIP_TRACKING_ENABLED flag (default off)

Adds the flag key, default value (false), and KRAIL_WEBSITE_URL constant
so downstream modules can gate trip-tracking behaviour.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(timetable): gate share URL on trip_tracking_enabled flag

When flag is off: all journey share URLs resolve to krail.app instead of
the deep link. TrackTripScreen share text also falls back to krail.app.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(track:ui): inject Flag into TrackTripViewModel, expose isTripTrackingEnabled

Reads trip_tracking_enabled at VM init so TrackTripScreen can choose the
correct share URL without a flag call in the composable. Tests cover both
flag states via FakeFlag.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

feat(deeplink): ignore incoming deep links when trip_tracking_enabled is off

Both iOS (IOSDeepLinkHandler) and Android (RealAppDeepLinkHandler) handlers
now early-return silently when the flag is off, so external deep link taps
land on the website instead of opening the track-trip screen.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>