### PR TITLE
feat(remote-config): add TRIP_TRACKING_ENABLED flag (default off)

### DIFF
--- a/androidApp/src/main/kotlin/xyz/ksharma/krail/deeplink/RealAppDeepLinkHandler.kt
+++ b/androidApp/src/main/kotlin/xyz/ksharma/krail/deeplink/RealAppDeepLinkHandler.kt
@@ -1,6 +1,8 @@
 package xyz.ksharma.krail.deeplink
 
 import android.net.Uri
+import xyz.ksharma.krail.core.deeplink.KRAIL_DEEP_LINK_HOST
+import xyz.ksharma.krail.core.deeplink.KRAIL_DEEP_LINK_PATH
 import xyz.ksharma.krail.core.deeplink.PendingDeepLinkManager
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
@@ -46,12 +48,10 @@ internal class RealAppDeepLinkHandler(
     }
 
     private fun Uri.extractEncodedData(): String? =
-        takeIf { host == DEEP_LINK_HOST && path?.startsWith(DEEP_LINK_PATH_PREFIX) == true }
+        takeIf { host == KRAIL_DEEP_LINK_HOST && path?.startsWith(KRAIL_DEEP_LINK_PATH) == true }
             ?.getQueryParameter(QUERY_PARAM_DATA)
 
     private companion object {
-        const val DEEP_LINK_HOST = "ksharma-xyz.github.io"
-        const val DEEP_LINK_PATH_PREFIX = "/trip"
         const val QUERY_PARAM_DATA = "d"
     }
 }

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/IOSDeepLinkHandler.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/IOSDeepLinkHandler.kt
@@ -2,6 +2,8 @@ package xyz.ksharma.krail
 
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import xyz.ksharma.krail.core.deeplink.KRAIL_DEEP_LINK_HOST
+import xyz.ksharma.krail.core.deeplink.KRAIL_DEEP_LINK_PATH
 import xyz.ksharma.krail.core.deeplink.PendingDeepLinkManager
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
@@ -42,13 +44,11 @@ class IOSDeepLinkHandler : KoinComponent {
     }
 
     private fun String.extractEncodedData(): String? {
-        val host = "ksharma-xyz.github.io"
-        // Resolve query start only when host is present and path starts with /trip
-        val queryStart = indexOf(host)
+        val queryStart = indexOf(KRAIL_DEEP_LINK_HOST)
             .takeIf { it >= 0 }
             ?.let { hostIdx ->
-                val pathSection = substring(hostIdx + host.length)
-                indexOf('?').takeIf { pathSection.startsWith("/trip") && it >= 0 }?.plus(1)
+                val pathSection = substring(hostIdx + KRAIL_DEEP_LINK_HOST.length)
+                indexOf('?').takeIf { pathSection.startsWith(KRAIL_DEEP_LINK_PATH) && it >= 0 }?.plus(1)
             }
             ?: return null
         return substring(queryStart).split("&")

--- a/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
+++ b/core/app-info/src/commonMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.kt
@@ -1,5 +1,7 @@
 package xyz.ksharma.krail.core.appinfo
 
+const val KRAIL_WEBSITE_URL = "https://krail.app"
+
 /**
  * Inject [AppInfoProvider] to get instance of [AppInfo].
  */

--- a/core/deeplink/src/commonMain/kotlin/xyz/ksharma/krail/core/deeplink/DeepLinkConfig.kt
+++ b/core/deeplink/src/commonMain/kotlin/xyz/ksharma/krail/core/deeplink/DeepLinkConfig.kt
@@ -1,0 +1,4 @@
+package xyz.ksharma.krail.core.deeplink
+
+const val KRAIL_DEEP_LINK_HOST = "ksharma-xyz.github.io"
+const val KRAIL_DEEP_LINK_PATH = "/trip"

--- a/core/share/build.gradle.kts
+++ b/core/share/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
 
         commonMain {
             dependencies {
+                implementation(projects.core.appInfo)
                 implementation(libs.compose.ui)
                 implementation(libs.compose.runtime)
                 api(libs.di.koinComposeViewmodel)

--- a/core/share/src/commonMain/kotlin/xyz/ksharma/krail/core/share/BrandingHeader.kt
+++ b/core/share/src/commonMain/kotlin/xyz/ksharma/krail/core/share/BrandingHeader.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.core.share
 
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
 
 /**
  * Returns a new [ImageBitmap] with a KRAIL branding header painted above the original image.
@@ -18,7 +19,7 @@ import androidx.compose.ui.graphics.ImageBitmap
  */
 expect fun ImageBitmap.withBrandingHeader(
     titleText: String = "KRAIL",
-    subtitleText: String = "https://krail.app",
+    subtitleText: String = KRAIL_WEBSITE_URL,
     backgroundColor: Color,
     textColor: Color,
     density: Float,

--- a/feature/track/state/build.gradle.kts
+++ b/feature/track/state/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.core.dateTime)
+                implementation(projects.core.deeplink)
                 implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.maps.state)

--- a/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLinkEncoder.kt
+++ b/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/TripDeepLinkEncoder.kt
@@ -2,12 +2,13 @@ package xyz.ksharma.krail.feature.track
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import xyz.ksharma.krail.core.deeplink.KRAIL_DEEP_LINK_HOST
+import xyz.ksharma.krail.core.deeplink.KRAIL_DEEP_LINK_PATH
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
-const val TRACK_DEEP_LINK_BASE_URL = "https://ksharma-xyz.github.io/trip"
-const val KRAIL_WEBSITE_URL = "https://krail.app"
+const val TRACK_DEEP_LINK_BASE_URL = "https://" + KRAIL_DEEP_LINK_HOST + KRAIL_DEEP_LINK_PATH
 
 object TripDeepLinkEncoder {
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -46,6 +46,7 @@ import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_clock
 import krail.feature.trip_planner.ui.generated.resources.ic_walk
 import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.core.share.withBrandingHeader
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.components.AlertButton
@@ -531,7 +532,7 @@ private fun buildShareText(
     } else {
         "I'll arrive at $destinationTime — about $totalTravelTime away."
     }
-    val link = deepLinkUrl ?: "https://krail.app"
+    val link = deepLinkUrl ?: KRAIL_WEBSITE_URL
     return "Hey mate!\n\n$journeyLine\n\nTrack this trip live on KRAIL!\n$link"
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModel.kt
@@ -23,6 +23,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick.S
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent.SocialConnectionSource
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
@@ -240,7 +241,7 @@ private fun createShareText(
     ctaLink: String? = null,
 ): String {
     log("ctaLink: $ctaLink")
-    val letsKrailText = "\n#LetsKRAIL https://krail.app"
+    val letsKrailText = "\n#LetsKRAIL $KRAIL_WEBSITE_URL"
 
     val postfix = when (cardType) {
         DiscoverCardType.Travel -> "\n$ctaLink\n\nFound in KRAIL App$letsKrailText"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -26,6 +26,7 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isBefore
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
@@ -43,7 +44,6 @@ import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 import xyz.ksharma.krail.core.share.ShareManager
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
-import xyz.ksharma.krail.feature.track.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.feature.track.TripDeepLinkEncoder
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -58,11 +58,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.share.withBrandingHeader
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.feature.track.DepartureDeviation
-import xyz.ksharma.krail.feature.track.KRAIL_WEBSITE_URL
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
 import xyz.ksharma.krail.feature.track.TrackTripState
 import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay


### PR DESCRIPTION
feat(remote-config): add TRIP_TRACKING_ENABLED flag (default off)

Adds the flag key, default value (false), and KRAIL_WEBSITE_URL constant
so downstream modules can gate trip-tracking behaviour.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

refactor: consolidate KRAIL_WEBSITE_URL and deep link host into single constants

KRAIL_WEBSITE_URL ("https://krail.app") now lives in core/app-info alongside
appStoreUrl. KRAIL_DEEP_LINK_HOST/PATH ("ksharma-xyz.github.io", "/trip") live
in core/deeplink, shared by iOS and Android handlers. All inline literals and
the duplicate const in TripDeepLinkEncoder.kt are replaced with these imports.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>