### PR TITLE
feat(origin-destination): show label icon in left slot, use themeBackgroundColor

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -70,7 +71,12 @@ internal fun OriginDestination(
             timeLineColor = timeLineColor,
             onClick = onOriginClick,
         )
-        Divider(modifier = Modifier.padding(start = dim.spacingXL + dim.iconSmall + dim.spacingM, end = dim.spacingL))
+        Divider(
+            modifier = Modifier.padding(
+                start = dim.spacingXL + dim.iconSmall + dim.spacingM,
+                end = dim.spacingL,
+            ),
+        )
         StopRow(
             display = destination,
             isOrigin = false,
@@ -92,11 +98,6 @@ private fun StopRow(
     val clickModifier = onClick?.let { handler ->
         Modifier.klickable { handler(display) }
     } ?: Modifier
-    val displayText = if (display.label != null) {
-        "${display.label} (${display.name})"
-    } else {
-        display.name
-    }
     val labelIcon = display.label?.let { stopLabelIcon(it) }
 
     Row(
@@ -118,11 +119,13 @@ private fun StopRow(
                     colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
                     modifier = Modifier.fillMaxSize(),
                 )
+
                 isOrigin -> Box(
                     modifier = Modifier
                         .size(ORIGIN_CIRCLE_SIZE)
                         .background(timeLineColor, CircleShape),
                 )
+
                 else -> Image(
                     painter = painterResource(Res.drawable.ic_location_on),
                     contentDescription = null,
@@ -133,7 +136,7 @@ private fun StopRow(
         }
 
         AnimatedContent(
-            targetState = displayText,
+            targetState = display,
             transitionSpec = {
                 (
                     fadeIn(animationSpec = tween(200)) +
@@ -151,12 +154,27 @@ private fun StopRow(
             },
             contentAlignment = Alignment.CenterStart,
             label = if (isOrigin) "originStopName" else "destinationStopName",
-        ) { targetText ->
-            Text(
-                text = targetText,
-                style = KrailTheme.typography.titleMedium,
-                color = KrailTheme.colors.onSurface,
-            )
+        ) { targetDisplay ->
+            targetDisplay.label?.let { label ->
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
+                    verticalArrangement = Arrangement.spacedBy(dim.spacingXS),
+                ) {
+                    Text(
+                        text = label,
+                        style = KrailTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = "(${targetDisplay.name})",
+                        style = KrailTheme.typography.bodySmall,
+                    )
+                }
+            } ?: run {
+                Text(
+                    text = targetDisplay.name,
+                    style = KrailTheme.typography.titleMedium,
+                )
+            }
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -10,7 +10,6 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,10 +23,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.shadow.Shadow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
@@ -46,9 +43,6 @@ import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopDisplay
 
-private val SHADOW_RADIUS = 12.dp
-private val SHADOW_SPREAD = 2.dp
-private const val SHADOW_ALPHA = 1f
 private val ORIGIN_CIRCLE_SIZE = 10.dp
 private val STOP_ROW_VERTICAL_PADDING = 12.dp
 
@@ -67,22 +61,8 @@ internal fun OriginDestination(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .dropShadow(
-                shape = cardShape,
-                shadow = Shadow(
-                    radius = SHADOW_RADIUS,
-                    color = themeBackgroundColor(),
-                    spread = SHADOW_SPREAD,
-                    alpha = SHADOW_ALPHA,
-                ),
-            )
             .clip(cardShape)
-            .border(
-                width = dim.strokeThin,
-                color = themeBackgroundColor(),
-                shape = cardShape,
-            )
-            .background(color = KrailTheme.colors.surface, shape = cardShape),
+            .background(color = themeBackgroundColor(), shape = cardShape),
     ) {
         StopRow(
             display = origin,
@@ -117,6 +97,7 @@ private fun StopRow(
     } else {
         display.name
     }
+    val labelIcon = display.label?.let { stopLabelIcon(it) }
 
     Row(
         modifier = modifier
@@ -130,14 +111,19 @@ private fun StopRow(
             modifier = Modifier.size(dim.iconSmall),
             contentAlignment = Alignment.Center,
         ) {
-            if (isOrigin) {
-                Box(
+            when {
+                labelIcon != null -> Image(
+                    painter = painterResource(labelIcon),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                    modifier = Modifier.fillMaxSize(),
+                )
+                isOrigin -> Box(
                     modifier = Modifier
                         .size(ORIGIN_CIRCLE_SIZE)
                         .background(timeLineColor, CircleShape),
                 )
-            } else {
-                Image(
+                else -> Image(
                     painter = painterResource(Res.drawable.ic_location_on),
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(timeLineColor),
@@ -166,26 +152,11 @@ private fun StopRow(
             contentAlignment = Alignment.CenterStart,
             label = if (isOrigin) "originStopName" else "destinationStopName",
         ) { targetText ->
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
-            ) {
-                display.label?.let { label ->
-                    stopLabelIcon(label)?.let { icon ->
-                        Image(
-                            painter = painterResource(icon),
-                            contentDescription = null,
-                            colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                            modifier = Modifier.size(dim.spacingXL),
-                        )
-                    }
-                }
-                Text(
-                    text = targetText,
-                    style = KrailTheme.typography.titleMedium,
-                    color = KrailTheme.colors.onSurface,
-                )
-            }
+            Text(
+                text = targetText,
+                style = KrailTheme.typography.titleMedium,
+                color = KrailTheme.colors.onSurface,
+            )
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -73,6 +73,7 @@ import xyz.ksharma.krail.taj.components.TextButton
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewScreen
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
@@ -207,7 +208,7 @@ fun TimeTableScreen(
                         onOriginClick = { display -> selectedStop = display },
                         onDestinationClick = { display -> selectedStop = display },
                         modifier = Modifier.fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .padding(horizontal = KrailTheme.dimensions.spacingL, vertical = 8.dp)
                             .background(color = KrailTheme.colors.surface),
                     )
                 }
@@ -217,7 +218,7 @@ fun TimeTableScreen(
                 FlowRow(
                     modifier = Modifier
                         .fillParentMaxWidth()
-                        .padding(horizontal = 12.dp)
+                        .padding(horizontal = KrailTheme.dimensions.spacingL)
                         .padding(top = 12.dp),
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -648,6 +649,7 @@ fun ActionButton(
 
 // region Preview
 
+@PreviewScreen
 @Composable
 private fun PreviewTimeTableScreen() {
     PreviewTheme {
@@ -693,6 +695,7 @@ private fun PreviewTimeTableScreen() {
     }
 }
 
+@PreviewScreen
 @Composable
 private fun PreviewTimeTableScreenError() {
     PreviewTheme {
@@ -720,6 +723,7 @@ private fun PreviewTimeTableScreenError() {
     }
 }
 
+@PreviewScreen
 @Composable
 private fun PreviewTimeTableScreenNoResults() {
     PreviewTheme {


### PR DESCRIPTION
When a stop has a label with a known icon (Home, Work, etc.), the label icon
replaces the dot/location_on in the left column so the icon is never shown twice.
Removed card shadow + border; card background is now themeBackgroundColor.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>