### PR TITLE
fix(ci): increase Gradle daemon heap to 5g for iOS arm64 K/N compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,12 @@
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
 #Fri Apr 12 23:04:35 AEST 2024
-org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+# Gradle daemon heap. K/N runs inside this process — 5g is needed for iOS arm64 Release
+# compilation on macOS 15 CI runners (7 GB RAM). Previously 4g caused OOM there.
+org.gradle.jvmargs=-Xmx5g
+# Kotlin compiler daemon (JVM targets). Separate process from the Gradle daemon.
+# The old form (-Dkotlin.daemon.jvm.options inside jvmargs) was incorrect syntax.
+kotlin.daemon.jvm.options=-Xmx4g
 android.useAndroidX=true
 org.gradle.caching=true
 kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
macos-latest (macOS 15) runners have 7 GB RAM. Kotlin/Native runs inside
the Gradle daemon process, so the daemon heap is the hard ceiling for
K/N compilation. 4 g was insufficient for feature:track:ui:compileKotlinIosArm64
on a Release archive, causing OOM in CI.

Also fixes the Kotlin compiler daemon JVM opts: the old
-Dkotlin.daemon.jvm.options inside org.gradle.jvmargs was incorrect
syntax and was silently ignored. Moved to the standalone
kotlin.daemon.jvm.options property which is what the Kotlin Gradle plugin
actually reads for separate-process JVM compilation.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>