### PR TITLE
refactor(ui): replace hardcoded dp values with dimension tokens (batch 1)

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.discover.state.DiscoverCardType

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverChipRow.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.discover.DiscoverChipDefaults.RowContentPadding
@@ -36,11 +37,12 @@ fun DiscoverChipRow(
                 type.displayName
             },
         ) { type ->
+            val dim = KrailTheme.dimensions
             DiscoverChip(
                 type = type,
                 selected = type == selectedType,
                 modifier = Modifier
-                    .padding(horizontal = 10.dp)
+                    .padding(horizontal = dim.spacingML)
                     .clickable(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -206,7 +206,7 @@ fun DiscoverScreenTablet(
     ) {
         Column {
             val dim = KrailTheme.dimensions
-        if (isLargeFontScale()) {
+            if (isLargeFontScale()) {
                 // Large font: centered lazy column
                 LazyColumn(
                     contentPadding = PaddingValues(top = DISCOVER_SCROLL_TOP_PADDING, bottom = DISCOVER_SCROLL_PADDING),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -107,14 +107,15 @@ fun DiscoverScreenCompact(
         return
     }
 
+    val dim = KrailTheme.dimensions
     Box(
         modifier = Modifier.fillMaxSize()
             .background(color = KrailTheme.colors.surface),
     ) {
         if (isLargeFontScale()) {
             LazyColumn(
-                contentPadding = PaddingValues(bottom = 200.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                contentPadding = PaddingValues(bottom = DISCOVER_SCROLL_PADDING),
+                verticalArrangement = Arrangement.spacedBy(dim.spacingXL),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = modifier.fillMaxSize(),
             ) {
@@ -204,11 +205,12 @@ fun DiscoverScreenTablet(
             .background(KrailTheme.colors.surface),
     ) {
         Column {
-            if (isLargeFontScale()) {
+            val dim = KrailTheme.dimensions
+        if (isLargeFontScale()) {
                 // Large font: centered lazy column
                 LazyColumn(
-                    contentPadding = PaddingValues(top = 120.dp, bottom = 200.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(top = DISCOVER_SCROLL_TOP_PADDING, bottom = DISCOVER_SCROLL_PADDING),
+                    verticalArrangement = Arrangement.spacedBy(dim.spacingXL),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = Modifier.fillMaxSize(),
                 ) {
@@ -241,15 +243,15 @@ fun DiscoverScreenTablet(
             } else {
                 // Normal font: grid layout
                 LazyVerticalGrid(
-                    columns = GridCells.Adaptive(minSize = 320.dp),
+                    columns = GridCells.Adaptive(minSize = DISCOVER_GRID_MIN_SIZE),
                     contentPadding = PaddingValues(
-                        top = 120.dp,
-                        start = 24.dp,
-                        end = 24.dp,
-                        bottom = 200.dp,
+                        top = DISCOVER_SCROLL_TOP_PADDING,
+                        start = dim.spacingXXXL,
+                        end = dim.spacingXXXL,
+                        bottom = DISCOVER_SCROLL_PADDING,
                     ),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(dim.spacingXL),
+                    verticalArrangement = Arrangement.spacedBy(dim.spacingXL),
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     items(
@@ -295,6 +297,7 @@ private fun BoxScope.DiscoverFooterChipsRow(
     onChipSelected: (DiscoverCardType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     DiscoverChipRow(
         chipTypes = state.sortedDiscoverCardTypes,
         selectedType = state.selectedType,
@@ -310,7 +313,7 @@ private fun BoxScope.DiscoverFooterChipsRow(
                     endY = Float.POSITIVE_INFINITY,
                 ),
             )
-            .padding(vertical = 16.dp)
+            .padding(vertical = dim.spacingXL)
             .navigationBarsPadding(),
         onChipSelected = onChipSelected,
     )
@@ -355,17 +358,22 @@ private fun BoxScope.DiscoverTitleBar(
         )
         val density = LocalDensity.current
         val fontScale = density.fontScale
+        val dim = KrailTheme.dimensions
 
         Text(
             text = "What's On, Sydney!",
             style = KrailTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Normal),
             modifier = Modifier
-                .padding(horizontal = 24.dp)
-                .padding(bottom = if (fontScale < 1.5f) 16.dp else 8.dp)
+                .padding(horizontal = dim.spacingXXXL)
+                .padding(bottom = if (fontScale < 1.5f) dim.spacingXL else dim.spacingM)
                 .background(color = Color.Transparent),
         )
     }
 }
+
+private val DISCOVER_SCROLL_PADDING = 200.dp
+private val DISCOVER_SCROLL_TOP_PADDING = 120.dp
+private val DISCOVER_GRID_MIN_SIZE = 320.dp
 
 // region Previews
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentAlerts.kt
@@ -17,12 +17,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import xyz.ksharma.krail.taj.components.AlertButton
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.alerts.CollapsibleAlert
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
@@ -42,13 +42,14 @@ fun IntroContentAlerts(
         }
     }
 
+    val dim = KrailTheme.dimensions
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(dim.spacingL),
         ) {
             AlertButton(
                 dimensions = ButtonDefaults.smallButtonSize(),
@@ -90,7 +91,7 @@ fun AnimatedAlertsOneByOne(
         }
     }
 
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingM)) {
         AnimatedVisibility(
             visible = showFirst,
             enter = scaleIn(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_android_share
 import app.krail.taj.resources.ic_ios_share
 import org.jetbrains.compose.resources.painterResource
@@ -28,7 +29,6 @@ import xyz.ksharma.krail.core.appinfo.getAppPlatformType
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.Res as TajRes
 
 @Composable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentInviteFriends.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_android_share
 import app.krail.taj.resources.ic_ios_share
 import org.jetbrains.compose.resources.painterResource
@@ -29,6 +28,7 @@ import xyz.ksharma.krail.core.appinfo.getAppPlatformType
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.Res as TajRes
 
 @Composable
@@ -38,12 +38,13 @@ fun IntroContentInviteFriends(
     onShareClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(dim.spacingL)) {
             Text(
                 text = "TRIPS ARE\nBETTER\nWITH FRIENDS",
                 style = KrailTheme.typography.introTagline,
@@ -58,7 +59,7 @@ fun IntroContentInviteFriends(
         ) {
             Box(
                 modifier = Modifier
-                    .size(64.dp)
+                    .size(SHARE_BUTTON_SIZE)
                     .clip(CircleShape)
                     .background(color = style.hexToComposeColor())
                     .clickable(
@@ -79,7 +80,7 @@ fun IntroContentInviteFriends(
                     },
                     contentDescription = "Invite Friends",
                     colorFilter = ColorFilter.tint(Color.White),
-                    modifier = Modifier.size(32.dp),
+                    modifier = Modifier.size(dim.iconL),
                 )
             }
         }
@@ -91,3 +92,5 @@ fun IntroContentInviteFriends(
         )
     }
 }
+
+private val SHARE_BUTTON_SIZE = 64.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentPlanTrip.kt
@@ -18,13 +18,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import xyz.ksharma.krail.core.datetime.rememberCurrentDateTime
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.JourneyTimeOptionsGroup
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.TimeSelection
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
@@ -67,12 +67,13 @@ fun IntroContentPlanTrip(
             }
         }
 
+        val dim = KrailTheme.dimensions
         Column(
             modifier = modifier
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(dim.spacingL)) {
                 JourneyTimeOptionsGroup(
                     selectedOption = journeyTimeOption,
                     themeColor = style.hexToComposeColor(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentRealTime.kt
@@ -12,11 +12,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.LegView
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
@@ -46,7 +46,7 @@ fun IntroContentRealTime(
         modifier = modifier.verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingML)) {
             LegView(
                 routeText = "Circular Quay to Mosman Bay",
                 transportModeLine = TransportModeLine(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Job
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -55,7 +56,8 @@ fun IntroContentSaveTrips(
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        val dim = KrailTheme.dimensions
+        Column(verticalArrangement = Arrangement.spacedBy(dim.spacingML)) {
             OriginDestination(
                 origin = demoOrigin,
                 destination = demoDestination,
@@ -95,7 +97,7 @@ fun IntroContentSaveTrips(
 
             Box(
                 modifier = Modifier
-                    .size(64.dp)
+                    .size(SAVE_BUTTON_SIZE)
                     .clip(CircleShape)
                     .background(color = style.hexToComposeColor())
                     .clickable(
@@ -128,7 +130,7 @@ fun IntroContentSaveTrips(
                         "Save Trip"
                     },
                     colorFilter = ColorFilter.tint(Color.White),
-                    modifier = Modifier.size(48.dp)
+                    modifier = Modifier.size(dim.iconXXXL)
                         .graphicsLayer(rotationZ = rotation.value),
                 )
             }
@@ -142,5 +144,6 @@ fun IntroContentSaveTrips(
     }
 }
 
+private val SAVE_BUTTON_SIZE = 64.dp
 private val demoOrigin = StopDisplay(stopId = "1", name = "Wynyard Station")
 private val demoDestination = StopDisplay(stopId = "2", name = "Central Station")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSaveTrips.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Job
-import xyz.ksharma.krail.taj.theme.KrailTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroContentSelectTransportMode.kt
@@ -11,11 +11,11 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import xyz.ksharma.krail.core.transport.TransportModeSortOrder
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.TransportModeChip
 
 @Composable
@@ -61,16 +61,17 @@ fun IntroContentSelectTransportMode(
         }
     }
 
+    val dim = KrailTheme.dimensions
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(dim.spacingL)) {
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
+                verticalArrangement = Arrangement.spacedBy(dim.spacingL),
             ) {
                 allModes.forEach { mode ->
                     TransportModeChip(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroParkRide.kt
@@ -12,10 +12,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentSetOf
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState.ParkRideFacilityDetail
@@ -33,13 +33,14 @@ fun IntroParkRide(tagline: String, style: String, modifier: Modifier) {
         }
     }
 
+    val dim = KrailTheme.dimensions
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.SpaceBetween,
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(dim.spacingL),
         ) {
             CompositionLocalProvider(LocalThemeColor provides themeColor) {
                 ParkRideCard(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -95,6 +95,7 @@ fun IntroScreen(
         displayKRAILButton = true
     }
 
+    val dim = KrailTheme.dimensions
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -106,7 +107,7 @@ fun IntroScreen(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 32.dp, horizontal = 24.dp),
+                    .padding(vertical = dim.spacingXXXXL, horizontal = dim.spacingXXXL),
             ) {
                 IntroTitle(
                     offsetFraction,
@@ -121,7 +122,7 @@ fun IntroScreen(
             BoxWithConstraints(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 24.dp),
+                    .padding(top = dim.spacingXXXL),
             ) {
                 val screenHeight = maxHeight
                 val selectedHeight = screenHeight * 0.75f
@@ -129,8 +130,8 @@ fun IntroScreen(
 
                 HorizontalPager(
                     state = pagerState,
-                    contentPadding = PaddingValues(horizontal = 64.dp),
-                    pageSpacing = 20.dp,
+                    contentPadding = PaddingValues(horizontal = PAGER_HORIZONTAL_PADDING),
+                    pageSpacing = dim.spacingXXL,
                     modifier = Modifier.fillMaxWidth(),
                 ) { pageNumber ->
                     val pageOffset =
@@ -184,7 +185,7 @@ fun IntroScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .navigationBarsPadding()
-                .padding(bottom = 10.dp),
+                .padding(bottom = dim.spacingML),
         ) {
             AnimatedVisibility(
                 visible = displayKRAILButton,
@@ -206,7 +207,7 @@ fun IntroScreen(
                         customContainerColor = animatedButtonColor,
                         customContentColor = Color.White,
                     ),
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                    modifier = Modifier.padding(horizontal = dim.spacingXXXL, vertical = dim.spacingML),
                 ) {
                     Text(
                         text = state.pages[startPage].ctaText,
@@ -262,7 +263,7 @@ private fun IntroPageContent(
             IntroContentSaveTrips(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
 
@@ -270,7 +271,7 @@ private fun IntroPageContent(
             IntroContentRealTime(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
 
@@ -278,7 +279,7 @@ private fun IntroPageContent(
             IntroContentAlerts(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
 
@@ -286,7 +287,7 @@ private fun IntroPageContent(
             IntroContentPlanTrip(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
 
@@ -294,7 +295,7 @@ private fun IntroPageContent(
             IntroContentSelectTransportMode(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
 
@@ -303,7 +304,7 @@ private fun IntroPageContent(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
                 onShareClick = onShareClick,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
 
@@ -311,7 +312,7 @@ private fun IntroPageContent(
             IntroParkRide(
                 tagline = pageData.tagline,
                 style = pageData.primaryStyle,
-                modifier = modifier.padding(20.dp),
+                modifier = modifier.padding(KrailTheme.dimensions.spacingXXL),
             )
         }
     }
@@ -320,3 +321,5 @@ private fun IntroPageContent(
 private fun PagerState.calculateCurrentOffsetForPage(page: Int): Float {
     return (currentPage - page) + currentPageOffsetFraction
 }
+
+private val PAGER_HORIZONTAL_PADDING = 64.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/TagLineWithEmoji.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/TagLineWithEmoji.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 
@@ -18,9 +17,10 @@ internal fun TagLineWithEmoji(
     tagColor: Color? = null,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     Column(
-        modifier = modifier.padding(top = 20.dp, end = 10.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.padding(top = dim.spacingXXL, end = dim.spacingML),
+        verticalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
         Text(
             text = emoji,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -53,6 +53,7 @@ fun SettingsScreen(
     onIntroClick: () -> Unit = {},
     onSocialLinkClick: (KrailSocialType) -> Unit = {},
 ) {
+    val dim = KrailTheme.dimensions
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -71,7 +72,7 @@ fun SettingsScreen(
 
             LazyColumn(
                 modifier = Modifier,
-                contentPadding = PaddingValues(bottom = 104.dp),
+                contentPadding = PaddingValues(bottom = CONTENT_BOTTOM_PADDING),
             ) {
                 item {
                     SettingsItem(
@@ -98,8 +99,8 @@ fun SettingsScreen(
                         text = "About",
                         style = KrailTheme.typography.title,
                         modifier = Modifier
-                            .padding(top = 24.dp, bottom = 16.dp)
-                            .padding(horizontal = 26.dp),
+                            .padding(top = dim.spacingXXXL, bottom = dim.spacingXL)
+                            .padding(horizontal = SECTION_TITLE_HORIZONTAL_PADDING),
                     )
                 }
 
@@ -127,7 +128,7 @@ fun SettingsScreen(
                             SocialConnectionRow(
                                 socialLinks = KrailSocialType.entries,
                                 modifier = Modifier
-                                    .padding(start = (24 + 16 + 6).dp, end = 16.dp),
+                                    .padding(start = SOCIAL_ROW_START_PADDING, end = dim.spacingXL),
                                 onClick = { onSocialLinkClick(it) },
                             )
                         },
@@ -135,7 +136,7 @@ fun SettingsScreen(
                 }
 
                 item {
-                    Spacer(modifier = Modifier.fillMaxWidth().height(108.dp))
+                    Spacer(modifier = Modifier.fillMaxWidth().height(FOOTER_SPACER_HEIGHT))
                 }
             }
         }
@@ -144,14 +145,14 @@ fun SettingsScreen(
             modifier = Modifier.align(Alignment.BottomCenter)
                 .background(KrailTheme.colors.surface)
                 .navigationBarsPadding()
-                .padding(bottom = 10.dp, top = 16.dp),
+                .padding(bottom = dim.spacingML, top = dim.spacingXL),
         ) {
             AppLogo()
             Text(
                 text = "v$appVersion",
                 style = KrailTheme.typography.bodyLarge,
                 color = KrailTheme.colors.softLabel,
-                modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                modifier = Modifier.fillMaxWidth().padding(top = dim.spacingXL),
                 textAlign = TextAlign.Center,
             )
         }
@@ -192,24 +193,25 @@ private fun SettingsItem(
     onClick: (() -> Unit)? = null,
 ) {
     val themeColor by LocalThemeColor.current
+    val dim = KrailTheme.dimensions
     Column(
         modifier = modifier.fillMaxWidth()
             .klickable(enabled = onClick != null, onClick = onClick ?: {})
             .semantics(mergeDescendants = true) {},
     ) {
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(dim.spacingXXXL))
         Row(
             modifier = Modifier
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = dim.pageHorizontalPadding)
                 .semantics(mergeDescendants = true) {},
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(dim.spacingXL),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Image(
                 contentDescription = null,
                 painter = icon,
                 colorFilter = ColorFilter.tint(color = themeColor.hexToComposeColor()),
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier.size(dim.iconM),
             )
             Text(
                 text = text,
@@ -220,10 +222,15 @@ private fun SettingsItem(
         if (detailContent != null) {
             detailContent.invoke()
         } else {
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXXXL))
         }
         if (showDivider) {
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Divider(modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding))
         }
     }
 }
+
+private val CONTENT_BOTTOM_PADDING = 104.dp
+private val SECTION_TITLE_HORIZONTAL_PADDING = 26.dp
+private val SOCIAL_ROW_START_PADDING = 46.dp
+private val FOOTER_SPACER_HEIGHT = 108.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
@@ -36,6 +36,7 @@ fun OurStoryScreen(
             )
         }
 
+        val dim = KrailTheme.dimensions
         Crossfade(
             targetState = state.isLoading,
             label = "OurStoryContent",
@@ -43,13 +44,13 @@ fun OurStoryScreen(
             if (!isLoading) {
                 LazyColumn(
                     modifier = Modifier,
-                    contentPadding = PaddingValues(top = 20.dp, bottom = 104.dp),
+                    contentPadding = PaddingValues(top = dim.spacingXXL, bottom = CONTENT_BOTTOM_PADDING),
                 ) {
                     item {
                         Text(
                             state.story,
                             style = KrailTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
+                            modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding, vertical = dim.spacingXXXL),
                         )
                     }
 
@@ -57,15 +58,18 @@ fun OurStoryScreen(
                         Text(
                             text = state.disclaimer,
                             style = KrailTheme.typography.labelLarge,
-                            modifier = Modifier.padding(horizontal = 16.dp).padding(top = 12.dp),
+                            modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding).padding(top = dim.spacingL),
                         )
                     }
 
                     item {
-                        AppLogo(modifier = Modifier.padding(top = 48.dp))
+                        AppLogo(modifier = Modifier.padding(top = APP_LOGO_TOP_PADDING))
                     }
                 }
             }
         }
     }
 }
+
+private val CONTENT_BOTTOM_PADDING = 104.dp
+private val APP_LOGO_TOP_PADDING = 48.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
@@ -50,7 +50,10 @@ fun OurStoryScreen(
                         Text(
                             state.story,
                             style = KrailTheme.typography.bodyLarge,
-                            modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding, vertical = dim.spacingXXXL),
+                            modifier = Modifier.padding(
+                                horizontal = dim.pageHorizontalPadding,
+                                vertical = dim.spacingXXXL,
+                            ),
                         )
                     }
 
@@ -58,7 +61,9 @@ fun OurStoryScreen(
                         Text(
                             text = state.disclaimer,
                             style = KrailTheme.typography.labelLarge,
-                            modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding).padding(top = dim.spacingL),
+                            modifier = Modifier
+                                .padding(horizontal = dim.pageHorizontalPadding)
+                                .padding(top = dim.spacingL),
                         )
                     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
@@ -106,16 +106,17 @@ fun ThemeSelectionRadioButton(
         label = "pulseAlpha",
     )
 
+    val dim = KrailTheme.dimensions
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 16.dp)
+            .padding(horizontal = dim.spacingL, vertical = dim.spacingXL)
             .scalingKlickable { onClick(themeStyle) },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
-                .size(40.dp)
+                .size(COLOR_SWATCH_OUTER_SIZE)
                 .then(
                     if (selected) {
                         Modifier.drawBehind {
@@ -137,7 +138,7 @@ fun ThemeSelectionRadioButton(
         ) {
             Box(
                 modifier = Modifier
-                    .size(32.dp)
+                    .size(dim.iconL)
                     .clip(CircleShape)
                     .background(color = themeStyle.hexColorCode.hexToComposeColor()),
             )
@@ -145,20 +146,20 @@ fun ThemeSelectionRadioButton(
 
         Box(
             modifier = Modifier
-                .padding(start = 16.dp),
+                .padding(start = dim.spacingXL),
         ) {
             if (selected && textLayoutResult != null) {
                 val textWidth = with(density) { textLayoutResult!!.size.width.toDp() }
                 Canvas(
                     modifier = Modifier
                         .width(textWidth)
-                        .padding(horizontal = 12.dp),
+                        .padding(horizontal = dim.spacingL),
                 ) {
                     val layout = textLayoutResult!!
                     val lineCount = layout.lineCount
-                    val strokeWidth = 32.dp.toPx()
-                    val amplitude = 14.dp.toPx()
-                    val waveLength = 32.dp.toPx()
+                    val strokeWidth = WAVE_STROKE_WIDTH.toPx()
+                    val amplitude = WAVE_AMPLITUDE.toPx()
+                    val waveLength = WAVE_LENGTH.toPx()
                     var remaining = currentPathLength
 
                     for (line in 0 until lineCount) {
@@ -210,7 +211,7 @@ fun ThemeSelectionRadioButton(
                 style = KrailTheme.typography.title.copy(fontWeight = FontWeight.Normal),
                 modifier = Modifier
                     .align(Alignment.CenterStart)
-                    .padding(horizontal = 2.dp),
+                    .padding(horizontal = dim.strokeRegular),
                 onTextLayout = { textLayoutResult = it },
                 color = KrailTheme.colors.onSurface,
                 textAlign = TextAlign.Start,
@@ -242,3 +243,8 @@ private fun ThemeSelectionRadioButtonUnselectedPreview() {
         )
     }
 }
+
+private val COLOR_SWATCH_OUTER_SIZE = 40.dp
+private val WAVE_STROKE_WIDTH = 32.dp
+private val WAVE_AMPLITUDE = 14.dp
+private val WAVE_LENGTH = 32.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioGroup.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioGroup.kt
@@ -75,15 +75,16 @@ fun ThemeSelectionRadioGroup(
     val textWidths = remember { mutableStateMapOf<Int, Float>() }
     val density = LocalDensity.current
 
+    val dim = KrailTheme.dimensions
     BoxWithConstraints(
         modifier = modifier
             .fillMaxWidth()
-            .height(56.dp)
+            .height(GROUP_HEIGHT)
             .background(
                 color = KrailTheme.colors.themeSelectionBackground,
-                shape = RoundedCornerShape(32.dp),
+                shape = RoundedCornerShape(GROUP_CORNER_RADIUS),
             )
-            .padding(4.dp),
+            .padding(dim.spacingXS),
     ) {
         val containerWidth = constraints.maxWidth.toFloat()
         val optionWidth = containerWidth / ThemeMode.entries.size
@@ -92,7 +93,7 @@ fun ThemeSelectionRadioGroup(
 
         // Current handle width based on selected text + padding
         val currentHandleWidth = textWidths[targetIndex] ?: fallbackWidth
-        val paddedHandleWidth = currentHandleWidth + with(density) { 24.dp.toPx() }
+        val paddedHandleWidth = currentHandleWidth + with(density) { HANDLE_LABEL_PADDING.toPx() }
 
         // Animate handle width
         val animatedWidth by animateFloatAsState(
@@ -132,7 +133,7 @@ fun ThemeSelectionRadioGroup(
         // Handle
         Box(
             modifier = Modifier
-                .height(48.dp)
+                .height(dim.buttonRoundSize)
                 .width(with(density) { animatedWidth.toDp() })
                 .offset { IntOffset(animatedOffset.roundToInt(), 0) }
                 .pointerInput(Unit) {
@@ -151,7 +152,7 @@ fun ThemeSelectionRadioGroup(
                         },
                     ) { change, dragAmount ->
                         change.consume()
-                        val horizontalPaddingPx = with(density) { 4.dp.toPx() }
+                        val horizontalPaddingPx = with(density) { dim.spacingXS.toPx() }
                         val minOffset = horizontalPaddingPx
                         val maxOffset = containerWidth - horizontalPaddingPx - animatedWidth
 
@@ -170,7 +171,7 @@ fun ThemeSelectionRadioGroup(
         // Labels with measurement
         Row(
             modifier = Modifier.fillMaxSize()
-                .padding(horizontal = 4.dp), // push edge labels inward
+                .padding(horizontal = dim.spacingXS), // push edge labels inward
             horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -180,7 +181,7 @@ fun ThemeSelectionRadioGroup(
                     isSelected = targetIndex == index,
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 8.dp) // spacing between text and handle edges
+                        .padding(horizontal = dim.spacingM) // spacing between text and handle edges
                         .onGloballyPositioned { coords ->
                             val width = coords.size.width.toFloat()
                             textWidths[index] = width
@@ -206,7 +207,7 @@ private fun ThemeSelectorHandle(
     )
 
     val shadowRadius by animateDpAsState(
-        targetValue = if (isDragging) 20.dp else 14.dp, // Always have shadow, more when dragging
+        targetValue = if (isDragging) SHADOW_RADIUS_DRAGGING else SHADOW_RADIUS_DEFAULT,
         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
         label = "shadowRadius",
     )
@@ -223,11 +224,12 @@ private fun ThemeSelectorHandle(
         label = "shadowAlpha",
     )
 
+    val dim = KrailTheme.dimensions
     Box(
         modifier = modifier
             .scale(scale)
             .dropShadow(
-                shape = RoundedCornerShape(28.dp),
+                shape = RoundedCornerShape(dim.radiusXXL),
                 shadow = Shadow(
                     color = pressedShadowColors[0],
                     radius = shadowRadius,
@@ -236,7 +238,7 @@ private fun ThemeSelectorHandle(
                 ),
             )
             .dropShadow(
-                shape = RoundedCornerShape(28.dp),
+                shape = RoundedCornerShape(dim.radiusXXL),
                 shadow = Shadow(
                     color = pressedShadowColors[1],
                     radius = (shadowRadius.value * 0.7f).dp,
@@ -245,7 +247,7 @@ private fun ThemeSelectorHandle(
                 ),
             )
             .dropShadow(
-                shape = RoundedCornerShape(28.dp),
+                shape = RoundedCornerShape(dim.radiusXXL),
                 shadow = Shadow(
                     color = pressedShadowColors[2],
                     radius = (shadowRadius.value * 0.4f).dp,
@@ -256,7 +258,7 @@ private fun ThemeSelectorHandle(
             // Handle background uses surface color
             .background(
                 color = KrailTheme.colors.surface,
-                shape = RoundedCornerShape(28.dp),
+                shape = RoundedCornerShape(dim.radiusXXL),
             ),
     )
 }
@@ -298,8 +300,9 @@ private fun ThemeOptionLabel(
         label = "letterSpacing",
     )
 
+    val dim = KrailTheme.dimensions
     Box(
-        modifier = modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+        modifier = modifier.padding(horizontal = dim.spacingM, vertical = dim.spacingM),
         contentAlignment = Alignment.Center,
     ) {
         Text(
@@ -320,6 +323,11 @@ private fun ThemeOptionLabel(
 }
 
 private const val FALLBACK_WIDTH_RATIO = 0.6f
+private val GROUP_HEIGHT = 56.dp
+private val GROUP_CORNER_RADIUS = 32.dp
+private val HANDLE_LABEL_PADDING = 24.dp
+private val SHADOW_RADIUS_DEFAULT = 14.dp
+private val SHADOW_RADIUS_DRAGGING = 20.dp
 
 // region Previews
 
@@ -344,7 +352,7 @@ private fun ThemeSelectionRadioGroupPreview() {
                     .systemBarsPadding()
                     .fillMaxWidth()
                     .background(KrailTheme.colors.surface)
-                    .padding(24.dp),
+                    .padding(KrailTheme.dimensions.spacingXXXL),
                 contentAlignment = Alignment.Center,
             ) {
                 ThemeSelectionRadioGroup(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -54,6 +54,7 @@ fun ThemeSelectionScreen(
             animationSpec = tween(durationMillis = 300, easing = LinearEasing),
         )
 
+        val dim = KrailTheme.dimensions
         Column {
             TitleBar(
                 onNavActionClick = onBackClick,
@@ -66,8 +67,8 @@ fun ThemeSelectionScreen(
                     text = "Pick your favourite colour!",
                     style = KrailTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Normal),
                     modifier = Modifier
-                        .padding(horizontal = 24.dp)
-                        .padding(bottom = 32.dp),
+                        .padding(horizontal = dim.spacingXXXL)
+                        .padding(bottom = dim.spacingXXXXL),
                 )
 
                 KrailThemeStyle.entries.forEachIndexed { index, theme ->
@@ -81,21 +82,21 @@ fun ThemeSelectionScreen(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(96.dp))
+                Spacer(modifier = Modifier.height(THEME_SCROLL_BOTTOM_PADDING))
             }
         }
 
         Column(
             modifier = Modifier.align(Alignment.BottomCenter)
                 .navigationBarsPadding()
-                .padding(bottom = 10.dp),
+                .padding(bottom = dim.spacingML),
         ) {
             val themeController = LocalThemeController.current
 
             ThemeSelectionRadioGroup(
                 selectedTheme = themeController.currentMode,
                 glowColor = buttonBackgroundColor,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 10.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXXXL, vertical = dim.spacingML),
                 onThemeSelect = { newTheme ->
                     themeController.setThemeMode(newTheme)
                     onThemeModeSelect(newTheme.code)
@@ -104,3 +105,5 @@ fun ThemeSelectionScreen(
         }
     }
 }
+
+private val THEME_SCROLL_BOTTOM_PADDING = 96.dp

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Divider.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Divider.kt
@@ -58,7 +58,7 @@ private fun DividerHorizontalPreview() {
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(30.dp)
+                .height(PREVIEW_BOX_SIZE)
                 .background(KrailTheme.colors.surface),
             contentAlignment = Alignment.Center,
         ) {
@@ -73,7 +73,7 @@ private fun DividerVerticalPreview() {
     PreviewTheme {
         Box(
             modifier = Modifier
-                .size(30.dp)
+                .size(PREVIEW_BOX_SIZE)
                 .background(KrailTheme.colors.surface),
             contentAlignment = Alignment.Center,
         ) {
@@ -81,3 +81,5 @@ private fun DividerVerticalPreview() {
         }
     }
 }
+
+private val PREVIEW_BOX_SIZE = 30.dp


### PR DESCRIPTION
Migrate settings, theme selection, discover, and intro screens to use
KrailTheme.dimensions tokens instead of raw dp literals. Non-token
component-specific values (scroll buffers, canvas drawing params,
animation radii) are extracted to named private constants.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>