### PR TITLE
refactor(ui): replace hardcoded dp values with dimension tokens (batch 2)

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AddLabelBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AddLabelBottomSheet.kt
@@ -219,7 +219,7 @@ fun AddLabelBottomSheet(
                                     painter = painterResource(icon),
                                     contentDescription = null,
                                     colorFilter = ColorFilter.tint(contentColor),
-                                    modifier = Modifier.size(14.dp),
+                                    modifier = Modifier.size(LABEL_ICON_SIZE),
                                 )
                                 Text(
                                     text = chipName,
@@ -302,7 +302,7 @@ private fun StopChip(stopName: String, modifier: Modifier = Modifier) {
             painter = painterResource(TripPlannerRes.drawable.ic_location_on),
             contentDescription = null,
             colorFilter = ColorFilter.tint(KrailTheme.colors.surface),
-            modifier = Modifier.size(12.dp),
+            modifier = Modifier.size(STOP_CHIP_ICON_SIZE),
         )
         Text(
             text = stopName,
@@ -329,7 +329,7 @@ private fun LabelPreviewPill(name: String) {
             painter = painterResource(icon),
             contentDescription = null,
             colorFilter = ColorFilter.tint(KrailTheme.colors.surface),
-            modifier = Modifier.size(14.dp),
+            modifier = Modifier.size(LABEL_ICON_SIZE),
         )
         Text(
             text = name,
@@ -385,3 +385,6 @@ private fun PreviewAddLabelBottomSheet_WithStop() {
 }
 
 // endregion
+
+private val LABEL_ICON_SIZE = 14.dp
+private val STOP_CHIP_ICON_SIZE = 12.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SaveStopAsLabelSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SaveStopAsLabelSheet.kt
@@ -130,7 +130,7 @@ private fun LabelChoiceChip(
             painter = painterResource(icon),
             contentDescription = null,
             colorFilter = ColorFilter.tint(contentColor),
-            modifier = Modifier.size(14.dp),
+            modifier = Modifier.size(LABEL_CHIP_ICON_SIZE),
         )
         Text(
             text = label.label,
@@ -185,3 +185,5 @@ private fun PreviewSaveStopAsLabelSheet() {
 }
 
 // endregion
+
+private val LABEL_CHIP_ICON_SIZE = 14.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
@@ -48,8 +48,9 @@ internal fun TrackedLegView(
     isArrived: Boolean = false,
     stopDelays: Map<String, Int> = emptyMap(),
 ) {
-    val circleRadius = 8.dp
-    val strokeWidth = 4.dp
+    val dim = KrailTheme.dimensions
+    val circleRadius = dim.spacingM
+    val strokeWidth = dim.strokeThick
     val lineColor = remember(leg.lineColorCode) { leg.lineColorCode.hexToComposeColor() }
     val pendingColor = KrailTheme.colors.softLabel
 
@@ -147,13 +148,13 @@ internal fun TrackedLegView(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(bottom = 16.dp, top = 16.dp),
+                .padding(bottom = dim.spacingXL, top = dim.spacingXL),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TransportModeBadge(
                 backgroundColor = lineColor,
                 badgeText = leg.lineName,
-                modifier = Modifier.padding(end = 10.dp),
+                modifier = Modifier.padding(end = dim.spacingML),
             )
             leg.headsign?.let { headsign ->
                 Text(
@@ -163,7 +164,7 @@ internal fun TrackedLegView(
             }
         }
 
-        Column(modifier = Modifier.fillMaxWidth().padding(start = 4.dp)) {
+        Column(modifier = Modifier.fillMaxWidth().padding(start = dim.spacingXS)) {
             // First stop (always prominent — origin)
             val firstStop = leg.stops.first()
             TrackedStopRow(
@@ -181,12 +182,12 @@ internal fun TrackedLegView(
                         circleRadius = stopCircleRadius(0),
                         circleColor = stopCircleColor(0),
                     )
-                    .padding(start = 16.dp),
+                    .padding(start = dim.spacingXL),
             )
 
             if (isActiveSegment(0)) {
                 Spacer(
-                    modifier = Modifier.height(16.dp)
+                    modifier = Modifier.height(dim.spacingXL)
                         .timeLineCenterSplit(
                             completedColor = lineColor,
                             pendingColor = pendingColor,
@@ -196,7 +197,7 @@ internal fun TrackedLegView(
                 )
             } else {
                 Spacer(
-                    modifier = Modifier.height(12.dp)
+                    modifier = Modifier.height(dim.spacingL)
                         .timeLineCenter(color = segmentColor(0), strokeWidth = strokeWidth),
                 )
             }
@@ -233,12 +234,12 @@ internal fun TrackedLegView(
                             circleRadius = stopCircleRadius(stopIdx),
                             circleColor = stopCircleColor(stopIdx),
                         )
-                        .padding(start = 16.dp),
+                        .padding(start = dim.spacingXL),
                 )
 
                 if (isActiveSegment(stopIdx)) {
                     Spacer(
-                        modifier = Modifier.height(16.dp)
+                        modifier = Modifier.height(dim.spacingXL)
                             .timeLineCenterSplit(
                                 lineColor,
                                 pendingColor,
@@ -248,7 +249,7 @@ internal fun TrackedLegView(
                     )
                 } else {
                     Spacer(
-                        modifier = Modifier.height(16.dp).timeLineCenter(
+                        modifier = Modifier.height(dim.spacingXL).timeLineCenter(
                             color = segmentColor(stopIdx),
                             strokeWidth = strokeWidth,
                         ),
@@ -280,7 +281,7 @@ internal fun TrackedLegView(
                         circleRadius = stopCircleRadius(lastIdx),
                         circleColor = stopCircleColor(lastIdx),
                     )
-                    .padding(start = 16.dp),
+                    .padding(start = dim.spacingXL),
             )
         }
     }
@@ -324,8 +325,8 @@ private fun TrackedStopRow(
             modifier = Modifier.fillMaxWidth(),
         ) {
             Row(
-                modifier = Modifier.padding(end = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.padding(end = KrailTheme.dimensions.spacingM),
+                horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingS),
             ) {
                 Text(text = time, style = timeStyle, color = contentColor)
                 scheduledTime?.let {
@@ -360,7 +361,7 @@ private fun ApproachingTimeText(
             text = "($timeText)",
             style = KrailTheme.typography.bodyMedium,
             color = contentColor,
-            modifier = Modifier.padding(vertical = 2.dp),
+            modifier = Modifier.padding(vertical = APPROACHING_TIME_VERTICAL_PADDING),
         )
     }
 }
@@ -415,7 +416,7 @@ private fun TrackedLegViewPreview() {
                 ),
             ),
             now = now,
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(KrailTheme.dimensions.spacingXL),
         )
     }
 }
@@ -425,8 +426,8 @@ private fun TrackedLegViewPreview() {
 private fun TrackedStopRowPreview() {
     PreviewTheme(themeStyle = KrailThemeStyle.Train) {
         Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(KrailTheme.dimensions.spacingXL),
+            verticalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingXL),
         ) {
             TrackedStopRow(
                 time = "12:05 PM",
@@ -451,3 +452,5 @@ private fun TrackedStopRowPreview() {
 }
 
 // endregion
+
+private val APPROACHING_TIME_VERTICAL_PADDING = 2.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/map/StopDetailsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/map/StopDetailsBottomSheet.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableList
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.components.Button
@@ -53,6 +52,7 @@ fun StopDetailsBottomSheet(
     additionalInfo: @Composable () -> Unit = {},
     actionButton: @Composable () -> Unit = {},
 ) {
+    val dim = KrailTheme.dimensions
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         containerColor = KrailTheme.colors.bottomSheetBackground,
@@ -70,8 +70,8 @@ fun StopDetailsBottomSheet(
                 style = KrailTheme.typography.headlineMedium,
                 color = KrailTheme.colors.onSurface,
                 modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 8.dp),
+                    .padding(horizontal = dim.spacingXL)
+                    .padding(bottom = dim.spacingM),
             )
 
             // Stop ID
@@ -79,14 +79,14 @@ fun StopDetailsBottomSheet(
                 text = "Stop ID - $stopId",
                 style = KrailTheme.typography.bodyMedium,
                 color = KrailTheme.colors.softLabel,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL),
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Divider(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
             // Additional info (custom content)
             additionalInfo()
@@ -97,24 +97,24 @@ fun StopDetailsBottomSheet(
                     text = "Transport Modes",
                     style = KrailTheme.typography.titleMedium,
                     color = KrailTheme.colors.onSurface,
-                    modifier = Modifier.padding(horizontal = 16.dp),
+                    modifier = Modifier.padding(horizontal = dim.spacingXL),
                 )
 
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(dim.spacingL))
 
                 TransportModeRow(
                     transportModes = transportModes,
                     modifier = Modifier.fillMaxWidth(),
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(dim.spacingXXXL))
             }
 
             // Action button (custom)
             actionButton()
 
             // Bottom spacer
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXXXL))
         }
     }
 }
@@ -127,15 +127,16 @@ private fun TransportModeRow(
     transportModes: ImmutableList<TransportMode>,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     LazyRow(
         modifier = modifier,
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = dim.spacingXL),
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
     ) {
         items(transportModes) { mode ->
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(dim.spacingM),
             ) {
                 TransportModeIcon(
                     transportMode = mode,
@@ -164,7 +165,7 @@ fun StopInfoRow(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .padding(horizontal = KrailTheme.dimensions.spacingXL, vertical = KrailTheme.dimensions.spacingXS),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -193,8 +194,8 @@ fun StopActionButton(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+            .padding(horizontal = KrailTheme.dimensions.spacingXL),
+        horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingL),
     ) {
         Button(
             onClick = onClick,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateSelection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateSelection.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_chevron_left
 import krail.feature.trip_planner.ui.generated.resources.ic_chevron_right
@@ -28,9 +27,10 @@ fun DateSelection(
     onNextClicked: () -> Unit = {},
     onPreviousClicked: () -> Unit = {},
 ) {
+    val dim = KrailTheme.dimensions
     Column(
-        modifier = modifier.fillMaxWidth().padding(top = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier.fillMaxWidth().padding(top = dim.spacingXL),
+        verticalArrangement = Arrangement.spacedBy(dim.spacingL),
     ) {
         Text(
             text = "Select Date",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -101,8 +100,9 @@ fun DateTimeSelectorScreen(
             journeyTimeOption == JourneyTimeOptions.LEAVE
     }
 
+    val dim = KrailTheme.dimensions
     LazyColumn(
-        contentPadding = PaddingValues(vertical = 16.dp),
+        contentPadding = PaddingValues(vertical = dim.spacingXL),
         modifier = modifier.background(color = KrailTheme.colors.bottomSheetBackground),
     ) {
         item("title_bar") {
@@ -137,7 +137,7 @@ fun DateTimeSelectorScreen(
                 onOptionSelected = {
                     journeyTimeOption = it
                 },
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingXL),
             )
         }
 
@@ -156,15 +156,15 @@ fun DateTimeSelectorScreen(
                     }
                 },
                 modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 12.dp),
+                    .padding(horizontal = dim.spacingXL)
+                    .padding(top = dim.spacingL),
             )
         }
 
         item("time_selection") {
             TimeSelection(
                 timePickerState = timePickerState,
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingL),
             )
         }
 
@@ -185,7 +185,7 @@ fun DateTimeSelectorScreen(
                     )
                 },
                 dimensions = ButtonDefaults.largeButtonSize(),
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXXXL, vertical = dim.spacingXL),
             ) {
                 Text(
                     text = if (reset) {
@@ -203,7 +203,7 @@ fun DateTimeSelectorScreen(
         }
 
         item("bottom_spacing") {
-            Spacer(modifier = Modifier.height(48.dp))
+            Spacer(modifier = Modifier.height(dim.buttonRoundSize))
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/JourneyTimeOptionsGroup.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/JourneyTimeOptionsGroup.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.OutlineRadioButton
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
 
@@ -19,7 +19,7 @@ fun JourneyTimeOptionsGroup(
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingM),
     ) {
         JourneyTimeOptions.entries.forEach { option ->
             OutlineRadioButton(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/TimeSelection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/TimeSelection.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -34,9 +33,10 @@ fun TimeSelection(
     val themeColor = themeColorHex.hexToComposeColor()
     val themeContentColor = getForegroundColor(themeColor)
 
+    val dim = KrailTheme.dimensions
     Column(
-        modifier = modifier.padding(top = 12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier.padding(top = dim.spacingL),
+        verticalArrangement = Arrangement.spacedBy(dim.spacingL),
     ) {
         val density = LocalDensity.current
         if (displayTitle) {
@@ -72,7 +72,7 @@ fun TimeSelection(
                     timeSelectorUnselectedContentColor = KrailTheme.colors.onSurface.copy(alpha = 0.8f),
                 ),
                 layoutType = TimePickerLayoutType.Vertical,
-                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                modifier = Modifier.fillMaxWidth().padding(top = dim.spacingL),
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/DepartureBoardStopSection.kt
@@ -114,12 +114,12 @@ internal fun DepartureBoardAccordionSectionHeader(
         label = "arrow-rotation",
     )
     val outerPadding by animateDpAsState(
-        targetValue = if (isExpanded) 0.dp else dim.spacingXL,
+        targetValue = if (isExpanded) dim.spacingNone else dim.spacingXL,
         animationSpec = tween(durationMillis = 300),
         label = "outer-padding",
     )
     val cornerRadius by animateDpAsState(
-        targetValue = if (isExpanded) 0.dp else dim.cardCornerRadius,
+        targetValue = if (isExpanded) dim.spacingNone else dim.cardCornerRadius,
         animationSpec = tween(durationMillis = 300),
         label = "corner-radius",
     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/LineBadgeChip.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/departureboard/LineBadgeChip.kt
@@ -18,17 +18,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
-
-private val chipMinHeight = 44.dp
-private val chipMinWidth = 44.dp
-private val chipShape = RoundedCornerShape(8.dp)
 
 /**
  * A tappable, selectable chip that displays a transport line number using [lineColorCode].
@@ -56,6 +51,8 @@ fun LineBadgeChip(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
+    val chipMinSize = dim.iconXXL
+    val chipShape = RoundedCornerShape(dim.radiusS)
     val lineColor = remember(lineColorCode) { lineColorCode.hexToComposeColor() }
 
     val backgroundColor by animateColorAsState(
@@ -76,8 +73,8 @@ fun LineBadgeChip(
 
     Box(
         modifier = modifier
-            .heightIn(min = chipMinHeight)
-            .widthIn(min = chipMinWidth)
+            .heightIn(min = chipMinSize)
+            .widthIn(min = chipMinSize)
             .clip(chipShape)
             .background(backgroundColor)
             .border(width = dim.strokeRegular, color = borderColor, shape = chipShape)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -39,6 +39,7 @@ import xyz.ksharma.krail.core.maps.ui.config.MapConfig
 import xyz.ksharma.krail.core.maps.ui.config.MapTileProvider
 import xyz.ksharma.krail.core.maps.ui.utils.MapCameraUtils
 import xyz.ksharma.krail.core.permission.PermissionStatus
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.TrackUserLocation
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyStopFeature
@@ -202,19 +203,19 @@ private fun JourneyMapContent(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .navigationBarsPadding()
-                .padding(16.dp),
+                .padding(KrailTheme.dimensions.spacingXL),
         )
 
         // Top overlays — permission banner (if shown) then freshness badge directly below it.
-        // fillMaxWidth + horizontal padding here so both children get consistent 16dp screen
+        // fillMaxWidth + horizontal padding here so both children get consistent spacingXL screen
         // margins without each child needing to specify it individually.
         if (showPermissionBanner || (showFreshnessBadge && badgeText != null)) {
             Column(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 8.dp),
+                    .padding(horizontal = KrailTheme.dimensions.spacingXL)
+                    .padding(top = KrailTheme.dimensions.spacingM),
             ) {
                 if (showPermissionBanner) {
                     LocationPermissionBanner(
@@ -231,7 +232,7 @@ private fun JourneyMapContent(
                             isStale = isStale,
                             modifier = Modifier
                                 .align(Alignment.CenterHorizontally)
-                                .padding(vertical = 8.dp),
+                                .padding(vertical = KrailTheme.dimensions.spacingM),
                         )
                     }
                 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyStopDetailsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyStopDetailsBottomSheet.kt
@@ -7,11 +7,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.components.map.StopInfoRow
 import xyz.ksharma.krail.trip.planner.ui.journeymap.business.JourneyStopUiMapper.getTimeInfo
@@ -41,17 +41,18 @@ fun JourneyStopDetailsBottomSheet(
         onDismiss = onDismiss,
         modifier = modifier,
         additionalInfo = {
+            val dim = KrailTheme.dimensions
             // Display time info rows
             timeInfo.forEach { info ->
                 StopInfoRow(
                     label = info.label,
                     value = info.value,
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(dim.spacingM))
             }
 
             if (timeInfo.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(dim.spacingM))
             }
         },
     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideContent.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
@@ -28,16 +27,17 @@ fun ParkRideLoadedContent(
     parkRideFacilityDetail: ParkRideFacilityDetail,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(dim.radiusM))
             .background(color = themeBackgroundColor())
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+            .padding(horizontal = dim.spacingXL, vertical = dim.spacingL),
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingXL),
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(dim.spacingXS),
         ) {
             // Facility Name
             Text(
@@ -49,10 +49,10 @@ fun ParkRideLoadedContent(
 
             // Spots Information
             FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(dim.spacingML),
+                verticalArrangement = Arrangement.spacedBy(dim.spacingXS),
             ) {
-                FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(dim.spacingXS)) {
                     Text(
                         text = "${parkRideFacilityDetail.spotsAvailable}",
                         style = KrailTheme.typography.headlineLarge,
@@ -68,7 +68,7 @@ fun ParkRideLoadedContent(
                 }
 
                 FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
                 ) {
                     Text(
                         text = "${parkRideFacilityDetail.percentageFull}%",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -441,9 +441,9 @@ private fun LazyListScope.savedTripsContent(
                 tracked = trackedJourney,
                 onCardClick = onTrackingCardClick,
                 onStopTracking = onStopTracking,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = KrailTheme.dimensions.spacingXL),
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(KrailTheme.dimensions.spacingXL))
         }
     }
 
@@ -507,7 +507,7 @@ private fun LazyListScope.savedTripsContent(
                 seed = trip.tripId.hashCode(),
             )
 
-            Column(modifier = Modifier.padding(top = if (editing) dim.spacingS else 0.dp)) {
+            Column(modifier = Modifier.padding(top = if (editing) dim.spacingS else dim.spacingNone)) {
                 Box(
                     modifier = Modifier
                         .graphicsLayer { rotationZ = rotation }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
@@ -40,6 +40,7 @@ import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.NavActionButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextField
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.MapToggleButton
 
@@ -79,6 +80,7 @@ fun SearchTopBar(
         }
     }
 
+    val dim = KrailTheme.dimensions
     Row(
         horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -86,9 +88,14 @@ fun SearchTopBar(
             .fillMaxWidth()
             .statusBarsPadding()
             .windowInsetsPadding(WindowInsets.ime)
-            .padding(horizontal = 16.dp, vertical = 12.dp)
-            .background(color = Color.Transparent, RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp))
-            .clip(RoundedCornerShape(bottomStart = 24.dp, bottomEnd = 24.dp)),
+            .padding(horizontal = dim.spacingXL, vertical = dim.spacingL)
+            .background(
+                color = Color.Transparent,
+                RoundedCornerShape(bottomStart = dim.bottomSheetCornerRadius, bottomEnd = dim.bottomSheetCornerRadius),
+            )
+            .clip(
+                RoundedCornerShape(bottomStart = dim.bottomSheetCornerRadius, bottomEnd = dim.bottomSheetCornerRadius),
+            ),
     ) {
         TextField(
             placeholder = placeholderText,
@@ -117,11 +124,11 @@ fun SearchTopBar(
 
         // animateContentSize is only applied when animateMapButton == true (NotDetermined).
         // For false (Granted/Denied) the button appears instantly with no animation.
-        // height(48.dp) locks height so only width animates, preventing the button from
+        // height(buttonRoundSize) locks height so only width animates, preventing the button from
         // drifting up from the bottom-right when both dimensions would otherwise animate.
         Box(
             modifier = Modifier
-                .height(48.dp)
+                .height(dim.buttonRoundSize)
                 .then(
                     if (animateMapButton == true) {
                         Modifier.animateContentSize(
@@ -136,7 +143,7 @@ fun SearchTopBar(
                 MapToggleButton(
                     selected = isMapSelected,
                     onClick = { onMapToggle(!isMapSelected) },
-                    modifier = Modifier.padding(start = 12.dp),
+                    modifier = Modifier.padding(start = dim.spacingL),
                 ) {
                     Text("Map")
                 }
@@ -164,7 +171,7 @@ private fun PreviewSearchTopBar_List() {
                 onMapToggle = {},
                 onBackClick = {},
                 onTextChange = {},
-                modifier = Modifier.height(72.dp),
+                modifier = Modifier.height(SEARCH_TOP_BAR_HEIGHT),
             )
         }
     }
@@ -187,7 +194,7 @@ private fun PreviewSearchTopBar_Map() {
                 onMapToggle = {},
                 onBackClick = {},
                 onTextChange = {},
-                modifier = Modifier.height(72.dp),
+                modifier = Modifier.height(SEARCH_TOP_BAR_HEIGHT),
             )
         }
     }
@@ -200,7 +207,7 @@ private fun PreviewSearchTopBar_Compact() {
         val themeColor = remember { mutableStateOf(NswTransportMode.Train.colorCode) }
         CompositionLocalProvider(LocalThemeColor provides themeColor) {
             val focusRequester = remember { FocusRequester() }
-            Box(modifier = Modifier.width(360.dp).height(72.dp)) {
+            Box(modifier = Modifier.width(SEARCH_TOP_BAR_PREVIEW_WIDTH).height(SEARCH_TOP_BAR_HEIGHT)) {
                 SearchTopBar(
                     placeholderText = "Station",
                     focusRequester = focusRequester,
@@ -219,3 +226,6 @@ private fun PreviewSearchTopBar_Compact() {
 }
 
 // endregion
+
+private val SEARCH_TOP_BAR_HEIGHT = 72.dp
+private val SEARCH_TOP_BAR_PREVIEW_WIDTH = 360.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapActionButtons.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapActionButtons.kt
@@ -20,6 +20,7 @@ import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 
 /**
@@ -38,11 +39,12 @@ internal fun MapActionButtons(
     modifier: Modifier = Modifier,
     isLocationActive: Boolean = false,
 ) {
+    val dim = KrailTheme.dimensions
     Row(
         modifier = modifier
             .fillMaxWidth()
             .navigationBarsPadding()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = dim.spacingXL, vertical = dim.spacingM),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -51,14 +53,14 @@ internal fun MapActionButtons(
             dimensions = ButtonDefaults.mediumButtonSize(),
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Image(
                     painter = painterResource(Res.drawable.ic_filter),
                     contentDescription = null,
                     colorFilter = ColorFilter.tint(ButtonDefaults.buttonColors().contentColor),
-                    modifier = Modifier.size(18.dp),
+                    modifier = Modifier.size(MAP_FILTER_ICON_SIZE),
                 )
                 Text(text = "Options")
             }
@@ -95,3 +97,5 @@ private fun MapActionButtonsInactivePreview() {
 }
 
 // endregion
+
+private val MAP_FILTER_ICON_SIZE = 18.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
@@ -301,6 +301,7 @@ private fun TransportModeFilterRow(
     val allModes = remember {
         NswTransportConfig.sortedModes(TransportModeSortOrder.PRIORITY)
     }
+    val dim = KrailTheme.dimensions
 
     LazyRow(
         modifier = modifier.fillMaxWidth(),
@@ -325,6 +326,7 @@ private fun MapControlToggle(
     modifier: Modifier = Modifier,
 ) {
     val themeColor = LocalThemeColor.current.value.hexToComposeColor()
+    val dim = KrailTheme.dimensions
 
     Row(
         modifier = modifier

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
@@ -65,6 +65,7 @@ fun MapOptionsBottomSheet(
     var pendingShowDistanceScale by remember { mutableStateOf(showDistanceScale) }
     var pendingShowCompass by remember { mutableStateOf(showCompass) }
 
+    val dim = KrailTheme.dimensions
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         containerColor = KrailTheme.colors.bottomSheetBackground,
@@ -80,8 +81,8 @@ fun MapOptionsBottomSheet(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(bottom = 16.dp),
+                    .padding(horizontal = dim.spacingXL)
+                    .padding(bottom = dim.spacingXL),
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
@@ -142,62 +143,62 @@ fun MapOptionsBottomSheet(
                 }
             }
 
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Divider(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
             Text(
                 text = "Tap any stop on the map to select it — no typing needed.",
                 style = KrailTheme.typography.bodySmall,
                 color = KrailTheme.colors.softLabel,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL),
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Divider(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
             // Search Radius Section
             Text(
                 text = "Search Distance",
                 style = KrailTheme.typography.titleMedium,
                 color = KrailTheme.colors.onSurface,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL),
             )
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(dim.spacingL))
 
             SearchRadiusChips(
                 selectedRadiusKm = pendingRadiusKm,
                 onRadiusSelect = { radius ->
                     pendingRadiusKm = radius
                 },
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL),
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Divider(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
             // Transport Mode Section
             Text(
                 text = "Show stops for",
                 style = KrailTheme.typography.titleMedium,
                 color = KrailTheme.colors.onSurface,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL),
             )
             Text(
                 text = "Choose which types of nearby stops appear on the map.",
                 style = KrailTheme.typography.bodySmall,
                 color = KrailTheme.colors.onSurface,
-                modifier = Modifier.padding(horizontal = 16.dp).padding(vertical = 4.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL).padding(vertical = dim.spacingXS),
             )
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(dim.spacingL))
 
             TransportModeFilterRow(
                 selectedModes = pendingTransportModes,
@@ -213,21 +214,21 @@ fun MapOptionsBottomSheet(
                 },
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            Divider(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
             // Map Controls Section
             Text(
                 text = "Map Display",
                 style = KrailTheme.typography.titleMedium,
                 color = KrailTheme.colors.onSurface,
-                modifier = Modifier.padding(horizontal = 16.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingXL),
             )
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(dim.spacingL))
 
             MapControlToggle(
                 label = "Show distance scale",
@@ -237,7 +238,7 @@ fun MapOptionsBottomSheet(
                 },
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.height(dim.spacingM))
 
             MapControlToggle(
                 label = "Show compass",
@@ -248,7 +249,7 @@ fun MapOptionsBottomSheet(
             )
 
             // Bottom spacer for better UX
-            Spacer(modifier = Modifier.height(108.dp))
+            Spacer(modifier = Modifier.height(MAP_OPTIONS_BOTTOM_SPACER))
         }
     }
 }
@@ -264,7 +265,7 @@ private fun SearchRadiusChips(
 
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingM),
     ) {
         radiusOptions.forEach { radius ->
             FilterChip(
@@ -303,8 +304,8 @@ private fun TransportModeFilterRow(
 
     LazyRow(
         modifier = modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        contentPadding = PaddingValues(horizontal = dim.spacingXL),
+        horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingM),
     ) {
         items(allModes) { mode ->
             TransportModeChip(
@@ -328,7 +329,7 @@ private fun MapControlToggle(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp),
+            .padding(horizontal = dim.spacingXL),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -369,3 +370,5 @@ private fun PreviewMapOptionsBottomSheet() {
 }
 
 // endregion
+
+private val MAP_OPTIONS_BOTTOM_SPACER = 108.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopDetailsBottomSheet.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import org.koin.compose.viewmodel.koinViewModel
@@ -50,6 +49,7 @@ fun StopDetailsBottomSheet(
         onDismiss = onDismiss,
         modifier = modifier,
         additionalInfo = {
+            val dim = KrailTheme.dimensions
             DepartureBoardStopCard(
                 stopId = stop.stopId,
                 stopName = stop.stopName,
@@ -57,18 +57,18 @@ fun StopDetailsBottomSheet(
                 onEvent = departuresViewModel::onEvent,
             )
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
 
             if (stop.hasParkAndRide) {
-                ParkingInfoSection(modifier = Modifier.padding(horizontal = 16.dp))
+                ParkingInfoSection(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(dim.spacingXL))
 
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                Divider(modifier = Modifier.padding(horizontal = dim.spacingXL))
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(dim.spacingXL))
             }
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(dim.spacingXL))
         },
         actionButton = { actionContent() },
     )
@@ -80,13 +80,13 @@ private fun ParkingInfoSection(
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingL),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ParkAndRideIcon()
 
         Column(
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingXS),
         ) {
             Text(
                 text = "Park & Ride Available",

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -110,6 +110,7 @@ fun TimeTableScreen(
     onModeClick: (Boolean) -> Unit = {},
     onMapClick: (String) -> Unit = {},
 ) {
+    val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
     val themeColor = themeColorHex.hexToComposeColor()
     var displayModeSelectionRow by rememberSaveable { mutableStateOf(false) }
@@ -127,14 +128,14 @@ fun TimeTableScreen(
     ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize().statusBarsPadding(),
-            contentPadding = PaddingValues(bottom = 16.dp),
+            contentPadding = PaddingValues(bottom = dim.spacingXL),
         ) {
             stickyHeader(key = "title-bar") {
                 TitleBar(
                     onNavActionClick = onBackClick,
                     title = {
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Text(
@@ -149,7 +150,7 @@ fun TimeTableScreen(
                             ) {
                                 AnimatedDots(
                                     color = themeColor,
-                                    modifier = Modifier.padding(start = 24.dp),
+                                    modifier = Modifier.padding(start = dim.spacingXXXL),
                                 )
                             }
                         }
@@ -174,7 +175,7 @@ fun TimeTableScreen(
                                 painter = painterResource(Res.drawable.ic_reverse),
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(24.dp),
+                                modifier = Modifier.size(dim.iconM),
                             )
                         }
                         ActionButton(
@@ -193,7 +194,7 @@ fun TimeTableScreen(
                                 },
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(24.dp),
+                                modifier = Modifier.size(dim.iconM),
                             )
                         }
                     },
@@ -208,7 +209,7 @@ fun TimeTableScreen(
                         onOriginClick = { display -> selectedStop = display },
                         onDestinationClick = { display -> selectedStop = display },
                         modifier = Modifier.fillMaxWidth()
-                            .padding(horizontal = KrailTheme.dimensions.spacingL, vertical = 8.dp)
+                            .padding(horizontal = dim.spacingL, vertical = dim.spacingM)
                             .background(color = KrailTheme.colors.surface),
                     )
                 }
@@ -218,10 +219,10 @@ fun TimeTableScreen(
                 FlowRow(
                     modifier = Modifier
                         .fillParentMaxWidth()
-                        .padding(horizontal = KrailTheme.dimensions.spacingL)
-                        .padding(top = 12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                        .padding(horizontal = dim.spacingL)
+                        .padding(top = dim.spacingL),
+                    horizontalArrangement = Arrangement.spacedBy(dim.spacingXL),
+                    verticalArrangement = Arrangement.spacedBy(dim.spacingL),
                 ) {
                     SubtleButton(
                         onClick = dateTimeSelectorClicked,
@@ -241,14 +242,14 @@ fun TimeTableScreen(
                     ) {
                         Row(
                             // todo -  handle in Button
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Image(
                                 painter = painterResource(Res.drawable.ic_filter),
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(ButtonDefaults.subtleButtonColors().contentColor),
-                                modifier = Modifier.size(18.dp),
+                                modifier = Modifier.size(FILTER_ICON_SIZE),
                             )
                             Text(text = "Mode")
                         }
@@ -259,11 +260,11 @@ fun TimeTableScreen(
             if (displayModeSelectionRow) {
                 item(key = "transport-mode-selection-row") {
                     LazyRow(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        contentPadding = PaddingValues(horizontal = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
+                        contentPadding = PaddingValues(horizontal = dim.spacingL),
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(top = 12.dp, bottom = 4.dp)
+                            .padding(top = dim.spacingL, bottom = dim.spacingXS)
                             .animateItem(),
                     ) {
                         items(
@@ -298,28 +299,28 @@ fun TimeTableScreen(
                             onModeSelectionChanged(unselectedModesProductClass.toSet())
                         },
                         modifier = Modifier
-                            .padding(vertical = 8.dp, horizontal = 12.dp)
+                            .padding(vertical = dim.spacingM, horizontal = dim.spacingL)
                             .animateItem(),
                     ) {
                         // todo -  handle in Button
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(dim.spacingXS),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Image(
                                 painter = painterResource(Res.drawable.ic_check),
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(color = getForegroundColor(themeColor)),
-                                modifier = Modifier.size(20.dp),
+                                modifier = Modifier.size(dim.iconS),
                             )
-                            Text("Done", modifier = Modifier.padding(start = 4.dp))
+                            Text("Done", modifier = Modifier.padding(start = dim.spacingXS))
                         }
                     }
                 }
             }
 
             item(key = "spacer-top") {
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(dim.spacingL))
             }
 
             if (timeTableState.isError) {
@@ -340,7 +341,7 @@ fun TimeTableScreen(
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             LoadingEmojiAnim(
                                 emoji = emoji.emoji,
-                                modifier = Modifier.padding(vertical = 60.dp).animateItem(),
+                                modifier = Modifier.padding(vertical = LOADING_VERTICAL_PADDING).animateItem(),
                             )
 
                             Text(
@@ -348,7 +349,7 @@ fun TimeTableScreen(
                                 style = KrailTheme.typography.bodyLarge,
                                 textAlign = TextAlign.Center,
                                 color = KrailTheme.colors.onSurface,
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = dim.spacingXL),
                             )
                         }
                     }
@@ -378,7 +379,7 @@ fun TimeTableScreen(
 
             item(key = "spacer-bottom") {
                 Spacer(
-                    modifier = Modifier.height(96.dp).systemBarsPadding(),
+                    modifier = Modifier.height(BOTTOM_SPACER_HEIGHT).systemBarsPadding(),
                 )
             }
         }
@@ -405,7 +406,7 @@ fun TimeTableScreen(
                         state = departuresState,
                         onEvent = departuresViewModel::onEvent,
                     )
-                    Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(modifier = Modifier.height(dim.spacingXL))
                 },
             )
         }
@@ -466,15 +467,15 @@ private fun LazyListScope.paginationHeader(
     item(key = "show-previous") {
         if (isLoadingPrevious) {
             Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = KrailTheme.dimensions.spacingL),
                 contentAlignment = Alignment.Center,
             ) {
-                AnimatedDots(color = themeColor, modifier = Modifier.padding(vertical = 8.dp))
+                AnimatedDots(color = themeColor, modifier = Modifier.padding(vertical = KrailTheme.dimensions.spacingM))
             }
         } else {
             Row(
                 modifier = Modifier.fillMaxWidth()
-                    .padding(vertical = 4.dp, horizontal = KrailTheme.dimensions.spacingXXS),
+                    .padding(vertical = KrailTheme.dimensions.spacingXS, horizontal = KrailTheme.dimensions.spacingXXS),
             ) {
                 TextButton(onClick = { onEvent(TimeTableUiEvent.LoadPreviousTrips) }) {
                     Text(text = "Show previous departures")
@@ -494,17 +495,17 @@ private fun LazyListScope.paginationFooter(
     if (isLoadingMore) {
         item(key = "loading-more") {
             Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 12.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = KrailTheme.dimensions.spacingL),
                 contentAlignment = Alignment.Center,
             ) {
-                AnimatedDots(color = themeColor, modifier = Modifier.padding(vertical = 8.dp))
+                AnimatedDots(color = themeColor, modifier = Modifier.padding(vertical = KrailTheme.dimensions.spacingM))
             }
         }
     } else if (canLoadMore) {
         item(key = "load-more-button") {
             Row(
                 modifier = Modifier.fillMaxWidth()
-                    .padding(vertical = 4.dp, horizontal = KrailTheme.dimensions.spacingXXS),
+                    .padding(vertical = KrailTheme.dimensions.spacingXS, horizontal = KrailTheme.dimensions.spacingXXS),
             ) {
                 TextButton(onClick = { onEvent(TimeTableUiEvent.LoadMoreTrips) }) {
                     Text(text = "Load more departures")
@@ -514,7 +515,7 @@ private fun LazyListScope.paginationFooter(
     } else {
         item(key = "plan-trip-button") {
             Box(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = KrailTheme.dimensions.spacingXS),
                 contentAlignment = Alignment.Center,
             ) {
                 TextButton(onClick = onPlanTripClick) {
@@ -567,7 +568,7 @@ private fun LazyListScope.journeyCardItems(
                     ),
                 )
             },
-            modifier = Modifier.padding(vertical = 8.dp).animateItem(),
+            modifier = Modifier.padding(vertical = KrailTheme.dimensions.spacingM).animateItem(),
             departureDeviation = journey.departureDeviation,
             scheduledOriginTime = journey.scheduledOriginTime,
             deepLinkUrl = state.deepLinkUrls[journey.journeyId],
@@ -635,7 +636,7 @@ fun ActionButton(
 ) {
     Box(
         modifier = modifier
-            .size(48.dp)
+            .size(KrailTheme.dimensions.buttonRoundSize)
             .clip(CircleShape)
             .klickable { onClick() }
             .semantics(mergeDescendants = true) {
@@ -752,3 +753,7 @@ private fun PreviewTimeTableScreenNoResults() {
 }
 
 // endregion
+
+private val FILTER_ICON_SIZE = 18.dp
+private val LOADING_VERTICAL_PADDING = 60.dp
+private val BOTTOM_SPACER_HEIGHT = 96.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -144,7 +144,8 @@ fun TrackTripScreen(
                         enter = fadeIn(),
                         exit = fadeOut(),
                     ) {
-                        AnimatedDots(modifier = Modifier.size(48.dp, 16.dp))
+                        val dim = KrailTheme.dimensions
+                        AnimatedDots(modifier = Modifier.size(dim.buttonRoundSize, dim.iconXS))
                     }
                     if (isJourneyActive) {
                         TextButton(onClick = { mapExpanded = !mapExpanded }) {
@@ -158,7 +159,7 @@ fun TrackTripScreen(
                                 painter = rememberShareIconPainter(),
                                 contentDescription = null,
                                 colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(24.dp),
+                                modifier = Modifier.size(KrailTheme.dimensions.iconM),
                             )
                         }
                     }
@@ -218,6 +219,7 @@ fun TrackTripScreen(
                 TrackTripState.NotFound -> Column(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
+                    val dim = KrailTheme.dimensions
                     ErrorMessage(
                         title = "Service not found",
                         message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
@@ -225,7 +227,7 @@ fun TrackTripScreen(
                         actionData = ActionData("Retry") { viewModel.retry() },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = dim.spacingXL),
                     )
                     Button(
                         onClick = {
@@ -234,7 +236,7 @@ fun TrackTripScreen(
                         },
                         modifier = Modifier
                             .align(Alignment.CenterHorizontally)
-                            .padding(bottom = 16.dp),
+                            .padding(bottom = dim.spacingXL),
                     ) {
                         Text("Stop Tracking")
                     }
@@ -243,13 +245,14 @@ fun TrackTripScreen(
                 TrackTripState.Error -> Column(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
+                    val dim = KrailTheme.dimensions
                     ErrorMessage(
                         title = "Something went wrong",
                         message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
                         actionData = ActionData("Retry") { viewModel.retry() },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = dim.spacingXL),
                     )
                     Button(
                         onClick = {
@@ -258,7 +261,7 @@ fun TrackTripScreen(
                         },
                         modifier = Modifier
                             .align(Alignment.CenterHorizontally)
-                            .padding(bottom = 16.dp),
+                            .padding(bottom = dim.spacingXL),
                     ) {
                         Text("Stop Tracking")
                     }
@@ -276,6 +279,7 @@ private fun PromptContent(
     onStartTracking: (TripDeepLink) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val dim = KrailTheme.dimensions
     Column(modifier = modifier.fillMaxSize()) {
         OriginDestination(
             origin = StopDisplay(stopId = deepLink.fromStopId, name = deepLink.fromStopName),
@@ -283,21 +287,21 @@ private fun PromptContent(
             timeLineColor = KrailTheme.colors.onSurface,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .padding(horizontal = dim.spacingXL, vertical = dim.spacingM)
                 .background(color = KrailTheme.colors.surface),
         )
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+                .padding(horizontal = dim.spacingXL, vertical = dim.spacingXL),
+            verticalArrangement = Arrangement.spacedBy(dim.spacingM),
         ) {
             Text(
                 text = "Track this trip for live real-time\u00A0updates.",
                 style = KrailTheme.typography.bodyMedium,
-                modifier = Modifier.padding(horizontal = 12.dp),
+                modifier = Modifier.padding(horizontal = dim.spacingL),
             )
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(dim.spacingM))
             Button(onClick = { onStartTracking(deepLink) }) {
                 Text("Start Tracking")
             }
@@ -312,6 +316,7 @@ private fun LoadingContent(
     emoji: String = "\uD83D\uDE86",
 ) {
     Column(modifier = modifier.fillMaxSize()) {
+        val dim = KrailTheme.dimensions
         deepLink?.let { dl ->
             OriginDestination(
                 origin = StopDisplay(stopId = dl.fromStopId, name = dl.fromStopName),
@@ -319,7 +324,7 @@ private fun LoadingContent(
                 timeLineColor = KrailTheme.colors.onSurface,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .padding(horizontal = dim.spacingXL, vertical = dim.spacingM)
                     .background(color = KrailTheme.colors.surface),
             )
         }
@@ -329,7 +334,7 @@ private fun LoadingContent(
         ) {
             LoadingEmojiAnim(
                 emoji = emoji,
-                modifier = Modifier.padding(vertical = 40.dp),
+                modifier = Modifier.padding(vertical = LOADING_EMOJI_VERTICAL_PADDING),
             )
         }
     }
@@ -376,6 +381,7 @@ private fun JourneyContent(
         }
     }
 
+    val dim = KrailTheme.dimensions
     Column(modifier = modifier.fillMaxSize()) {
         AnimatedVisibility(
             visible = mapExpanded,
@@ -397,7 +403,7 @@ private fun JourneyContent(
         }
 
         LazyColumn(
-            contentPadding = PaddingValues(top = 24.dp, bottom = 80.dp),
+            contentPadding = PaddingValues(top = dim.spacingXXXL, bottom = JOURNEY_CONTENT_BOTTOM_PADDING),
             modifier = Modifier.fillMaxSize()
                 .drawWithContent {
                     graphicsLayer.record { this@drawWithContent.drawContent() }
@@ -411,7 +417,7 @@ private fun JourneyContent(
                     timeLineColor = KrailTheme.colors.onSurface,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .padding(horizontal = dim.spacingXL, vertical = dim.spacingM)
                         .background(color = KrailTheme.colors.surface),
                 )
             }
@@ -422,19 +428,19 @@ private fun JourneyContent(
                     value = countdownDisplay.second,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                        .padding(horizontal = dim.spacingXL, vertical = dim.spacingM),
                 )
             }
 
             item(key = "divider") {
                 Divider(
-                    modifier = Modifier.padding(horizontal = 16.dp)
-                        .padding(top = 16.dp, bottom = 12.dp),
+                    modifier = Modifier.padding(horizontal = dim.spacingXL)
+                        .padding(top = dim.spacingXL, bottom = dim.spacingL),
                 )
             }
 
             itemsIndexed(journey.legs, key = { index, _ -> "leg_$index" }) { _, leg ->
-                Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Box(modifier = Modifier.padding(horizontal = dim.spacingXL)) {
                     when (leg) {
                         is TrackedLeg.Transport -> TrackedLegView(
                             leg = leg,
@@ -445,15 +451,18 @@ private fun JourneyContent(
 
                         is TrackedLeg.Walk -> WalkingLeg(
                             duration = leg.durationText,
-                            modifier = Modifier.padding(vertical = 8.dp, horizontal = 2.dp),
+                            modifier = Modifier.padding(
+                                vertical = dim.spacingM,
+                                horizontal = WALKING_LEG_HORIZONTAL_PADDING,
+                            ),
                         )
                     }
                 }
 
-                Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(dim.spacingXL))
 
                 Divider(
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                    modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingXS),
                 )
             }
         }
@@ -574,7 +583,8 @@ private fun TrackTripScreenPreview(state: TrackTripState) {
                 onNavActionClick = {},
                 actions = {
                     if (state is TrackTripState.Tracking && state.isRefreshing) {
-                        AnimatedDots(modifier = Modifier.size(48.dp, 16.dp))
+                        val dim = KrailTheme.dimensions
+                        AnimatedDots(modifier = Modifier.size(dim.buttonRoundSize, dim.iconXS))
                     }
                 },
             )
@@ -601,6 +611,7 @@ private fun TrackTripScreenPreview(state: TrackTripState) {
                 )
 
                 TrackTripState.NotFound -> Column(modifier = Modifier.fillMaxWidth()) {
+                    val dim = KrailTheme.dimensions
                     ErrorMessage(
                         title = "Service not found",
                         message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
@@ -608,32 +619,33 @@ private fun TrackTripScreenPreview(state: TrackTripState) {
                         actionData = ActionData("Retry") { },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = dim.spacingXL),
                     )
                     Button(
                         onClick = {},
                         modifier = Modifier
                             .align(Alignment.CenterHorizontally)
-                            .padding(bottom = 16.dp),
+                            .padding(bottom = dim.spacingXL),
                     ) {
                         Text("Stop Tracking")
                     }
                 }
 
                 TrackTripState.Error -> Column(modifier = Modifier.fillMaxWidth()) {
+                    val dim = KrailTheme.dimensions
                     ErrorMessage(
                         title = "Something went wrong",
                         message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
                         actionData = ActionData("Retry") { },
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
+                            .padding(horizontal = dim.spacingXL),
                     )
                     Button(
                         onClick = {},
                         modifier = Modifier
                             .align(Alignment.CenterHorizontally)
-                            .padding(bottom = 16.dp),
+                            .padding(bottom = dim.spacingXL),
                     ) {
                         Text("Stop Tracking")
                     }
@@ -827,3 +839,7 @@ private fun TrackTripScreenTrackingMapButtonPreview() {
 }
 
 // endregion
+
+private val JOURNEY_CONTENT_BOTTOM_PADDING = 80.dp
+private val LOADING_EMOJI_VERTICAL_PADDING = 40.dp
+private val WALKING_LEG_HORIZONTAL_PADDING = 2.dp


### PR DESCRIPTION
Migrate TrackTripScreen, TimeTableScreen, TrackedLegView, SearchTopBar,
MapOptionsBottomSheet, departureboard, datetimeselector, savedtrips,
journeymap, and label bottom sheets to use KrailTheme.dimensions tokens.
Non-token component-specific values are extracted to named private constants.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>