### PR TITLE
feat(analytics): track stop label create, assign, and remove events

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -8,6 +8,7 @@ private const val PROP_STOP_ID = "stopId"
 private const val PROP_SOURCE = "source"
 private const val PROP_EXPAND = "expand"
 private const val PROP_STOP_NAME = "stopName"
+private const val PROP_LABEL_NAME = "labelName"
 
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
 
@@ -86,6 +87,114 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             "recentSearchCount" to recentSearchCount,
         ),
     )
+
+    // endregion
+
+    // region StopLabels
+
+    /**
+     * Fired when the user creates a new custom stop label via the save / create-label sheet.
+     * Use to measure adoption: how many users actually create labels, and which semantics
+     * they reach for (e.g. "Gym", "Airport", "Mom's").
+     *
+     * Aggregations this enables:
+     *  - "What % of users ever create a custom label?" → distinct user count on event name.
+     *  - "Which label names are most common?" → group by [labelName].
+     *  - "Are power users emerging?" → bucket [totalLabelsCountAfter] (1, 2, 3-5, 6+).
+     *  - "What emoji do people pick?" → group by [emoji].
+     *
+     * @param labelName             The normalised label text persisted to the DB
+     *                              (emoji and whitespace already stripped).
+     * @param emoji                 The emoji chosen in the picker.
+     * @param totalLabelsCountAfter Total number of labels the user has *after* this creation —
+     *                              lets us split casual users (1–2 labels) from heavy users.
+     */
+    data class StopLabelCreatedEvent(
+        val labelName: String,
+        val emoji: String,
+        val totalLabelsCountAfter: Int,
+    ) : AnalyticsEvent(
+        name = "stop_label_created",
+        properties = mapOf(
+            PROP_LABEL_NAME to labelName,
+            "emoji" to emoji,
+            "totalLabelsCountAfter" to totalLabelsCountAfter,
+        ),
+    )
+
+    /**
+     * Fired when the user pins a stop to a label — the core "label is being used" signal.
+     * This is the moment a label transitions from empty to actionable.
+     *
+     * Aggregations this enables:
+     *  - "Which labels actually get filled?" → group by [labelName].
+     *  - "Which stops are most pinned?" → group by [PROP_STOP_ID].
+     *  - "Are users replacing existing pins or filling empty slots?" → filter [isReassignment].
+     *  - "Does the protected Home label behave differently from custom labels?"
+     *    → filter [isProtectedLabel].
+     *
+     * @param labelName         The label receiving the stop.
+     * @param stopId            NSW Transport stop ID being pinned.
+     * @param stopName          Human-readable stop name.
+     * @param isReassignment    `true` if the label already had a different stop pinned and
+     *                          this assignment is overwriting it.
+     * @param isProtectedLabel  `true` for the protected Home label (special-cased
+     *                          throughout the app — non-deletable).
+     */
+    data class StopLabelStopAssignedEvent(
+        val labelName: String,
+        val stopId: String,
+        val stopName: String,
+        val isReassignment: Boolean,
+        val isProtectedLabel: Boolean,
+    ) : AnalyticsEvent(
+        name = "stop_label_stop_assigned",
+        properties = mapOf(
+            PROP_LABEL_NAME to labelName,
+            PROP_STOP_ID to stopId,
+            PROP_STOP_NAME to stopName,
+            "isReassignment" to isReassignment,
+            "isProtectedLabel" to isProtectedLabel,
+        ),
+    )
+
+    /**
+     * Fired when the user either deletes a label entirely or clears the stop attached
+     * to it. One event with the [action] discriminator answers the unified
+     * "label cleanup behaviour" question without joining two streams.
+     *
+     * Aggregations this enables:
+     *  - "Are users removing labels or just clearing them?" → group by [action].
+     *  - "Are users deleting labels they never filled?" → filter [action] = DELETE,
+     *    [hadStop] = false.
+     *  - "Do users churn through the same label name?" → join with
+     *    [StopLabelCreatedEvent] on [labelName].
+     *
+     * Note: protected Home label deletions are silently no-op'd by the handler, so this
+     * event does not fire for them — keeps the data clean from defensive UI calls.
+     *
+     * @param labelName Label being removed.
+     * @param action    [Action.DELETE] when the entire label is removed,
+     *                  [Action.CLEAR] when only the stop is unlinked.
+     * @param hadStop   Whether the label had a stop attached at the moment of removal.
+     */
+    data class StopLabelRemovedEvent(
+        val labelName: String,
+        val action: Action,
+        val hadStop: Boolean,
+    ) : AnalyticsEvent(
+        name = "stop_label_removed",
+        properties = mapOf(
+            PROP_LABEL_NAME to labelName,
+            "action" to action.value,
+            "hadStop" to hadStop,
+        ),
+    ) {
+        enum class Action(val value: String) {
+            DELETE("delete"),
+            CLEAR("clear"),
+        }
+    }
 
     // endregion
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelLabelHandlersTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelLabelHandlersTest.kt
@@ -15,6 +15,7 @@ import xyz.ksharma.core.test.fakes.FakeNearbyStopsManagerForMap
 import xyz.ksharma.core.test.fakes.FakeSandook
 import xyz.ksharma.core.test.fakes.FakeSandookPreferences
 import xyz.ksharma.core.test.fakes.FakeStopResultsManager
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
@@ -23,6 +24,8 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -407,6 +410,177 @@ class SearchStopViewModelLabelHandlersTest {
             assertTrue(state.stopLabels.any { it.label == "Gym" })
         }
     }
+
+    // endregion
+
+    // region Analytics — StopLabelCreatedEvent / StopLabelStopAssignedEvent / StopLabelRemovedEvent
+    //
+    // These tests lock down the wire-up between label handlers and the analytics
+    // tracker. The product question we're protecting: can BigQuery answer
+    // "how are users actually using stop labels?" from these three events alone.
+    // If a handler stops firing its event, the dashboard goes silent without any
+    // crash signal — so the assertion is "the event arrived" plus "the payload
+    // matches what the dashboard expects to group on".
+
+    @Test
+    fun `Given new label name When CreateLabel fires Then StopLabelCreatedEvent is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "Gym", emoji = "🏋"))
+                advanceUntilIdle()
+
+                val tracked = fakeAnalytics.getTrackedEvent("stop_label_created")
+                assertNotNull(tracked, "expected stop_label_created to fire")
+                val event = assertIs<AnalyticsEvent.StopLabelCreatedEvent>(tracked)
+                assertEquals("Gym", event.labelName)
+                assertEquals("🏋", event.emoji)
+                // Seeded Home + Work + new Gym = 3.
+                assertEquals(3, event.totalLabelsCountAfter)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given duplicate label name When CreateLabel fires Then no analytics event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "home", emoji = "🏠"))
+                advanceUntilIdle()
+
+                // Duplicate path is a silent no-op — analytics must mirror that, otherwise
+                // the dashboard would inflate "labels created" with phantom rows.
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_created"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given blank label name When CreateLabel fires Then no analytics event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "   ", emoji = "🌀"))
+                advanceUntilIdle()
+
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_created"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given empty label When AssignLabelStop fires Then assigned event reports first-time pin`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                val central = StopItem(stopId = "stop_central", stopName = "Central Station")
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                advanceUntilIdle()
+
+                val tracked = fakeAnalytics.getTrackedEvent("stop_label_stop_assigned")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.StopLabelStopAssignedEvent>(tracked)
+                assertEquals("Home", event.labelName)
+                assertEquals("stop_central", event.stopId)
+                assertEquals("Central Station", event.stopName)
+                assertFalse(event.isReassignment, "first pin should not be a reassignment")
+                assertTrue(event.isProtectedLabel, "Home is the protected label")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given previously pinned label When AssignLabelStop fires again Then assigned event reports reassignment`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                // Pin Central first, then overwrite with Town Hall — the second event
+                // should carry isReassignment=true so the dashboard can separate
+                // "filling empty slots" from "swapping pins".
+                val central = StopItem(stopId = "stop_central", stopName = "Central Station")
+                val townHall = StopItem(stopId = "stop_townhall", stopName = "Town Hall")
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Work", central))
+                advanceUntilIdle()
+                fakeAnalytics.clear()
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Work", townHall))
+                advanceUntilIdle()
+
+                val tracked = fakeAnalytics.getTrackedEvent("stop_label_stop_assigned")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.StopLabelStopAssignedEvent>(tracked)
+                assertEquals("Work", event.labelName)
+                assertEquals("stop_townhall", event.stopId)
+                assertTrue(event.isReassignment, "second pin overwrote a different stop")
+                assertFalse(event.isProtectedLabel, "Work is a default but not protected")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given pinned label When ClearLabelStop fires Then removed event reports CLEAR with hadStop true`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                val central = StopItem(stopId = "stop_central", stopName = "Central Station")
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                advanceUntilIdle()
+                fakeAnalytics.clear()
+                viewModel.onEvent(SearchStopUiEvent.ClearLabelStop("Home"))
+                advanceUntilIdle()
+
+                val tracked = fakeAnalytics.getTrackedEvent("stop_label_removed")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.StopLabelRemovedEvent>(tracked)
+                assertEquals("Home", event.labelName)
+                assertEquals(AnalyticsEvent.StopLabelRemovedEvent.Action.CLEAR, event.action)
+                assertTrue(event.hadStop, "label had a pinned stop before clear")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given non-protected label When DeleteLabel fires Then removed event reports DELETE`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.DeleteLabel("Work"))
+                advanceUntilIdle()
+
+                val tracked = fakeAnalytics.getTrackedEvent("stop_label_removed")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.StopLabelRemovedEvent>(tracked)
+                assertEquals("Work", event.labelName)
+                assertEquals(AnalyticsEvent.StopLabelRemovedEvent.Action.DELETE, event.action)
+                // Seeded Work has no pinned stop, so hadStop must be false. This keeps
+                // the "users delete labels they never used" funnel honest.
+                assertFalse(event.hadStop)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given protected Home label When DeleteLabel fires Then no removed event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.DeleteLabel(StopLabel.PROTECTED_LABEL))
+                advanceUntilIdle()
+
+                // Handler early-returns for Home; analytics must mirror the no-op so
+                // defensive UI clicks don't pollute the dataset.
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_removed"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     // endregion
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -20,6 +20,9 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.ClearRecentSearchClickEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelCreatedEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelRemovedEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelStopAssignedEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopSelectedEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.log.log
@@ -221,6 +224,13 @@ class SearchStopViewModel(
             }
 
             is SearchStopUiEvent.AssignLabelStop -> {
+                // Snapshot pre-state so isReassignment is captured against the value
+                // *before* the optimistic update mutates it.
+                val previousStopId = _uiState.value.stopLabels
+                    .firstOrNull { it.label == event.labelKey }
+                    ?.stopId
+                val isReassignment = previousStopId != null && previousStopId != event.stopItem.stopId
+
                 // Optimistic: update state immediately so the pill row reflects the
                 // assignment before the IO write completes. The DB observer re-emits
                 // the same shape and the second update is a no-op.
@@ -234,6 +244,16 @@ class SearchStopViewModel(
                     }.toImmutableList()
                     copy(stopLabels = updated)
                 }
+                analytics.track(
+                    StopLabelStopAssignedEvent(
+                        labelName = event.labelKey,
+                        stopId = event.stopItem.stopId,
+                        stopName = event.stopItem.stopName,
+                        isReassignment = isReassignment,
+                        isProtectedLabel = event.labelKey
+                            .equals(StopLabel.PROTECTED_LABEL, ignoreCase = true),
+                    ),
+                )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                     sandook.updateStopLabelStop(event.labelKey, event.stopItem.stopId, event.stopItem.stopName)
                     // Stops the user pins to a label are also stops they "interacted
@@ -261,6 +281,13 @@ class SearchStopViewModel(
                                     .toImmutableList(),
                             )
                         }
+                        analytics.track(
+                            StopLabelCreatedEvent(
+                                labelName = cleanedName,
+                                emoji = event.emoji,
+                                totalLabelsCountAfter = _uiState.value.stopLabels.size,
+                            ),
+                        )
                         viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                             sandook.upsertStopLabel(cleanedName, event.emoji, null, null, sortOrder)
                         }
@@ -269,6 +296,9 @@ class SearchStopViewModel(
             }
 
             is SearchStopUiEvent.ClearLabelStop -> {
+                val hadStop = _uiState.value.stopLabels
+                    .firstOrNull { it.label == event.labelKey }
+                    ?.stopId != null
                 updateUiState {
                     val updated = stopLabels.map { label ->
                         if (label.label == event.labelKey) {
@@ -279,6 +309,13 @@ class SearchStopViewModel(
                     }.toImmutableList()
                     copy(stopLabels = updated)
                 }
+                analytics.track(
+                    StopLabelRemovedEvent(
+                        labelName = event.labelKey,
+                        action = StopLabelRemovedEvent.Action.CLEAR,
+                        hadStop = hadStop,
+                    ),
+                )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                     sandook.updateStopLabelStop(event.labelKey, null, null)
                 }
@@ -290,10 +327,20 @@ class SearchStopViewModel(
                 if (event.labelKey.equals(StopLabel.PROTECTED_LABEL, ignoreCase = true)) {
                     return
                 }
+                val hadStop = _uiState.value.stopLabels
+                    .firstOrNull { it.label == event.labelKey }
+                    ?.stopId != null
                 updateUiState {
                     val updated = stopLabels.filterNot { it.label == event.labelKey }.toImmutableList()
                     copy(stopLabels = updated)
                 }
+                analytics.track(
+                    StopLabelRemovedEvent(
+                        labelName = event.labelKey,
+                        action = StopLabelRemovedEvent.Action.DELETE,
+                        hadStop = hadStop,
+                    ),
+                )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                     sandook.deleteStopLabel(event.labelKey)
                 }


### PR DESCRIPTION
## Summary
Adds three high-signal analytics events covering the stop labels lifecycle (create → assign → remove) so BigQuery can answer "how are users actually using stop labels?" from a single dataset, plus ViewModel tests that lock down the wire-up.

### Events
1. **`stop_label_created`** — adoption signal.
   Properties: `labelName`, `emoji`, `totalLabelsCountAfter` (so casual vs heavy users can be split).
2. **`stop_label_stop_assigned`** — the core "label is being used" signal, fired when a stop is pinned to a label.
   Properties: `labelName`, `stopId`, `stopName`, `isReassignment` (overwriting an existing pin vs filling an empty slot), `isProtectedLabel` (true for Home).
3. **`stop_label_removed`** — unified cleanup event.
   Properties: `labelName`, `action` (`"delete"` or `"clear"`), `hadStop` (was a stop attached at the moment of removal).
   Note: protected Home-delete attempts are silently no-op'd by the handler, so this event does not fire for them — keeps the dataset honest from defensive UI calls.

### Why these three
- Cover the full label lifecycle (create → fill → remove), so funnel analysis works without joining multiple event streams.
- Carry enough metadata to answer the most likely product questions (which labels are popular, which stops people pin most, are users replacing pins or filling slots, are users abandoning labels they never filled).
- All three already have ViewModel-native handler entry points — no UI-layer instrumentation needed.

## Where
- `core/analytics/.../AnalyticsEvent.kt` — three new sealed-class entries in a new `StopLabels` region. New `PROP_LABEL_NAME` private const to satisfy the existing `StringLiteralDuplication` rule.
- `feature/trip-planner/ui/.../searchstop/SearchStopViewModel.kt` — `analytics.track(...)` calls wired into `CreateLabel`, `AssignLabelStop`, `ClearLabelStop`, and `DeleteLabel` handlers. Pre-mutation snapshots used so `isReassignment` and `hadStop` reflect state *before* the optimistic update.
- `core/test/.../SearchStopViewModelLabelHandlersTest.kt` — eight new tests in a dedicated `Analytics` region covering: created event payload, no-emit on duplicate / blank name, first-pin vs reassignment, clear with `hadStop=true`, delete with `hadStop=false`, and silent no-op on protected Home delete.

## Test plan
- [x] `./gradlew :core:test:testAndroidHostTest --tests 'xyz.ksharma.core.test.viewmodels.SearchStopViewModelLabelHandlersTest'` — all green.
- [x] `./gradlew :core:analytics:detekt :feature:trip-planner:ui:detekt :core:test:detekt --continue` — clean.
- [ ] Manual sanity check on a debug build: create a label, pin a stop to it, clear it, delete a custom label, attempt to delete Home → confirm the four expected events appear in the analytics console (and the Home-delete attempt does not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)