### PR TITLE
chore(git): ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ fastlane/test_output/
 # AI
 .claude/scheduled_tasks.lock
 
+
+# Claude Code worktrees (per-feature scratch trees, not part of the repo)
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Adds \`.claude/worktrees/\` to \`.gitignore\` so Claude Code's per-feature scratch worktrees cannot land in commits.

## Why
On #1553 (\`feature/snapshot-tests\`), three worktree directories accidentally got staged via \`git add -A\` and embedded as gitlinks in the commit. Removed in \`c232fd456\`; this prevents the same accident on future branches.

## Test plan
- [ ] \`git status\` after running this PR's branch shows \`.claude/worktrees/*\` as ignored (not untracked).