### PR TITLE
ci(release): distribute RC release APK to Firebase Friends group

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -6,6 +6,19 @@ on:
       variant:
         required: true
         type: string
+      release-notes:
+        # Optional override for the Firebase release notes. Defaults to the head
+        # commit subject (used by main pushes). RC distributions pass the RC tag
+        # here so testers see "v1.21.0-RC2" instead of a random commit title.
+        required: false
+        type: string
+        default: ''
+      group:
+        # Optional override for the Firebase tester group. Defaults to "Internal"
+        # for debug builds and "Friends" for release builds.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   distribute-apk:
@@ -43,20 +56,28 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
+          NOTES_OVERRIDE: ${{ inputs.release-notes }}
+          GROUP_OVERRIDE: ${{ inputs.group }}
         run: |
           COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n1 | tr -d '\n' | tr -d '\r')
 
           if [ "${{ inputs.variant }}" = "debug" ]; then
-            firebase appdistribution:distribute androidApp-debug.apk \
-              --app "$FIREBASE_APP_ID" \
-              --groups "Internal" \
-              --release-notes "Debug: $COMMIT_TITLE"
+            DEFAULT_NOTES="Debug: $COMMIT_TITLE"
+            DEFAULT_GROUP="Internal"
+            APK="androidApp-debug.apk"
           else
-            firebase appdistribution:distribute androidApp-release.apk \
-              --app "$FIREBASE_APP_ID" \
-              --groups "Friends" \
-              --release-notes "Release: $COMMIT_TITLE"
+            DEFAULT_NOTES="Release: $COMMIT_TITLE"
+            DEFAULT_GROUP="Friends"
+            APK="androidApp-release.apk"
           fi
+
+          NOTES="${NOTES_OVERRIDE:-$DEFAULT_NOTES}"
+          GROUP="${GROUP_OVERRIDE:-$DEFAULT_GROUP}"
+
+          firebase appdistribution:distribute "$APK" \
+            --app "$FIREBASE_APP_ID" \
+            --groups "$GROUP" \
+            --release-notes "$NOTES"
 
       - name: Cleanup sensitive files
         run: rm -f gcloud.json

--- a/.github/workflows/release-2-deploy-rc.yml
+++ b/.github/workflows/release-2-deploy-rc.yml
@@ -79,7 +79,20 @@ jobs:
       track: internal
     secrets: inherit
 
-  # ── 5. Distribute to TestFlight (runs in parallel with Android pipeline) ────
+  # ── 5. Distribute the same RC APK to Firebase Friends group ─────────────────
+  # Lets testers without Google Play Internal access (or who prefer Firebase
+  # for installs) try the same release-signed build that's heading to prod.
+  # Release notes carry the RC tag (e.g. "v1.21.0-RC2") so it's obvious which
+  # candidate they're looking at.
+  distribute-firebase:
+    needs: [build-android-release, tag-release-candidate]
+    uses: ./.github/workflows/distribute-firebase.yml
+    with:
+      variant: release
+      release-notes: ${{ needs.tag-release-candidate.outputs.tag }}
+    secrets: inherit
+
+  # ── 6. Distribute to TestFlight (runs in parallel with Android pipeline) ────
   distribute-testflight:
     uses: ./.github/workflows/distribute-testflight.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- \`release-2-deploy-rc.yml\` now also pushes the release APK to Firebase App Distribution (Friends group), in addition to Google Play Internal + TestFlight.
- Release notes carry the RC tag (e.g. \`v1.21.0-RC2\`) instead of a commit subject — easier for testers to tell builds apart in the Firebase app list.
- \`distribute-firebase.yml\` gains optional \`release-notes\` and \`group\` inputs (backwards compatible — existing callers unchanged).

## Why
The Friends Firebase group has been getting a rolling preview of \`main\` as a release-variant APK, but **never** the actual release candidates heading to production. RC builds only flowed to Google Play Internal + TestFlight, which excluded testers without a Play Console internal account. Friends should see the candidate that's about to ship.

## What it doesn't change
- Debug builds: still only distributed from \`main\` pushes (per the earlier discussion — debug builds don't represent the production artifact, so debug RCs would dilute the testing signal).
- Existing main → Firebase Internal (debug) / Friends (release) jobs: untouched.
- TestFlight + Google Play Internal RC distribution: unchanged.

## Test plan
- [ ] Push to a \`prod/*\` branch and confirm a release APK appears in Firebase Friends within ~5 min of the AAB build finishing.
- [ ] Open the Firebase release entry and confirm the notes read \`v{version}-RC{n}\` (e.g. \`v1.21.0-RC1\`).
- [ ] Confirm \`main\` push still distributes both debug → Internal and release → Friends as before.