### PR TITLE
feat(analytics): track saved-trip + label reorder, plus timetable stop-header click

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -9,6 +9,11 @@ private const val PROP_SOURCE = "source"
 private const val PROP_EXPAND = "expand"
 private const val PROP_STOP_NAME = "stopName"
 private const val PROP_LABEL_NAME = "labelName"
+private const val PROP_FROM_STOP_ID = "fromStopId"
+private const val PROP_TO_STOP_ID = "toStopId"
+private const val PROP_PREVIOUS_INDEX = "previousIndex"
+private const val PROP_NEW_INDEX = "newIndex"
+private const val PROP_TOTAL_COUNT = "totalCount"
 
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
 
@@ -22,13 +27,13 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class SavedTripCardClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "saved_trip_card_click",
-            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     data class DeleteSavedTripClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "delete_saved_trip_card_click",
-            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     data object ReverseStopClickEvent : AnalyticsEvent(name = "reverse_stop_click")
@@ -36,7 +41,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class LoadTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "load_timetable_click",
-            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     data object SettingsClickEvent : AnalyticsEvent(name = "settings_click")
@@ -44,6 +49,42 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data object FromFieldClickEvent : AnalyticsEvent(name = "from_field_click")
 
     data object ToFieldClickEvent : AnalyticsEvent(name = "to_field_click")
+
+    /**
+     * Fired when the user reorders a saved-trip card by drag-and-drop in edit mode.
+     * Use to measure whether reorder is actually used and how. Specifically:
+     *  - "What % of users with saved trips ever reorder?" → distinct user count.
+     *  - "Are users mostly promoting trips to the top, or shuffling middle slots?"
+     *    → distribution of [newIndex], filter [newIndex] = 0.
+     *  - "Does reorder usage scale with list size?" → bucket on [totalCount].
+     *  - "Which trips get reordered most often?" → group by [PROP_FROM_STOP_ID]
+     *    + [PROP_TO_STOP_ID]; can be joined with [SavedTripCardClickEvent].
+     *
+     * @param fromStopId    NSW Transport stop ID for the trip's origin — anchors
+     *                      the moved card to a specific saved trip.
+     * @param toStopId      Stop ID for the trip's destination.
+     * @param previousIndex Position the card was at before the move.
+     * @param newIndex      Position the card landed at after the move.
+     * @param totalCount    Number of saved trips in the list at the time of the
+     *                      reorder. Lets us split "casual user with 2 cards"
+     *                      from "power user with 8".
+     */
+    data class SavedTripCardReorderedEvent(
+        val fromStopId: String,
+        val toStopId: String,
+        val previousIndex: Int,
+        val newIndex: Int,
+        val totalCount: Int,
+    ) : AnalyticsEvent(
+        name = "saved_trip_card_reordered",
+        properties = mapOf(
+            PROP_FROM_STOP_ID to fromStopId,
+            PROP_TO_STOP_ID to toStopId,
+            PROP_PREVIOUS_INDEX to previousIndex,
+            PROP_NEW_INDEX to newIndex,
+            PROP_TOTAL_COUNT to totalCount,
+        ),
+    )
 
     // endregion
 
@@ -196,6 +237,41 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         }
     }
 
+    /**
+     * Fired when the user reorders a stop label pill by drag-and-drop.
+     *
+     * Aggregations this enables:
+     *  - "Are stop labels actually being reordered, or do users leave Home/Work in
+     *    the seeded order?" → presence/count of this event.
+     *  - "Are users moving the protected Home label around?" → filter
+     *    [isProtectedLabel] = true. Useful because Home is non-deletable but is
+     *    still draggable; this answers "do users want it elsewhere".
+     *  - "Promotion vs shuffle behaviour" → [newIndex] distribution.
+     *
+     * @param labelName        Label that was moved.
+     * @param previousIndex    Index before the move.
+     * @param newIndex         Index after the move.
+     * @param totalCount       Total labels in the list at reorder time.
+     * @param isProtectedLabel `true` for the Home label (non-deletable but
+     *                         still draggable).
+     */
+    data class StopLabelReorderedEvent(
+        val labelName: String,
+        val previousIndex: Int,
+        val newIndex: Int,
+        val totalCount: Int,
+        val isProtectedLabel: Boolean,
+    ) : AnalyticsEvent(
+        name = "stop_label_reordered",
+        properties = mapOf(
+            PROP_LABEL_NAME to labelName,
+            PROP_PREVIOUS_INDEX to previousIndex,
+            PROP_NEW_INDEX to newIndex,
+            PROP_TOTAL_COUNT to totalCount,
+            "isProtectedLabel" to isProtectedLabel,
+        ),
+    )
+
     // endregion
 
     // region Theme
@@ -218,17 +294,17 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class ReverseTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "reverse_time_table_click",
-            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     data class SaveTripClickEvent(val fromStopId: String, val toStopId: String) : AnalyticsEvent(
         name = "save_trip_click",
-        properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+        properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
     )
 
     data class PlanTripClickEvent(val fromStopId: String, val toStopId: String) : AnalyticsEvent(
         name = "plan_trip_click",
-        properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+        properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
     )
 
     data class ModeClickEvent(
@@ -238,8 +314,8 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     ) : AnalyticsEvent(
         name = "mode_click",
         properties = mapOf(
-            "fromStopId" to fromStopId,
-            "toStopId" to toStopId,
+            PROP_FROM_STOP_ID to fromStopId,
+            PROP_TO_STOP_ID to toStopId,
             "displayModeSelectionRow" to displayModeSelectionRow,
         ),
     )
@@ -251,8 +327,8 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     ) : AnalyticsEvent(
         name = "mode_selection_done",
         properties = mapOf(
-            "fromStopId" to fromStopId,
-            "toStopId" to toStopId,
+            PROP_FROM_STOP_ID to fromStopId,
+            PROP_TO_STOP_ID to toStopId,
             "unselected" to unselectedProductClasses.toString(),
         ),
     )
@@ -325,8 +401,46 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class JourneyAlertClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "journey_alert_click",
-            properties = mapOf("fromStopId" to fromStopId, "toStopId" to toStopId),
+            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
+
+    /**
+     * Fired when the user taps the origin or destination label in the timetable
+     * sticky header — the gesture that opens the stop-details bottom sheet.
+     *
+     * The single most useful field is [isOrigin]: it answers
+     * "are users more curious about where they're leaving from, or where they're
+     * going to?". Combined with [PROP_FROM_STOP_ID] / [PROP_TO_STOP_ID] (which
+     * anchor to the same trip referenced by [LoadTimeTableClickEvent] and
+     * [PlanTripClickEvent]) the dashboard can also answer
+     * "of users who plan a trip, what % drill into stop details before boarding?".
+     *
+     * @param stopId        The stop the user tapped.
+     * @param stopName      Human-readable stop name for that tap.
+     * @param isOrigin      `true` if the tapped label was the trip origin,
+     *                      `false` if it was the destination.
+     * @param tripFromStopId Origin of the trip the click happened inside —
+     *                       always present, even when [isOrigin] is true (so
+     *                       a single dashboard query can join on the trip pair
+     *                       without re-deriving it from [stopId]).
+     * @param tripToStopId   Destination of the trip the click happened inside.
+     */
+    data class TimeTableStopHeaderClickEvent(
+        val stopId: String,
+        val stopName: String,
+        val isOrigin: Boolean,
+        val tripFromStopId: String,
+        val tripToStopId: String,
+    ) : AnalyticsEvent(
+        name = "timetable_stop_header_click",
+        properties = mapOf(
+            PROP_STOP_ID to stopId,
+            PROP_STOP_NAME to stopName,
+            "isOrigin" to isOrigin,
+            PROP_FROM_STOP_ID to tripFromStopId,
+            PROP_TO_STOP_ID to tripToStopId,
+        ),
+    )
 
     // endregion
 

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SavedTripViewModelsTest.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -43,6 +44,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -840,4 +843,77 @@ class SavedTripsViewModelTest {
         }
 
     // endregion Selected Stop Events Tests
+
+    // region MoveSavedTrip — reorder analytics
+    //
+    // The reorder handler is the only path that writes to `sort_order` based on
+    // user gesture. These tests lock down the analytics wire-up so the
+    // dashboard "is reorder used?" question keeps a reliable signal.
+
+    @Test
+    fun `GIVEN three saved trips WHEN MoveSavedTripToIndex fires THEN reorder event is tracked`() =
+        runTest {
+            // Seed three trips so the move has somewhere to go and totalCount > 1.
+            sandook.insertOrReplaceTrip(
+                tripId = "AB", fromStopId = "A", fromStopName = "Alpha",
+                toStopId = "B", toStopName = "Bravo",
+            )
+            sandook.insertOrReplaceTrip(
+                tripId = "CD", fromStopId = "C", fromStopName = "Charlie",
+                toStopId = "D", toStopName = "Delta",
+            )
+            sandook.insertOrReplaceTrip(
+                tripId = "EF", fromStopId = "E", fromStopName = "Echo",
+                toStopId = "F", toStopName = "Foxtrot",
+            )
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.uiState.test {
+                skipItems(1)
+                // Wait for savedTrips to land in state before issuing the move.
+                awaitItem()
+
+                viewModel.onEvent(SavedTripUiEvent.MoveSavedTripToIndex("AB", 2))
+
+                // Drain emissions until we have the reorder event tracked. The
+                // optimistic state update can emit before analytics fires, so we
+                // assert on the tracker rather than racing on uiState.
+                advanceUntilIdle()
+                val tracked = analytics.getTrackedEvent("saved_trip_card_reordered")
+                assertNotNull(tracked, "expected saved_trip_card_reordered to fire")
+                val event = assertIs<AnalyticsEvent.SavedTripCardReorderedEvent>(tracked)
+                assertEquals("A", event.fromStopId)
+                assertEquals("B", event.toStopId)
+                assertEquals(0, event.previousIndex)
+                assertEquals(2, event.newIndex)
+                assertEquals(3, event.totalCount)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN target equals source WHEN MoveSavedTripToIndex fires THEN no reorder event is tracked`() =
+        runTest {
+            sandook.insertOrReplaceTrip(
+                tripId = "AB", fromStopId = "A", fromStopName = "Alpha",
+                toStopId = "B", toStopName = "Bravo",
+            )
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.uiState.test {
+                skipItems(1)
+                awaitItem()
+
+                // Source == target is a no-op in the handler. Analytics must mirror
+                // that, otherwise drop-in-place gestures inflate reorder counts.
+                viewModel.onEvent(SavedTripUiEvent.MoveSavedTripToIndex("AB", 0))
+                advanceUntilIdle()
+
+                assertFalse(analytics.isEventTracked("saved_trip_card_reordered"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion MoveSavedTrip
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelLabelHandlersTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelLabelHandlersTest.kt
@@ -582,5 +582,59 @@ class SearchStopViewModelLabelHandlersTest {
             }
         }
 
+    @Test
+    fun `Given two labels When MoveLabelToIndex moves Home to position 1 Then reordered event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("Home", 1))
+                advanceUntilIdle()
+
+                val tracked = fakeAnalytics.getTrackedEvent("stop_label_reordered")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.StopLabelReorderedEvent>(tracked)
+                assertEquals("Home", event.labelName)
+                assertEquals(0, event.previousIndex)
+                assertEquals(1, event.newIndex)
+                assertEquals(2, event.totalCount)
+                // Home is the protected label; flag must be true so the dashboard can
+                // separate "user moved Home" from "user moved a custom label".
+                assertTrue(event.isProtectedLabel)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given target equal to source When MoveLabelToIndex fires Then no reordered event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                // The handler returns early when source == target, so no analytics
+                // should fire either — otherwise drop-in-place drags would inflate
+                // the reorder counts.
+                viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("Home", 0))
+                advanceUntilIdle()
+
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_reordered"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given unknown label key When MoveLabelToIndex fires Then no reordered event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("DoesNotExist", 0))
+                advanceUntilIdle()
+
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_reordered"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     // endregion
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -25,6 +25,7 @@ import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTr
 import xyz.ksharma.core.test.fakes.FakeImageBitmap
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
@@ -46,6 +47,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -1306,4 +1308,94 @@ class TimeTableViewModelTest {
             totalUniqueServiceAlerts = 0,
         )
     }
+
+    // region OriginDestinationStopHeaderClicked — analytics for the gesture that
+    // opens the stop-details sheet. The trip context (tripFromStopId / tripToStopId)
+    // comes from the VM's `tripInfo` field, which is set by LoadTimeTable.
+
+    @Test
+    fun `GIVEN trip loaded WHEN origin header is clicked THEN stop header click event is tracked with isOrigin true`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.uiState.test {
+                skipItems(1)
+                // LoadTimeTable populates `tripInfo` so the click handler can
+                // include the trip pair in the analytics payload.
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                advanceUntilIdle()
+                analytics.clear()
+
+                viewModel.onEvent(
+                    TimeTableUiEvent.OriginDestinationStopHeaderClicked(
+                        stopId = "FROM_STOP_ID_1",
+                        stopName = "STOP_NAME_1",
+                        isOrigin = true,
+                    ),
+                )
+                advanceUntilIdle()
+
+                val tracked = analytics.getTrackedEvent("timetable_stop_header_click")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.TimeTableStopHeaderClickEvent>(tracked)
+                assertEquals("FROM_STOP_ID_1", event.stopId)
+                assertEquals("STOP_NAME_1", event.stopName)
+                assertTrue(event.isOrigin)
+                // Payload anchors to the trip pair so the dashboard can join with
+                // PlanTripClickEvent / LoadTimeTableClickEvent.
+                assertEquals("FROM_STOP_ID_1", event.tripFromStopId)
+                assertEquals("TO_STOP_ID_1", event.tripToStopId)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN trip loaded WHEN destination header is clicked THEN stop header click event is tracked with isOrigin false`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                advanceUntilIdle()
+                analytics.clear()
+
+                viewModel.onEvent(
+                    TimeTableUiEvent.OriginDestinationStopHeaderClicked(
+                        stopId = "TO_STOP_ID_1",
+                        stopName = "STOP_NAME_2",
+                        isOrigin = false,
+                    ),
+                )
+                advanceUntilIdle()
+
+                val tracked = analytics.getTrackedEvent("timetable_stop_header_click")
+                assertNotNull(tracked)
+                val event = assertIs<AnalyticsEvent.TimeTableStopHeaderClickEvent>(tracked)
+                assertEquals("TO_STOP_ID_1", event.stopId)
+                assertEquals("STOP_NAME_2", event.stopName)
+                assertFalse(event.isOrigin)
+                assertEquals("FROM_STOP_ID_1", event.tripFromStopId)
+                assertEquals("TO_STOP_ID_1", event.tripToStopId)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion
 }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -43,4 +43,18 @@ sealed interface TimeTableUiEvent {
 
     /** Load past trips before the earliest currently shown departure. */
     data object LoadPreviousTrips : TimeTableUiEvent
+
+    /**
+     * Fired when the user taps the origin or destination label in the timetable
+     * sticky header (the gesture that opens the stop-details bottom sheet).
+     *
+     * Analytics-only — the sheet itself is opened by local Compose state in
+     * `TimeTableScreen`. Routing this through the VM keeps analytics calls in
+     * one place and makes the path testable with `FakeAnalytics`.
+     */
+    data class OriginDestinationStopHeaderClicked(
+        val stopId: String,
+        val stopName: String,
+        val isOrigin: Boolean,
+    ) : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -409,8 +409,19 @@ class SavedTripsViewModel(
         val trips = _uiState.value.savedTrips.toMutableList()
         val fromIndex = trips.indexOfFirst { it.tripId == tripId }
         if (fromIndex == -1 || targetIndex !in trips.indices) return
-        trips.add(targetIndex, trips.removeAt(fromIndex))
+        if (fromIndex == targetIndex) return
+        val moved = trips.removeAt(fromIndex)
+        trips.add(targetIndex, moved)
         updateUiState { copy(savedTrips = trips.toImmutableList()) }
+        analytics.track(
+            AnalyticsEvent.SavedTripCardReorderedEvent(
+                fromStopId = moved.fromStopId,
+                toStopId = moved.toStopId,
+                previousIndex = fromIndex,
+                newIndex = targetIndex,
+                totalCount = trips.size,
+            ),
+        )
         viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
             trips.forEachIndexed { index, trip ->
                 sandook.updateSavedTripSortOrder(tripId = trip.tripId, sortOrder = index.toLong())

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -22,6 +22,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.ClearRecentSearchClickEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelCreatedEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelRemovedEvent
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelReorderedEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopLabelStopAssignedEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.StopSelectedEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
@@ -356,6 +357,16 @@ class SearchStopViewModel(
                 current.add(target, moved)
                 val reordered = current.toImmutableList()
                 updateUiState { copy(stopLabels = reordered) }
+                analytics.track(
+                    StopLabelReorderedEvent(
+                        labelName = moved.label,
+                        previousIndex = sourceIndex,
+                        newIndex = target,
+                        totalCount = reordered.size,
+                        isProtectedLabel = moved.label
+                            .equals(StopLabel.PROTECTED_LABEL, ignoreCase = true),
+                    ),
+                )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                     reordered.forEachIndexed { index, label ->
                         sandook.upsertStopLabel(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -206,8 +206,26 @@ fun TimeTableScreen(
                         origin = trip.fromStopDisplay(timeTableState.stopLabels),
                         destination = trip.toStopDisplay(timeTableState.stopLabels),
                         timeLineColor = KrailTheme.colors.onSurface,
-                        onOriginClick = { display -> selectedStop = display },
-                        onDestinationClick = { display -> selectedStop = display },
+                        onOriginClick = { display ->
+                            selectedStop = display
+                            onEvent(
+                                TimeTableUiEvent.OriginDestinationStopHeaderClicked(
+                                    stopId = display.stopId,
+                                    stopName = display.name,
+                                    isOrigin = true,
+                                ),
+                            )
+                        },
+                        onDestinationClick = { display ->
+                            selectedStop = display
+                            onEvent(
+                                TimeTableUiEvent.OriginDestinationStopHeaderClicked(
+                                    stopId = display.stopId,
+                                    stopName = display.name,
+                                    isOrigin = false,
+                                ),
+                            )
+                        },
                         modifier = Modifier.fillMaxWidth()
                             .padding(horizontal = dim.spacingL, vertical = dim.spacingM)
                             .background(color = KrailTheme.colors.surface),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -282,6 +282,18 @@ class TimeTableViewModel(
             TimeTableUiEvent.LoadMoreTrips -> onLoadMoreTrips()
 
             TimeTableUiEvent.LoadPreviousTrips -> onLoadPreviousTrips()
+
+            is TimeTableUiEvent.OriginDestinationStopHeaderClicked -> {
+                analytics.track(
+                    AnalyticsEvent.TimeTableStopHeaderClickEvent(
+                        stopId = event.stopId,
+                        stopName = event.stopName,
+                        isOrigin = event.isOrigin,
+                        tripFromStopId = tripInfo?.fromStopId.orEmpty(),
+                        tripToStopId = tripInfo?.toStopId.orEmpty(),
+                    ),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Adds three high-signal analytics events that close gaps in the saved-trips and timetable dashboards. Same disciplined approach as #1556 — every event carries enough context to answer specific product questions without joining multiple streams, and each path has a ViewModel test.

### Events

**1. `saved_trip_card_reordered`** — wired into `SavedTripsViewModel.onMoveSavedTrip`.
- `fromStopId`, `toStopId` — anchors the moved card to a specific saved trip (matches the `SavedTripCardClickEvent` pattern, so dashboards can join).
- `previousIndex`, `newIndex` — direction + delta of the move.
- `totalCount` — list size at reorder time, splits casual users (2 cards) from heavy users (8+).
- Handler also tightened: source == target now hard-returns before any state write or analytics fire, so drop-in-place gestures don't inflate counts.

**2. `stop_label_reordered`** — wired into the existing `SearchStopUiEvent.MoveLabelToIndex` handler in `SearchStopViewModel`.
- `labelName`, `previousIndex`, `newIndex`, `totalCount` — same shape as event 1.
- `isProtectedLabel` — true when the moved label is the protected Home. Lets the dashboard separate "user reorders Home" (which is non-deletable but draggable) from "user reorders custom labels".

**3. `timetable_stop_header_click`** — the gesture that opens the stop-details bottom sheet from the timetable sticky header.
- New analytics-only `TimeTableUiEvent.OriginDestinationStopHeaderClicked(stopId, stopName, isOrigin)` fired by the UI; the VM enriches with the trip context.
- Payload: `stopId`, `stopName`, `isOrigin` (origin vs destination), `tripFromStopId`, `tripToStopId`.
- `isOrigin` is the highest-signal field: "are users more curious about where they're leaving from, or where they're going to?". The trip pair anchors back to `PlanTripClickEvent` / `LoadTimeTableClickEvent` so "of users who plan a trip, what % drill into stop details" is one join away.

## Why these three (and not more)

- All three previously had **zero** instrumentation despite being core gestures.
- Each event answers a distinct product question; payloads were sized to make that question answerable from BigQuery without joining sister streams.
- Skipped: per-side stop tap on saved-trip cards (already covered by `SavedTripCardClickEvent` — the card is one click target, not two), stop-info dwell time (the existing `DepartureBoardScreenViewEvent` already fires inside the sheet), drag duration / distance / cancelled-drag attempts (low signal, hard to test).

## Test plan
- [x] `./gradlew :core:test:testAndroidHostTest --tests SavedTripViewModelsTest --tests SearchStopViewModelLabelHandlersTest --tests TimeTableViewModelTest --continue` — green.
- [x] Detekt clean on `:core:analytics`, `:feature:trip-planner:state`, `:feature:trip-planner:ui`, `:core:test`. Cleaned up pre-existing `"fromStopId"` / `"toStopId"` raw-string duplications by promoting them to shared `PROP_FROM_STOP_ID` / `PROP_TO_STOP_ID` constants now that more events share the keys.
- [ ] Manual sanity: enter saved-trips edit mode → drag a card → expect `saved_trip_card_reordered`. Long-press a stop label and drag it → expect `stop_label_reordered`. Plan a trip → on the timetable, tap origin and destination labels in the sticky header → expect two `timetable_stop_header_click` events with `isOrigin` flipped between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)