### PR TITLE
ci: prevent shell injection via commit messages in firebase distribute

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -53,15 +53,27 @@ jobs:
           fi
 
       - name: Distribute APK to Firebase App Distribution
+        # IMPORTANT: never inline `${{ ... }}` containing untrusted data (commit
+        # messages, PR titles, branch names, issue bodies, etc.) directly into a
+        # `run:` shell script. GitHub Actions substitutes `${{ ... }}` as raw
+        # text BEFORE the shell parses, so any shell metacharacter in the value
+        # (`(`, `)`, `"`, `$`, `;`, backticks, `&&`, ...) breaks the script or
+        # executes arbitrary commands. This bit us with a commit titled
+        # `... auto-bump PR (#1566)` whose `(#1566)` parsed as a sub-shell.
+        # Always pass such values through `env:` and reference them as `$VAR`,
+        # which the shell expands AFTER parsing and treats as opaque data.
         env:
           GOOGLE_APPLICATION_CREDENTIALS: gcloud.json
           FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
           NOTES_OVERRIDE: ${{ inputs.release-notes }}
           GROUP_OVERRIDE: ${{ inputs.group }}
+          VARIANT: ${{ inputs.variant }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n1 | tr -d '\n' | tr -d '\r')
+          # Take only the first line of the commit message (the subject).
+          COMMIT_TITLE=$(printf '%s' "$COMMIT_MESSAGE" | head -n1 | tr -d '\r')
 
-          if [ "${{ inputs.variant }}" = "debug" ]; then
+          if [ "$VARIANT" = "debug" ]; then
             DEFAULT_NOTES="Debug: $COMMIT_TITLE"
             DEFAULT_GROUP="Internal"
             APK="androidApp-debug.apk"

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,46 @@
+name: Lint Workflows
+
+# Runs actionlint on every change touching .github/workflows/. actionlint
+# catches a few classes of bug that bit us in distribute-firebase.yml:
+#
+#   - Shell-injection via raw `${{ github.event.head_commit.message }}` in a
+#     `run:` script (commit message contained `(#1566)` -> shell parse error,
+#     and could have been arbitrary command execution if the message had been
+#     `; rm -rf /; #`).
+#   - Undefined env vars, bad needs/inputs/outputs references.
+#   - Shellcheck warnings inside run blocks.
+#
+# https://github.com/rhysd/actionlint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actionlint.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run actionlint
+        # `-shellcheck=` (empty value) disables actionlint's shellcheck
+        # integration. We keep actionlint's NATIVE checks — which catch the
+        # `${{ ... }}` shell-injection that motivated this lint — but skip
+        # shellcheck. Shellcheck is noisy with SC2086 (unquoted variable) infos
+        # against a dozen pre-existing workflow scripts we don't want to refactor
+        # in this PR. Re-enable when we're ready to do that cleanup separately.
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color -shellcheck=


### PR DESCRIPTION
## What broke

The latest run of \`distribute-firebase.yml\` failed with a bash syntax error:

\`\`\`
/home/runner/work/_temp/.../591cde88....sh: line 5: syntax error near unexpected token \`(\`
\`\`\`

…because the commit title \`ci(release): use krail-gtfs-bot App token for auto-bump PR (#1566)\` contained \`(#1566)\` and the workflow was inlining the raw commit message directly into a shell script:

\`\`\`yaml
run: |
  COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n1 | ...)
\`\`\`

\`\${{ ... }}\` substitution happens as **raw text before the shell parses**, so the parens parsed as a sub-shell. Today the script just crashed; tomorrow's bad-faith commit \`"; rm -rf $HOME; #\` would have executed during the workflow run on a runner that has access to our Firebase credentials.

## The fix

Two parts:

1. **\`distribute-firebase.yml\`** — pass the commit message (and \`inputs.variant\`) through \`env:\` and reference as \`$COMMIT_MESSAGE\` / \`$VARIANT\` in the run block. Env-var expansion happens **after** shell parsing and treats the value as opaque data. No more injection.
2. **\`lint-workflows.yml\` (new)** — runs [actionlint](https://github.com/rhysd/actionlint) on every PR/push that touches \`.github/workflows/\`. actionlint flags the \`echo "\${{ ... }}"\` anti-pattern (and a handful of other workflow misconfigurations) at PR time so this class of bug stays caught.

## Test plan

- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(...)"\` on both files)
- [ ] CI green
- [ ] Firebase distribute step succeeds on next \`main\` push without breaking on commit messages with \`()\`/\`""\`/\`\\$\` in them

🤖 Generated with [Claude Code](https://claude.com/claude-code)