### PR TITLE
feat(taj): add CloudGradientBackground and use on SearchStopScreen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -91,9 +90,9 @@ import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.LocalThemeColor
-import xyz.ksharma.krail.taj.backgroundColorOf
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.CloudGradientBackground
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
@@ -687,17 +686,9 @@ private fun SearchStopScreenSinglePane(
             exit = fadeOut(animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing)),
             modifier = Modifier.fillMaxSize(),
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                backgroundColorOf(themeColor.hexToComposeColor()),
-                                KrailTheme.colors.surface,
-                            ),
-                        ),
-                    ),
+            CloudGradientBackground(
+                modifier = Modifier.fillMaxSize(),
+                themeColor = themeColor.hexToComposeColor(),
             ) {
                 SearchStopListContent(
                     listState = searchStopState.listState,
@@ -822,82 +813,79 @@ private fun SearchStopScreenDualPane(
         }
     }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(
-                brush = Brush.verticalGradient(
-                    colors = listOf(
-                        backgroundColorOf(themeColor.hexToComposeColor()),
-                        KrailTheme.colors.surface,
-                    ),
-                ),
-            )
-            .imePadding(),
+    CloudGradientBackground(
+        modifier = modifier.fillMaxSize(),
+        themeColor = themeColor.hexToComposeColor(),
     ) {
-        // Split view: List on left, Map on right
-        Row(
+        Column(
             modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
+                .fillMaxSize()
+                .imePadding(),
         ) {
-            // Left pane: List with search bar
-            Column(
+            // Split view: List on left, Map on right
+            Row(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxHeight(),
+                    .fillMaxWidth(),
             ) {
-                // Search top bar only spans the list width
-                SearchTopBar(
-                    placeholderText = placeholderText,
-                    initialText = initialText,
-                    focusRequester = focusRequester,
-                    keyboard = keyboard,
-                    isMapSelected = false,
-                    isMapAvailable = false,
-                    onMapToggle = { },
-                    onBackClick = onBackClick,
-                    onTextChange = onTextChange,
-                )
-
-                SearchStopListContent(
-                    listState = searchStopState.listState,
-                    searchStopState = searchStopState,
-                    keyboard = keyboard,
-                    focusRequester = focusRequester,
-                    assigningLabel = assigningLabel,
-                    editingLabels = editingLabels,
-                    onStopSelect = onStopSelect,
-                    onSaveAsLabel = onSaveAsLabel,
-                    onUnsaveLabel = onUnsaveLabel,
-                    onUnsetLabelClick = onUnsetLabelClick,
-                    onEnterEditing = onEnterEditing,
-                    onDeleteLabel = onDeleteLabel,
-                    onMoveLabel = onMoveLabel,
-                    onAddLabelClick = onAddLabelClick,
-                    onDoneEditing = onDoneEditing,
-                    onEvent = onEvent,
-                    isMapsAvailable = false, // map already visible in right pane
-                    onOpenMap = {},
-                )
-            }
-
-            // Right pane: Map (edge-to-edge)
-            // Show map if available and initialized
-            searchStopState.mapUiState?.let { mapState ->
-                // Push compass/scale bar below the status bar so they don't sit behind it.
-                val statusBarTopPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-                SearchStopMap(
+                // Left pane: List with search bar
+                Column(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxHeight(),
-                    mapUiState = mapState,
-                    keyboard = keyboard,
-                    focusRequester = focusRequester,
-                    ornamentTopPadding = statusBarTopPadding,
-                    onEvent = onEvent,
-                    onStopSelect = onStopSelect,
-                )
+                ) {
+                    // Search top bar only spans the list width
+                    SearchTopBar(
+                        placeholderText = placeholderText,
+                        initialText = initialText,
+                        focusRequester = focusRequester,
+                        keyboard = keyboard,
+                        isMapSelected = false,
+                        isMapAvailable = false,
+                        onMapToggle = { },
+                        onBackClick = onBackClick,
+                        onTextChange = onTextChange,
+                    )
+
+                    SearchStopListContent(
+                        listState = searchStopState.listState,
+                        searchStopState = searchStopState,
+                        keyboard = keyboard,
+                        focusRequester = focusRequester,
+                        assigningLabel = assigningLabel,
+                        editingLabels = editingLabels,
+                        onStopSelect = onStopSelect,
+                        onSaveAsLabel = onSaveAsLabel,
+                        onUnsaveLabel = onUnsaveLabel,
+                        onUnsetLabelClick = onUnsetLabelClick,
+                        onEnterEditing = onEnterEditing,
+                        onDeleteLabel = onDeleteLabel,
+                        onMoveLabel = onMoveLabel,
+                        onAddLabelClick = onAddLabelClick,
+                        onDoneEditing = onDoneEditing,
+                        onEvent = onEvent,
+                        isMapsAvailable = false, // map already visible in right pane
+                        onOpenMap = {},
+                    )
+                }
+
+                // Right pane: Map (edge-to-edge)
+                // Show map if available and initialized
+                searchStopState.mapUiState?.let { mapState ->
+                    // Push compass/scale bar below the status bar so they don't sit behind it.
+                    val statusBarTopPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+                    SearchStopMap(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                        mapUiState = mapState,
+                        keyboard = keyboard,
+                        focusRequester = focusRequester,
+                        ornamentTopPadding = statusBarTopPadding,
+                        onEvent = onEvent,
+                        onStopSelect = onStopSelect,
+                    )
+                }
             }
         }
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackground.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackground.kt
@@ -11,42 +11,67 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalWindowInfo
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.themeColor
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
 
 /**
- * Slowly drifting "cloud" gradient suitable as a full-screen background.
+ * Slowly morphing "cloud" gradient suitable as a full-screen background.
  *
- * Three large radial blobs feather to transparent and translate on independent
- * non-harmonic sine paths over a [KrailTheme.colors.surface] base. Periods are
- * deliberately coprime so the blobs never sync into a visible pulse.
+ * Three large radial blobs — all derived from the user's theme color at
+ * descending tint strengths — drift on coprime periods over a
+ * [KrailTheme.colors.surface] base. Each blob also breathes its radius on a
+ * separate slow cycle, so the *combined* envelope morphs (a downward triangle
+ * collapsing into an arc, etc.) rather than reading as discrete circles.
  *
- * Why it stays cheap:
- *   - Single drawBehind — only the lambda re-runs each frame, no recomposition.
- *   - Offscreen compositing is required so the blobs' transparent edges blend
- *     into a single layer instead of painting straight onto the destination
- *     (without it, soft edges look chalky against the surface wash).
- *   - No Modifier.blur — the radial feather already gives soft edges, and per-
- *     frame blur is significantly more expensive on both Android and iOS Skia.
+ * Why every centre sits in the top quarter of the screen with capped y-drift:
+ * by request the cloud field stays in the top half only, so the bottom of the
+ * screen reads as a clean [KrailTheme.colors.surface] wash. Centres are at
+ * y ≤ 0.25 with small y-amplitude so the *visible* radial fade lands roughly
+ * at the mid-line on a typical phone aspect ratio (h ≈ 2w).
  *
- * The driving InfiniteTransition is paused automatically when the host activity
- * stops producing frames (background, locked screen), so there is no separate
- * lifecycle plumbing to do here.
+ * Why blob centres and radii are anchored to [LocalWindowInfo.containerSize]:
+ * the window size stays constant when the IME shows, while a parent that uses
+ * `imePadding()` will shrink the local draw area. Anchoring to window space
+ * keeps the blobs visually still — only the visible bottom edge gets clipped
+ * as the keyboard rises, so the gradient feels like a fixed sky behind the
+ * content rather than something that lurches up with the keyboard.
+ *
+ * Why a 3-stop radial (peak → mid → transparent) and not a 2-stop:
+ * a single peak→transparent stop falls off too fast and reads as a hard disc.
+ * The mid-stop spreads the bulk of each blob's color over ~45% of its radius,
+ * which is what lets the three blobs merge into one continuous field instead
+ * of looking like three separate planets.
+ *
+ * Performance:
+ *   - Single drawBehind. Only the lambda re-runs each frame.
+ *   - Offscreen compositing so transparent blob edges blend cleanly into one
+ *     layer instead of painting straight onto the destination.
+ *   - No Modifier.blur — the multi-stop falloff already gives soft edges, and
+ *     per-frame blur is significantly more expensive on both Android and Skia.
+ *   - Brushes are allocated inside drawBehind (radial gradients are cheap);
+ *     the brush has to change every frame anyway because center/radius animate.
+ *
+ * The driving InfiniteTransition pauses automatically when the host stops
+ * producing frames (background, locked screen).
  */
 @Composable
 fun CloudGradientBackground(
@@ -54,6 +79,22 @@ fun CloudGradientBackground(
     themeColor: Color = themeColor(),
     content: @Composable BoxScope.() -> Unit = {},
 ) {
+    val surface = KrailTheme.colors.surface
+    val darkMode = isAppInDarkMode()
+    val peakAlpha = if (darkMode) DARK_PEAK_ALPHA else LIGHT_PEAK_ALPHA
+
+    val tintA = lerp(themeColor, surface, BLOB_TINT_A_BLEND)
+    val tintB = lerp(themeColor, surface, BLOB_TINT_B_BLEND)
+
+    val windowSize = LocalWindowInfo.current.containerSize
+    val refSize: Size? = remember(windowSize.width, windowSize.height) {
+        if (windowSize.width > 0 && windowSize.height > 0) {
+            Size(windowSize.width.toFloat(), windowSize.height.toFloat())
+        } else {
+            null
+        }
+    }
+
     val transition = rememberInfiniteTransition(label = "cloud-gradient")
     val t1 by transition.animateFloat(
         initialValue = 0f,
@@ -73,9 +114,14 @@ fun CloudGradientBackground(
         animationSpec = infiniteRepeatable(tween(BLOB_3_PERIOD_MS, easing = LinearEasing)),
         label = "cloud-blob-3",
     )
-
-    val surface = KrailTheme.colors.surface
-    val tintA = lerp(themeColor, surface, BLOB_TINT_A_BLEND)
+    // Separate "breathe" phase drives radius pulsing — independent of position
+    // so the envelope shape morphs even when blob centres happen to align.
+    val breathe by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(BREATHE_PERIOD_MS, easing = LinearEasing)),
+        label = "cloud-breathe",
+    )
 
     Box(
         modifier = modifier
@@ -83,29 +129,39 @@ fun CloudGradientBackground(
             .background(surface)
             .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
             .drawBehind {
+                val ref = refSize ?: size
+                val pulse = sin(breathe * TWO_PI) * RADIUS_BREATHE_AMP
+                val antiPulse = -pulse
+
                 drawBlob(
+                    referenceSize = ref,
+                    color = themeColor,
+                    peakAlpha = peakAlpha,
                     centerFrac = Offset(
                         x = BLOB_1_CENTER_X + BLOB_1_AMP_X * sin(t1 * TWO_PI),
                         y = BLOB_1_CENTER_Y + BLOB_1_AMP_Y * cos(t1 * TWO_PI),
                     ),
-                    color = themeColor,
-                    radiusFrac = BLOB_1_RADIUS_FRAC,
+                    rFrac = BLOB_1_RADIUS_FRAC + pulse,
                 )
                 drawBlob(
+                    referenceSize = ref,
+                    color = tintA,
+                    peakAlpha = peakAlpha,
                     centerFrac = Offset(
                         x = BLOB_2_CENTER_X + BLOB_2_AMP_X * cos(t2 * TWO_PI),
                         y = BLOB_2_CENTER_Y + BLOB_2_AMP_Y * sin(t2 * TWO_PI),
                     ),
-                    color = tintA,
-                    radiusFrac = BLOB_2_RADIUS_FRAC,
+                    rFrac = BLOB_2_RADIUS_FRAC + antiPulse,
                 )
                 drawBlob(
+                    referenceSize = ref,
+                    color = tintB,
+                    peakAlpha = peakAlpha * BLOB_3_ALPHA_SCALE,
                     centerFrac = Offset(
                         x = BLOB_3_CENTER_X + BLOB_3_AMP_X * sin(t3 * TWO_PI),
                         y = BLOB_3_CENTER_Y + BLOB_3_AMP_Y * cos(t3 * TWO_PI),
                     ),
-                    color = surface,
-                    radiusFrac = BLOB_3_RADIUS_FRAC,
+                    rFrac = BLOB_3_RADIUS_FRAC + pulse * BLOB_3_BREATHE_SCALE,
                 )
             },
         content = content,
@@ -113,15 +169,21 @@ fun CloudGradientBackground(
 }
 
 private fun DrawScope.drawBlob(
-    centerFrac: Offset,
+    referenceSize: Size,
     color: Color,
-    radiusFrac: Float,
+    peakAlpha: Float,
+    centerFrac: Offset,
+    rFrac: Float,
 ) {
-    val center = Offset(size.width * centerFrac.x, size.height * centerFrac.y)
-    val radius = size.minDimension * radiusFrac
+    val center = Offset(referenceSize.width * centerFrac.x, referenceSize.height * centerFrac.y)
+    val radius = referenceSize.minDimension * rFrac
     drawCircle(
         brush = Brush.radialGradient(
-            colors = listOf(color.copy(alpha = BLOB_PEAK_ALPHA), Color.Transparent),
+            colorStops = arrayOf(
+                0f to color.copy(alpha = peakAlpha),
+                BLOB_MID_STOP to color.copy(alpha = peakAlpha * MID_ALPHA_RATIO),
+                1f to Color.Transparent,
+            ),
             center = center,
             radius = radius,
         ),
@@ -132,35 +194,51 @@ private fun DrawScope.drawBlob(
 
 private const val TWO_PI = (2 * PI).toFloat()
 
-// Coprime periods avoid a perceived pulse when blobs would otherwise re-align.
-private const val BLOB_1_PERIOD_MS = 18_000
-private const val BLOB_2_PERIOD_MS = 23_000
-private const val BLOB_3_PERIOD_MS = 31_000
+// Light mode tolerates a stronger peak because surface is white; dark mode
+// needs much less alpha or the saturated theme colour reads as a hot spot.
+private const val LIGHT_PEAK_ALPHA = 0.55f
+private const val DARK_PEAK_ALPHA = 0.32f
+private const val MID_ALPHA_RATIO = 0.45f
+private const val BLOB_MID_STOP = 0.45f
 
-private const val BLOB_PEAK_ALPHA = 0.55f
-private const val BLOB_TINT_A_BLEND = 0.4f
+private const val RADIUS_BREATHE_AMP = 0.10f
+private const val BREATHE_PERIOD_MS = 23_000
 
-private const val BLOB_1_CENTER_X = 0.20f
-private const val BLOB_1_CENTER_Y = 0.25f
-private const val BLOB_1_AMP_X = 0.15f
-private const val BLOB_1_AMP_Y = 0.10f
-private const val BLOB_1_RADIUS_FRAC = 0.75f
+private const val BLOB_TINT_A_BLEND = 0.35f
+private const val BLOB_TINT_B_BLEND = 0.60f
 
-private const val BLOB_2_CENTER_X = 0.80f
-private const val BLOB_2_CENTER_Y = 0.40f
-private const val BLOB_2_AMP_X = 0.12f
-private const val BLOB_2_AMP_Y = 0.18f
-private const val BLOB_2_RADIUS_FRAC = 0.65f
+// All four periods (incl. BREATHE_PERIOD_MS above) are pairwise coprime so
+// blobs never sync into a visible pulse.
+//
+// Sizing rule of thumb: on a phone (h ≈ 2w, minDim = w), a blob's *visible*
+// fade reaches roughly 0.7 × radius beyond its centre. With centres at
+// y ≤ 0.25 and radii ≤ ~0.85, the visible field stays in the top 50%.
+private const val BLOB_1_PERIOD_MS = 16_000
+private const val BLOB_1_CENTER_X = 0.30f
+private const val BLOB_1_CENTER_Y = 0.12f
+private const val BLOB_1_AMP_X = 0.10f
+private const val BLOB_1_AMP_Y = 0.05f
+private const val BLOB_1_RADIUS_FRAC = 0.85f
 
+private const val BLOB_2_PERIOD_MS = 19_000
+private const val BLOB_2_CENTER_X = 0.70f
+private const val BLOB_2_CENTER_Y = 0.12f
+private const val BLOB_2_AMP_X = 0.10f
+private const val BLOB_2_AMP_Y = 0.05f
+private const val BLOB_2_RADIUS_FRAC = 0.85f
+
+private const val BLOB_3_PERIOD_MS = 25_000
 private const val BLOB_3_CENTER_X = 0.50f
-private const val BLOB_3_CENTER_Y = 0.85f
-private const val BLOB_3_AMP_X = 0.20f
-private const val BLOB_3_AMP_Y = 0.08f
-private const val BLOB_3_RADIUS_FRAC = 0.90f
+private const val BLOB_3_CENTER_Y = 0.22f
+private const val BLOB_3_AMP_X = 0.12f
+private const val BLOB_3_AMP_Y = 0.05f
+private const val BLOB_3_RADIUS_FRAC = 0.70f
+private const val BLOB_3_ALPHA_SCALE = 0.85f
+private const val BLOB_3_BREATHE_SCALE = 0.6f
 
 @PreviewComponent
 @Composable
-private fun CloudGradientBackgroundPreview() {
+private fun CloudGradientBackgroundTrainPreview() {
     PreviewTheme(themeStyle = KrailThemeStyle.Train) {
         CloudGradientBackground(modifier = Modifier.fillMaxSize())
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackground.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackground.kt
@@ -1,0 +1,175 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.themeColor
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Slowly drifting "cloud" gradient suitable as a full-screen background.
+ *
+ * Three large radial blobs feather to transparent and translate on independent
+ * non-harmonic sine paths over a [KrailTheme.colors.surface] base. Periods are
+ * deliberately coprime so the blobs never sync into a visible pulse.
+ *
+ * Why it stays cheap:
+ *   - Single drawBehind — only the lambda re-runs each frame, no recomposition.
+ *   - Offscreen compositing is required so the blobs' transparent edges blend
+ *     into a single layer instead of painting straight onto the destination
+ *     (without it, soft edges look chalky against the surface wash).
+ *   - No Modifier.blur — the radial feather already gives soft edges, and per-
+ *     frame blur is significantly more expensive on both Android and iOS Skia.
+ *
+ * The driving InfiniteTransition is paused automatically when the host activity
+ * stops producing frames (background, locked screen), so there is no separate
+ * lifecycle plumbing to do here.
+ */
+@Composable
+fun CloudGradientBackground(
+    modifier: Modifier = Modifier,
+    themeColor: Color = themeColor(),
+    content: @Composable BoxScope.() -> Unit = {},
+) {
+    val transition = rememberInfiniteTransition(label = "cloud-gradient")
+    val t1 by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(BLOB_1_PERIOD_MS, easing = LinearEasing)),
+        label = "cloud-blob-1",
+    )
+    val t2 by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(BLOB_2_PERIOD_MS, easing = LinearEasing)),
+        label = "cloud-blob-2",
+    )
+    val t3 by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(tween(BLOB_3_PERIOD_MS, easing = LinearEasing)),
+        label = "cloud-blob-3",
+    )
+
+    val surface = KrailTheme.colors.surface
+    val tintA = lerp(themeColor, surface, BLOB_TINT_A_BLEND)
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(surface)
+            .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+            .drawBehind {
+                drawBlob(
+                    centerFrac = Offset(
+                        x = BLOB_1_CENTER_X + BLOB_1_AMP_X * sin(t1 * TWO_PI),
+                        y = BLOB_1_CENTER_Y + BLOB_1_AMP_Y * cos(t1 * TWO_PI),
+                    ),
+                    color = themeColor,
+                    radiusFrac = BLOB_1_RADIUS_FRAC,
+                )
+                drawBlob(
+                    centerFrac = Offset(
+                        x = BLOB_2_CENTER_X + BLOB_2_AMP_X * cos(t2 * TWO_PI),
+                        y = BLOB_2_CENTER_Y + BLOB_2_AMP_Y * sin(t2 * TWO_PI),
+                    ),
+                    color = tintA,
+                    radiusFrac = BLOB_2_RADIUS_FRAC,
+                )
+                drawBlob(
+                    centerFrac = Offset(
+                        x = BLOB_3_CENTER_X + BLOB_3_AMP_X * sin(t3 * TWO_PI),
+                        y = BLOB_3_CENTER_Y + BLOB_3_AMP_Y * cos(t3 * TWO_PI),
+                    ),
+                    color = surface,
+                    radiusFrac = BLOB_3_RADIUS_FRAC,
+                )
+            },
+        content = content,
+    )
+}
+
+private fun DrawScope.drawBlob(
+    centerFrac: Offset,
+    color: Color,
+    radiusFrac: Float,
+) {
+    val center = Offset(size.width * centerFrac.x, size.height * centerFrac.y)
+    val radius = size.minDimension * radiusFrac
+    drawCircle(
+        brush = Brush.radialGradient(
+            colors = listOf(color.copy(alpha = BLOB_PEAK_ALPHA), Color.Transparent),
+            center = center,
+            radius = radius,
+        ),
+        radius = radius,
+        center = center,
+    )
+}
+
+private const val TWO_PI = (2 * PI).toFloat()
+
+// Coprime periods avoid a perceived pulse when blobs would otherwise re-align.
+private const val BLOB_1_PERIOD_MS = 18_000
+private const val BLOB_2_PERIOD_MS = 23_000
+private const val BLOB_3_PERIOD_MS = 31_000
+
+private const val BLOB_PEAK_ALPHA = 0.55f
+private const val BLOB_TINT_A_BLEND = 0.4f
+
+private const val BLOB_1_CENTER_X = 0.20f
+private const val BLOB_1_CENTER_Y = 0.25f
+private const val BLOB_1_AMP_X = 0.15f
+private const val BLOB_1_AMP_Y = 0.10f
+private const val BLOB_1_RADIUS_FRAC = 0.75f
+
+private const val BLOB_2_CENTER_X = 0.80f
+private const val BLOB_2_CENTER_Y = 0.40f
+private const val BLOB_2_AMP_X = 0.12f
+private const val BLOB_2_AMP_Y = 0.18f
+private const val BLOB_2_RADIUS_FRAC = 0.65f
+
+private const val BLOB_3_CENTER_X = 0.50f
+private const val BLOB_3_CENTER_Y = 0.85f
+private const val BLOB_3_AMP_X = 0.20f
+private const val BLOB_3_AMP_Y = 0.08f
+private const val BLOB_3_RADIUS_FRAC = 0.90f
+
+@PreviewComponent
+@Composable
+private fun CloudGradientBackgroundPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        CloudGradientBackground(modifier = Modifier.fillMaxSize())
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun CloudGradientBackgroundMetroPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        CloudGradientBackground(modifier = Modifier.fillMaxSize())
+    }
+}


### PR DESCRIPTION
feat(taj): add CloudGradientBackground and use on SearchStopScreen

Replaces the static themeColor->surface vertical gradient on
SearchStopScreen with a slowly drifting "cloud" of three radial
blobs animated on coprime periods. Lives in taj so other screens
can adopt the same background.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(taj): rework CloudGradientBackground for dark mode + IME + top-half framing

- Three theme-tinted blobs (was four; the surface-coloured blob was invisible).
- Dark-mode peak alpha drops to 0.32 so the saturated theme colour does not
  read as a hot spot against the dark surface.
- 3-stop radial (peak / mid / transparent) so the bulk of each blob spreads
  soft instead of feathering hard near the centre.
- Centres anchored to LocalWindowInfo.containerSize so an IME-padded ancestor
  no longer drags the gradient up and down with the keyboard.
- All centres pinned to the top quarter of the screen (y in [0.12, 0.22])
  with capped y-drift, so the visible field stays in the top half and the
  bottom of the screen is a clean surface wash.
- 1.2x faster drift; pairwise-coprime periods (16/19/25 + 23s breathe) keep
  the envelope morphing instead of pulsing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>