### PR TITLE
feat(analytics): track timetable load-more and load-previous taps

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -442,6 +442,72 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         ),
     )
 
+    /**
+     * Fired when the user taps "Load more" at the bottom of the timetable list to
+     * page in the next window of future trips.
+     *
+     * @param loadMoreCount Pre-increment page index — number of additional pages already
+     *   successfully fetched at tap time. Lets the dashboard answer "what % of users go
+     *   past N pages?" and tell us whether `MAX_LOAD_MORE_COUNT` is set sensibly.
+     * @param isCustomDateTime `true` when the user picked a non-default departure/arrival
+     *   time, `false` when they're viewing the default "now". Splits exploratory
+     *   pagination from "I want a slightly later option" pagination.
+     * @param latestVisibleDepartureMinutesFromNow Minutes between now and the latest
+     *   user-visible (filtered) departure when the tap happened. Tells us how far ahead
+     *   users are already looking when they reach for more.
+     * @param visibleJourneyCount How many journeys were rendered (post-filter) at tap
+     *   time. Sparse lists imply pagination is essential, not exploratory.
+     */
+    data class TimeTableLoadMoreClickEvent(
+        val fromStopId: String,
+        val toStopId: String,
+        val loadMoreCount: Int,
+        val isCustomDateTime: Boolean,
+        val latestVisibleDepartureMinutesFromNow: Int,
+        val visibleJourneyCount: Int,
+    ) : AnalyticsEvent(
+        name = "timetable_load_more_click",
+        properties = mapOf(
+            PROP_FROM_STOP_ID to fromStopId,
+            PROP_TO_STOP_ID to toStopId,
+            "loadMoreCount" to loadMoreCount,
+            "isCustomDateTime" to isCustomDateTime,
+            "latestVisibleDepartureMinutesFromNow" to latestVisibleDepartureMinutesFromNow,
+            "visibleJourneyCount" to visibleJourneyCount,
+        ),
+    )
+
+    /**
+     * Fired when the user taps "Load previous" at the top of the timetable list to
+     * page in trips that departed before the earliest currently shown departure.
+     *
+     * @param isCustomDateTime `true` when the user picked a non-default departure/arrival
+     *   time. High `false` volume here means users land on the screen with the wrong
+     *   default time and are reaching backwards.
+     * @param earliestVisibleDepartureMinutesFromNow Minutes between now and the earliest
+     *   user-visible (filtered) departure when the tap happened. Negative when the user
+     *   is already looking at past trips, positive when they're scrolling backwards from
+     *   a future-scheduled view.
+     * @param visibleJourneyCount How many journeys were rendered (post-filter) at tap
+     *   time.
+     */
+    data class TimeTableLoadPreviousClickEvent(
+        val fromStopId: String,
+        val toStopId: String,
+        val isCustomDateTime: Boolean,
+        val earliestVisibleDepartureMinutesFromNow: Int,
+        val visibleJourneyCount: Int,
+    ) : AnalyticsEvent(
+        name = "timetable_load_previous_click",
+        properties = mapOf(
+            PROP_FROM_STOP_ID to fromStopId,
+            PROP_TO_STOP_ID to toStopId,
+            "isCustomDateTime" to isCustomDateTime,
+            "earliestVisibleDepartureMinutesFromNow" to earliestVisibleDepartureMinutesFromNow,
+            "visibleJourneyCount" to visibleJourneyCount,
+        ),
+    )
+
     // endregion
 
     // region Generic Events

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -1206,6 +1206,101 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN loaded journeys WHEN LoadMoreTrips fires THEN load_more_click is tracked with trip pair and pre-increment count`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "S1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "S2",
+            )
+            tripPlanningService.isSuccess = true
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            val visibleAtTap = viewModel.uiState.value.journeyList.size
+            assertTrue(visibleAtTap > 0)
+            analytics.clear()
+
+            viewModel.onEvent(TimeTableUiEvent.LoadMoreTrips)
+            advanceUntilIdle()
+
+            val tracked = analytics.getTrackedEvent("timetable_load_more_click")
+            assertNotNull(tracked)
+            val event = assertIs<AnalyticsEvent.TimeTableLoadMoreClickEvent>(tracked)
+            assertEquals("FROM_STOP_ID_1", event.fromStopId)
+            assertEquals("TO_STOP_ID_1", event.toStopId)
+            // First tap, no successful pages yet → 0
+            assertEquals(0, event.loadMoreCount)
+            // Default time used → not custom
+            assertFalse(event.isCustomDateTime)
+            // Captured the visible list size at tap time, before this fetch's results merged in
+            assertEquals(visibleAtTap, event.visibleJourneyCount)
+        }
+
+    @Test
+    fun `GIVEN multiple successful LoadMoreTrips WHEN tapped again THEN loadMoreCount reflects pages already fetched`() =
+        runTest {
+            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
+            tripPlanningService.isSuccess = true
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            // First two pages succeed, then we inspect the third tap's payload
+            viewModel.onEvent(TimeTableUiEvent.LoadMoreTrips)
+            advanceUntilIdle()
+            viewModel.onEvent(TimeTableUiEvent.LoadMoreTrips)
+            advanceUntilIdle()
+            analytics.clear()
+
+            viewModel.onEvent(TimeTableUiEvent.LoadMoreTrips)
+            advanceUntilIdle()
+
+            val tracked = analytics.getTrackedEvent("timetable_load_more_click")
+            assertNotNull(tracked)
+            val event = assertIs<AnalyticsEvent.TimeTableLoadMoreClickEvent>(tracked)
+            // Two pages already fetched before this tap
+            assertEquals(2, event.loadMoreCount)
+        }
+
+    @Test
+    fun `GIVEN loaded journeys WHEN LoadPreviousTrips fires THEN load_previous_click is tracked with trip pair and visible count`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "S1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "S2",
+            )
+            tripPlanningService.isSuccess = true
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            val visibleAtTap = viewModel.uiState.value.journeyList.size
+            assertTrue(visibleAtTap > 0)
+            analytics.clear()
+
+            viewModel.onEvent(TimeTableUiEvent.LoadPreviousTrips)
+            advanceUntilIdle()
+
+            val tracked = analytics.getTrackedEvent("timetable_load_previous_click")
+            assertNotNull(tracked)
+            val event = assertIs<AnalyticsEvent.TimeTableLoadPreviousClickEvent>(tracked)
+            assertEquals("FROM_STOP_ID_1", event.fromStopId)
+            assertEquals("TO_STOP_ID_1", event.toStopId)
+            assertFalse(event.isCustomDateTime)
+            assertEquals(visibleAtTap, event.visibleJourneyCount)
+        }
+
+    @Test
     fun `GIVEN load-more journeys WHEN trip changes THEN loadMoreJourneys and previousJourneysCache are cleared`() =
         runTest {
             val trip1 = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -582,6 +582,7 @@ class TimeTableViewModel(
      */
     @OptIn(ExperimentalTime::class)
     private fun onLoadMoreTrips() {
+        trackLoadMoreClick()
         if (loadMoreCount >= MAX_LOAD_MORE_COUNT) return
         val allJourneys = (journeys.values + loadMoreJourneys.values)
         val lastInstant = allJourneys
@@ -620,6 +621,7 @@ class TimeTableViewModel(
      */
     @OptIn(ExperimentalTime::class)
     private fun onLoadPreviousTrips() {
+        trackLoadPreviousClick()
         val allJourneys = (previousJourneysCache.values + journeys.values + loadMoreJourneys.values)
         val firstInstant = allJourneys
             .minByOrNull { Instant.parse(it.originUtcDateTime) }
@@ -646,6 +648,49 @@ class TimeTableViewModel(
             }
             updateUiState { copy(isLoadingPrevious = false) }
         }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun trackLoadMoreClick() {
+        val info = tripInfo ?: return
+        val visibleList = _uiState.value.journeyList
+        val now = Clock.System.now()
+        val latestMinutes = visibleList
+            .mapNotNull { runCatching { Instant.parse(it.originUtcDateTime) }.getOrNull() }
+            .maxOrNull()
+            ?.let { (it - now).inWholeMinutes.toInt() }
+            ?: 0
+        analytics.track(
+            AnalyticsEvent.TimeTableLoadMoreClickEvent(
+                fromStopId = info.fromStopId,
+                toStopId = info.toStopId,
+                loadMoreCount = loadMoreCount,
+                isCustomDateTime = dateTimeSelectionItem != null,
+                latestVisibleDepartureMinutesFromNow = latestMinutes,
+                visibleJourneyCount = visibleList.size,
+            ),
+        )
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun trackLoadPreviousClick() {
+        val info = tripInfo ?: return
+        val visibleList = _uiState.value.journeyList
+        val now = Clock.System.now()
+        val earliestMinutes = visibleList
+            .mapNotNull { runCatching { Instant.parse(it.originUtcDateTime) }.getOrNull() }
+            .minOrNull()
+            ?.let { (it - now).inWholeMinutes.toInt() }
+            ?: 0
+        analytics.track(
+            AnalyticsEvent.TimeTableLoadPreviousClickEvent(
+                fromStopId = info.fromStopId,
+                toStopId = info.toStopId,
+                isCustomDateTime = dateTimeSelectionItem != null,
+                earliestVisibleDepartureMinutesFromNow = earliestMinutes,
+                visibleJourneyCount = visibleList.size,
+            ),
+        )
     }
 
     /** Like [loadTrip] but uses explicit [date]/[time] params instead of [dateTimeSelectionItem]. */


### PR DESCRIPTION
## Summary

- New `TimeTableLoadMoreClickEvent` and `TimeTableLoadPreviousClickEvent` in `core/analytics`.
- Wired into `TimeTableViewModel.onLoadMoreTrips()` and `onLoadPreviousTrips()`.
- Each event carries the trip pair plus four context fields:
  - `loadMoreCount` (LoadMore only): pre-increment page index, for the "what % go past N pages" funnel and to validate `MAX_LOAD_MORE_COUNT`.
  - `isCustomDateTime`: splits "user picked a time" from default "now" pagination; high `false` volume on LoadPrevious is a signal the default time on entry is wrong.
  - `latestVisibleDepartureMinutesFromNow` / `earliestVisibleDepartureMinutesFromNow`: how far ahead/back the user is already looking when they reach for more.
  - `visibleJourneyCount`: how full the list was at tap time; sparse lists imply pagination is essential, not exploratory.

Closes #1578

## Test plan

- [x] `./gradlew :core:test:testAndroidHostTest --tests "*TimeTableViewModelTest*" --continue` passes
- [x] `./gradlew detekt --continue` clean
- [ ] Manual: tap Load more / Load previous on a real trip, confirm events arrive in the analytics dashboard with the expected fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)