### PR TITLE
chore(saved-trips): remove hardcoded invite-friends info tile

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -121,7 +121,6 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
                 tripPlannerNavigator.navigateToDiscover()
             },
             onEvent = { event -> viewModel.onEvent(event) },
-            onInviteFriendsTileDisplay = { viewModel.markInviteFriendsTileAsSeen() },
             departureBoardEntries = departureBoardEntries,
             expandedDepartureBoardStopId = expandedDepartureBoardStopId,
             onDepartureBoardEvent = departureBoardViewModel::onEvent,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -68,9 +68,7 @@ import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import xyz.ksharma.krail.feature.track.TrackedJourney
 import xyz.ksharma.krail.feature.track.ui.components.TrackingCard
-import xyz.ksharma.krail.info.tile.state.InfoTileCta
 import xyz.ksharma.krail.info.tile.state.InfoTileData
-import xyz.ksharma.krail.info.tile.state.InfoTileState
 import xyz.ksharma.krail.info.tiles.ui.InfoTile
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalTextStyle
@@ -112,7 +110,6 @@ fun SavedTripsScreen(
     onSettingsButtonClick: () -> Unit = {},
     onDiscoverButtonClick: () -> Unit = {},
     onEvent: (SavedTripUiEvent) -> Unit = {},
-    onInviteFriendsTileDisplay: () -> Unit = {},
     onTrackingCardClick: () -> Unit = {},
     onStopTracking: () -> Unit = {},
     departureBoardEntries: ImmutableList<StopDepartureBoardEntry> = persistentListOf(),
@@ -255,56 +252,6 @@ fun SavedTripsScreen(
                                     onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
                                 },
                             )
-                        }
-
-                        val hasInviteFriendsInRemoteConfig =
-                            savedTripsState.infoTiles?.any { tile ->
-                                tile.key.startsWith("invite_friends", ignoreCase = true) ||
-                                    tile.type == InfoTileData.InfoTileType.INVITE_FRIENDS
-                            } ?: false
-
-                        val shouldShowInviteFriends = savedTripsState.savedTrips.size >= 2 &&
-                            !hasInviteFriendsInRemoteConfig
-
-                        if (shouldShowInviteFriends) {
-                            item(key = "invite_friends_tile_hardcoded") {
-                                LaunchedEffect(!savedTripsState.hasSeenInviteFriendsTile) {
-                                    if (!savedTripsState.hasSeenInviteFriendsTile) {
-                                        onInviteFriendsTileDisplay()
-                                    }
-                                }
-
-                                InfoTile(
-                                    infoTileData = InfoTileData(
-                                        key = "invite_friends_hardcoded",
-                                        title = "Invite Your Friends",
-                                        description = "You're the reason KRAIL is ad-free. Share it " +
-                                            "with friends and help Sydney ride better.",
-                                        primaryCta = InfoTileCta(
-                                            text = "Invite",
-                                            url = null,
-                                        ),
-                                        type = InfoTileData.InfoTileType.INVITE_FRIENDS,
-                                        showDismissButton = false,
-                                    ),
-                                    initialState = if (savedTripsState.hasSeenInviteFriendsTile) {
-                                        InfoTileState.COLLAPSED
-                                    } else {
-                                        InfoTileState.EXPANDED
-                                    },
-                                    onCtaClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                    },
-                                    onDismissClick = { },
-                                    onTileExpand = { tileData ->
-                                        onEvent(SavedTripUiEvent.InfoTileExpand(tileData.key))
-                                    },
-                                    modifier = Modifier.padding(
-                                        horizontal = dim.pageHorizontalPadding,
-                                        vertical = dim.spacingM,
-                                    ),
-                                )
-                            }
                         }
 
                         savedTripsContent(


### PR DESCRIPTION
The invite-friends tile is now sourced exclusively from Firebase Remote
Config. Removes the hardcoded fallback that used to render below the
saved-trips list when no remote-config tile was present.

Existing DB-backed rules for the tile are unchanged:
  - SandookPreferences.KEY_HAS_SEEN_INVITE_FRIENDS_TILE stays
  - InviteFriendsTileManager + RealInviteFriendsTileManager stay
  - SavedTripsViewModel.markInviteFriendsTileAsSeen() stays
  - SavedTripsState.hasSeenInviteFriendsTile stays

These remain available infrastructure for any future caller; only the
hardcoded UI block in SavedTripsScreen.kt that consumed them is gone.

Dismiss / never-show-expanded-again behavior for remote-config tiles
continues to flow through InfoTilePreferences via SavedTripUiEvent
(InfoTileExpand, DismissInfoTile) — untouched by this change.

Removed:
  - SavedTripsScreen.kt: the `if (shouldShowInviteFriends) { item { InfoTile(...) } }`
    block + the gating calculations (hasInviteFriendsInRemoteConfig,
    shouldShowInviteFriends).
  - SavedTripsScreen.kt: onInviteFriendsTileDisplay parameter (unused
    after the block was removed; flagged by detekt UnusedParameter).
  - SavedTripsEntry.kt: onInviteFriendsTileDisplay caller wiring.
  - Two unused imports (InfoTileCta, InfoTileState).

Verified via:
  - ./scripts/fullQualityChecks.sh → BUILD SUCCESSFUL
  - ./gradlew testAndroidHostTest --continue → BUILD SUCCESSFUL, 0 failures

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>