### PR TITLE
feat(network): add X-Krail-Version default header (Phase B prep)

### DIFF
--- a/core/network/src/androidMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/androidMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -4,9 +4,11 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -18,6 +20,9 @@ actual fun baseHttpClient(
 ): HttpClient {
     return HttpClient(OkHttp) {
         expectSuccess = true
+        defaultRequest {
+            header("X-Krail-Version", appInfoProvider.getAppInfo().appVersion)
+        }
         install(ContentNegotiation) {
             json(
                 Json {

--- a/core/network/src/iosMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
+++ b/core/network/src/iosMain/kotlin/xyz/ksharma/krail/core/network/HttpClient.kt
@@ -4,9 +4,11 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
@@ -18,6 +20,9 @@ actual fun baseHttpClient(
 ): HttpClient {
     return HttpClient(Darwin) {
         expectSuccess = true
+        defaultRequest {
+            header("X-Krail-Version", appInfoProvider.getAppInfo().appVersion)
+        }
         install(ContentNegotiation) {
             json(
                 Json {


### PR DESCRIPTION
Phase B prep. Per KRAIL-BFF/docs/handover/MIGRATION_GUIDE.md §3.2 and
KRAIL-BFF/docs/handover/API_REFERENCE.md §1, the BFF will start
enforcing X-Krail-Version once it raises MIN_APP_VERSION above 0.0.0.
Missing or below-floor versions get 403 version_too_old.

Adding the header now removes a future failure mode: the moment BFF
flips MIN_APP_VERSION in prod, every request without this header
would 403. With this in place we just need to coordinate the floor
with the BFF team when they're ready.

Implementation:
- defaultRequest { header("X-Krail-Version", appInfo.appVersion) }
  installed once in both Android and iOS actual baseHttpClient(...).
- Plumbed via the existing AppInfoProvider constructor param; no
  new injection or DI changes needed.
- Header is sent on every outgoing request including the NSW direct
  path. NSW Open Data ignores unknown headers, so no harm there.
- BFF dev locally has MIN_APP_VERSION=0.0.0 (gate disabled), so this
  is a no-op behaviour change today; it's purely future-proofing.

Verified: ./scripts/fullQualityChecks.sh BUILD SUCCESSFUL.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>