### PR TITLE
fix(search): sort bus stops below all other transport modes in results

### DIFF
--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
@@ -19,18 +19,19 @@ sealed class TransportMode(
     val name: String,
     val productClass: Int,
     val priority: Int,
+    val searchPriority: Int,
 ) {
-    @Serializable object Train : TransportMode("#F6891F", "Train", 1, 1)
+    @Serializable object Train : TransportMode("#F6891F", "Train", 1, 1, 1)
 
-    @Serializable object Metro : TransportMode("#009B77", "Metro", 2, 3)
+    @Serializable object Metro : TransportMode("#009B77", "Metro", 2, 3, 2)
 
-    @Serializable object Bus : TransportMode("#00B5EF", "Bus", 5, 2)
+    @Serializable object Bus : TransportMode("#00B5EF", "Bus", 5, 2, 6)
 
-    @Serializable object LightRail : TransportMode("#E4022D", "Light Rail", 4, 4)
+    @Serializable object LightRail : TransportMode("#E4022D", "Light Rail", 4, 4, 3)
 
-    @Serializable object Ferry : TransportMode("#5AB031", "Ferry", 9, 5)
+    @Serializable object Ferry : TransportMode("#5AB031", "Ferry", 9, 5, 4)
 
-    @Serializable object Coach : TransportMode("#742282", "Coach", 7, 6)
+    @Serializable object Coach : TransportMode("#742282", "Coach", 7, 6, 5)
 
     companion object {
         val all: List<TransportMode> by lazy { listOf(Train, Metro, Bus, LightRail, Ferry, Coach) }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -14,7 +14,6 @@ import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
 import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 import xyz.ksharma.krail.core.transport.TransportMode
-import xyz.ksharma.krail.core.transport.TransportModeSortOrder
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.sandook.NswBusRoutesSandook
 import xyz.ksharma.krail.sandook.NswBusTripOptions
@@ -243,26 +242,17 @@ class RealStopResultsManager(
     // TODO - move to another file and add UT for it. Inject and use.
     override fun prioritiseStops(
         stopResults: List<SearchStopState.SearchResult.Stop>,
-    ): List<SearchStopState.SearchResult.Stop> {
-        val sortedTransportModes = NswTransportConfig.sortedModes(TransportModeSortOrder.PRIORITY)
-        val transportModePriorityMap = sortedTransportModes.mapIndexed { index, transportMode ->
-            NswTransportConfig.productClassFor(transportMode) to index
-        }.toMap()
-
-        return stopResults.sortedWith(
-            compareBy(
-                { stopResult ->
-                    if (stopResult.stopId in highPriorityStopIdList) 0 else 1
-                },
-                { stopResult ->
-                    stopResult.transportModeType.minOfOrNull {
-                        transportModePriorityMap[NswTransportConfig.productClassFor(it)] ?: Int.MAX_VALUE
-                    } ?: Int.MAX_VALUE
-                },
-                { it.stopName },
-            ),
-        )
-    }
+    ): List<SearchStopState.SearchResult.Stop> = stopResults.sortedWith(
+        compareBy(
+            { stopResult ->
+                if (stopResult.stopId in highPriorityStopIdList) 0 else 1
+            },
+            { stopResult ->
+                stopResult.transportModeType.minOfOrNull { it.searchPriority } ?: Int.MAX_VALUE
+            },
+            { it.stopName },
+        ),
+    )
 
     override fun fetchLocalStopName(stopId: String): String? {
         val resultsDb = sandook.selectStops(stopName = stopId, excludeProductClassList = listOf())

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultMapper.kt
@@ -42,7 +42,7 @@ object StopResultMapper {
             )
         }.sortedBy { stopResult ->
             stopResult.transportModeType.minOfOrNull { mode ->
-                mode.priority
+                mode.searchPriority
             } ?: Int.MAX_VALUE
         }
     }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsPrioritisationTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsPrioritisationTest.kt
@@ -89,6 +89,98 @@ class StopResultsPrioritisationTest {
         assertEquals("TRAIN", result.first().stopId)
     }
 
+    // region bus is always last among transport modes
+
+    @Test
+    fun `prioritiseStops places metro before bus`() {
+        val manager = managerWithHighPriorityIds()
+
+        val busStop = stop("BUS", "Random Bus Stop", TransportMode.Bus)
+        val metroStop = stop("METRO", "Metro Station", TransportMode.Metro)
+
+        val result = manager.prioritiseStops(listOf(busStop, metroStop))
+
+        assertEquals("METRO", result.first().stopId)
+    }
+
+    @Test
+    fun `prioritiseStops places light rail before bus`() {
+        val manager = managerWithHighPriorityIds()
+
+        val busStop = stop("BUS", "Random Bus Stop", TransportMode.Bus)
+        val lightRailStop = stop("LR", "Light Rail Stop", TransportMode.LightRail)
+
+        val result = manager.prioritiseStops(listOf(busStop, lightRailStop))
+
+        assertEquals("LR", result.first().stopId)
+    }
+
+    @Test
+    fun `prioritiseStops places ferry before bus`() {
+        val manager = managerWithHighPriorityIds()
+
+        val busStop = stop("BUS", "Random Bus Stop", TransportMode.Bus)
+        val ferryStop = stop("FERRY", "Ferry Wharf", TransportMode.Ferry)
+
+        val result = manager.prioritiseStops(listOf(busStop, ferryStop))
+
+        assertEquals("FERRY", result.first().stopId)
+    }
+
+    @Test
+    fun `prioritiseStops places coach before bus`() {
+        val manager = managerWithHighPriorityIds()
+
+        val busStop = stop("BUS", "Random Bus Stop", TransportMode.Bus)
+        val coachStop = stop("COACH", "Coach Terminal", TransportMode.Coach)
+
+        val result = manager.prioritiseStops(listOf(busStop, coachStop))
+
+        assertEquals("COACH", result.first().stopId)
+    }
+
+    @Test
+    fun `prioritiseStops places all non-bus modes before bus regardless of input order`() {
+        val manager = managerWithHighPriorityIds()
+
+        val busStop = stop("BUS", "Bus Interchange", TransportMode.Bus)
+        val trainStop = stop("TRAIN", "Central Station", TransportMode.Train)
+        val metroStop = stop("METRO", "Metro Station", TransportMode.Metro)
+        val lightRailStop = stop("LR", "Light Rail Stop", TransportMode.LightRail)
+        val ferryStop = stop("FERRY", "Circular Quay Wharf", TransportMode.Ferry)
+        val coachStop = stop("COACH", "Coach Terminal", TransportMode.Coach)
+
+        val result = manager.prioritiseStops(
+            listOf(busStop, metroStop, lightRailStop, trainStop, coachStop, ferryStop),
+        )
+
+        val busIndex = result.indexOfFirst { it.stopId == "BUS" }
+        val nonBusIds = listOf("TRAIN", "METRO", "LR", "FERRY", "COACH")
+        nonBusIds.forEach { id ->
+            val idx = result.indexOfFirst { it.stopId == id }
+            assertTrue(idx < busIndex, "Expected $id (index $idx) before BUS (index $busIndex)")
+        }
+    }
+
+    @Test
+    fun `prioritiseStops sorts non-bus modes among themselves by priority`() {
+        val manager = managerWithHighPriorityIds()
+
+        val trainStop = stop("TRAIN", "Central Station", TransportMode.Train)
+        val metroStop = stop("METRO", "Metro Station", TransportMode.Metro)
+        val lightRailStop = stop("LR", "Light Rail Stop", TransportMode.LightRail)
+        val ferryStop = stop("FERRY", "Circular Quay Wharf", TransportMode.Ferry)
+        val coachStop = stop("COACH", "Coach Terminal", TransportMode.Coach)
+
+        val result = manager.prioritiseStops(
+            listOf(coachStop, ferryStop, lightRailStop, metroStop, trainStop),
+        )
+
+        assertEquals(listOf("TRAIN", "METRO", "LR", "FERRY", "COACH"), result.map { it.stopId })
+    }
+
+    // endregion
+
     @Test
     fun `prioritiseStops is idempotent`() {
         val manager = managerWithHighPriorityIds("HP001")


### PR DESCRIPTION
Bus priority demoted to last (6) so Train, Metro, Light Rail, Ferry,
and Coach always surface above bus-only stops in fuzzy search results.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>