### PR TITLE
fix(timetable): calculate share "X mins away" from now to arrival, not journey duration

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -47,9 +47,13 @@ import krail.feature.trip_planner.ui.generated.resources.ic_clock
 import krail.feature.trip_planner.ui.generated.resources.ic_walk
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeString
 import xyz.ksharma.krail.core.share.withBrandingHeader
 import xyz.ksharma.krail.core.snapshot.ScreenshotTest
 import xyz.ksharma.krail.core.transport.TransportMode
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import xyz.ksharma.krail.taj.components.AlertButton
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
@@ -102,6 +106,7 @@ fun JourneyCard(
     departureDeviation: TimeTableState.JourneyCardInfo.DepartureDeviation? = null,
     scheduledOriginTime: String? = null,
     deepLinkUrl: String? = null,
+    destinationUtcDateTime: String = "",
 ) {
     val dim = KrailTheme.dimensions
     val isPast by remember(timeToDeparture) {
@@ -203,6 +208,7 @@ fun JourneyCard(
                                 destinationTime = destinationTime,
                                 totalTravelTime = totalTravelTime,
                                 deepLinkUrl = deepLinkUrl,
+                                destinationUtcDateTime = destinationUtcDateTime,
                             ),
                             isPast,
                         )
@@ -515,12 +521,16 @@ private fun JourneyOriginTimeRow(
  * https://krail.app
  * ```
  */
+@OptIn(ExperimentalTime::class)
 private fun buildShareText(
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
     destinationTime: String,
     totalTravelTime: String,
     deepLinkUrl: String? = null,
+    destinationUtcDateTime: String = "",
 ): String {
+    val timeAway = shareTimeAwayText(destinationUtcDateTime, totalTravelTime)
+
     val lastStopName = legList
         .filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
         .lastOrNull()
@@ -529,12 +539,29 @@ private fun buildShareText(
         ?.name
 
     val journeyLine = if (lastStopName != null) {
-        "I'll reach $lastStopName at $destinationTime — about $totalTravelTime away."
+        "I'll reach $lastStopName at $destinationTime — about $timeAway away."
     } else {
-        "I'll arrive at $destinationTime — about $totalTravelTime away."
+        "I'll arrive at $destinationTime — about $timeAway away."
     }
     val link = deepLinkUrl ?: KRAIL_WEBSITE_URL
     return "Hey mate!\n\n$journeyLine\n\nTrack this trip live on KRAIL!\n$link"
+}
+
+/**
+ * Returns a human-readable "X mins / Xh Ym" string representing the time between now and
+ * [destinationUtcDateTime]. Falls back to [totalTravelTime] when no UTC timestamp is available.
+ *
+ * [clock] is injectable so unit tests can supply a fixed instant.
+ */
+@OptIn(ExperimentalTime::class)
+internal fun shareTimeAwayText(
+    destinationUtcDateTime: String,
+    totalTravelTime: String,
+    clock: Clock = Clock.System,
+): String = if (destinationUtcDateTime.isNotEmpty()) {
+    (Instant.parse(destinationUtcDateTime) - clock.now()).absoluteValue.toFormattedDurationTimeString()
+} else {
+    totalTravelTime
 }
 
 // region Previews

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -51,9 +51,6 @@ import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeStr
 import xyz.ksharma.krail.core.share.withBrandingHeader
 import xyz.ksharma.krail.core.snapshot.ScreenshotTest
 import xyz.ksharma.krail.core.transport.TransportMode
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 import xyz.ksharma.krail.taj.components.AlertButton
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
@@ -67,6 +64,9 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.pastDepartureTextStyle
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * A card that displays information about a journey.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -590,6 +590,7 @@ private fun LazyListScope.journeyCardItems(
             departureDeviation = journey.departureDeviation,
             scheduledOriginTime = journey.scheduledOriginTime,
             deepLinkUrl = state.deepLinkUrls[journey.journeyId],
+            destinationUtcDateTime = journey.destinationUtcDateTime,
         )
     }
 }
@@ -617,6 +618,7 @@ private fun JourneyCardItem(
     departureDeviation: TimeTableState.JourneyCardInfo.DepartureDeviation? = null,
     scheduledOriginTime: String? = null,
     deepLinkUrl: String? = null,
+    destinationUtcDateTime: String = "",
 ) {
     if (!transportModeLineList.isNullOrEmpty() && legList.isNotEmpty()) {
         JourneyCard(
@@ -641,6 +643,7 @@ private fun JourneyCardItem(
             departureDeviation = departureDeviation,
             scheduledOriginTime = scheduledOriginTime,
             deepLinkUrl = deepLinkUrl,
+            destinationUtcDateTime = destinationUtcDateTime,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ShareTimeAwayTextTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ShareTimeAwayTextTest.kt
@@ -1,0 +1,96 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class ShareTimeAwayTextTest {
+
+    private fun fixedClock(utc: String) = object : Clock {
+        override fun now(): Instant = Instant.parse(utc)
+    }
+
+    @Test
+    fun `returns time from now to arrival in minutes`() {
+        val clock = fixedClock("2026-05-14T08:00:00Z")
+        val arrival = "2026-05-14T08:45:00Z" // 45 mins away
+
+        val result = shareTimeAwayText(
+            destinationUtcDateTime = arrival,
+            totalTravelTime = "30 mins",
+            clock = clock,
+        )
+
+        assertEquals("45 mins", result)
+    }
+
+    @Test
+    fun `returns time from now to arrival in hours and minutes`() {
+        val clock = fixedClock("2026-05-14T08:00:00Z")
+        val arrival = "2026-05-14T09:35:00Z" // 1h 35m away
+
+        val result = shareTimeAwayText(
+            destinationUtcDateTime = arrival,
+            totalTravelTime = "30 mins",
+            clock = clock,
+        )
+
+        assertEquals("1h 35m", result)
+    }
+
+    @Test
+    fun `returns journey duration when destinationUtcDateTime is empty`() {
+        val result = shareTimeAwayText(
+            destinationUtcDateTime = "",
+            totalTravelTime = "30 mins",
+        )
+
+        assertEquals("30 mins", result)
+    }
+
+    @Test
+    fun `uses absolute value so past arrivals still produce positive duration`() {
+        // Journey has already arrived — clock is after the destination time.
+        val clock = fixedClock("2026-05-14T09:10:00Z")
+        val arrival = "2026-05-14T09:00:00Z" // 10 mins in the past
+
+        val result = shareTimeAwayText(
+            destinationUtcDateTime = arrival,
+            totalTravelTime = "30 mins",
+            clock = clock,
+        )
+
+        assertEquals("10 mins", result)
+    }
+
+    @Test
+    fun `formats exact hours without a minutes suffix`() {
+        val clock = fixedClock("2026-05-14T08:00:00Z")
+        val arrival = "2026-05-14T10:00:00Z" // exactly 2h
+
+        val result = shareTimeAwayText(
+            destinationUtcDateTime = arrival,
+            totalTravelTime = "30 mins",
+            clock = clock,
+        )
+
+        assertEquals("2h", result)
+    }
+
+    @Test
+    fun `formats single minute correctly`() {
+        val clock = fixedClock("2026-05-14T08:00:00Z")
+        val arrival = "2026-05-14T08:01:00Z" // 1 min away
+
+        val result = shareTimeAwayText(
+            destinationUtcDateTime = arrival,
+            totalTravelTime = "30 mins",
+            clock = clock,
+        )
+
+        assertEquals("1 min", result)
+    }
+}


### PR DESCRIPTION
Previously the share text reused travelTime (departure → arrival duration),
so "about 30 mins away" reflected how long the journey takes rather than how
long until the user actually arrives. Now the time is calculated as
abs(destinationUtcDateTime − Clock.now()) at share-tap time.

Extracted shareTimeAwayText() as an internal function with an injectable
Clock so the logic is directly unit-tested without a Compose harness.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>