### PR TITLE
feat(analytics): enrich journey leg/card events + replace map toggle with select-on-map

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -14,6 +14,8 @@ private const val PROP_TO_STOP_ID = "toStopId"
 private const val PROP_PREVIOUS_INDEX = "previousIndex"
 private const val PROP_NEW_INDEX = "newIndex"
 private const val PROP_TOTAL_COUNT = "totalCount"
+private const val PROP_LEG_COUNT = "legCount"
+private const val PROP_TRANSPORT_MODES = "transportModes"
 
 sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
 
@@ -374,28 +376,52 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     ) : AnalyticsEvent(
         name = "share_journey_click",
         properties = mapOf(
-            "transportModes" to transportModes,
+            PROP_TRANSPORT_MODES to transportModes,
             "lines" to lines,
-            "legCount" to legCount,
+            PROP_LEG_COUNT to legCount,
             "totalTravelTime" to totalTravelTime,
             "originTime" to originTime,
             "isPastDeparture" to isPastDeparture,
         ),
     )
 
-    data class JourneyCardExpandEvent(val hasStarted: Boolean) : AnalyticsEvent(
-        name = "journey_card_expand",
-        properties = mapOf("hasStarted" to hasStarted),
+    /**
+     * @param transportModes Sorted comma-separated product-class integers of modes in this journey
+     *                       (e.g. "1,5" = Train + Bus). Matches the encoding used by [MapOptionsSavedEvent].
+     */
+    data class JourneyCardToggleEvent(
+        val expanded: Boolean,
+        val hasStarted: Boolean,
+        val legCount: Int,
+        val transportModes: String,
+    ) : AnalyticsEvent(
+        name = "journey_card_toggle",
+        properties = mapOf(
+            "expanded" to expanded,
+            "hasStarted" to hasStarted,
+            PROP_LEG_COUNT to legCount,
+            PROP_TRANSPORT_MODES to transportModes,
+        ),
     )
 
-    data class JourneyCardCollapseEvent(val hasStarted: Boolean) : AnalyticsEvent(
-        name = "journey_card_collapse",
-        properties = mapOf("hasStarted" to hasStarted),
-    )
-
-    data class JourneyLegClickEvent(val expanded: Boolean) : AnalyticsEvent(
+    /**
+     * Fired when the user taps a transport leg row inside an expanded journey card.
+     *
+     * @param expanded      true = stops list opened, false = collapsed.
+     * @param transportMode Human-readable transport mode name (e.g. "Train", "Bus", "Ferry").
+     * @param lineName      Line identifier displayed on the leg badge (e.g. "T1", "700", "F2").
+     */
+    data class JourneyLegClickEvent(
+        val expanded: Boolean,
+        val transportMode: String,
+        val lineName: String,
+    ) : AnalyticsEvent(
         name = "journey_leg_click",
-        properties = mapOf("expanded" to expanded),
+        properties = mapOf(
+            "expanded" to expanded,
+            "transportMode" to transportMode,
+            "lineName" to lineName,
+        ),
     )
 
     data class JourneyAlertClickEvent(val fromStopId: String, val toStopId: String) :
@@ -719,15 +745,10 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     // region SearchStopMap
 
     /**
-     * Fired when the user taps the Map toggle button in SearchTopBar.
-     * Use to measure map feature adoption: how many users ever discover and open the map view.
-     *
-     * @param selected true = user opened map view, false = returned to list view.
+     * Fired when the user taps the "Select on map" button in the SearchStop list.
+     * Use to measure how many users discover and use the map entry point.
      */
-    data class MapToggleClickEvent(val selected: Boolean) : AnalyticsEvent(
-        name = "search_stop_map_toggle_click",
-        properties = mapOf("selected" to selected),
-    )
+    data object SelectOnMapButtonClickEvent : AnalyticsEvent(name = "select_on_map_button_click")
 
     /**
      * Fired when the user taps "Save" on the MapOptionsBottomSheet.
@@ -758,7 +779,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         name = "search_stop_map_options_saved",
         properties = mapOf(
             "radiusKm" to radiusKm,
-            "transportModes" to transportModes,
+            PROP_TRANSPORT_MODES to transportModes,
             "showDistanceScale" to showDistanceScale,
             "showCompass" to showCompass,
             "radiusChanged" to radiusChanged,

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/SearchStopViewModelTest.kt
@@ -398,4 +398,21 @@ class SearchStopViewModelTest {
         }
 
     // endregion RecentSearchStops
+
+    // region SelectOnMapButtonClicked
+
+    @Test
+    fun `GIVEN SelectOnMapButtonClicked WHEN sent to ViewModel THEN select_on_map_button_click event is tracked`() =
+        runTest {
+            viewModel.onEvent(SearchStopUiEvent.SelectOnMapButtonClicked)
+            advanceUntilIdle()
+
+            assertTrue(fakeAnalytics is FakeAnalytics)
+            assertTrue(fakeAnalytics.isEventTracked("select_on_map_button_click"))
+            assertIs<AnalyticsEvent.SelectOnMapButtonClickEvent>(
+                fakeAnalytics.getTrackedEvent("select_on_map_button_click"),
+            )
+        }
+
+    // endregion SelectOnMapButtonClicked
 }

--- a/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
+++ b/core/test/src/commonTest/kotlin/xyz/ksharma/core/test/viewmodels/TimeTableViewModelTest.kt
@@ -523,40 +523,112 @@ class TimeTableViewModelTest {
     // region Test for JourneyCardClicked
 
     @Test
-    fun `GIVEN a trip with journey list WHEN JourneyCardClicked is triggered THEN analytics event for collapse or expand is triggered`() =
+    fun `GIVEN a trip with journey list WHEN JourneyCardClicked is triggered THEN toggle event fires with expanded true then false`() =
         runTest {
-            // GIVEN
             val trip = Trip(
                 fromStopId = "FROM_STOP_ID_1",
                 fromStopName = "STOP_NAME_1",
                 toStopId = "TO_STOP_ID_1",
-                toStopName = "STOP_NAME_2"
+                toStopName = "STOP_NAME_2",
             )
             val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
 
-            // THEN journey details should be loaded
             viewModel.uiState.test {
-
                 skipItems(1)
-
                 viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
                 viewModel.fetchTrip()
-                skipItems(4) // silent loading toggle
+                skipItems(4)
 
-                // WHEN JourneyCardClicked is triggered
+                // First click — should expand
                 viewModel.onEvent(TimeTableUiEvent.JourneyCardClicked("TransportationId0null"))
-                // THEN
-                assertTrue(analytics.isEventTracked("journey_card_expand"))
+                assertTrue(analytics.isEventTracked("journey_card_toggle"))
+                val expandEvent = analytics.getTrackedEvent("journey_card_toggle")
+                assertIs<AnalyticsEvent.JourneyCardToggleEvent>(expandEvent)
+                assertTrue(expandEvent.expanded)
                 fakeAnalytics.clear()
 
-                // WHEN JourneyCardClicked is triggered again
+                // Second click — should collapse
                 viewModel.onEvent(TimeTableUiEvent.JourneyCardClicked("TransportationId0null"))
-                // THEN
-                assertTrue(analytics.isEventTracked("journey_card_collapse"))
+                assertTrue(analytics.isEventTracked("journey_card_toggle"))
+                val collapseEvent = analytics.getTrackedEvent("journey_card_toggle")
+                assertIs<AnalyticsEvent.JourneyCardToggleEvent>(collapseEvent)
+                assertFalse(collapseEvent.expanded)
                 fakeAnalytics.clear()
 
                 cancelAndConsumeRemainingEvents()
             }
+        }
+
+    @Test
+    fun `GIVEN journey with one Train leg WHEN JourneyCardClicked THEN toggle event carries correct transportModes and legCount`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                viewModel.fetchTrip()
+                skipItems(4)
+
+                viewModel.onEvent(TimeTableUiEvent.JourneyCardClicked("TransportationId0null"))
+
+                val event = analytics.getTrackedEvent("journey_card_toggle")
+                assertIs<AnalyticsEvent.JourneyCardToggleEvent>(event)
+                // Fake builder produces one Train leg (productClass = 1)
+                assertEquals("1", event.transportModes)
+                assertEquals(1, event.legCount)
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN AnalyticsJourneyLegClicked WHEN sent to ViewModel THEN JourneyLegClickEvent is tracked with all properties`() =
+        runTest {
+            val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.onEvent(
+                TimeTableUiEvent.AnalyticsJourneyLegClicked(
+                    expanded = true,
+                    transportMode = "Train",
+                    lineName = "T1",
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(analytics.isEventTracked("journey_leg_click"))
+            val event = analytics.getTrackedEvent("journey_leg_click")
+            assertIs<AnalyticsEvent.JourneyLegClickEvent>(event)
+            assertTrue(event.expanded)
+            assertEquals("Train", event.transportMode)
+            assertEquals("T1", event.lineName)
+        }
+
+    @Test
+    fun `GIVEN AnalyticsJourneyLegClicked with expanded false WHEN sent to ViewModel THEN JourneyLegClickEvent reflects collapse`() =
+        runTest {
+            val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.onEvent(
+                TimeTableUiEvent.AnalyticsJourneyLegClicked(
+                    expanded = false,
+                    transportMode = "Bus",
+                    lineName = "700",
+                ),
+            )
+            advanceUntilIdle()
+
+            val event = analytics.getTrackedEvent("journey_leg_click")
+            assertIs<AnalyticsEvent.JourneyLegClickEvent>(event)
+            assertFalse(event.expanded)
+            assertEquals("Bus", event.transportMode)
+            assertEquals("700", event.lineName)
         }
 
     // endregion
@@ -645,14 +717,16 @@ class TimeTableViewModelTest {
     @Test
     fun `GIVEN expanded state WHEN JourneyLegClicked is triggered THEN analytics event should be tracked`() =
         runTest {
-            // GIVEN
-            val expanded = true
             val analytics: FakeAnalytics = fakeAnalytics as FakeAnalytics
 
-            // WHEN JourneyLegClicked is triggered
-            viewModel.onEvent(TimeTableUiEvent.AnalyticsJourneyLegClicked(expanded))
+            viewModel.onEvent(
+                TimeTableUiEvent.AnalyticsJourneyLegClicked(
+                    expanded = true,
+                    transportMode = "Train",
+                    lineName = "T1",
+                ),
+            )
 
-            // THEN analytics event should be tracked
             assertTrue(analytics.isEventTracked("journey_leg_click"))
         }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
@@ -39,8 +39,8 @@ sealed interface SearchStopUiEvent {
 
     data class ShowCompassToggled(val enabled: Boolean) : SearchStopUiEvent
 
-    /** Fired when the user taps the Map toggle button in SearchTopBar. Analytics-only. */
-    data class MapToggleClicked(val selected: Boolean) : SearchStopUiEvent
+    /** Fired when the user taps the "Select on map" button in the stop list. Analytics-only. */
+    data object SelectOnMapButtonClicked : SearchStopUiEvent
 
     /** Fired when the user taps the Options button on the SearchStopMap. Analytics-only. */
     data object MapOptionsButtonClicked : SearchStopUiEvent

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -22,7 +22,11 @@ sealed interface TimeTableUiEvent {
 
     data object BackClick : TimeTableUiEvent
 
-    data class AnalyticsJourneyLegClicked(val expanded: Boolean) : TimeTableUiEvent
+    data class AnalyticsJourneyLegClicked(
+        val expanded: Boolean,
+        val transportMode: String,
+        val lineName: String,
+    ) : TimeTableUiEvent
 
     data class ModeSelectionChanged(val unselectedModes: Set<Int>) : TimeTableUiEvent
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -95,7 +95,7 @@ fun JourneyCard(
     totalUniqueServiceAlerts: Int,
     modifier: Modifier = Modifier,
     onAlertClick: () -> Unit = {},
-    onLegClick: (Boolean) -> Unit = {},
+    onLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit = { _, _, _ -> },
     onMapClick: () -> Unit = {},
     onShareJourney: (
         bitmap: ImageBitmap,
@@ -232,7 +232,7 @@ fun ExpandedJourneyCardContent(
     legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
     totalUniqueServiceAlerts: Int,
     onAlertClick: () -> Unit,
-    onLegClick: (Boolean) -> Unit,
+    onLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit,
     onMapClick: () -> Unit,
     modifier: Modifier = Modifier,
     isMapsAvailable: Boolean = false,
@@ -356,7 +356,11 @@ fun ExpandedJourneyCardContent(
                             ),
                             onClick = {
                                 displayAllStops = !displayAllStops
-                                onLegClick(displayAllStops)
+                                onLegClick(
+                                    displayAllStops,
+                                    leg.transportModeLine.transportMode.name,
+                                    leg.transportModeLine.lineName,
+                                )
                             },
                         )
                     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -117,9 +117,14 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                     }
                 },
                 onBackClick = { tripPlannerNavigator.goBack() },
-                onJourneyLegClick = { expanded ->
-                    // Track analytics when user expands/collapses journey legs
-                    viewModel.onEvent(TimeTableUiEvent.AnalyticsJourneyLegClicked(expanded))
+                onJourneyLegClick = { expanded, transportMode, lineName ->
+                    viewModel.onEvent(
+                        TimeTableUiEvent.AnalyticsJourneyLegClicked(
+                            expanded = expanded,
+                            transportMode = transportMode,
+                            lineName = lineName,
+                        ),
+                    )
                 },
                 dateTimeSelectorClicked = {
                     // Track analytics for date/time selector

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -710,7 +710,7 @@ private fun SearchStopScreenSinglePane(
                     isMapsAvailable = searchStopState.isMapsAvailable,
                     onOpenMap = {
                         onShowMapChange(true)
-                        onEvent(SearchStopUiEvent.MapToggleClicked(true))
+                        onEvent(SearchStopUiEvent.SelectOnMapButtonClicked)
                         if (searchStopState.mapUiState == null) {
                             onEvent(SearchStopUiEvent.InitializeMap)
                         }
@@ -731,7 +731,6 @@ private fun SearchStopScreenSinglePane(
             animateMapButton = animateMapButton,
             onMapToggle = { shouldShowMap ->
                 onShowMapChange(shouldShowMap)
-                onEvent(SearchStopUiEvent.MapToggleClicked(shouldShowMap))
                 if (shouldShowMap && searchStopState.mapUiState == null) {
                     onEvent(SearchStopUiEvent.InitializeMap)
                 }
@@ -743,7 +742,6 @@ private fun SearchStopScreenSinglePane(
                 // dark/light mode changes too, which would spuriously reset map mode.
                 if (showMap) {
                     onShowMapChange(false)
-                    onEvent(SearchStopUiEvent.MapToggleClicked(false))
                 }
                 onTextChange(value)
             },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -174,8 +174,8 @@ class SearchStopViewModel(
                 onShowCompassToggled(event.enabled)
             }
 
-            is SearchStopUiEvent.MapToggleClicked -> {
-                analytics.track(AnalyticsEvent.MapToggleClickEvent(selected = event.selected))
+            SearchStopUiEvent.SelectOnMapButtonClicked -> {
+                analytics.track(AnalyticsEvent.SelectOnMapButtonClickEvent)
             }
 
             SearchStopUiEvent.MapOptionsButtonClicked -> {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAnalytics.kt
@@ -14,12 +14,20 @@ import kotlin.time.Instant
 
 private const val AEST_TIMEZONE = "Australia/Sydney"
 
-internal fun Analytics.trackJourneyCardExpandEvent(hasStarted: Boolean) {
-    track(AnalyticsEvent.JourneyCardExpandEvent(hasStarted = hasStarted))
-}
-
-internal fun Analytics.trackJourneyCardCollapseEvent(hasStarted: Boolean) {
-    track(AnalyticsEvent.JourneyCardCollapseEvent(hasStarted = hasStarted))
+internal fun Analytics.trackJourneyCardToggleEvent(
+    expanded: Boolean,
+    hasStarted: Boolean,
+    legCount: Int,
+    transportModes: String,
+) {
+    track(
+        AnalyticsEvent.JourneyCardToggleEvent(
+            expanded = expanded,
+            hasStarted = hasStarted,
+            legCount = legCount,
+            transportModes = transportModes,
+        ),
+    )
 }
 
 /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -103,7 +103,7 @@ fun TimeTableScreen(
     onEvent: (TimeTableUiEvent) -> Unit,
     onAlertClick: (String) -> Unit,
     onBackClick: () -> Unit,
-    onJourneyLegClick: (Boolean) -> Unit,
+    onJourneyLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit,
     modifier: Modifier = Modifier,
     dateTimeSelectorClicked: () -> Unit = {},
     onModeSelectionChanged: (Set<Int>) -> Unit = {},
@@ -434,7 +434,7 @@ fun TimeTableScreen(
 private data class JourneyCallbacks(
     val onEvent: (TimeTableUiEvent) -> Unit,
     val onAlertClick: (String) -> Unit,
-    val onLegClick: (Boolean) -> Unit,
+    val onLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit,
     val onMapClick: (String) -> Unit,
 )
 
@@ -611,7 +611,7 @@ private fun JourneyCardItem(
     totalUniqueServiceAlerts: Int,
     modifier: Modifier = Modifier,
     transportModeLineList: ImmutableList<TransportModeLine>? = null,
-    onLegClick: (Boolean) -> Unit,
+    onLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit,
     onMapClick: () -> Unit = {},
     onShareJourney: (ImageBitmap, String, Boolean) -> Unit = { _, _, _ -> },
     isMapsAvailable: Boolean = false,
@@ -711,7 +711,7 @@ private fun PreviewTimeTableScreen() {
                 onAlertClick = {},
                 onBackClick = {},
                 dateTimeSelectionItem = null,
-                onJourneyLegClick = {},
+                onJourneyLegClick = { _, _, _ -> },
             )
         }
     }
@@ -739,7 +739,7 @@ private fun PreviewTimeTableScreenError() {
                 onAlertClick = {},
                 onBackClick = {},
                 dateTimeSelectionItem = null,
-                onJourneyLegClick = {},
+                onJourneyLegClick = { _, _, _ -> },
             )
         }
     }
@@ -767,7 +767,7 @@ private fun PreviewTimeTableScreenNoResults() {
                 onEvent = {},
                 onAlertClick = {},
                 onBackClick = {},
-                onJourneyLegClick = {},
+                onJourneyLegClick = { _, _, _ -> },
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -268,7 +268,13 @@ class TimeTableViewModel(
             }
 
             is TimeTableUiEvent.AnalyticsJourneyLegClicked -> {
-                analytics.track(AnalyticsEvent.JourneyLegClickEvent(expanded = event.expanded))
+                analytics.track(
+                    AnalyticsEvent.JourneyLegClickEvent(
+                        expanded = event.expanded,
+                        transportMode = event.transportMode,
+                        lineName = event.lineName,
+                    ),
+                )
             }
 
             is TimeTableUiEvent.ModeSelectionChanged -> onModeSelectionChanged(event.unselectedModes)
@@ -749,15 +755,24 @@ class TimeTableViewModel(
     }
 
     private fun onJourneyCardClicked(journeyId: String) {
-        val hasJourneyStarted = journeys[journeyId]?.hasJourneyStarted ?: false
+        val journey = journeys[journeyId]
+        val hasJourneyStarted = journey?.hasJourneyStarted ?: false
+        val legCount = journey?.legs?.size ?: 0
+        val transportModes = journey?.transportModeLines
+            ?.map { it.transportMode.productClass }
+            ?.sorted()
+            ?.joinToString(",")
+            .orEmpty()
         val expandedJourneyId = _expandedJourneyId.value
         log("Journey Card Clicked(JourneyId): $journeyId")
         _expandedJourneyId.update { if (it == journeyId) null else journeyId }
-        if (expandedJourneyId == journeyId) {
-            analytics.trackJourneyCardCollapseEvent(hasStarted = hasJourneyStarted)
-        } else {
-            analytics.trackJourneyCardExpandEvent(hasStarted = hasJourneyStarted)
-        }
+        val expanding = expandedJourneyId != journeyId
+        analytics.trackJourneyCardToggleEvent(
+            expanded = expanding,
+            hasStarted = hasJourneyStarted,
+            legCount = legCount,
+            transportModes = transportModes,
+        )
     }
 
     private fun onLoadTimeTable(trip: Trip) {


### PR DESCRIPTION
- JourneyLegClickEvent now captures transportMode and lineName so dashboards
  can answer which line types users drill into most.
- JourneyCardExpandEvent / JourneyCardCollapseEvent gain legCount so we can
  correlate journey complexity with card interaction rate.
- Replaced the generic search_stop_map_toggle_click event (fired for open,
  close, and implicit dismissal) with a focused select_on_map_button_click
  that fires only when the user explicitly taps the "Select on map" row in
  the stop list — the only entry point now that the top-bar map pill is gone.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>