### PR TITLE
chore(ci): remove redundant AAB signing + bump upload-google-play to v1.1.5

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -125,25 +125,16 @@ jobs:
           name: androidApp-release-apk-${{ github.run_id }}
           path: androidApp/build/outputs/apk/release/androidApp-release.apk
 
-      # Release AAB Signing and Uploading
-      - name: Sign Android Release AAB
-        if: ${{ inputs.variant == 'release' }}
-        id: signed_release_aab
-        uses: filippoLeporati93/android-release-signer@v1
-        with:
-          releaseDirectory: androidApp/build/outputs/bundle/release
-          signingKeyBase64: ${{ secrets.ANDROID_KEYSTORE_FILE }}
-          alias: ${{ secrets.ANDROID_KEY_ALIAS }}
-          keyStorePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
-
+      # Release AAB upload
+      # No separate signing step needed — build.gradle.kts signingConfig signs the AAB
+      # during bundleRelease using the keystore decoded above.
       - name: Upload Release AAB
         if: ${{ inputs.variant == 'release' }}
         uses: actions/upload-artifact@v7
         with:
           retention-days: 1
           name: androidApp-release-aab-${{ github.run_id }}
-          path: ${{ steps.signed_release_aab.outputs.signedReleaseFile }}
+          path: androidApp/build/outputs/bundle/release/androidApp-release.aab
 
       - name: Cleanup sensitive files
         run: rm -f keystore.jks

--- a/.github/workflows/distribute-google-play.yml
+++ b/.github/workflows/distribute-google-play.yml
@@ -45,8 +45,10 @@ jobs:
           name: ${{ inputs.artifact-name || format('androidApp-release-aab-{0}', github.run_id) }}
           path: aab
 
+      # TODO: update to a Node 24-compatible version when available (Node 20 deprecated June 2026).
+      # v1.1.3 is the latest as of 2026-03-17 — no v2 exists yet.
       - name: Deploy to Play Store
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: xyz.ksharma.krail

--- a/.github/workflows/distribute-google-play.yml
+++ b/.github/workflows/distribute-google-play.yml
@@ -45,10 +45,8 @@ jobs:
           name: ${{ inputs.artifact-name || format('androidApp-release-aab-{0}', github.run_id) }}
           path: aab
 
-      # TODO: update to a Node 24-compatible version when available (Node 20 deprecated June 2026).
-      # v1.1.3 is the latest as of 2026-03-17 — no v2 exists yet.
       - name: Deploy to Play Store
-        uses: r0adkll/upload-google-play@v1.1.3
+        uses: r0adkll/upload-google-play@v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: xyz.ksharma.krail

--- a/docs/release/RELEASE_PROCESS.md
+++ b/docs/release/RELEASE_PROCESS.md
@@ -319,9 +319,9 @@ End-to-end test on `prod/0.0.1-test` ([run #23094566868](https://github.com/ksha
 | tag-release-candidate | ✅ created `v0.0.1-test-RC1` |
 | distribute-google-play (Internal) | ✅ uploaded |
 
-**Pending before June 2, 2026**: update two actions away from Node.js 20:
-- `filippoLeporati93/android-release-signer@v1`
-- `r0adkll/upload-google-play@v1`
+**Pending before June 2, 2026**: `r0adkll/upload-google-play@v1.1.3` targets Node.js 20 (deprecated June 2026).
+No v2 exists yet — monitor the repo and update when a Node 24-compatible release ships.
+(`filippoLeporati93/android-release-signer` was removed — Gradle's signingConfig already signs the AAB.)
 
 ### iOS TestFlight — ✅ Confirmed working (tested 2026-03-16)
 

--- a/docs/release/RELEASE_PROCESS.md
+++ b/docs/release/RELEASE_PROCESS.md
@@ -319,9 +319,8 @@ End-to-end test on `prod/0.0.1-test` ([run #23094566868](https://github.com/ksha
 | tag-release-candidate | ✅ created `v0.0.1-test-RC1` |
 | distribute-google-play (Internal) | ✅ uploaded |
 
-**Pending before June 2, 2026**: `r0adkll/upload-google-play@v1.1.3` targets Node.js 20 (deprecated June 2026).
-No v2 exists yet — monitor the repo and update when a Node 24-compatible release ships.
 (`filippoLeporati93/android-release-signer` was removed — Gradle's signingConfig already signs the AAB.)
+`r0adkll/upload-google-play@v1.1.5` runs on Node 24 (upgraded in v1.1.4). No further action needed.
 
 ### iOS TestFlight — ✅ Confirmed working (tested 2026-03-16)
 


### PR DESCRIPTION
### TL;DR

Removes the redundant AAB signing step and updates the Google Play upload action to the latest version.

### What changed?

- Removed the separate \`Sign Android Release AAB\` step — Gradle's \`signingConfig\` already signs the AAB during \`bundleRelease\`
- Updated AAB upload path to point directly to the Gradle-signed output
- Bumped \`r0adkll/upload-google-play\` from \`v1\` to \`v1.1.5\`
  - v1.1.4: upgraded runtime to Node 24 (Node 20 deprecated June 2026)
  - v1.1.5: fixed \`track\`/\`releaseFiles\` deprecation warnings
- Updated release process docs accordingly

### Why?

The signing action was redundant; removing it simplifies the workflow. The upload action bump resolves deprecation warnings and future-proofs the workflow against Node 20 EOL in June 2026.