### PR TITLE
fix(navigation): prevent transient NoEntriesUI flash

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.ui.NavDisplay
 import org.koin.compose.koinInject
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.deeplink.PendingDeepLinkManager
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.navigation.LocalResultEventBusObj
@@ -75,6 +77,7 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
     //
     // Guard: if Splash is still active (cold-start race where a hot intent arrives within
     // the 1-second splash window), skip — SplashEntry will call consumePending() instead.
+    val analytics: Analytics = koinInject()
     val pendingDeepLinkManager: PendingDeepLinkManager = koinInject()
     LaunchedEffect(Unit) {
         pendingDeepLinkManager.hotEvents.collect { encodedData ->
@@ -119,6 +122,17 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
 
     // Calculate entries explicitly to check for emptiness
     val entries = navigationState.toEntries(entryProvider)
+
+    val hasNoEntries = entries.isEmpty()
+    LaunchedEffect(hasNoEntries) {
+        if (hasNoEntries) {
+            analytics.track(
+                AnalyticsEvent.NoEntriesDetectedEvent(
+                    topLevelRoute = navigationState.topLevelRoute::class.simpleName ?: "Unknown",
+                ),
+            )
+        }
+    }
 
     CompositionLocalProvider(
         LocalThemeColor provides mutableStateOf(navigator.themeColor),

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailNavHost.kt
@@ -128,7 +128,7 @@ fun KrailNavHost(modifier: Modifier = Modifier) {
     ) {
         if (entries.isNotEmpty()) {
             NavDisplay(
-                entries = navigationState.toEntries(entryProvider),
+                entries = entries,
                 onBack = { navigator.pop() },
                 sceneStrategy = listDetailStrategy,
                 modifier = modifier.fillMaxSize(),

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -511,6 +511,23 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     // endregion
 
     // region Generic Events
+
+    /**
+     * Fired when the nav back stack produces zero entries, causing the NoEntriesUI fallback
+     * to appear. Should never fire after the fixes to resetRoot() and the duplicate toEntries()
+     * call. Monitor this event post-release — if it stays silent, remove the fallback.
+     *
+     * @param topLevelRoute Simple class name of the active top-level route at the time the
+     *                      empty state was observed. Helps identify which navigation path
+     *                      triggered the condition.
+     */
+    data class NoEntriesDetectedEvent(
+        val topLevelRoute: String,
+    ) : AnalyticsEvent(
+        name = "no_entries_detected",
+        properties = mapOf("topLevelRoute" to topLevelRoute),
+    )
+
     data class BackClickEvent(
         val fromScreen: AnalyticsScreen,
     ) : AnalyticsEvent(

--- a/core/navigation/src/commonMain/kotlin/xyz/ksharma/krail/core/navigation/NavigationState.kt
+++ b/core/navigation/src/commonMain/kotlin/xyz/ksharma/krail/core/navigation/NavigationState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.navigation3.runtime.NavBackStack
@@ -109,9 +110,13 @@ class NavigationState(
      * Used when user shouldn't be able to navigate back.
      */
     fun resetRoot(route: NavKey) {
-        val currentStack = backStacks[topLevelRoute]
-        currentStack?.clear()
-        currentStack?.add(route)
+        val currentStack = backStacks[topLevelRoute] ?: return
+        // Batch clear + add so Compose never observes a transient empty stack,
+        // which would otherwise cause a NoEntriesUI flash between the two writes.
+        Snapshot.withMutableSnapshot {
+            currentStack.clear()
+            currentStack.add(route)
+        }
     }
 
     /**
@@ -119,9 +124,11 @@ class NavigationState(
      * Equivalent to navigate with popUpTo inclusive.
      */
     fun replaceCurrent(route: NavKey) {
-        val currentStack = backStacks[topLevelRoute]
-        currentStack?.removeLastOrNull()
-        goTo(route)
+        val currentStack = backStacks[topLevelRoute] ?: return
+        Snapshot.withMutableSnapshot {
+            currentStack.removeLastOrNull()
+            goTo(route)
+        }
     }
 }
 


### PR DESCRIPTION
fix(navigation): prevent transient NoEntriesUI flash

Two bugs caused NoEntriesUI to appear randomly:

1. KrailNavHost called toEntries() twice — once for the guard check and
   again inside NavDisplay. Each call is a separate @Composable call-site,
   so Compose gives them independent rememberDecoratedNavEntries slots.
   The guard checked instance A while NavDisplay received instance B,
   creating a window where they could diverge. Fixed by reusing the single
   computed `entries` val in NavDisplay.

2. NavigationState.resetRoot() called clear() then add() as two separate
   SnapshotStateList mutations. Between those two writes Compose could
   observe an empty back stack and trigger a recomposition that hit the
   else branch. Same risk existed in replaceCurrent(). Fixed by wrapping
   both pairs in Snapshot.withMutableSnapshot{} so the mutations are
   applied atomically and no intermediate empty state is ever visible.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

analytics(navigation): track no_entries_detected for fallback UI monitoring

Keeps the NoEntriesUI fallback in place as a safety net, but now fires a
no_entries_detected event (with topLevelRoute) whenever entries go empty so
we can monitor Firebase to confirm the root-cause fixes (duplicate toEntries
call + non-atomic resetRoot mutations) eliminated the condition in production.
If the event stays silent after a release, the fallback and this event can be
removed together.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>