### PR TITLE
fix(datetime): show Xh Ym ago for past departures between 1h and 2h

### DIFF
--- a/core/date-time/build.gradle.kts
+++ b/core/date-time/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
         namespace = "xyz.ksharma.krail.core.datetime"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
+        withHostTest {}
     }
 
     iosArm64()

--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -103,10 +103,16 @@ object DateTimeHelper {
                 val absDays = (-this).inWholeDays
                 "$absDays ${if (absDays == 1L) "day" else "days"} ago"
             }
-            // Hours in the past — only beyond 2 h so 60–90 min shows as "X mins ago"
+            // 2 h or more in the past — drop minutes, just show hours
             this <= -PAST_HOURS_THRESHOLD -> {
                 val absHours = (-this).inWholeHours
                 "$absHours ${if (absHours == 1L) "hour" else "hours"} ago"
+            }
+            // Between 1 h and 2 h in the past — "Xh Ym ago" (mirrors future "in 1h Xm")
+            this <= (-1).hours -> {
+                val absHours = (-this).inWholeHours
+                val absPartialMinutes = ((-this) - absHours.hours).inWholeMinutes
+                if (absPartialMinutes == 0L) "${absHours}h ago" else "${absHours}h ${absPartialMinutes}m ago"
             }
             // More than a full minute in the past — "X min(s) ago"
             this <= (-1).minutes -> {

--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -11,7 +11,6 @@ import xyz.ksharma.krail.core.log.logError
 import kotlin.math.absoluteValue
 import kotlin.time.Clock
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -98,37 +97,29 @@ object DateTimeHelper {
         val partialMinutes = (this - hours.hours).inWholeMinutes
 
         return when {
-            // Days in the past — "X day(s) ago"
-            this <= (-1).days -> {
-                val absDays = (-this).inWholeDays
-                "$absDays ${if (absDays == 1L) "day" else "days"} ago"
-            }
-            // 2 h or more in the past — drop minutes, just show hours
-            this <= -PAST_HOURS_THRESHOLD -> {
-                val absHours = (-this).inWholeHours
-                "$absHours ${if (absHours == 1L) "hour" else "hours"} ago"
-            }
-            // Between 1 h and 2 h in the past — "Xh Ym ago" (mirrors future "in 1h Xm")
-            this <= (-1).hours -> {
-                val absHours = (-this).inWholeHours
-                val absPartialMinutes = ((-this) - absHours.hours).inWholeMinutes
-                if (absPartialMinutes == 0L) "${absHours}h ago" else "${absHours}h ${absPartialMinutes}m ago"
-            }
-            // More than a full minute in the past — "X min(s) ago"
-            this <= (-1).minutes -> {
-                val abs = totalMinutes.absoluteValue
-                "$abs ${if (abs == 1L) "min" else "mins"} ago"
-            }
-            // Within NOW_THRESHOLD of departure (past or future) — "Now"
+            this <= (-1).minutes -> toPastTimeString()
             this <= NOW_THRESHOLD -> "Now"
-            // 16–59 s away — round up and floor to "in 1 min"
             this < 1.minutes -> "in 1 min"
-            // Under an hour — "in X min(s)"
             this < 1.hours -> "in $totalMinutes ${if (totalMinutes == 1L) "min" else "mins"}"
-            // Exactly 1 h up to (but not including) 2 h — "in 1h Xm"
             this < 2.hours -> "in ${hours}h ${partialMinutes}m"
-            // 2 h or more — drop the minutes, just show hours
             else -> "in ${hours}h"
+        }
+    }
+
+    private fun Duration.toPastTimeString(): String {
+        val abs = -this
+        val absDays = abs.inWholeDays
+        val absHours = abs.inWholeHours
+        val absPartialMinutes = (abs - absHours.hours).inWholeMinutes
+        val absMinutes = abs.inWholeMinutes
+
+        return when {
+            absDays >= 1 -> "$absDays ${if (absDays == 1L) "day" else "days"} ago"
+            absHours >= PAST_HOURS_THRESHOLD.inWholeHours ->
+                "$absHours ${if (absHours == 1L) "hour" else "hours"} ago"
+            absHours >= 1 ->
+                if (absPartialMinutes == 0L) "${absHours}h ago" else "${absHours}h ${absPartialMinutes}m ago"
+            else -> "$absMinutes ${if (absMinutes == 1L) "min" else "mins"} ago"
         }
     }
 

--- a/core/date-time/src/commonTest/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelperTest.kt
+++ b/core/date-time/src/commonTest/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelperTest.kt
@@ -71,15 +71,26 @@ class DateTimeHelperTest {
     // region toGenericFormattedTimeString
 
     @Test
-    fun `toGenericFormattedTimeString — past departures`() {
-        // More than 1 minute in the past → "X min(s) ago"
+    fun `toGenericFormattedTimeString — past departures under 1 h`() {
         assertEquals("1 min ago", (-1).minutes.toGenericFormattedTimeString())
         assertEquals("2 mins ago", (-2).minutes.toGenericFormattedTimeString())
         assertEquals("40 mins ago", (-40).minutes.toGenericFormattedTimeString())
         assertEquals("59 mins ago", (-59).minutes.toGenericFormattedTimeString())
-        // Hours in the past (totalMinutes drives the display)
-        assertEquals("60 mins ago", (-60).minutes.toGenericFormattedTimeString())
-        assertEquals("90 mins ago", (-90).minutes.toGenericFormattedTimeString())
+    }
+
+    @Test
+    fun `toGenericFormattedTimeString — past departures 1h to 2h show Xh Ym ago`() {
+        assertEquals("1h ago", (-60).minutes.toGenericFormattedTimeString())
+        assertEquals("1h 1m ago", (-61).minutes.toGenericFormattedTimeString())
+        assertEquals("1h 20m ago", (-80).minutes.toGenericFormattedTimeString())
+        assertEquals("1h 30m ago", (-90).minutes.toGenericFormattedTimeString())
+        assertEquals("1h 59m ago", (-119).minutes.toGenericFormattedTimeString())
+    }
+
+    @Test
+    fun `toGenericFormattedTimeString — past departures 2h or more drop minutes`() {
+        assertEquals("2 hours ago", (-120).minutes.toGenericFormattedTimeString())
+        assertEquals("3 hours ago", (-180).minutes.toGenericFormattedTimeString())
     }
 
     @Test


### PR DESCRIPTION
Past times in the 1–2 h range were falling through to the minutes branch
and displaying "80 mins ago" instead of "1h 20m ago", asymmetric with
the future side ("in 1h 20m"). Added an explicit branch that mirrors the
future 1h–2h case, and enabled withHostTest on core:date-time so the
formatter tests can run on the Android host.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>