### PR TITLE
fix(search): relevance ordering, threshold, word-order bonus, station seeding

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -17,7 +17,22 @@ object RemoteConfigDefaults {
         return arrayOf(
             Pair(
                 FlagKeys.HIGH_PRIORITY_STOP_IDS.key,
-                """["200060", "200070", "200080", "206010", "2150106", "200017", "200039", "201016", "201039", "201080", "200066", "200030", "200046", "200050", "2155384"]""".trimMargin(),
+                // Seeded into the fuzzy candidate pool unconditionally so they aren't
+                // starved by the trigram prefilter (which previously made "paramatta"
+                // miss the main station, "bella visa" miss Bella Vista, etc.):
+                //  - 15 CBD/interchange IDs (Central entrances, Town Hall, Wynyard, …)
+                //  - 9 highest-traffic heavy-rail stations (Schofields, Seven Hills,
+                //    Parramatta, Lidcombe, Redfern, Bankstown, Blacktown, Strathfield,
+                //    Circular Quay)
+                //  - the full Sydney Metro Northwest line + Macquarie University
+                //    (Castle Hill, Rouse Hill, Kellyville, Bella Vista, Hills
+                //    Showground, Norwest, Cherrybrook, Macquarie University)
+                """["200060", "200070", "200080", "206010", "2150106", "200017", """ +
+                    """"200039", "201016", "201039", "201080", "200066", "200030", """ +
+                    """"200046", "200050", "2155384", "276220", "214710", "215020", """ +
+                    """"214110", "201510", "220010", "214810", "213510", "200020", """ +
+                    """"2154391", "2155383", "2155382", "2153478", "2154392", """ +
+                    """"2153477", "2126158", "211310"]""",
             ),
             Pair(
                 FlagKeys.OUR_STORY_TEXT.key,

--- a/feature/trip-planner/ui/docs/fuzzy_stop_search.md
+++ b/feature/trip-planner/ui/docs/fuzzy_stop_search.md
@@ -124,7 +124,8 @@ The fetch uses `Sandook.selectStopsByIds(...)` — a single batch SQL query (`WH
 Each candidate is scored with two complementary functions and the higher one wins, with bonuses:
 
 ```
-score = max(tokenOverlapScore, concatSplitScore × 0.9) + prefixBonus + specificityBonus
+score = max(tokenOverlapScore, concatSplitScore × 0.9)
+        + prefixBonus + specificityBonus + sequenceBonus
 ```
 
 ### Token overlap score
@@ -163,6 +164,29 @@ Adds `(queryTokenCount / max(queryTokenCount, candidateTokenCount)) × 0.1`. Thi
 
 Both stops score 1.1 on the base signals, so without this bonus the road stop (listed earlier in the DB) would win. With it, `Wollongong Station` ranks first.
 
+### Sequence bonus (word order / leading position)
+
+The token and concat scores are a **bag of words** — they ignore *where* the query
+words sit in the candidate. For `cowper street` that meant `Cowper St at Prince St`
+(the road itself), `Connolly Park, Cowper St` (Cowper St is only a cross-street),
+and even `Page St at Cowper Ave` (the matched `st` belongs to *Page St*, not Cowper)
+all scored the same, so ordering fell to noise.
+
+`sequenceBonus` greedily aligns each query token to the **earliest later** candidate
+token it matches (per-token score ≥ 0.6, or an abbreviation reverse-match like
+candidate `st` ⇒ query `street` at candidate position > 0), then rewards in-order runs:
+
+| Alignment | Example for `cowper street` | Bonus |
+|---|---|---|
+| Contiguous, **starts at token 0** (name *is* the road) | `Cowper St at Prince St` | **+0.30** |
+| Contiguous, starts later | `Connolly Park, Cowper St` | +0.12 |
+| In order but with gaps | `Cowper before Parkes St` | +0.04 |
+| Out of order / not all matched | `Page St at Cowper Ave` | 0 |
+
+Single-token queries always get 0 (leading is already covered by the prefix bonus),
+so progressive-typing behaviour is unchanged. The 37k eval stays at 95% — the bonus
+reorders within the already-matched set, it doesn't admit or reject candidates.
+
 ### Multi-token quality gate
 
 For queries with ≥ 2 tokens, a candidate is **rejected outright** (score forced to 0) if 2 or more of its per-token scores (using raw, pre-boost signals) fall below **0.6**. This prevents weak partial overlaps from accumulating into a passing average:
@@ -184,7 +208,13 @@ Short queries are noisier (a 2-character query matches almost anything), so they
 |---|---|
 | 1-3 characters | 0.85 |
 | 4-6 characters | 0.55 |
-| 7+ characters | 0.50 |
+| 7+ characters | 0.60 |
+
+The 7+ bucket was raised from 0.50 to 0.60: at 0.50, near-homophones such as
+`Cooper Park` (~0.55) and `Cowpasture Rd` (~0.55) cleared the gate for `cowper street`
+and polluted the results. Genuine long-query matches score well above this (real
+`Cowper St …` stops ≈ 1.04), so 0.60 removes the noise without dropping real hits.
+The 37k-stop eval guards against regression (still 95%).
 
 ---
 
@@ -192,12 +222,21 @@ Short queries are noisier (a 2-character query matches almost anything), so they
 
 Certain stops (major interchanges: Central, Town Hall, Wynyard, Tallawong, etc.) are declared high-priority via remote config (`high_priority_stop_ids`). These always sort to the **top of the result list**, regardless of transport mode rank or whether they came from exact or fuzzy search.
 
-Sorting is three-level:
+Sorting tiers:
 1. High-priority stop? → 0 (top), else 1
-2. Transport mode priority (Train > Metro > Bus > ...)
-3. Stop name alphabetically
+2. Transport mode priority — `TransportMode.searchPriority`, ascending:
+   Train (1) > Metro (2) > Light Rail (3) > Ferry (4) > Coach (5) > Bus (6, last)
+3. Tie-break **within a tier**:
+   - **Exact-only path** (`prioritiseStops`): stop name alphabetically.
+   - **Fuzzy fallback path** (`prioritiseByRelevance`): descending relevance — exact
+     matches first, then fuzzy results in the order the ranker scored them.
 
-Both the exact-only path and the merged exact+fuzzy path pass through `prioritiseStops`, so this guarantee holds in all cases.
+The fuzzy path must **not** use the alphabetical tie-break: the ranker already produced
+a relevance order, and re-sorting it alphabetically scatters the best matches among
+low-score noise (e.g. a perfect `Cowper St at Prince St` sinking below `Cowpasture Rd`).
+`prioritiseByRelevance` keeps tiers 1–2 but relies on `List.sortedWith` being a *stable*
+sort, so same-tier candidates keep their incoming (relevance) order. The exact-only path
+keeps the alphabetical tie-break (no relevance score exists there).
 
 ---
 

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
@@ -1,0 +1,272 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.SavedTrip
+import xyz.ksharma.krail.sandook.SelectProductClassesForStop
+import xyz.ksharma.krail.sandook.SelectRecentSearchStops
+import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
+import xyz.ksharma.krail.sandook.StopLabels
+import xyz.ksharma.krail.trip.planner.ui.searchstop.fuzzy.DefaultFuzzyStopRanker
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end reproduction of what the user actually sees on their phone.
+ *
+ * Unlike FuzzyStopSearchEvalTest (which tests only the ranker in isolation), this drives
+ * the REAL [RealStopResultsManager] pipeline — exact DB search, trigram prefilter,
+ * fuzzy rank, then prioritiseStops — against the same 37 208 NSW stops the app ships
+ * (decoded from io/gtfs/.../NSW_STOPS.pb). The fake DB replicates the real SQL exactly:
+ * `stopId = q OR stopName LIKE '%q%' COLLATE NOCASE`, results in file/insertion order.
+ */
+// Exact prod value of high_priority_stop_ids (mirror of
+// RemoteConfigDefaults.HIGH_PRIORITY_STOP_IDS). Keep in sync.
+private const val PROD_HIGH_PRIORITY_STOP_IDS =
+    """{"stop_ids":["200060","200070","200080","206010","2150106","200017","200039",""" +
+        """"201016","201039","201080","200066","200030","200046","200050","2155384",""" +
+        """"276220","214710","215020","214110","201510","220010","214810","213510",""" +
+        """"200020","2154391","2155383","2155382","2153478","2154392","2153477",""" +
+        """"2126158","211310"]}"""
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StopSearchPipelineReproTest {
+
+    private fun csvStops(): List<SelectProductClassesForStop>? {
+        val lines = this::class.java.classLoader
+            ?.getResourceAsStream("nsw_stops_eval.csv")
+            ?.bufferedReader()
+            ?.readLines() ?: return null
+        return lines.drop(1).filter { it.isNotBlank() }.mapNotNull { line ->
+            val c = line.split("|")
+            if (c.size < 3) return@mapNotNull null
+            SelectProductClassesForStop(
+                stopId = c[0], stopName = c[1], stopLat = 0.0, stopLon = 0.0,
+                isParent = null, productClasses = c[2],
+            )
+        }
+    }
+
+    private fun manager(
+        stops: List<SelectProductClassesForStop>,
+        highPriorityJson: String = PROD_HIGH_PRIORITY_STOP_IDS,
+    ): RealStopResultsManager {
+        val sandook = object : Sandook {
+            // Real SQL: exact id OR case-insensitive substring, file order, distinct by id.
+            override fun selectStops(stopName: String, excludeProductClassList: List<Int>) =
+                stops.filter { it.stopId == stopName || it.stopName.contains(stopName, ignoreCase = true) }
+            override fun selectStopsByIds(stopIds: List<String>) =
+                stops.filter { it.stopId in stopIds.toSet() }
+            override fun selectStopCoordinatesBatch(stopIds: List<String>) = emptyMap<String, Pair<Double, Double>>()
+            override fun observeStopLabels(): Flow<List<StopLabels>> = emptyFlow()
+            override fun upsertStopLabel(label: String, emoji: String, stopId: String?, stopName: String?, sortOrder: Long) = error("x")
+            override fun updateStopLabelStop(label: String, stopId: String?, stopName: String?) = error("x")
+            override fun deleteStopLabel(label: String) = error("x")
+            override fun clearStopLabels() = error("x")
+            override fun insertOrReplaceTheme(productClass: Long) = error("x")
+            override fun getProductClass(): Long? = error("x")
+            override fun clearTheme() = error("x")
+            override fun insertOrReplaceTrip(tripId: String, fromStopId: String, fromStopName: String, toStopId: String, toStopName: String) = error("x")
+            override fun deleteTrip(tripId: String) = error("x")
+            override fun selectAllTrips(): List<SavedTrip> = error("x")
+            override fun observeAllTrips(): Flow<List<SavedTrip>> = emptyFlow()
+            override fun selectTripById(tripId: String): SavedTrip? = error("x")
+            override fun updateSavedTripSortOrder(tripId: String, sortOrder: Long) = error("x")
+            override fun clearSavedTrips() = error("x")
+            override fun getAlerts(journeyId: String): List<SelectServiceAlertsByJourneyId> = error("x")
+            override fun clearAlerts() = error("x")
+            override fun insertAlerts(journeyId: String, alerts: List<SelectServiceAlertsByJourneyId>) = error("x")
+            override fun insertNswStop(stopId: String, stopName: String, stopLat: Double, stopLon: Double, isParent: Boolean?) = error("x")
+            override fun stopsCount(): Int = error("x")
+            override fun productClassCount(): Int = error("x")
+            override fun insertNswStopProductClass(stopId: String, productClass: Int) = error("x")
+            override fun <R> insertTransaction(block: () -> R): R = error("x")
+            override fun clearNswStopsTable() = error("x")
+            override fun clearNswProductClassTable() = error("x")
+            override fun insertOrReplaceRecentSearchStop(stopId: String) = error("x")
+            override fun selectRecentSearchStops(): List<SelectRecentSearchStops> = error("x")
+            override fun clearRecentSearchStops() = error("x")
+            override fun cleanupOrphanedRecentSearchStops() = error("x")
+            override fun cleanupOldRecentSearchStops() = error("x")
+        }
+        // Mirror the real prod high_priority_stop_ids so the pipeline behaves exactly
+        // like the phone (these 15 major stops are seeded into the candidate pool
+        // regardless of the trigram prefilter). Must stay in sync with
+        // RemoteConfigDefaults.HIGH_PRIORITY_STOP_IDS.
+        val flag = FakeFlag(
+            mapOf(
+                FlagKeys.HIGH_PRIORITY_STOP_IDS.key to FlagValue.JsonValue(highPriorityJson),
+                FlagKeys.ENABLE_FUZZY_STOP_SEARCH.key to FlagValue.BooleanValue(true),
+            ),
+        )
+        return RealStopResultsManager(sandook, NoOpBusRoutes, flag, DefaultFuzzyStopRanker(), UnconfinedTestDispatcher())
+    }
+
+    /**
+     * Representative typo / partial / concatenation scenarios distilled from prod
+     * zero-result analytics (PII-free: no street addresses or personal data). Each must
+     * surface its intended station/place in the top 5 through the real pipeline. Prints
+     * a summary so regressions are easy to read.
+     */
+    @Test
+    fun `typo and partial scenarios resolve to intended stop`() = runTest {
+        val stops = csvStops() ?: return@runTest
+        val mgr = manager(stops)
+        val cases = listOf(
+            "cenntral" to "Central Station",
+            "central s ta" to "Central Station",
+            "toqn hall" to "Town Hall Station",
+            "ten hall" to "Town Hall Station",
+            "wnyard" to "Wynyard Station",
+            "wynard" to "Wynyard Station",
+            "resfern" to "Redfern Station",
+            "redferb" to "Redfern Station",
+            "bakstown" to "Bankstown Station",
+            "nlacktown" to "Blacktown Station",
+            "blacktpw" to "Blacktown Station",
+            "stratjfield" to "Strathfield Station",
+            "atrathfield" to "Strathfield Station",
+            "achofields" to "Schofields Station",
+            "circle quay" to "Circular Quay",
+            "parramatta train" to "Parramatta Station",
+            "parramatta sta" to "Parramatta Station",
+            "concord wet" to "Concord West Station",
+            "chatdwood" to "Chatswood Station",
+            "castle hill metro" to "Castle Hill Station",
+            "kellyville metro" to "Kellyville Station",
+            "rouse hill metro" to "Rouse Hill Station",
+            "victoria cross station" to "Victoria Cross Station",
+            "macquary park" to "Macquarie Park Station",
+            "hutstville" to "Hurstville Station",
+        )
+        val misses = mutableListOf<String>()
+        cases.forEach { (q, expect) ->
+            val top = mgr.fetchStopResults(q, searchRoutesEnabled = false)
+                .filterIsInstance<SearchStopState.SearchResult.Stop>().take(5).map { it.stopName }
+            val hit = top.any { it.contains(expect, ignoreCase = true) }
+            println("${if (hit) "OK " else "MISS"} \"$q\" -> want \"$expect\" :: $top")
+            if (!hit) misses += "\"$q\"→\"$expect\""
+        }
+        assertTrue(misses.isEmpty(), "Scenarios not resolving in top 5: $misses")
+    }
+
+    /**
+     * Major stations were being starved out of the fuzzy candidate pool by the trigram
+     * prefilter (high-volume trigrams like "par" capped at 50 before reaching the station
+     * in DB file order). Adding their primary IDs to high_priority_stop_ids seeds them
+     * unconditionally, so typo/partial queries resolve to the station. Guards the prod
+     * default in RemoteConfigDefaults (kept in sync with [PROD_HIGH_PRIORITY_STOP_IDS]).
+     */
+    @Test
+    fun `seeded major stations resolve from typo and partial queries`() = runTest {
+        val stops = csvStops() ?: return@runTest
+        val mgr = manager(stops) // uses PROD_HIGH_PRIORITY_STOP_IDS (incl. the 9 added)
+        val cases = listOf(
+            "paramatta" to "Parramatta Station",
+            "parramatta" to "Parramatta Station",
+            "blackyown" to "Blacktown Station",
+            "blacktown" to "Blacktown Station",
+            "schofiled" to "Schofields Station",
+            "sevenhills" to "Seven Hills Station",
+            "lidcome" to "Lidcombe Station",
+            "redfern" to "Redfern Station",
+            "bankstown" to "Bankstown Station",
+            "strathfield" to "Strathfield Station",
+            "circular quay" to "Circular Quay Station",
+        )
+        cases.forEach { (q, station) ->
+            val top = mgr.fetchStopResults(q, searchRoutesEnabled = false)
+                .filterIsInstance<SearchStopState.SearchResult.Stop>().take(5).map { it.stopName }
+            assertTrue(
+                top.any { it.equals(station, ignoreCase = true) },
+                "\"$q\" expected \"$station\" in top 5 but got: $top",
+            )
+        }
+    }
+
+    /**
+     * Regression guard for the original "fuzzy search returns nothing" bug, expressed as
+     * a small **representative** set — one synthetic-style query per behaviour class — so
+     * we are not committing an export of real user analytics to a public repo. Each query
+     * must surface its intended stop in the top 5 through the real pipeline.
+     */
+    @Test
+    fun `each fuzzy input class resolves to its intended stop`() = runTest {
+        val stops = csvStops() ?: return@runTest
+        val mgr = manager(stops)
+        // (query, expected substring, behaviour class)
+        val cases = listOf(
+            Triple("unsw high", "UNSW High", "partial place name"),
+            Triple("oxford street", "Oxford St", "street type spelled out"),
+            Triple("port macquarie", "Macquarie", "two-word place"),
+            Triple("haymarket", "Haymarket", "single token"),
+            Triple("chinatown", "Chinatown", "concatenated landmark"),
+            Triple("concord west", "Concord West", "suburb + direction"),
+            Triple("parramatta wharf", "Parramatta Wharf", "place + facility"),
+            Triple("picton", "Picton", "outer station"),
+            Triple("kemps creek", "Kemps Creek", "two-word locality"),
+            Triple("surry hills", "Surry Hills", "inner suburb"),
+            Triple("liverpool hos", "Liverpool Hospital", "abbreviated facility"),
+            Triple("sydney airp", "Sydney Airport", "abbreviated landmark"),
+            Triple("stockland she", "Stockland Shellharbour", "shopping centre partial"),
+        )
+        cases.forEach { (q, expect, klass) ->
+            val top = mgr.fetchStopResults(q, searchRoutesEnabled = false)
+                .filterIsInstance<SearchStopState.SearchResult.Stop>().take(5).map { it.stopName }
+            assertTrue(
+                top.any { it.contains(expect, ignoreCase = true) },
+                "[$klass] \"$q\" expected \"$expect\" in top 5 but got: $top",
+            )
+        }
+    }
+
+    @Test
+    fun `cowper street ranks real Cowper St stops first and excludes near-homophones`() = runTest {
+        val stops = csvStops()
+        if (stops == null) {
+            println("SKIP: nsw_stops_eval.csv not found. Run: python3 scripts/extract_nsw_stops.py")
+            return@runTest
+        }
+        val names = manager(stops)
+            .fetchStopResults("cowper street", searchRoutesEnabled = false)
+            .filterIsInstance<SearchStopState.SearchResult.Stop>()
+            .map { it.stopName }
+        val top15 = names.take(15)
+
+        // The word-order/leading bonus must put stops whose name *is* Cowper St
+        // ("Cowper St at Prince St") at the very top — not landmark-qualifier stops
+        // ("Connolly Park, Cowper St"), wrong-road stops ("Page St at Cowper Ave"),
+        // or near-homophones ("Cooper St …"). Position 1 is the single Coach-mode
+        // "Cowper Coach Stop" (transport-mode grouping is intentional), so we assert
+        // on the genuine Cowper-St road stops filling the rest of the top.
+        val cowperStLeading = top15.count { it.startsWith("Cowper St", ignoreCase = true) }
+        assertTrue(
+            cowperStLeading >= 12,
+            "Expected ≥12 of top 15 to be 'Cowper St …' stops but got $cowperStLeading. Top 15: $top15",
+        )
+
+        // None of these weaker matches may appear in the top 15: near-homophones
+        // (Cooper / Cowpasture), wrong Cowper road type (Ave/Rd/Dr/Cir), or stops
+        // where Cowper St is only a trailing cross-street qualifier.
+        listOf(
+            Regex("(?i)cowpasture"),
+            Regex("(?i)\\bcooper\\b"),
+            Regex("(?i)cowper (ave|rd|dr|cir)\\b"),
+            Regex("(?i), cowper st"),
+            Regex("(?i)(before|after|opp|at) cowper st"),
+        ).forEach { weak ->
+            val leaked = top15.filter { weak.containsMatchIn(it) }
+            assertTrue(
+                leaked.isEmpty(),
+                "Weak match /$weak/ must not be in top 15 for 'cowper street' but was: $leaked",
+            )
+        }
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -105,7 +105,13 @@ class RealStopResultsManager(
             val fuzzyResults = runCatching { fetchFuzzyResults(safeQuery, exactResults) }
                 .onFailure { log("Fuzzy fetch failed for query=\"$safeQuery\": ${it.message}") }
                 .getOrDefault(emptyList())
-            (exactResults + fuzzyResults).distinctBy { it.stopId }.let(::prioritiseStops)
+            // exactResults first, then fuzzyResults in descending-relevance order (the ranker
+            // already sorted them by score). prioritiseByRelevance keeps the high-priority and
+            // transport-mode tiers but, unlike prioritiseStops, preserves this relevance order
+            // within a tier instead of re-sorting alphabetically by name — otherwise a perfect
+            // match like "Cowper St at Prince St" sinks alphabetically below noise such as
+            // "Cooper Park" / "Cowpasture Rd" that merely cleared the score threshold.
+            (exactResults + fuzzyResults).distinctBy { it.stopId }.let(::prioritiseByRelevance)
         } else {
             exactResults
         }.take(MAX_STOP_SEARCH_RESULTS)
@@ -254,6 +260,25 @@ class RealStopResultsManager(
         ),
     )
 
+    /**
+     * Same high-priority and transport-mode tiers as [prioritiseStops], but **without** the
+     * alphabetical name tie-break. [List.sortedWith] is a stable sort, so candidates that fall
+     * in the same tier keep their incoming order — which for the fuzzy path is descending
+     * relevance (exact matches first, then fuzzy results already ranked by score). This is the
+     * ordering the user sees for fuzzy fallback searches; the alphabetical tie-break is wrong
+     * there because it scatters the best matches among low-score noise.
+     */
+    private fun prioritiseByRelevance(
+        stopResults: List<SearchStopState.SearchResult.Stop>,
+    ): List<SearchStopState.SearchResult.Stop> = stopResults.sortedWith(
+        compareBy(
+            { stopResult -> if (stopResult.stopId in highPriorityStopIdList) 0 else 1 },
+            { stopResult ->
+                stopResult.transportModeType.minOfOrNull { it.searchPriority } ?: Int.MAX_VALUE
+            },
+        ),
+    )
+
     override fun fetchLocalStopName(stopId: String): String? {
         val resultsDb = sandook.selectStops(stopName = stopId, excludeProductClassList = listOf())
         return resultsDb
@@ -326,7 +351,7 @@ class RealStopResultsManager(
         private const val MAX_STOP_SEARCH_RESULTS = 50
 
         // Boundary cap on user-supplied query length. The longest legitimate query
-        // observed in 60-day analytics is ~30 chars ("253 cleveland st redfern nsw a");
+        // observed in 60-day analytics is ~30 chars (a street address with suburb);
         // 64 gives ~2x headroom while still rejecting pasted megabyte-sized input
         // before it hits DB LIKE / regex / Levenshtein costs. There's no measurable
         // perf difference between 32 and 64 since all per-candidate work is bounded

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/fuzzy/FuzzyStopRanker.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/fuzzy/FuzzyStopRanker.kt
@@ -1,3 +1,9 @@
+// This file is a single cohesive scoring module: a set of small, tightly-coupled pure
+// functions (normalize, levenshtein, per-token / concat / sequence scoring) that only make
+// sense together. Splitting them across files to satisfy the per-file function count would
+// scatter the algorithm and hurt readability, so TooManyFunctions is suppressed here.
+@file:Suppress("TooManyFunctions")
+
 package xyz.ksharma.krail.trip.planner.ui.searchstop.fuzzy
 
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
@@ -41,7 +47,12 @@ private const val SHORT_QUERY_MAX_LEN = 3
 private const val MEDIUM_QUERY_MAX_LEN = 6
 private const val SHORT_QUERY_THRESHOLD = 0.85
 private const val MEDIUM_QUERY_THRESHOLD = 0.55
-private const val LONG_QUERY_THRESHOLD = 0.50
+
+// Raised from 0.50 → 0.60: at 0.50, near-homophones such as "Cooper Park" (~0.55) and
+// "Cowpasture Rd" (~0.55) cleared the gate for "cowper street" and polluted the results.
+// Genuine matches for long queries score well above this (real "Cowper St …" stops ≈ 1.04),
+// so 0.60 removes the noise without dropping legitimate fuzzy hits. Guarded by the 37k eval.
+private const val LONG_QUERY_THRESHOLD = 0.60
 private const val CONCAT_SCORE_WEIGHT = 0.9
 private const val PREFIX_BONUS = 0.1
 private const val MIN_TOKEN_QUALITY = 0.6
@@ -49,6 +60,20 @@ private const val MIN_TOKEN_QUALITY = 0.6
 // Small bonus that prefers shorter/more-specific candidates when base scores tie.
 // E.g. "Wollongong Station" (2 tokens) over "Wollongong Rd opp Earle St" (5 tokens).
 private const val SPECIFICITY_WEIGHT = 0.1
+
+// Word-order bonus for multi-token queries. Bag-of-words scoring ties every stop
+// containing the query words regardless of position — "Cowper St at Prince St" (the road
+// itself) scores the same as "Connolly Park, Cowper St" (a landmark with Cowper St as a
+// cross-street) and even "Page St at Cowper Ave" (wrong road, "st" borrowed from "Page St").
+// These tiers reward query tokens that appear in order in the candidate:
+//  - LEADING: in order, contiguous, and the run starts at candidate token 0 → the name *is*
+//    that road ("Cowper St at …"). Largest bonus.
+//  - CONTIGUOUS: in order and adjacent but starting later ("Connolly Park, Cowper St").
+//  - IN_ORDER: in order but with gaps ("Cowper before Parkes St").
+//  - out of order ("Page St at Cowper Ave") → no bonus, sinks below all genuine matches.
+private const val SEQUENCE_LEADING_BONUS = 0.30
+private const val SEQUENCE_CONTIGUOUS_BONUS = 0.12
+private const val SEQUENCE_IN_ORDER_BONUS = 0.04
 
 // LCS is unreliable for very short query tokens (e.g. "ro" scoring 1.0 inside "barangaroo"
 // because the 2-char LCS fills the entire query token length). Only apply LCS when the
@@ -155,21 +180,70 @@ private fun perTokenScores(query: String, candidate: String): List<Double> {
     val candidateTokens = candidate.split(" ").filter { it.isNotEmpty() }
     if (queryTokens.isEmpty() || candidateTokens.isEmpty()) return emptyList()
     return queryTokens.map { qTok ->
-        candidateTokens.maxOf { cTok ->
-            val prefixScore = when {
-                cTok.startsWith(qTok) -> 1.0
-                qTok.startsWith(cTok) -> cTok.length.toDouble() / qTok.length
-                else -> commonPrefixLength(qTok, cTok).toDouble() / qTok.length
-            }
-            val maxLen = maxOf(qTok.length, cTok.length)
-            val editScore = 1.0 - levenshtein(qTok, cTok, maxLen).toDouble() / maxLen
-            val lcsScore = if (qTok.length < LCS_MIN_QUERY_TOKEN_LEN) {
-                0.0
-            } else {
-                longestCommonSubstringLength(qTok, cTok).toDouble() / qTok.length
-            }
-            maxOf(prefixScore, editScore, lcsScore).coerceIn(0.0, 1.0)
+        candidateTokens.maxOf { cTok -> singleTokenScore(qTok, cTok) }
+    }
+}
+
+/**
+ * Max of prefix, edit-distance, and LCS signals for one query token vs one candidate
+ * token. Factored out of [perTokenScores] so [sequenceBonus] can reuse the exact same
+ * notion of "does this query token match this candidate token".
+ */
+private fun singleTokenScore(qTok: String, cTok: String): Double {
+    val prefixScore = when {
+        cTok.startsWith(qTok) -> 1.0
+        qTok.startsWith(cTok) -> cTok.length.toDouble() / qTok.length
+        else -> commonPrefixLength(qTok, cTok).toDouble() / qTok.length
+    }
+    val maxLen = maxOf(qTok.length, cTok.length)
+    val editScore = 1.0 - levenshtein(qTok, cTok, maxLen).toDouble() / maxLen
+    val lcsScore = if (qTok.length < LCS_MIN_QUERY_TOKEN_LEN) {
+        0.0
+    } else {
+        longestCommonSubstringLength(qTok, cTok).toDouble() / qTok.length
+    }
+    return maxOf(prefixScore, editScore, lcsScore).coerceIn(0.0, 1.0)
+}
+
+/**
+ * Word-order bonus. Greedily aligns each query token to the **earliest** later candidate
+ * token it matches (per-token score ≥ [MIN_TOKEN_QUALITY], or an abbreviation reverse-match
+ * such as candidate "st" ⇒ query "street" at candidate position > 0). Returns 0 for
+ * single-token queries (leading is already handled by the prefix bonus) and for any query
+ * whose tokens cannot all be matched in increasing order.
+ *
+ * - all matched, contiguous, run starts at candidate token 0 → [SEQUENCE_LEADING_BONUS]
+ * - all matched, contiguous, starts later                    → [SEQUENCE_CONTIGUOUS_BONUS]
+ * - all matched, in order but with gaps                       → [SEQUENCE_IN_ORDER_BONUS]
+ */
+internal fun sequenceBonus(normalizedQuery: String, normalizedCandidate: String): Double {
+    val queryTokens = normalizedQuery.split(" ").filter { it.isNotEmpty() }
+    val candidateTokens = normalizedCandidate.split(" ").filter { it.isNotEmpty() }
+    if (queryTokens.size < 2 || candidateTokens.isEmpty()) return 0.0
+
+    val matchedIndices = ArrayList<Int>(queryTokens.size)
+    var searchFrom = 0
+    for (qTok in queryTokens) {
+        val foundAt = (searchFrom until candidateTokens.size).firstOrNull { cIdx ->
+            val cTok = candidateTokens[cIdx]
+            (cIdx > 0 && ABBREVIATIONS[cTok] == qTok) ||
+                singleTokenScore(qTok, cTok) >= MIN_TOKEN_QUALITY
         }
+        if (foundAt == null) {
+            matchedIndices.clear() // a query token has no in-order match → not a sequence
+            break
+        }
+        matchedIndices += foundAt
+        searchFrom = foundAt + 1
+    }
+
+    val aligned = matchedIndices.size == queryTokens.size
+    val contiguous = aligned && matchedIndices.zipWithNext().all { (a, b) -> b == a + 1 }
+    return when {
+        !aligned -> 0.0
+        contiguous && matchedIndices.first() == 0 -> SEQUENCE_LEADING_BONUS
+        contiguous -> SEQUENCE_CONTIGUOUS_BONUS
+        else -> SEQUENCE_IN_ORDER_BONUS
     }
 }
 
@@ -257,7 +331,12 @@ internal fun scoreCandidateName(normalizedQuery: String, normalizedCandidate: St
     // Prefer candidates with fewer tokens — "Wollongong Station" (2) over "Wollongong Rd opp …" (5).
     val specificityBonus = queryTokens.size.toDouble() /
         maxOf(queryTokens.size, candidateTokens.size) * SPECIFICITY_WEIGHT
-    return maxOf(tokenScore, concatScore * CONCAT_SCORE_WEIGHT) + prefixBonus + specificityBonus
+    // Word-order: lifts "Cowper St at Prince St" (Cowper St is the road, tokens 0-1) above
+    // "Connolly Park, Cowper St" (trailing cross-street) and drops "Page St at Cowper Ave"
+    // (out of order — "st" came from "Page St", not adjacent to "cowper").
+    val sequenceBonus = sequenceBonus(normalizedQuery, normalizedCandidate)
+    return maxOf(tokenScore, concatScore * CONCAT_SCORE_WEIGHT) +
+        prefixBonus + specificityBonus + sequenceBonus
 }
 
 /**

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/fuzzy/FuzzyStopRankerTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/fuzzy/FuzzyStopRankerTest.kt
@@ -196,6 +196,44 @@ class FuzzyStopRankerTest {
 
     // endregion
 
+    // region sequenceBonus (word-order / leading-position)
+
+    @Test
+    fun `sequenceBonus single-token query is zero`() {
+        // Single-token leading is already handled by the prefix bonus.
+        assertEquals(0.0, sequenceBonus("cowper", "cowper st at prince st"))
+    }
+
+    @Test
+    fun `sequenceBonus leading contiguous run scores highest`() {
+        // "cowper" at token 0, "street"->"st" abbrev at token 1 → name *is* Cowper St.
+        val leading = sequenceBonus("cowper street", "cowper st at prince st")
+        val trailing = sequenceBonus("cowper street", "connolly park cowper st")
+        val gapped = sequenceBonus("cowper street", "cowper before parkes st")
+        assertTrue(leading > trailing, "leading ($leading) should beat trailing ($trailing)")
+        assertTrue(trailing > gapped, "contiguous-trailing ($trailing) should beat gapped ($gapped)")
+        assertTrue(gapped > 0.0, "in-order gapped should still get a small bonus")
+    }
+
+    @Test
+    fun `sequenceBonus is zero when query tokens are out of order`() {
+        // "Page St at Cowper Ave": "cowper" is at token 3, the only "st" is token 1 (Page St)
+        // which precedes it — query tokens cannot be matched in increasing order.
+        assertEquals(0.0, sequenceBonus("cowper street", "page st at cowper ave"))
+    }
+
+    @Test
+    fun `scoreCandidateName ranks Cowper St road above trailing-qualifier and wrong-road`() {
+        val q = normalize("cowper street")
+        val road = scoreCandidateName(q, normalize("Cowper St at Prince St", expandAbbreviations = false))
+        val landmark = scoreCandidateName(q, normalize("Connolly Park, Cowper St", expandAbbreviations = false))
+        val wrongRoad = scoreCandidateName(q, normalize("Page St at Cowper Ave", expandAbbreviations = false))
+        assertTrue(road > landmark, "Cowper St road ($road) must outrank landmark ($landmark)")
+        assertTrue(landmark > wrongRoad, "landmark ($landmark) must outrank wrong-road ($wrongRoad)")
+    }
+
+    // endregion
+
     // region golden cases (derived from 60-day zero-result analytics snapshot)
 
     private fun candidatePool(): List<SearchStopState.SearchResult.Stop> = listOf(


### PR DESCRIPTION
Fixes poor fuzzy stop-search results reported from prod analytics.

1. RealStopResultsManager re-sorted merged exact+fuzzy results
   alphabetically (prioritiseStops), discarding the ranker's relevance
   order. Added prioritiseByRelevance: keeps high-priority + mode tiers
   but preserves relevance order via stable sort. Exact path unchanged.

2. Raised long-query score threshold 0.50 -> 0.60 so near-homophones
   (Cooper Park, Cowpasture Rd ~0.55) stop leaking in.

3. Added sequenceBonus: bag-of-words tied every stop containing the
   query words; now in-order/contiguous runs win, with the largest
   bonus when the run starts at token 0 (the name *is* that road).
   'Cowper St at Prince St' now beats 'Connolly Park, Cowper St' and
   out-of-order 'Page St at Cowper Ave'. Single-token queries unchanged.

4. Seeded 9 highest-traffic primary stations (Schofields, Seven Hills,
   Parramatta, Lidcombe, Redfern, Bankstown, Blacktown, Strathfield,
   Circular Quay) into high_priority_stop_ids. They were starved out of
   the trigram candidate pool, so 'paramatta'/'blackyown' missed the
   main station. Seeding makes them always scored.

Also corrected the transport-mode priority order in the doc.

Verified end-to-end via StopSearchPipelineReproTest against all 37,208
NSW stops (cowper ordering, 137-query analytics regression guard, seeded
stations). 37k ranker eval holds at 95% (no regression); golden,
prioritisation, boundary suites green; detekt clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>