### PR TITLE
feat(search): curated quick-select stops on first open

### DIFF
--- a/feature/trip-planner/ui/SEARCH_STOP_UX.md
+++ b/feature/trip-planner/ui/SEARCH_STOP_UX.md
@@ -48,6 +48,34 @@ users tap into a dead-end state.
 
 ---
 
+### Empty-state stops (`shouldShowEmptyStateStops`)
+
+On a true first open — Recent mode with **zero** recent stops — the screen would
+otherwise be a near-blank canvas (just the "select on map" button). Instead we render
+a small hardcoded curated list, `EMPTY_STATE_STOPS`: **Town Hall, Central, Parramatta,
+Wynyard** (order intentional), so a brand-new user can reach a major interchange
+without typing.
+
+| List state | Empty-state stops |
+|---|---|
+| Recent, no recents yet | **visible** (the 4 curated stops) |
+| Recent, ≥ 1 recent stop | hidden (recents replace them) |
+| Results / NoMatch / Error | hidden |
+
+Rules:
+- **No header.** A brand-new user just sees a few tappable stops; no "Popular"/
+  "Suggested" label (product decision).
+- **Replace, never coexist.** They are a first-open fallback only. The instant the
+  user has any recent stop, recents take over and the curated list disappears.
+- **Same tap path as recents.** Tapping one calls `onStopSelect` → the stop is saved
+  to recents, so next open it appears under Recents (and the curated list is gone).
+  Fires `TrackStopSelected(isRecentSearch = false)` — not a recent, not a search.
+- **Pill row stays hidden here** (unchanged): `shouldShowPillRow` still returns false
+  with zero recents, so a first-open user sees only the curated stops, not label
+  pills. Reaching assigning mode still requires a recent first.
+
+---
+
 ## Stops & saving
 
 ### Saving auto-pins to recents

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/EmptyStateStops.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/EmptyStateStops.kt
@@ -1,0 +1,42 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+
+/**
+ * Curated quick-select stops shown on SearchStopScreen's empty state — when the user
+ * has no recent search history (true first open). Lets a brand-new user jump to a major
+ * interchange without typing, instead of facing a blank canvas. Replaced by real recents
+ * the moment the user has any — see [shouldShowEmptyStateStops] and `SEARCH_STOP_UX.md`.
+ *
+ * Hardcoded by product decision; the order is intentional (Town Hall, Central,
+ * Parramatta, Wynyard). Stop IDs and transport modes match the bundled NSW GTFS data.
+ */
+internal val EMPTY_STATE_STOPS: ImmutableList<SearchStopState.StopResult> = persistentListOf(
+    SearchStopState.StopResult(
+        stopName = "Town Hall Station",
+        stopId = "200070",
+        transportModeType = persistentListOf(TransportMode.Train, TransportMode.LightRail),
+    ),
+    SearchStopState.StopResult(
+        stopName = "Central Station",
+        stopId = "200060",
+        transportModeType = persistentListOf(
+            TransportMode.Train,
+            TransportMode.Metro,
+            TransportMode.LightRail,
+        ),
+    ),
+    SearchStopState.StopResult(
+        stopName = "Parramatta Station",
+        stopId = "215020",
+        transportModeType = persistentListOf(TransportMode.Train, TransportMode.Bus),
+    ),
+    SearchStopState.StopResult(
+        stopName = "Wynyard Station",
+        stopId = "200080",
+        transportModeType = persistentListOf(TransportMode.Train, TransportMode.LightRail),
+    ),
+)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRules.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRules.kt
@@ -107,6 +107,18 @@ internal fun shouldShowPillRow(
     ListState.NoMatch, ListState.Error -> false
 }
 
+/**
+ * On a fresh install (Recent mode, zero recents) we surface a small curated set of
+ * [EMPTY_STATE_STOPS] so a brand-new user can pick a major interchange without typing,
+ * instead of facing a blank canvas. As soon as the user has at least one recent stop,
+ * recents take over and this returns false (empty-state stops are a first-open
+ * fallback, never shown alongside recents).
+ */
+internal fun shouldShowEmptyStateStops(
+    listState: ListState,
+    recentStops: List<SearchStopState.StopResult>,
+): Boolean = listState == ListState.Recent && recentStops.isEmpty()
+
 internal sealed interface AssignConflict {
     data class StopAlreadyOnAnotherLabel(
         val target: StopLabel,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -921,6 +921,9 @@ private fun SearchStopListContent(
     val showPillRow = remember(listState, searchStopState.recentStops) {
         shouldShowPillRow(listState, searchStopState.recentStops)
     }
+    val showEmptyStateStops = remember(listState, searchStopState.recentStops) {
+        shouldShowEmptyStateStops(listState, searchStopState.recentStops)
+    }
     when (listState) {
         ListState.Recent -> {
             // Box wrapper lets the floating "searching..." pill sit on the z-axis above
@@ -953,6 +956,16 @@ private fun SearchStopListContent(
                     selectOnMapItem(isMapsAvailable = isMapsAvailable, onOpenMap = onOpenMap)
                     recentSearchStopsList(
                         recentStops = searchStopState.recentStops,
+                        keyboard = keyboard,
+                        focusRequester = focusRequester,
+                        savedStopIds = savedStopIds,
+                        onStopSelect = onStopSelect,
+                        onSaveAsLabel = onSaveAsLabel,
+                        onUnsaveLabel = onUnsaveLabel,
+                        onEvent = onEvent,
+                    )
+                    emptyStateStopsList(
+                        show = showEmptyStateStops,
                         keyboard = keyboard,
                         focusRequester = focusRequester,
                         savedStopIds = savedStopIds,
@@ -1256,6 +1269,58 @@ private fun LazyListScope.recentSearchStopsList(
                     SearchStopUiEvent.TrackStopSelected(
                         stopItem = stopItem,
                         isRecentSearch = true,
+                    ),
+                )
+            },
+            isSaved = isSaved,
+            onSaveAsLabel = if (!isSaved) onSaveAsLabel else null,
+            onUnsaveLabel = if (isSaved) onUnsaveLabel else null,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Divider(
+            modifier = Modifier.padding(horizontal = KrailTheme.dimensions.pageHorizontalPadding),
+        )
+    }
+}
+
+/**
+ * First-open quick-select list. Renders [EMPTY_STATE_STOPS] only when [show] is true
+ * (Recent mode with zero recents — see [shouldShowEmptyStateStops]). No header by
+ * product decision: a brand-new user just sees a few tappable major stops. Tapping
+ * flows through the same [onStopSelect] path as recents, so the chosen stop is saved
+ * and shows up under Recents next time (empty-state stops then disappear).
+ * See `SEARCH_STOP_UX.md`.
+ */
+@Suppress("LongParameterList")
+private fun LazyListScope.emptyStateStopsList(
+    show: Boolean,
+    keyboard: androidx.compose.ui.platform.SoftwareKeyboardController?,
+    focusRequester: FocusRequester,
+    savedStopIds: Set<String>,
+    onStopSelect: (StopItem) -> Unit,
+    onSaveAsLabel: (StopItem) -> Unit,
+    onUnsaveLabel: (StopItem) -> Unit,
+    onEvent: (SearchStopUiEvent) -> Unit,
+) {
+    if (!show) return
+    items(
+        items = EMPTY_STATE_STOPS,
+        key = { "empty_state_${it.stopId}" },
+    ) { stop ->
+        val isSaved = stop.stopId in savedStopIds
+        StopSearchListItem(
+            stopId = stop.stopId,
+            stopName = stop.stopName,
+            transportModeSet = stop.transportModeType.toImmutableSet(),
+            textColor = KrailTheme.colors.label,
+            onClick = { stopItem ->
+                keyboard?.hide()
+                focusRequester.freeFocus()
+                onStopSelect(stopItem)
+                onEvent(
+                    SearchStopUiEvent.TrackStopSelected(
+                        stopItem = stopItem,
+                        isRecentSearch = false,
                     ),
                 )
             },

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRulesTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRulesTest.kt
@@ -224,4 +224,51 @@ class SearchStopRulesTest {
     }
 
     // endregion
+
+    // region shouldShowEmptyStateStops
+
+    @Test
+    fun `empty-state stops shown on fresh Recent state with no recents`() {
+        assertTrue(shouldShowEmptyStateStops(ListState.Recent, recentStops = emptyList()))
+    }
+
+    @Test
+    fun `empty-state stops hidden once at least one recent exists`() {
+        assertFalse(shouldShowEmptyStateStops(ListState.Recent, recentStops = listOf(centralRecent)))
+    }
+
+    @Test
+    fun `empty-state stops hidden in Results state`() {
+        val state = ListState.Results(results = persistentListOf(centralResult), isLoading = false)
+        assertFalse(shouldShowEmptyStateStops(state, recentStops = emptyList()))
+    }
+
+    @Test
+    fun `empty-state stops hidden in NoMatch and Error states`() {
+        assertFalse(shouldShowEmptyStateStops(ListState.NoMatch, recentStops = emptyList()))
+        assertFalse(shouldShowEmptyStateStops(ListState.Error, recentStops = emptyList()))
+    }
+
+    // endregion
+
+    // region EMPTY_STATE_STOPS contents
+
+    @Test
+    fun `empty-state stops are the four curated interchanges in order`() {
+        assertEquals(
+            listOf("Town Hall Station", "Central Station", "Parramatta Station", "Wynyard Station"),
+            EMPTY_STATE_STOPS.map { it.stopName },
+        )
+        assertEquals(
+            listOf("200070", "200060", "215020", "200080"),
+            EMPTY_STATE_STOPS.map { it.stopId },
+        )
+    }
+
+    @Test
+    fun `empty-state stops all carry at least one transport mode`() {
+        assertTrue(EMPTY_STATE_STOPS.all { it.transportModeType.isNotEmpty() })
+    }
+
+    // endregion
 }


### PR DESCRIPTION
A brand-new user with no recent searches saw a near-blank canvas (just
the 'select on map' button). Now SearchStopScreen renders a small
hardcoded curated set — Town Hall, Central, Parramatta, Wynyard — so
they can reach a major interchange without typing.

- EMPTY_STATE_STOPS: the 4 curated StopResults (IDs + modes match the
  bundled NSW GTFS data); order intentional.
- shouldShowEmptyStateStops: pure rule — Recent mode AND zero recents.
  Replace-only: the instant the user has any recent, recents take over
  and the curated list disappears (never coexist).
- No header (product decision). Tapping flows through the same
  onStopSelect path as recents, so the choice is saved and appears
  under Recents next open. Fires TrackStopSelected(isRecentSearch=false).
- Pill row visibility unchanged (still hidden on zero recents).
- SEARCH_STOP_UX.md documents the new behaviour.
- SearchStopRulesTest covers the rule + curated-list contents.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>