### PR TITLE
fix(departures): gate pollStop collection on uiState subscribers

### DIFF
--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt
@@ -10,9 +10,12 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingCommand
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
@@ -69,14 +72,29 @@ class DeparturesViewModel(
     init {
         log("[$LOG_TAG] t=${nowMs()} ViewModel CREATED")
         // Collect repository flow into _uiState so updateRelativeTimeText() can mutate it.
+        //
+        // Gated on uiState having subscribers via SharingStarted.WhileSubscribed(5_000) —
+        // the same lifecycle the sibling DepartureBoardViewModel uses. Without this gate the
+        // repository's infinite pollStop loop runs for the ViewModel's entire lifetime
+        // (network hit every refresh interval) even when the sheet is closed/backgrounded,
+        // and never lets a TestCoroutineScheduler reach idle. The 5_000 ms grace keeps
+        // polling alive across config changes / brief detaches, matching the sibling.
         viewModelScope.launchWithExceptionHandler<DeparturesViewModel>(ioDispatcher) {
-            activeStopId
-                .flatMapLatest { stopId ->
-                    log("[$LOG_TAG] t=${nowMs()} activeStopId changed → $stopId, switching repo flow")
-                    if (stopId != null) {
-                        repository.pollStop(stopId)
+            SharingStarted.WhileSubscribed(POLL_SUBSCRIPTION_GRACE_MS)
+                .command(_uiState.subscriptionCount)
+                .distinctUntilChanged()
+                .flatMapLatest { command ->
+                    if (command == SharingCommand.START) {
+                        activeStopId.flatMapLatest { stopId ->
+                            log("[$LOG_TAG] t=${nowMs()} activeStopId changed → $stopId, switching repo flow")
+                            if (stopId != null) {
+                                repository.pollStop(stopId)
+                            } else {
+                                flowOf(DeparturesState(isLoading = false))
+                            }
+                        }
                     } else {
-                        flowOf(DeparturesState(isLoading = false))
+                        emptyFlow()
                     }
                 }
                 .collect { state ->
@@ -240,5 +258,10 @@ class DeparturesViewModel(
     companion object {
         const val LOG_TAG = "DEPARTURES"
         private const val REFRESH_TIME_TEXT_DURATION = 10_000L
+
+        // Keep the repository poll alive for this long after the last uiState subscriber
+        // leaves, so config changes / brief detaches don't restart polling. Matches the
+        // SharingStarted.WhileSubscribed(5_000) used by the sibling DepartureBoardViewModel.
+        private const val POLL_SUBSCRIPTION_GRACE_MS = 5_000L
     }
 }


### PR DESCRIPTION
## What

`DeparturesViewModel` collected the repository `pollStop()` flow in an
**unconditional `init {}` block**. Once a stop was active, the departure
board hit the network every refresh interval for the ViewModel's entire
lifetime — even when the sheet was closed or backgrounded.

This gates the collector on `uiState` having subscribers via
`SharingStarted.WhileSubscribed(POLL_SUBSCRIPTION_GRACE_MS).command(...)`,
mirroring the sibling `DepartureBoardViewModel`. Polling now runs only
while the screen observes `uiState` and stops 5 s after it goes away.
`_uiState` stays the single source of truth, so the relative-time ticker
and previous-departures behaviour are unchanged.

## Why standalone

This is a real background-polling bug, independent of the analytics work.
It is the base of a 2-PR stack: the analytics + test changes (#1597) sit
on top, because their test rewrite depends on this gating to be bounded.

## Verification

`:feature:departures:ui:detekt` + `:feature:departures:ui:compileKotlinIosSimulatorArm64` green.

## Follow-up

The 5 s `WhileSubscribed` grace is duplicated across ViewModels — tracked
as tech debt in #1602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
