### PR TITLE
build(testing): canonical fakes for Analytics, Flag, Trip+Departures services + builders

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -55,6 +55,10 @@ kotlin {
                 // is what keeps `:core:testing` thin and prevents the god-module that
                 // `:core:test` became (see plan: anti-god-module guarantees).
                 api(projects.sandook) // Sandook + SandookPreferences interfaces
+                api(projects.core.analytics) // Analytics + AnalyticsEvent
+                api(projects.core.remoteConfig) // Flag + FlagKeys + FlagValue
+                api(projects.feature.tripPlanner.network) // TripPlanningService, Stop/TripResponse, StopType, DepArr
+                api(projects.feature.departures.network) // DeparturesService + DepartureMonitorResponse
             }
         }
 

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAnalytics.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAnalytics.kt
@@ -1,0 +1,37 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+
+class FakeAnalytics : Analytics {
+
+    private val trackedEvents = mutableListOf<AnalyticsEvent>()
+    private var fakeUserId: String? = null
+
+    fun isEventTracked(eventName: String): Boolean {
+        println("trackedEvents: $trackedEvents")
+        return trackedEvents.any { it.name == eventName }
+    }
+
+    fun getTrackedEvent(eventName: String): AnalyticsEvent? {
+        return trackedEvents.find { it.name == eventName }
+    }
+
+    override fun track(event: AnalyticsEvent) {
+        println("Tracking event: $event")
+        trackedEvents.add(event)
+    }
+
+    override fun setUserId(userId: String) {
+        fakeUserId = userId
+    }
+
+    override fun setUserProperty(name: String, value: String) {
+        println("Setting user property $name to $value")
+    }
+
+    fun clear() {
+        trackedEvents.clear()
+        fakeUserId = null
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeDeparturesService.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeDeparturesService.kt
@@ -1,0 +1,34 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
+import xyz.ksharma.krail.departures.network.api.service.DeparturesService
+
+/**
+ * Canonical fake for [DeparturesService]. Promoted from the private inline class that
+ * was being copy-pasted across departure-board tests.
+ *
+ * - [response] is the next value returned to `departures(...)`. Mutate before / between
+ *   calls to drive different states (loading, refresh, error recovery).
+ * - [shouldThrow] flips the next call into an error path (and every subsequent call until
+ *   reset) so tests can exercise repository error handling without rebuilding the fake.
+ * - [callCount] records how many times `departures` was invoked — useful for verifying
+ *   that caching / refresh-throttling / `pollStop`-gating logic is wired correctly.
+ */
+class FakeDeparturesService(
+    var response: DepartureMonitorResponse = DepartureMonitorResponse(stopEvents = emptyList()),
+    var shouldThrow: Boolean = false,
+) : DeparturesService {
+
+    var callCount = 0
+        private set
+
+    override suspend fun departures(
+        stopId: String,
+        date: String?,
+        time: String?,
+    ): DepartureMonitorResponse {
+        callCount++
+        if (shouldThrow) error("Fake network error")
+        return response
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeFlag.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeFlag.kt
@@ -1,0 +1,25 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
+
+class FakeFlag : Flag {
+    private val flagValues = mutableMapOf<String, FlagValue>()
+
+    fun setFlagValue(key: String, value: FlagValue) {
+        flagValues[key] = value
+    }
+
+    override fun getFlagValue(key: String): FlagValue {
+        return flagValues[key] ?: when (key) {
+            FlagKeys.OUR_STORY_TEXT.key -> FlagValue.StringValue("Story Text")
+            FlagKeys.DISCLAIMER_TEXT.key -> FlagValue.StringValue("Disclaimer Text")
+            else -> FlagValue.BooleanValue(false)
+        }
+    }
+
+    fun setDiscoverAvailable(value: Boolean) {
+        setFlagValue(FlagKeys.DISCOVER_AVAILABLE.key, FlagValue.BooleanValue(value))
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeStopFinderResponseBuilder.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeStopFinderResponseBuilder.kt
@@ -1,0 +1,35 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
+
+object FakeStopFinderResponseBuilder {
+
+    // ProductClass ints (see reference_transport_mode): Train=1, Metro=2, Bus=5, Ferry=9.
+    private const val TRAIN = 1
+    private const val METRO = 2
+    private const val BUS = 5
+    private const val FERRY = 9
+
+    fun buildStopFinderResponse(): StopFinderResponse {
+        return StopFinderResponse(
+            locations = listOf(
+                StopFinderResponse.Location(
+                    id = "1",
+                    name = "Stop 1",
+                    type = "stop",
+                    disassembledName = "Stop 1, Suburb 1",
+                    properties = StopFinderResponse.Properties("1"),
+                    productClasses = listOf(TRAIN, BUS, FERRY),
+                ),
+                StopFinderResponse.Location(
+                    id = "2",
+                    name = "Stop 2",
+                    type = "stop",
+                    disassembledName = "Stop 2, Suburb 2",
+                    properties = StopFinderResponse.Properties("2"),
+                    productClasses = listOf(TRAIN, METRO),
+                ),
+            ),
+        )
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeTripPlanningService.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeTripPlanningService.kt
@@ -1,0 +1,84 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
+import xyz.ksharma.krail.trip.planner.network.api.model.StopType
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
+import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
+
+class FakeTripPlanningService : TripPlanningService {
+
+    var isSuccess: Boolean = true
+
+    var tripCallCount: Int = 0
+        private set
+
+    var lastCalledOriginStopId: String? = null
+        private set
+    var lastCalledDestinationStopId: String? = null
+        private set
+    var lastCalledDate: String? = null
+        private set
+    var lastCalledTime: String? = null
+        private set
+    var lastCalledDepArr: DepArr? = null
+        private set
+    var lastCalledExcludeProductClassSet: Set<Int>? = null
+        private set
+
+    // Configures a custom response for a specific call index (0-based); null = use default.
+    private val customResponses: MutableMap<Int, TripResponse?> = mutableMapOf()
+
+    fun setResponseForCall(callIndex: Int, response: TripResponse?) {
+        customResponses[callIndex] = response
+    }
+
+    fun reset() {
+        isSuccess = true
+        tripCallCount = 0
+        lastCalledOriginStopId = null
+        lastCalledDestinationStopId = null
+        lastCalledDate = null
+        lastCalledTime = null
+        lastCalledDepArr = null
+        lastCalledExcludeProductClassSet = null
+        customResponses.clear()
+    }
+
+    override suspend fun trip(
+        originStopId: String,
+        destinationStopId: String,
+        depArr: DepArr,
+        date: String?,
+        time: String?,
+        excludeProductClassSet: Set<Int>,
+    ): TripResponse {
+        lastCalledOriginStopId = originStopId
+        lastCalledDestinationStopId = destinationStopId
+        lastCalledDate = date
+        lastCalledTime = time
+        lastCalledDepArr = depArr
+        lastCalledExcludeProductClassSet = excludeProductClassSet
+        val callIndex = tripCallCount
+        tripCallCount++
+        val customResponse = customResponses[callIndex]
+        if (customResponse != null) return customResponse
+        return if (isSuccess) {
+            FakeTripResponseBuilder.buildTripResponse()
+        } else {
+            error("Failed to fetch trip")
+        }
+    }
+
+    override suspend fun stopFinder(
+        stopSearchQuery: String,
+        stopType: StopType,
+    ): StopFinderResponse {
+        // Return a fake StopFinderResponse
+        return if (isSuccess) {
+            FakeStopFinderResponseBuilder.buildStopFinderResponse()
+        } else {
+            error("Failed to fetch stops")
+        }
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeTripResponseBuilder.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeTripResponseBuilder.kt
@@ -1,0 +1,150 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.trip.planner.network.api.model.StopType
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse.StopSequence
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+
+// Builder pattern intrinsically has many small `setX` / `buildY` methods. Not refactorable.
+@Suppress("TooManyFunctions")
+object FakeTripResponseBuilder {
+    private var originStopSequence: StopSequence = buildStopSequence()
+    private var destinationStopSequence: StopSequence = buildStopSequence()
+    private var stopSequence: List<StopSequence> = listOf(buildStopSequence())
+    private var transportation: TripResponse.Transportation =
+        buildTransportation()
+    private var duration: Long = 200
+
+    fun setOriginStopSequence(originStopSequence: StopSequence) =
+        apply { this.originStopSequence = originStopSequence }
+
+    fun setDestinationStopSequence(destinationStopSequence: StopSequence) =
+        apply { this.destinationStopSequence = destinationStopSequence }
+
+    fun setStopSequence(stopSequence: List<StopSequence>) =
+        apply { this.stopSequence = stopSequence }
+
+    fun setTransportation(transportation: TripResponse.Transportation) =
+        apply { this.transportation = transportation }
+
+    fun setDuration(duration: Long) = apply { this.duration = duration }
+
+    fun build(): TripResponse.Leg {
+        return TripResponse.Leg(
+            origin = originStopSequence,
+            destination = destinationStopSequence,
+            stopSequence = stopSequence,
+            transportation = transportation,
+            duration = duration,
+        )
+    }
+
+    // All six params have sensible defaults; tests override individually as needed.
+    @Suppress("LongParameterList")
+    private fun buildStopSequence(
+        arrivalTimePlanned: String = "2024-09-24T19:00:00Z",
+        arrivalTimeEstimated: String = "2024-09-24T19:00:00Z",
+        departureTimePlanned: String = "2024-09-24T19:10:00Z",
+        departureTimeEstimated: String = "2024-09-24T19:10:00Z",
+        name: String = "Stop",
+        id: String = "stop_id",
+    ) = StopSequence(
+        arrivalTimePlanned = arrivalTimePlanned,
+        arrivalTimeEstimated = arrivalTimeEstimated,
+        departureTimePlanned = departureTimePlanned,
+        departureTimeEstimated = departureTimeEstimated,
+        name = name,
+        disassembledName = name,
+        id = id,
+        type = StopType.STOP.type,
+    )
+
+    private fun buildTransportation(transportationId: String = "Transportation Id") = TripResponse.Transportation(
+        disassembledName = "Transportation Name",
+        product = TripResponse.Product(
+            productClass = 1,
+            name = "Train",
+        ),
+        destination = TripResponse.OperatorClass(
+            name = "Destination Operator",
+            id = "Destination Operator Id",
+        ),
+        name = "Transportation Name",
+        id = transportationId,
+        description = "Transportation Description",
+    )
+
+    @OptIn(ExperimentalTime::class)
+    private fun buildJourneyLeg(legIndex: Int, stops: Int, journeyIndex: Int = 0) =
+        TripResponse.Leg(
+            origin = buildStopSequence(
+                name = "Origin Stop $legIndex",
+                arrivalTimeEstimated = Clock.System.now().plus(5.minutes * journeyIndex).toString(),
+                arrivalTimePlanned = Clock.System.now().plus(5.minutes * journeyIndex).toString(),
+                departureTimeEstimated = Clock.System.now().plus(5.minutes * journeyIndex).toString(),
+                departureTimePlanned = Clock.System.now().plus(5.minutes * journeyIndex).toString(),
+            ),
+            destination = buildStopSequence(
+                name = "Destination Stop $legIndex",
+                arrivalTimeEstimated = Clock.System.now().plus(10.minutes * journeyIndex).toString(),
+                arrivalTimePlanned = Clock.System.now().plus(10.minutes * journeyIndex).toString(),
+                departureTimeEstimated = Clock.System.now().plus(10.minutes * journeyIndex).toString(),
+                departureTimePlanned = Clock.System.now().plus(10.minutes * journeyIndex).toString(),
+            ),
+            stopSequence = List(stops) { index ->
+                buildStopSequence(
+                    id = "stop_id_${index + 1}",
+                    name = "Stop ${index + 1}",
+                    arrivalTimeEstimated = Clock.System.now().plus(5.minutes + journeyIndex.minutes)
+                        .toString(),
+                    arrivalTimePlanned = Clock.System.now().plus(5.minutes + journeyIndex.minutes)
+                        .toString(),
+                    departureTimeEstimated = Clock.System.now().plus(5.minutes + journeyIndex.minutes)
+                        .toString(),
+                    departureTimePlanned = Clock.System.now().plus(5.minutes + journeyIndex.minutes)
+                        .toString(),
+                )
+            },
+            transportation = buildTransportation(
+                transportationId = "Transportation Id $journeyIndex",
+            ),
+            duration = 120,
+        )
+
+    private fun buildJourneyList(
+        numberOfJourney: Int = 1,
+        numberOfLegs: Int = 1,
+        reverseTimeOrder: Boolean = false,
+    ): List<TripResponse.Journey> {
+        val journeyList = List(numberOfJourney) { buildJourney(numberOfLegs = numberOfLegs, journeyIndex = it) }
+        return if (reverseTimeOrder) journeyList.reversed() else journeyList
+    }
+
+    private fun buildJourney(
+        numberOfLegs: Int = 1,
+        stops: Int = 1,
+        journeyIndex: Int = 0,
+    ): TripResponse.Journey {
+        return TripResponse.Journey(
+            legs = List(numberOfLegs) { index ->
+                buildJourneyLeg(legIndex = index, stops = stops, journeyIndex = journeyIndex)
+            },
+        )
+    }
+
+    fun buildTripResponse(
+        numberOfJourney: Int = 1,
+        numberOfLegs: Int = 1,
+        reverseTimeOrder: Boolean = false,
+    ): TripResponse {
+        return TripResponse(
+            journeys = buildJourneyList(
+                numberOfJourney = numberOfJourney,
+                numberOfLegs = numberOfLegs,
+                reverseTimeOrder = reverseTimeOrder,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Second chunk of the canonical fakes for :core:testing. Copies the remaining
core/test fakes (package rewritten) and promotes FakeDeparturesService from
the private inline class that was being copy-pasted into departure-board tests.

Fakes added (all in commonMain, ~360 LOC total):
- FakeAnalytics              (37 LOC)  -> core/analytics
- FakeFlag                   (24 LOC)  -> core/remote-config
- FakeTripPlanningService    (78 LOC)  -> feature/trip-planner/network
- FakeStopFinderResponseBuilder (29 LOC)
- FakeTripResponseBuilder    (145 LOC)
- FakeDeparturesService      (NEW, 35 LOC) -> feature/departures/network

Detekt adjustments (intrinsic to test-double / builder patterns):
- @Suppress("TooManyFunctions") on FakeTripResponseBuilder (builder pattern).
- @Suppress("LongParameterList") on buildStopSequence (6 defaulted params).
- Extracted TRAIN/METRO/BUS/FERRY product-class constants in
  FakeStopFinderResponseBuilder to drop MagicNumber.
- `throw IllegalStateException(...)` -> `error(...)` per UseCheckOrError.
- KDoc on private property -> line comment per CommentOverPrivateProperty.

Interface module deps added to commonMain (api, never Real*):
core.analytics, core.remoteConfig, feature.tripPlanner.network,
feature.departures.network. No prod consumer yet — verifyTestingModuleUsage
enforces that invariant.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>