### PR TITLE
test(app-version): migrate AppVersionManagerTest to :core:app-version via :core:testing

### DIFF
--- a/core/app-version/build.gradle.kts
+++ b/core/app-version/build.gradle.kts
@@ -16,6 +16,8 @@ kotlin {
         namespace = "xyz.ksharma.krail.core.appversion"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
+
+        withHostTest {}
     }
 
     iosArm64()
@@ -51,6 +53,16 @@ kotlin {
                 implementation(libs.compose.material)
                 implementation(libs.compose.ui)
                 api(libs.di.koinComposeViewmodel)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(projects.core.testing)
+                // kotlin-test in commonMain `api` is not visible to consumer commonTest in
+                // KMP; per project convention each consumer also adds it to its commonTest.
+                implementation(libs.test.kotlin)
+                implementation(libs.test.kotlinxCoroutineTest)
             }
         }
     }

--- a/core/app-version/src/commonTest/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManagerTest.kt
+++ b/core/app-version/src/commonTest/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManagerTest.kt
@@ -1,9 +1,9 @@
-package xyz.ksharma.core.test.appversion
+package xyz.ksharma.krail.core.appversion
 
 import kotlinx.coroutines.test.runTest
-import xyz.ksharma.core.test.fakes.FakeAppInfo
-import xyz.ksharma.core.test.fakes.FakeAppInfoProvider
-import xyz.ksharma.core.test.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeAppInfo
+import xyz.ksharma.krail.core.testing.fakes.FakeAppInfoProvider
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
 import xyz.ksharma.krail.core.appversion.AppVersionUpdateState
 import xyz.ksharma.krail.core.appinfo.DevicePlatformType
 import xyz.ksharma.krail.core.appversion.RealAppVersionManager

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -59,6 +59,8 @@ kotlin {
                 api(projects.core.remoteConfig) // Flag + FlagKeys + FlagValue
                 api(projects.feature.tripPlanner.network) // TripPlanningService, Stop/TripResponse, StopType, DepArr
                 api(projects.feature.departures.network) // DeparturesService + DepartureMonitorResponse
+                api(projects.core.appInfo) // AppInfo + AppInfoProvider + DevicePlatformType
+                api(projects.core.appVersion) // AppVersionManager + AppVersionUpdateState
             }
         }
 

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAppInfo.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAppInfo.kt
@@ -1,0 +1,21 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.core.appinfo.AppInfo
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+
+// Defaulted properties mirror the production AppInfo contract one-for-one.
+@Suppress("LongParameterList")
+class FakeAppInfo(
+    override val devicePlatformType: DevicePlatformType = DevicePlatformType.ANDROID,
+    override val isDebug: Boolean = false,
+    override val appVersion: String = "1.0.0",
+    override val appBuildNumber: String = "123",
+    override val osVersion: String = "30",
+    override val fontSize: String = "1.0",
+    override val isDarkTheme: Boolean = false,
+    override val deviceModel: String = "Pixel 4",
+    override val deviceManufacturer: String = "Google",
+    override val locale: String = "en_AU",
+    override val timeZone: String = "Australia/Sydney",
+    override val appStoreUrl: String = "https://play.google.com/store/apps/details?id=xyz.ksharma.krail",
+) : AppInfo

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAppInfoProvider.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAppInfoProvider.kt
@@ -1,0 +1,15 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.core.appinfo.AppInfo
+import xyz.ksharma.krail.core.appinfo.AppInfoProvider
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+
+class FakeAppInfoProvider : AppInfoProvider {
+
+    var mockAppInfo: AppInfo = FakeAppInfo(
+        appVersion = "1.0.0",
+        devicePlatformType = DevicePlatformType.ANDROID,
+    )
+
+    override fun getAppInfo(): AppInfo = mockAppInfo
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAppVersionManager.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAppVersionManager.kt
@@ -1,0 +1,37 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.core.appversion.AppVersionManager
+import xyz.ksharma.krail.core.appversion.AppVersionUpdateState
+
+class FakeAppVersionManager : AppVersionManager {
+
+    var versionUpdateState: AppVersionUpdateState = AppVersionUpdateState.UpToDate
+    var mockCurrentVersion: String = "1.0.0"
+    var mockUpdateCopy: AppVersionManager.AppVersionUpdateCopy? = null
+
+    override suspend fun checkForUpdates(): AppVersionUpdateState {
+        return versionUpdateState
+    }
+
+    override fun getCurrentVersion(): String {
+        return mockCurrentVersion
+    }
+
+    override suspend fun getUpdateCopy(): AppVersionManager.AppVersionUpdateCopy? {
+        return mockUpdateCopy
+    }
+
+    fun setUpdateCopy(
+        title: String,
+        description: String,
+        ctaText: String,
+        key: String = mockCurrentVersion,
+    ) {
+        mockCurrentVersion = key
+        mockUpdateCopy = AppVersionManager.AppVersionUpdateCopy(
+            title = title,
+            description = description,
+            ctaText = ctaText,
+        )
+    }
+}


### PR DESCRIPTION
First of the per-module test migrations out of the :core:test god-module.
Establishes the pattern other migrations follow.

What this PR does:
- Bring FakeAppInfo, FakeAppInfoProvider, FakeAppVersionManager across to
  :core:testing/commonMain (package rewrite from xyz.ksharma.core.test.fakes
  to xyz.ksharma.krail.core.testing.fakes). Detekt: @Suppress("LongParameterList")
  on FakeAppInfo because the 12 defaulted props mirror the production
  AppInfo contract one-for-one — not refactorable.
- Add :core:app-info + :core:app-version as `api` deps on :core:testing so
  consumers see the types these fakes use.
- Enable `withHostTest {}` on :core:app-version (was missing — the test never
  would have run there as-is).
- Move AppVersionManagerTest from
    core/test/src/commonTest/kotlin/xyz/ksharma/core/test/appversion/
  to
    core/app-version/src/commonTest/kotlin/xyz/ksharma/krail/core/appversion/
  rewriting the package and swapping
    `import xyz.ksharma.core.test.fakes.Fake*` ->
    `import xyz.ksharma.krail.core.testing.fakes.Fake*`.
- Wire :core:app-version commonTest to `implementation(projects.core.testing)`
  plus libs.test.kotlin + libs.test.kotlinxCoroutineTest. The kotlin-test
  `api` on :core:testing's commonMain isn't visible to consumer commonTest
  in KMP, so each consumer adds the test framework directly (project convention,
  see feature/track/state).
- :core:test still compiles and its other tests still run; full deletion is
  Stack D2 once every consumer has migrated.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>