### PR TITLE
build(snapshot): add krail.snapshot.testing convention plugin

### DIFF
--- a/gradle/build-logic/convention/build.gradle.kts
+++ b/gradle/build-logic/convention/build.gradle.kts
@@ -92,5 +92,14 @@ gradlePlugin {
             id = "krail.android.kmp.library"
             implementationClass = "xyz.ksharma.krail.gradle.AndroidKmpLibraryConventionPlugin"
         }
+
+        /**
+         * One-line snapshot-testing adoption: applies the roborazzi plugin and wires the
+         * `:core:snapshot-testing(-annotations)` deps into commonMain / androidHostTest.
+         */
+        register("snapshotTesting") {
+            id = "krail.snapshot.testing"
+            implementationClass = "xyz.ksharma.krail.gradle.SnapshotTestingConventionPlugin"
+        }
     }
 }

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/SnapshotTestingConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/SnapshotTestingConventionPlugin.kt
@@ -1,0 +1,87 @@
+package xyz.ksharma.krail.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+/**
+ * One-line snapshot-testing adoption for KRAIL modules.
+ *
+ * Before:
+ * ```
+ * plugins {
+ *     alias(libs.plugins.roborazzi)            // 1
+ *     // …other plugins
+ * }
+ * kotlin {
+ *     sourceSets {
+ *         commonMain.dependencies {
+ *             implementation(projects.core.snapshotTestingAnnotations)   // 2
+ *         }
+ *         getByName("androidHostTest").dependencies {
+ *             implementation(projects.core.snapshotTesting)              // 3
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * After:
+ * ```
+ * plugins {
+ *     alias(libs.plugins.krail.snapshot.testing)                          // single line
+ *     // …other plugins
+ * }
+ * ```
+ *
+ * Still required in the module (intentionally — the convention plugins stay thin and
+ * don't touch `androidLibrary {}`):
+ * ```
+ * androidLibrary {
+ *     withHostTest {
+ *         isIncludeAndroidResources = true        // Roborazzi needs Android resources.
+ *     }
+ *     androidResources {
+ *         enable = true                           // MANDATORY for AGP 9.
+ *     }
+ * }
+ * sourceSets {
+ *     getByName("androidHostTest") {
+ *         kotlin.srcDir("src/androidHostTest/kotlin")  // explicit srcDir for clarity
+ *     }
+ * }
+ * ```
+ *
+ * Then write `<Module>SnapshotTest.kt` extending `BaseSnapshotTest`, annotate the
+ * `@PreviewComponent` / `@PreviewScreen` previews with `@ScreenshotTest`, and run
+ * `./gradlew :module:recordRoborazziAndroidHostTest` to capture goldens.
+ */
+class SnapshotTestingConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("io.github.takahirom.roborazzi")
+
+            // Wire the deps once the KMP extension is configured (which happens after the
+            // module's `plugins { alias(libs.plugins.krail.kotlin.multiplatform) }` block).
+            pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+                extensions.configure<KotlinMultiplatformExtension> {
+                    sourceSets.named("commonMain") {
+                        dependencies {
+                            implementation(project(":core:snapshot-testing-annotations"))
+                        }
+                    }
+                    // androidHostTest source set is created by `withHostTest {}` in the
+                    // module's androidLibrary block — match by name (`configureEach` is
+                    // lazy, so it fires whether the source set exists yet or not).
+                    sourceSets.configureEach {
+                        if (name == "androidHostTest") {
+                            dependencies {
+                                implementation(project(":core:snapshot-testing"))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -201,3 +201,4 @@ krail-compose-multiplatform = { id = "krail.compose.multiplatform", version = "u
 krail-android-kmp-library = { id = "krail.android.kmp.library", version = "unspecified" }
 krail-kotlin-multiplatform = { id = "krail.kotlin.multiplatform", version = "unspecified" }
 krail-maplibre = { id = "krail.maplibre", version = "unspecified" }
+krail-snapshot-testing = { id = "krail.snapshot.testing", version = "unspecified" }

--- a/taj/build.gradle.kts
+++ b/taj/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.krail.kotlin.multiplatform)
     alias(libs.plugins.krail.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.roborazzi)
+    alias(libs.plugins.krail.snapshot.testing)
     alias(libs.plugins.krail.android.kmp.library)
 }
 
@@ -48,8 +48,7 @@ kotlin {
                 implementation(libs.material.icons.core)
                 implementation(libs.compose.ui.tooling.preview)
 
-                // Lightweight annotation only - no Roborazzi/Robolectric bloat!
-                implementation(projects.core.snapshotTestingAnnotations)
+                // `:core:snapshot-testing-annotations` is added by `krail.snapshot.testing`.
             }
         }
 
@@ -60,12 +59,10 @@ kotlin {
             }
         }
 
-        // Test infrastructure with all the heavy dependencies
+        // `:core:snapshot-testing` is added by `krail.snapshot.testing`; this srcDir
+        // declaration is kept explicit so the host-test sources are unambiguous.
         getByName("androidHostTest") {
             kotlin.srcDir("src/androidHostTest/kotlin")
-            dependencies {
-                implementation(projects.core.snapshotTesting)
-            }
         }
 
         androidMain.dependencies {


### PR DESCRIPTION
Pulls the repeated snapshot-testing boilerplate (roborazzi plugin alias +
both :core:snapshot-testing(-annotations) module deps) into a single
convention plugin so future modules adopt snapshot coverage with one line.

Plugin behaviour:
- Applies io.github.takahirom.roborazzi.
- Adds :core:snapshot-testing-annotations to commonMain (the lightweight
  @ScreenshotTest annotation).
- Adds :core:snapshot-testing to androidHostTest (the heavy
  BaseSnapshotTest + ComposablePreviewScanner + Robolectric infra).
- Intentionally does NOT touch `androidLibrary {}` — keeps the convention
  plugins thin, per the same rule the test-wiring plugin follows. Modules
  still declare `withHostTest { isIncludeAndroidResources = true }` and
  `androidResources { enable = true }` (mandatory for AGP 9).

Proven by porting :taj — the existing snapshot suite (~189 PNGs) still
records and verifies via Roborazzi after the swap. `:feature:trip-planner:ui`
is left on the inline wiring for now to keep this PR focused; it migrates in
a follow-up. Onboarding the 6 uncovered UI modules (park-ride/ui,
debug-settings/ui, discover/ui, social/ui, info-tile/ui, core/maps/ui) ships
as separate per-module PRs so each golden-image batch stays reviewable.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>