### PR TITLE
build(snapshot): in-code excludedPreviewNames for BaseSnapshotTest

### DIFF
--- a/core/snapshot-testing/src/androidMain/kotlin/xyz/ksharma/krail/core/snapshot/BaseSnapshotTest.kt
+++ b/core/snapshot-testing/src/androidMain/kotlin/xyz/ksharma/krail/core/snapshot/BaseSnapshotTest.kt
@@ -80,6 +80,23 @@ abstract class BaseSnapshotTest {
         get() = SnapshotDefaults.testDarkMode
 
     /**
+     * Preview method names to SKIP — Robolectric hangs on composables that drive infinite
+     * animations (e.g. shimmer, indeterminate loading dots) because the snapshot capture
+     * never sees a stable frame. Listing them here replaces the old "documented in the
+     * README" workaround, so the skip lives next to the test and won't drift.
+     *
+     * Match is by exact preview function name (the value the scanner reports), e.g.
+     * `"PreviewLoadingDotsPill_Visible"`. Override per module:
+     * ```
+     * override val excludedPreviewNames = setOf(
+     *     "PreviewLoadingDotsPill_Visible",
+     *     "LoadingEmojiAnimPreview",
+     * )
+     * ```
+     */
+    open val excludedPreviewNames: Set<String> = emptySet()
+
+    /**
      * Main test method that scans and generates all snapshots.
      * Call this from your @Test method.
      */
@@ -95,9 +112,16 @@ abstract class BaseSnapshotTest {
             scanner
         }
 
-        val previews = scannerWithPrivacy.getPreviews()
+        val allPreviews = scannerWithPrivacy.getPreviews()
+        val (skipped, previews) = allPreviews.partition { it.methodName in excludedPreviewNames }
 
-        println("Found ${previews.size} previews with @ScreenshotTest in $packageToScan")
+        println("Found ${allPreviews.size} previews with @ScreenshotTest in $packageToScan")
+        if (skipped.isNotEmpty()) {
+            // Explicit, single-line skip log per excluded preview makes drift obvious if
+            // an entry in `excludedPreviewNames` no longer matches a real preview.
+            println("Skipping ${skipped.size} preview(s) via excludedPreviewNames:")
+            skipped.forEach { println("  - ${it.methodName}") }
+        }
 
         previews.forEach { preview ->
             capturePreviewSnapshots(preview)


### PR DESCRIPTION
BaseSnapshotTest: add `excludedPreviewNames: Set<String>` (default empty) that
modules override to skip composables Robolectric hangs on (infinite shimmer,
indeterminate loading dots). Replaces the today's "documented exclusions in
the snapshot-testing README" workaround so the skip lives next to the test
class and won't drift away from reality. Skip log is printed so a now-stale
entry is obvious.

CI yaml stays untouched on purpose: an explicit `verifyRoborazziAndroidHostTest`
step would force snapshot verify on every PR before the suite has been
de-flaked / re-recorded on Linux. Deferred until a follow-up that adds a
workflow_dispatch record-and-commit workflow and stabilises the non-
deterministic preview families (PrimaryButton*, AddLabelBottomSheet_*).

A real per-test timeout would need running each capture on a worker thread
with `ExecutorService.submit(...).get(timeout)`, which fights Robolectric's
main-thread looper. Deferred to a focused PR with its own iteration loop.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>