### PR TITLE
fix(departures): re-enable DepartureBoardRepositoryTest via krailRunTest (closes #1601)

### DIFF
--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/KrailTestScope.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/KrailTestScope.kt
@@ -61,6 +61,19 @@ class KrailTestScope internal constructor(
     val mainDispatcher: CoroutineDispatcher = StandardTestDispatcher(scheduler, name = "krail-main")
 
     /**
+     * Drain all coroutines whose dispatch time is the *current* virtual instant.
+     * Does NOT advance virtual time, so it's safe against infinite pollers (unlike
+     * `advanceUntilIdle()`, which is deliberately NOT exposed here — see [pumpOnce]).
+     *
+     * Use this after a one-shot launch (e.g. `repo.refresh(...)`, the first fetch on a
+     * fresh `pollStop` collection) where you want the work to complete without time
+     * passing.
+     */
+    fun runCurrent() {
+        scheduler.runCurrent()
+    }
+
+    /**
      * Bounded advance — the ONLY safe pattern against `channelFlow` / `while(true){…}`
      * pollers. Advances [interval] of virtual time, then drains the work scheduled at
      * exactly that instant. Never use `advanceUntilIdle()` against an infinite poller

--- a/feature/departures/ui/build.gradle.kts
+++ b/feature/departures/ui/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
                 implementation(libs.test.turbine)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(projects.core.analytics)
+                implementation(projects.core.testing)
             }
         }
     }

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepositoryTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepositoryTest.kt
@@ -2,98 +2,75 @@ package xyz.ksharma.krail.departures.ui
 
 import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.core.testing.fakes.FakeDeparturesService
 import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
-import xyz.ksharma.krail.departures.network.api.service.DeparturesService
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * DISABLED — these tests have never run successfully.
+ * Re-enabled #1601. Two structural fixes since the original suite shipped @Ignore'd:
  *
- * The suite was added on `main` but `feature/departures/ui` had no `withHostTest {}`,
- * so CI never executed it. This PR enables host tests (for the new DeparturesViewModel
- * analytics tests) and that exposed two pre-existing defects in this suite:
+ *  1. ONE shared scheduler. `krailRunTest` (KrailTestKit, :core:testing) owns the single
+ *     `TestCoroutineScheduler` exposed via `ioDispatcher`. Production
+ *     `DepartureBoardRepository` accepts `ioDispatcher` in its constructor, so passing
+ *     `ioDispatcher` makes the repository's internal launches run on the same virtual
+ *     clock as `runTest`. No more "Detected use of different schedulers" trap.
  *
- *  1. Scheduler mismatch — fixed here: a field-level `StandardTestDispatcher()` created
- *     its own `TestCoroutineScheduler` while bare `runTest {}` created another, tripping
- *     the "Detected use of different schedulers" check on the first `ioDispatcher`
- *     dispatch. Now a single shared `testScheduler` is passed to `runTest(testScheduler)`.
+ *  2. Bounded virtual time. `pollStop` is a `channelFlow { while (true) { delay(...);
+ *     fetch() } }` infinite poller. `advanceUntilIdle()` against this never returns —
+ *     it spun forever and produced a 98 GB Gradle log. The fix is to use only:
+ *       - `runCurrent()` to drain work already scheduled at the *current* virtual instant
+ *         (the first fetch after a fresh collection)
+ *       - `pumpOnce(intervalMs + δ)` to advance time by exactly one refresh window and
+ *         then drain — fires precisely ONE auto-refresh cycle, no more.
+ *     `cancelAndIgnoreRemainingEvents()` on the Turbine block is mandatory so the
+ *     channelFlow is structurally cancelled before the next test inherits a live job.
  *
- *  2. Unbounded virtual time — NOT fixed here: `DepartureBoardRepository.pollStop()` is a
- *     `channelFlow` with an infinite `while (true) { delay(refreshIntervalMs); fetch() }`
- *     loop. Every test calls `advanceUntilIdle()`, which never returns against an
- *     infinite self-rescheduling loop — it spins forever logging each iteration
- *     (observed: a 98 GB Gradle output file). The real fix is to replace
- *     `advanceUntilIdle()` with bounded advancement (`runCurrent()`, and
- *     `advanceTimeBy(...) + runCurrent()` for the auto-refresh test).
- *
- * Tracked in #1601 so this PR stays scoped to analytics + worktree docs.
- * Re-enable by removing the class-level @Ignore once the rewrite lands.
+ * The local `FakeDeparturesService` was removed in favour of the canonical one from
+ * `:core:testing`, which carries the same `response` / `shouldThrow` / `callCount` API.
  */
-@Ignore
 @OptIn(ExperimentalCoroutinesApi::class)
 class DepartureBoardRepositoryTest {
 
-    // Single scheduler shared between runTest and the repository's ioDispatcher.
-    // Passing it into runTest(testScheduler) keeps both on the same virtual clock —
-    // a field-level StandardTestDispatcher() would create its own scheduler and
-    // trip the "Detected use of different schedulers" check on first dispatch.
-    private val testScheduler = TestCoroutineScheduler()
-    private val testDispatcher = StandardTestDispatcher(testScheduler)
-
-    // Minimal config with a short refresh interval so tests don't wait 30 s.
+    // Minimal config with a short refresh interval so tests don't wait 30 s of virtual time.
     private val testConfig = DepartureBoardConfig(
-        refreshIntervalMs = 1_000L,
-        previousDeparturesWindowMinutes = 30L,
-    )
-
-    private fun makeRepo(service: DeparturesService) = DepartureBoardRepository(
-        departuresService = service,
-        ioDispatcher = testDispatcher,
-        config = testConfig,
+        refreshIntervalMs = REFRESH_INTERVAL_MS,
+        previousDeparturesWindowMinutes = PREV_WINDOW_MINUTES,
     )
 
     // ── pollStop — initial fetch ──────────────────────────────────────────────
 
     @Test
-    fun `Given no cached data When pollStop collected Then emits loading then success`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 3))
-            val repo = makeRepo(service)
+    fun `Given no cached data When pollStop collected Then emits loading then success`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 3))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.pollStop(STOP_A).test {
-                // loading
-                val loading = awaitItem()
-                assertTrue(loading.isLoading, "Should show full loading when no cached data")
+        repo.pollStop(STOP_A).test {
+            val loading = awaitItem()
+            assertTrue(loading.isLoading, "Should show full loading when no cached data")
 
-                advanceUntilIdle()
+            runCurrent()
 
-                val success = awaitItem()
-                assertFalse(success.isLoading)
-                assertFalse(success.isError)
-                assertEquals(3, success.departures.size)
+            val success = awaitItem()
+            assertFalse(success.isLoading)
+            assertFalse(success.isError)
+            assertEquals(3, success.departures.size)
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `Given no cached data When API fails Then emits error state`() = runTest(testScheduler) {
+    fun `Given no cached data When API fails Then emits error state`() = krailRunTest {
         val service = FakeDeparturesService(shouldThrow = true)
-        val repo = makeRepo(service)
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
         repo.pollStop(STOP_A).test {
             awaitItem() // loading
-
-            advanceUntilIdle()
+            runCurrent()
 
             val error = awaitItem()
             assertFalse(error.isLoading)
@@ -106,71 +83,73 @@ class DepartureBoardRepositoryTest {
     // ── pollStop — cancellation clears loading state ──────────────────────────
 
     @Test
-    fun `Given pollStop collected When collection cancelled Then loading flags cleared`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
+    fun `Given pollStop collected When collection cancelled Then loading flags cleared`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 1))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading — cancelled mid-flight
-                cancelAndIgnoreRemainingEvents()
-            }
-            advanceUntilIdle()
-
-            // After cancellation, cache should have isLoading=false
-            repo.observeStop(STOP_A).test {
-                val state = awaitItem()
-                assertFalse(state.isLoading, "isLoading must be cleared after pollStop cancelled")
-                assertFalse(state.silentLoading, "silentLoading must be cleared after pollStop cancelled")
-                cancelAndIgnoreRemainingEvents()
-            }
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading — cancelled mid-flight
+            cancelAndIgnoreRemainingEvents()
         }
+        runCurrent()
+
+        // After cancellation, cache should have isLoading=false.
+        repo.observeStop(STOP_A).test {
+            val state = awaitItem()
+            assertFalse(state.isLoading, "isLoading must be cleared after pollStop cancelled")
+            assertFalse(state.silentLoading, "silentLoading must be cleared after pollStop cancelled")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 
     // ── pollStop — auto-refresh loop ──────────────────────────────────────────
 
     @Test
-    fun `Given active pollStop When refresh interval elapses Then API is called again`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
+    fun `Given active pollStop When refresh interval elapses Then API is called again`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 1))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // first success
-                val callsAfterFirst = service.callCount
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // first success
+            val callsAfterFirst = service.callCount
 
-                advanceTimeBy(testConfig.refreshIntervalMs + 100)
-                advanceUntilIdle()
+            pumpOnce(REFRESH_INTERVAL_MS + EXTRA_DELTA_MS)
 
-                assertTrue(service.callCount > callsAfterFirst, "Auto-refresh should fire after interval elapses")
-                cancelAndIgnoreRemainingEvents()
-            }
+            assertTrue(
+                service.callCount > callsAfterFirst,
+                "Auto-refresh should fire after interval elapses",
+            )
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ── pollStop — refresh window (cache hit) ─────────────────────────────────
 
     @Test
     fun `Given recent successful fetch When pollStop re-collected quickly Then waits for window before fetch`() =
-        runTest(testScheduler) {
+        krailRunTest {
             val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
+            val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            // First collection — fetches immediately
+            // First collection — fetches immediately.
             repo.pollStop(STOP_A).test {
                 awaitItem() // loading
-                advanceUntilIdle()
+                runCurrent()
                 awaitItem() // success
                 cancelAndIgnoreRemainingEvents()
             }
             val callsAfterFirst = service.callCount
 
-            // Re-collect immediately — still within the refresh window
+            // Re-collect immediately — still within the refresh window. Must NOT call
+            // `pumpOnce` here: that would advance virtual time and fire the auto-refresh.
             repo.pollStop(STOP_A).test {
-                // Should NOT emit a new loading state (has cached data)
-                advanceUntilIdle()
-                // No new fetch should have fired yet
-                assertEquals(callsAfterFirst, service.callCount, "No immediate re-fetch within the refresh window")
+                runCurrent()
+                assertEquals(
+                    callsAfterFirst, service.callCount,
+                    "No immediate re-fetch within the refresh window",
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -178,34 +157,33 @@ class DepartureBoardRepositoryTest {
     // ── observeStop — reads cache without polling ─────────────────────────────
 
     @Test
-    fun `Given no active polling When observeStop collected Then emits idle state — no API call`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 2))
-            val repo = makeRepo(service)
+    fun `Given no active polling When observeStop collected Then emits idle state — no API call`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 2))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.observeStop(STOP_A).test {
-                val initial = awaitItem()
-                assertFalse(initial.isLoading, "observeStop should not trigger loading")
-                assertEquals(0, service.callCount, "observeStop must not call the API")
-                cancelAndIgnoreRemainingEvents()
-            }
+        repo.observeStop(STOP_A).test {
+            val initial = awaitItem()
+            assertFalse(initial.isLoading, "observeStop should not trigger loading")
+            assertEquals(0, service.callCount, "observeStop must not call the API")
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ── refresh ───────────────────────────────────────────────────────────────
 
     @Test
-    fun `Given cached data When refresh called Then API is called immediately`() = runTest(testScheduler) {
+    fun `Given cached data When refresh called Then API is called immediately`() = krailRunTest {
         val service = FakeDeparturesService(response = buildResponse(count = 1))
-        val repo = makeRepo(service)
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
         repo.pollStop(STOP_A).test {
             awaitItem() // loading
-            advanceUntilIdle()
+            runCurrent()
             awaitItem() // success
             val callsBefore = service.callCount
 
             repo.refresh(STOP_A)
-            advanceUntilIdle()
+            runCurrent()
 
             assertEquals(callsBefore + 1, service.callCount, "refresh should trigger one extra API call")
             cancelAndIgnoreRemainingEvents()
@@ -215,180 +193,173 @@ class DepartureBoardRepositoryTest {
     // ── loadPreviousDepartures ────────────────────────────────────────────────
 
     @Test
-    fun `Given loadPreviousDepartures called When API succeeds Then previousDepartures populated`() =
-        runTest(testScheduler) {
-            val pastTime = "2020-01-01T00:00:00Z"
-            val service = FakeDeparturesService(response = buildResponse(count = 2, plannedTime = pastTime))
-            val repo = makeRepo(service)
+    fun `Given loadPreviousDepartures called When API succeeds Then previousDepartures populated`() = krailRunTest {
+        val pastTime = "2020-01-01T00:00:00Z"
+        val service = FakeDeparturesService(response = buildResponse(count = 2, plannedTime = pastTime))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // success
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // success
 
-                repo.loadPreviousDepartures(STOP_A)
-                advanceUntilIdle()
+            repo.loadPreviousDepartures(STOP_A)
+            runCurrent()
 
-                val loading = awaitItem()
-                assertTrue(loading.isPreviousLoading)
+            val loading = awaitItem()
+            assertTrue(loading.isPreviousLoading)
 
-                val done = awaitItem()
-                assertFalse(done.isPreviousLoading)
-                assertTrue(done.previousDepartures.isNotEmpty(), "Previous departures should be populated")
+            val done = awaitItem()
+            assertFalse(done.isPreviousLoading)
+            assertTrue(done.previousDepartures.isNotEmpty(), "Previous departures should be populated")
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     @Test
-    fun `Given loadPreviousDepartures called When API fails Then isPreviousLoading is reset to false`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
+    fun `Given loadPreviousDepartures called When API fails Then isPreviousLoading is reset to false`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 1))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // success
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // success
 
-                service.shouldThrow = true
+            service.shouldThrow = true
 
-                repo.loadPreviousDepartures(STOP_A)
-                advanceUntilIdle()
+            repo.loadPreviousDepartures(STOP_A)
+            runCurrent()
 
-                val loading = awaitItem()
-                assertTrue(loading.isPreviousLoading)
+            val loading = awaitItem()
+            assertTrue(loading.isPreviousLoading)
 
-                val done = awaitItem()
-                assertFalse(done.isPreviousLoading, "isPreviousLoading must be cleared even on failure")
+            val done = awaitItem()
+            assertFalse(done.isPreviousLoading, "isPreviousLoading must be cleared even on failure")
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ── silent-loading cleared on cancellation ────────────────────────────────
 
     @Test
-    fun `Given silent refresh in flight When collection cancelled Then silentLoading cleared`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 1))
-            val repo = makeRepo(service)
+    fun `Given silent refresh in flight When collection cancelled Then silentLoading cleared`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 1))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            // First collect — populates cache so next collect does a silent refresh
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // success
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            // Second collect — cancels while silentLoading may be in flight
-            repo.pollStop(STOP_A).test {
-                cancelAndIgnoreRemainingEvents()
-            }
-            advanceUntilIdle()
-
-            repo.observeStop(STOP_A).test {
-                val state = awaitItem()
-                assertFalse(state.silentLoading, "silentLoading must be cleared after cancellation")
-                cancelAndIgnoreRemainingEvents()
-            }
+        // First collect — populates cache so next collect does a silent refresh.
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // success
+            cancelAndIgnoreRemainingEvents()
         }
+
+        // Second collect — cancels while silentLoading may be in flight.
+        repo.pollStop(STOP_A).test {
+            cancelAndIgnoreRemainingEvents()
+        }
+        runCurrent()
+
+        repo.observeStop(STOP_A).test {
+            val state = awaitItem()
+            assertFalse(state.silentLoading, "silentLoading must be cleared after cancellation")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 
     // ── cache isolation ───────────────────────────────────────────────────────
 
     @Test
-    fun `Given two stops polled separately When each succeeds Then their states are independent`() =
-        runTest(testScheduler) {
-            val service = FakeDeparturesService(response = buildResponse(count = 2))
-            val repo = makeRepo(service)
+    fun `Given two stops polled separately When each succeeds Then their states are independent`() = krailRunTest {
+        val service = FakeDeparturesService(response = buildResponse(count = 2))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            // Poll STOP_A — 2 departures
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // success
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            // Poll STOP_B — 4 departures (change response)
-            service.response = buildResponse(count = 4)
-            repo.pollStop(STOP_B).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // success
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            // STOP_A should still have its original 2 departures
-            repo.observeStop(STOP_A).test {
-                val stateA = awaitItem()
-                assertEquals(2, stateA.departures.size, "STOP_A state must not be affected by STOP_B poll")
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            // STOP_B should have 4 departures
-            repo.observeStop(STOP_B).test {
-                val stateB = awaitItem()
-                assertEquals(4, stateB.departures.size, "STOP_B state should reflect its own poll")
-                cancelAndIgnoreRemainingEvents()
-            }
+        // Poll STOP_A — 2 departures.
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // success
+            cancelAndIgnoreRemainingEvents()
         }
+
+        // Poll STOP_B — 4 departures (change response).
+        service.response = buildResponse(count = 4)
+        repo.pollStop(STOP_B).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // success
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // STOP_A should still have its original 2 departures.
+        repo.observeStop(STOP_A).test {
+            val stateA = awaitItem()
+            assertEquals(2, stateA.departures.size, "STOP_A state must not be affected by STOP_B poll")
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        repo.observeStop(STOP_B).test {
+            val stateB = awaitItem()
+            assertEquals(4, stateB.departures.size, "STOP_B state should reflect its own poll")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 
     // ── loadPreviousDepartures — cache hit ────────────────────────────────────
 
     @Test
-    fun `Given loadPreviousDepartures succeeded When called again quickly Then no extra API call`() =
-        runTest(testScheduler) {
-            val pastTime = "2020-01-01T00:00:00Z"
-            val service = FakeDeparturesService(response = buildResponse(count = 2, plannedTime = pastTime))
-            val repo = makeRepo(service)
+    fun `Given loadPreviousDepartures succeeded When called again quickly Then no extra API call`() = krailRunTest {
+        val pastTime = "2020-01-01T00:00:00Z"
+        val service = FakeDeparturesService(response = buildResponse(count = 2, plannedTime = pastTime))
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
-            repo.pollStop(STOP_A).test {
-                awaitItem() // loading
-                advanceUntilIdle()
-                awaitItem() // success
+        repo.pollStop(STOP_A).test {
+            awaitItem() // loading
+            runCurrent()
+            awaitItem() // success
 
-                repo.loadPreviousDepartures(STOP_A)
-                advanceUntilIdle()
+            repo.loadPreviousDepartures(STOP_A)
+            runCurrent()
 
-                awaitItem() // isPreviousLoading = true
-                awaitItem() // done — previousDepartures populated
+            awaitItem() // isPreviousLoading = true
+            awaitItem() // done — previousDepartures populated
 
-                val callsAfterFirst = service.callCount
+            val callsAfterFirst = service.callCount
 
-                // Second call within the refresh window — cache hit: returns immediately without
-                // suspending. Do NOT call advanceUntilIdle() here — that would advance virtual
-                // time, fire the auto-refresh loop, and inflate callCount.
-                repo.loadPreviousDepartures(STOP_A)
+            // Second call within the refresh window — cache hit: returns immediately
+            // without suspending. Do NOT `pumpOnce` here — that would advance virtual
+            // time, fire the auto-refresh loop, and inflate callCount.
+            repo.loadPreviousDepartures(STOP_A)
 
-                assertEquals(
-                    callsAfterFirst,
-                    service.callCount,
-                    "Second loadPreviousDepartures within the refresh window must not call the API",
-                )
+            assertEquals(
+                callsAfterFirst, service.callCount,
+                "Second loadPreviousDepartures within the refresh window must not call the API",
+            )
 
-                cancelAndIgnoreRemainingEvents()
-            }
+            cancelAndIgnoreRemainingEvents()
         }
+    }
 
     // ── fetchDepartures — error with existing data ────────────────────────────
 
     @Test
-    fun `Given cached departures When refresh fails Then isError stays false`() = runTest(testScheduler) {
+    fun `Given cached departures When refresh fails Then isError stays false`() = krailRunTest {
         val service = FakeDeparturesService(response = buildResponse(count = 2))
-        val repo = makeRepo(service)
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
         repo.pollStop(STOP_A).test {
             awaitItem() // loading
-            advanceUntilIdle()
+            runCurrent()
             awaitItem() // success (2 departures cached)
 
             service.shouldThrow = true
             repo.refresh(STOP_A)
-            advanceUntilIdle()
+            runCurrent()
 
-            // silentLoading cleared; departures preserved; isError stays false
+            // silentLoading cleared; departures preserved; isError stays false.
             val afterFailure = awaitItem()
             assertFalse(afterFailure.isError, "isError must stay false when cached data exists")
             assertEquals(2, afterFailure.departures.size, "Cached departures must survive a failed refresh")
@@ -400,18 +371,18 @@ class DepartureBoardRepositoryTest {
     // ── observeStop — reflects pollStop results ───────────────────────────────
 
     @Test
-    fun `Given pollStop completed When observeStop collected Then returns cached data`() = runTest(testScheduler) {
+    fun `Given pollStop completed When observeStop collected Then returns cached data`() = krailRunTest {
         val service = FakeDeparturesService(response = buildResponse(count = 3))
-        val repo = makeRepo(service)
+        val repo = DepartureBoardRepository(service, ioDispatcher, testConfig)
 
         repo.pollStop(STOP_A).test {
             awaitItem() // loading
-            advanceUntilIdle()
+            runCurrent()
             awaitItem() // success
             cancelAndIgnoreRemainingEvents()
         }
 
-        // observeStop should see the data that pollStop fetched
+        // observeStop should see the data that pollStop fetched.
         repo.observeStop(STOP_A).test {
             val state = awaitItem()
             assertEquals(3, state.departures.size, "observeStop should reflect data fetched by pollStop")
@@ -447,27 +418,8 @@ class DepartureBoardRepositoryTest {
     private companion object {
         const val STOP_A = "10111010"
         const val STOP_B = "10111020"
-    }
-}
-
-/**
- * Fake [DeparturesService] that returns a configurable response or throws.
- */
-class FakeDeparturesService(
-    var response: DepartureMonitorResponse = DepartureMonitorResponse(stopEvents = emptyList()),
-    var shouldThrow: Boolean = false,
-) : DeparturesService {
-
-    var callCount = 0
-        private set
-
-    override suspend fun departures(
-        stopId: String,
-        date: String?,
-        time: String?,
-    ): DepartureMonitorResponse {
-        callCount++
-        if (shouldThrow) throw RuntimeException("Fake network error")
-        return response
+        const val REFRESH_INTERVAL_MS = 1_000L
+        const val EXTRA_DELTA_MS = 100L
+        const val PREV_WINDOW_MINUTES = 30L
     }
 }

--- a/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModelTest.kt
+++ b/feature/departures/ui/src/commonTest/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModelTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.test.setMain
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
+import xyz.ksharma.krail.core.testing.fakes.FakeDeparturesService
 import xyz.ksharma.krail.departures.network.api.model.DepartureMonitorResponse
 import xyz.ksharma.krail.departures.ui.state.DeparturesUiEvent
 import kotlin.test.AfterTest


### PR DESCRIPTION
The 11-test suite shipped @Ignore'd: every test ran `advanceUntilIdle()`
against `pollStop` (a `channelFlow { while (true) { delay; fetch } }`
infinite poller), which spun forever and produced a 98 GB Gradle log.

Now green. Rewrite uses `:core:testing`'s krailRunTest harness:

- `krailRunTest { … }` owns the one shared TestCoroutineScheduler, eliminating
  the previous "Detected use of different schedulers" hazard. Production
  `DepartureBoardRepository` already accepts an `ioDispatcher` constructor
  arg, so no production code change is needed — tests pass
  `scope.ioDispatcher`.
- `runCurrent()` (new on KrailTestScope — added here because this is its
  first real consumer) drains coroutines at the *current* virtual instant
  without advancing time. Safe against infinite pollers; replaces
  `advanceUntilIdle()` on every one-shot fetch / refresh / cancellation
  scenario.
- `pumpOnce(1100L)` fires exactly ONE refresh cycle on the auto-refresh test
  — bounded `advanceTimeBy + runCurrent`.
- `advanceUntilIdle()` is deliberately NOT exposed on KrailTestScope so this
  anti-pattern can't sneak back in.
- `cancelAndIgnoreRemainingEvents()` is mandatory on every Turbine block so
  the channelFlow is structurally cancelled before the next test.

Local FakeDeparturesService removed in favour of the canonical
`:core:testing` one (same API surface). DeparturesViewModelTest's import
updated to match. :core:testing added to feature/departures/ui's commonTest
deps.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>