### PR TITLE
build(testing): port remaining canonical fakes for C-stack migrations

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -61,6 +61,16 @@ kotlin {
                 api(projects.feature.departures.network) // DeparturesService + DepartureMonitorResponse
                 api(projects.core.appInfo) // AppInfo + AppInfoProvider + DevicePlatformType
                 api(projects.core.appVersion) // AppVersionManager + AppVersionUpdateState
+                api(projects.core.festival) // FestivalManager + Festival model
+                api(projects.core.share) // ShareManager
+                api(projects.core.maps.data) // NearbyStop + NearbyStopsRepository
+                api(projects.infoTile.network.api) // InfoTileManager + db extensions
+                api(projects.infoTile.state) // InfoTileData
+                api(projects.feature.parkRide.network) // NswParkRideFacilityManager + CarPark models
+                api(projects.platform.ops) // PlatformOps
+                api(projects.core.transport) // TransportMode (for stop.transportModes in fakes)
+
+                api(libs.kotlinx.datetime) // LocalDate used by FakeFestivalManager
             }
         }
 

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/builders/ParkRideTestData.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/builders/ParkRideTestData.kt
@@ -1,0 +1,63 @@
+package xyz.ksharma.krail.core.testing.builders
+
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.model.Location
+import xyz.ksharma.krail.park.ride.network.model.Occupancy
+import xyz.ksharma.krail.park.ride.network.model.Zone
+
+fun buildOccupancy(
+    loop: String? = "32707",
+    total: String? = "200",
+    monthlies: String? = null,
+    openGate: String? = null,
+    transients: String? = "100",
+) = Occupancy(loop, total, monthlies, openGate, transients)
+
+fun buildZone(
+    spots: String = "774",
+    zoneId: String = "1",
+    occupancy: Occupancy = buildOccupancy(),
+    zoneName: String = "SYD392 Bella Vista Car Park",
+    parentZoneId: String = "0",
+) = Zone(spots, zoneId, occupancy, zoneName, parentZoneId)
+
+fun buildLocation(
+    suburb: String = "Bella Vista",
+    address: String = "Byles Place",
+    latitude: String = "-33.727438",
+    longitude: String = "150.941761",
+) = Location(suburb, address, latitude, longitude)
+
+// All 11 params defaulted; consumers override only what they care about.
+@Suppress("LongParameterList")
+fun buildCarParkFacilityDetailResponse(
+    tsn: String = "2153478",
+    time: String = "803037917",
+    spots: String = "774",
+    zones: List<Zone> = listOf(buildZone()),
+    parkID: Int = 1,
+    location: Location = buildLocation(),
+    occupancy: Occupancy = buildOccupancy(),
+    messageDate: String = "2025-06-12T20:05:17",
+    facilityId: String = "31",
+    facilityName: String = "Park&Ride - Bella Vista",
+    tfnswFacilityId: String = "2153478TPR001",
+) = CarParkFacilityDetailResponse(
+    tsn,
+    time,
+    spots,
+    zones,
+    parkID,
+    location,
+    occupancy,
+    messageDate,
+    facilityId,
+    facilityName,
+    tfnswFacilityId,
+)
+
+val facilityResponse = buildCarParkFacilityDetailResponse(
+    facilityName = "Test Facility",
+    spots = "1000",
+    occupancy = buildOccupancy(transients = "200"),
+)

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeDiscoverCardSeenPreferences.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeDiscoverCardSeenPreferences.kt
@@ -1,0 +1,32 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.sandook.DiscoverCardSeenPreferences
+
+class FakeDiscoverCardSeenPreferences : DiscoverCardSeenPreferences {
+    private val seenCards = mutableSetOf<String>()
+
+    override fun insertCardSeen(cardId: String) {
+        seenCards.add(cardId)
+    }
+
+    override fun deleteCardSeenById(cardId: String) {
+        seenCards.remove(cardId)
+    }
+
+    override fun deleteAllCardSeen() {
+        seenCards.clear()
+    }
+
+    override fun selectAllCardSeen(): List<String> {
+        return seenCards.toList()
+    }
+
+    // Test helper methods
+    fun markAsSeen(vararg cardIds: String) {
+        cardIds.forEach { seenCards.add(it) }
+    }
+
+    fun clear() {
+        seenCards.clear()
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeFestivalManager.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeFestivalManager.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import kotlinx.datetime.LocalDate
+import xyz.ksharma.krail.core.festival.FestivalManager
+import xyz.ksharma.krail.core.festival.model.Festival
+
+class FakeFestivalManager : FestivalManager {
+    var festivalForDate: MutableMap<LocalDate, Festival?> = mutableMapOf()
+    var emojiForDate: MutableMap<LocalDate, String> = mutableMapOf()
+
+    override fun festivalOnDate(date: LocalDate): Festival? {
+        return festivalForDate[date]
+    }
+
+    override fun emojiForDate(date: LocalDate): String {
+        return emojiForDate[date] ?: "😀"
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeImageBitmap.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeImageBitmap.kt
@@ -1,0 +1,26 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import androidx.compose.ui.graphics.colorspace.ColorSpace
+import androidx.compose.ui.graphics.colorspace.ColorSpaces
+
+class FakeImageBitmap : ImageBitmap {
+    override val width = 1
+    override val height = 1
+    override val config = ImageBitmapConfig.Argb8888
+    override val hasAlpha = true
+    override val colorSpace: ColorSpace = ColorSpaces.Srgb
+
+    override fun readPixels(
+        buffer: IntArray,
+        startX: Int,
+        startY: Int,
+        width: Int,
+        height: Int,
+        bufferOffset: Int,
+        stride: Int,
+    ) = Unit
+
+    override fun prepareToDraw() = Unit
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeInfoTileManager.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeInfoTileManager.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.info.tile.network.api.InfoTileManager
+import xyz.ksharma.krail.info.tile.state.InfoTileData
+
+class FakeInfoTileManager : InfoTileManager {
+
+    private val tiles: MutableList<InfoTileData> = mutableListOf()
+
+    private val dismissedKeys = mutableSetOf<String>()
+
+    override suspend fun getInfoTiles(): List<InfoTileData> {
+        return tiles.filter { it.key !in dismissedKeys }
+            .take(InfoTileManager.MAX_INFO_TILE_COUNT)
+    }
+
+    override fun isInfoTileActive(key: String): Boolean {
+        return key !in dismissedKeys
+    }
+
+    override fun markInfoTileDismissed(infoTileData: InfoTileData) {
+        dismissedKeys.add(infoTileData.key)
+    }
+
+    fun setTiles(newTiles: List<InfoTileData>) {
+        tiles.clear()
+        tiles.addAll(newTiles)
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeNearbyStopsRepository.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeNearbyStopsRepository.kt
@@ -1,0 +1,63 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.core.maps.data.model.NearbyStop
+import xyz.ksharma.krail.core.maps.data.repository.NearbyStopsRepository
+
+class FakeNearbyStopsRepository : NearbyStopsRepository {
+
+    private val stops = mutableListOf<NearbyStop>()
+    var shouldThrowError = false
+    var errorMessage = "Test error"
+
+    fun addStop(stop: NearbyStop) {
+        stops.add(stop)
+    }
+
+    fun clearStops() {
+        stops.clear()
+    }
+
+    override suspend fun getStopsNearby(
+        centerLat: Double,
+        centerLon: Double,
+        radiusKm: Double,
+        productClasses: Set<Int>,
+        maxResults: Int,
+    ): List<NearbyStop> {
+        if (shouldThrowError) {
+            error(errorMessage)
+        }
+
+        // Simple distance-based filtering for testing
+        return stops
+            .filter { stop ->
+                val distance = calculateDistance(centerLat, centerLon, stop.latitude, stop.longitude)
+                distance <= radiusKm
+            }
+            .filter { stop ->
+                if (productClasses.isEmpty()) {
+                    true
+                } else {
+                    stop.transportModes.any { mode ->
+                        productClasses.contains(mode.productClass)
+                    }
+                }
+            }
+            .sortedBy { stop ->
+                calculateDistance(centerLat, centerLon, stop.latitude, stop.longitude)
+            }
+            .take(maxResults)
+    }
+
+    private fun calculateDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        // Simple Euclidean distance for testing (not accurate for real geo calculations).
+        val latDiff = lat2 - lat1
+        val lonDiff = lon2 - lon1
+        return kotlin.math.sqrt(latDiff * latDiff + lonDiff * lonDiff) * APPROX_KM_PER_DEGREE
+    }
+
+    private companion object {
+        // Rough equator-latitude km per 1° — fine for tests, NOT for real geo calcs.
+        const val APPROX_KM_PER_DEGREE = 111.0
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeNswParkRideSandook.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeNswParkRideSandook.kt
@@ -1,0 +1,94 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import xyz.ksharma.krail.sandook.NSWParkRideFacilityDetail
+import xyz.ksharma.krail.sandook.NswParkRideSandook
+import xyz.ksharma.krail.sandook.SavedParkRide
+
+// Intrinsic to faking the production NswParkRideSandook interface. Not refactorable.
+@Suppress("TooManyFunctions")
+class FakeNswParkRideSandook : NswParkRideSandook {
+    private val data = MutableStateFlow<List<NSWParkRideFacilityDetail>>(emptyList())
+    private val savedParkRides = MutableStateFlow<List<SavedParkRide>>(emptyList())
+
+    override fun observeSavedParkRides(): Flow<List<SavedParkRide>> = savedParkRides.asStateFlow()
+
+    override fun getAllParkRideFacilityDetail(): Flow<List<NSWParkRideFacilityDetail>> = data.asStateFlow()
+
+    override fun getByStopIds(stopIds: List<String>): List<NSWParkRideFacilityDetail> =
+        data.value.filter { it.stopId in stopIds }
+
+    override suspend fun insertOrReplace(parkRide: NSWParkRideFacilityDetail) {
+        data.value = data.value.filterNot { it.facilityId == parkRide.facilityId } + parkRide
+    }
+
+    override suspend fun insertOrReplaceAll(parkRides: List<NSWParkRideFacilityDetail>) {
+        val ids = parkRides.map { it.facilityId }.toSet()
+        data.value = data.value.filterNot { it.facilityId in ids } + parkRides
+    }
+
+    override suspend fun deleteAll() {
+        data.value = emptyList()
+    }
+
+    override fun getFacilitiesByStopIdAndSource(
+        stopId: String,
+        source: NswParkRideSandook.Companion.SavedParkRideSource,
+    ): Flow<List<String>> =
+        savedParkRides.asStateFlow().map { list ->
+            list.filter { it.stopId == stopId && it.source == source.value }
+                .map { it.facilityId }
+        }
+
+    override suspend fun insertOrReplaceSavedParkRides(
+        parkRideInfoList: Set<SavedParkRide>,
+        source: NswParkRideSandook.Companion.SavedParkRideSource,
+    ) {
+        val newRides = parkRideInfoList.map { info ->
+            SavedParkRide(
+                stopId = info.stopId,
+                facilityId = info.facilityId,
+                stopName = info.stopName,
+                facilityName = info.facilityName,
+                source = source.value,
+            )
+        }
+
+        val filtered = savedParkRides.value.filterNot { ride ->
+            newRides.any {
+                it.stopId == ride.stopId &&
+                    it.facilityId == ride.facilityId &&
+                    it.source == ride.source
+            }
+        }
+
+        savedParkRides.value = filtered + newRides
+    }
+
+    override suspend fun clearAllSavedParkRidesBySource(source: NswParkRideSandook.Companion.SavedParkRideSource) {
+        savedParkRides.value = savedParkRides.value.filterNot { it.source == source.value }
+    }
+
+    override suspend fun getLastApiCallTimestamp(facilityId: String): Long? {
+        return data.value.firstOrNull { it.facilityId == facilityId }?.timestamp
+    }
+
+    override suspend fun updateApiCallTimestamp(facilityId: String, timestamp: Long) {
+        data.value = data.value.map { detail ->
+            if (detail.facilityId == facilityId) detail.copy(timestamp = timestamp) else detail
+        }
+    }
+
+    override fun getSavedParkRideByFacilityId(facilityId: String): SavedParkRide? {
+        return savedParkRides.value.firstOrNull { it.facilityId == facilityId }
+    }
+
+    override suspend fun deleteSavedParkRide(stopId: String, facilityId: String) {
+        savedParkRides.value = savedParkRides.value.filterNot {
+            it.stopId == stopId && it.facilityId == facilityId
+        }
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeParkRideFacilityManager.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeParkRideFacilityManager.kt
@@ -1,0 +1,33 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+
+class FakeParkRideFacilityManager : NswParkRideFacilityManager {
+
+    var facilities: List<NswParkRideFacility> = listOf(
+        NswParkRideFacility(
+            stopId = "207210",
+            parkRideFacilityId = "6",
+            parkRideName = "Sample Park & Ride 1",
+        ),
+        NswParkRideFacility(
+            stopId = "207211",
+            parkRideFacilityId = "7",
+            parkRideName = "Sample Park & Ride 2",
+        ),
+        NswParkRideFacility(
+            stopId = "2153478",
+            parkRideFacilityId = "31",
+            parkRideName = "Park and Ride - Bella Vista",
+        ),
+    )
+
+    override fun getParkRideFacilities(): List<NswParkRideFacility> {
+        return facilities
+    }
+
+    override fun getParkRideFacilityById(facilityId: String): NswParkRideFacility? {
+        return facilities.find { it.parkRideFacilityId == facilityId }
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeParkRideService.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeParkRideService.kt
@@ -1,0 +1,113 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.model.Location
+import xyz.ksharma.krail.park.ride.network.model.Occupancy
+import xyz.ksharma.krail.park.ride.network.model.ParkingStopBatchResponse
+import xyz.ksharma.krail.park.ride.network.model.Zone
+import xyz.ksharma.krail.park.ride.network.service.ParkRideService
+
+class FakeParkRideService(
+    private val facilityResponses: Map<String, CarParkFacilityDetailResponse> = defaultFacilityResponses,
+) : ParkRideService {
+
+    override suspend fun fetchCarParkFacilities(facilityId: String): Result<CarParkFacilityDetailResponse> {
+        return facilityResponses[facilityId]
+            ?.let { Result.success(it) }
+            ?: Result.failure(IllegalArgumentException("No fake response for facilityId: $facilityId"))
+    }
+
+    override suspend fun fetchCarParkFacilities(): Result<Map<String, String>> {
+        return Result.success(facilityResponses.mapValues { it.value.facilityName })
+    }
+
+    /**
+     * Default fake mirrors the production override-off behaviour: returns
+     * `null` so callers exercise the NSW per-facility fallback. Tests that
+     * need to assert the BFF batch path can subclass or wrap this fake.
+     */
+    override suspend fun fetchAvailabilityForStops(
+        stopIds: List<String>,
+    ): ParkingStopBatchResponse? = null
+
+    companion object {
+        val defaultFacilityResponses = mapOf(
+            "31" to CarParkFacilityDetailResponse(
+                tsn = "2153478",
+                time = "803037917",
+                spots = "774",
+                zones = listOf(
+                    Zone(
+                        spots = "774",
+                        zoneId = "1",
+                        occupancy = Occupancy(
+                            loop = "32707",
+                            total = "200",
+                            monthlies = null,
+                            openGate = null,
+                            transients = "100",
+                        ),
+                        zoneName = "SYD392 Bella Vista Car Park",
+                        parentZoneId = "0",
+                    ),
+                ),
+                parkID = 1,
+                location = Location(
+                    suburb = "Bella Vista",
+                    address = "Byles Place",
+                    latitude = "-33.727438",
+                    longitude = "150.941761",
+                ),
+                occupancy = Occupancy(
+                    loop = "32707",
+                    total = "200",
+                    monthlies = null,
+                    openGate = null,
+                    transients = "100",
+                ),
+                messageDate = "2025-06-12T20:05:17",
+                facilityId = "31",
+                facilityName = "Park&Ride - Bella Vista",
+                tfnswFacilityId = "2153478TPR001",
+            ),
+            "42" to CarParkFacilityDetailResponse(
+                tsn = "9999999",
+                time = "803037999",
+                spots = "500",
+                zones = listOf(
+                    Zone(
+                        spots = "500",
+                        zoneId = "2",
+                        occupancy = Occupancy(
+                            loop = "12345",
+                            total = "50",
+                            monthlies = "10",
+                            openGate = null,
+                            transients = "40",
+                        ),
+                        zoneName = "SYD400 Norwest Car Park",
+                        parentZoneId = "0",
+                    ),
+                ),
+                parkID = 2,
+                location = Location(
+                    suburb = "Norwest",
+                    address = "Norwest Blvd",
+                    latitude = "-33.733333",
+                    longitude = "150.950000",
+                ),
+                occupancy = Occupancy(
+                    loop = "12345",
+                    total = "50",
+                    monthlies = "10",
+                    openGate = null,
+                    transients = "40",
+                ),
+                messageDate = "2025-06-13T10:00:00",
+                facilityId = "42",
+                facilityName = "Park&Ride - Norwest",
+                tfnswFacilityId = "9999999TPR002",
+            ),
+        )
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakePlatformOps.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakePlatformOps.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import xyz.ksharma.krail.platform.ops.PlatformOps
+
+class FakePlatformOps : PlatformOps {
+    var lastSharedText: String? = null
+    var lastShareTitle: String? = null
+    var lastOpenedUrl: String? = null
+
+    override fun sharePlainText(text: String, title: String) {
+        lastSharedText = text
+        lastShareTitle = title
+    }
+
+    override fun openUrl(url: String) {
+        lastOpenedUrl = url
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeRateLimiter.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeRateLimiter.kt
@@ -1,0 +1,24 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import xyz.ksharma.krail.trip.planner.network.api.ratelimit.RateLimiter
+
+class FakeRateLimiter : RateLimiter {
+
+    var triggerCount: Int = 0
+        private set
+
+    override fun <T> rateLimitFlow(block: suspend () -> T): Flow<T> {
+        return flow { emit(block()) }
+    }
+
+    override fun triggerEvent(): Boolean {
+        triggerCount++
+        return true
+    }
+
+    fun reset() {
+        triggerCount = 0
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeShareManager.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeShareManager.kt
@@ -1,0 +1,33 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import androidx.compose.ui.graphics.ImageBitmap
+import xyz.ksharma.krail.core.share.ShareManager
+
+class FakeShareManager : ShareManager {
+
+    var shareImageCalled = false
+        private set
+    var lastSharedBitmap: ImageBitmap? = null
+        private set
+    var lastSharedText: String? = null
+        private set
+    var shouldFail = false
+
+    override suspend fun shareImage(
+        bitmap: ImageBitmap,
+        title: String,
+        text: String?,
+    ): Result<Unit> {
+        shareImageCalled = true
+        lastSharedBitmap = bitmap
+        lastSharedText = text
+        return if (shouldFail) Result.failure(RuntimeException("share failed")) else Result.success(Unit)
+    }
+
+    fun reset() {
+        shareImageCalled = false
+        lastSharedBitmap = null
+        lastSharedText = null
+        shouldFail = false
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/helpers/AnalyticsTestHelper.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/helpers/AnalyticsTestHelper.kt
@@ -1,0 +1,22 @@
+package xyz.ksharma.krail.core.testing.helpers
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+object AnalyticsTestHelper {
+
+    fun assertScreenViewEventTracked(
+        fakeAnalytics: Analytics,
+        expectedScreenName: String,
+    ) {
+        assertIs<FakeAnalytics>(fakeAnalytics)
+        assertTrue(fakeAnalytics.isEventTracked("view_screen"))
+        val event = fakeAnalytics.getTrackedEvent("view_screen")
+        assertIs<AnalyticsEvent.ScreenViewEvent>(event)
+        assertEquals(expectedScreenName, event.screen.name)
+    }
+}


### PR DESCRIPTION
12 more fakes + 1 helper + 1 builder copied from core/test/fakes (package
rewritten to xyz.ksharma.krail.core.testing.*), unlocking the upcoming
per-module test migrations:

  fakes/:
    FakeFestivalManager, FakeImageBitmap, FakeRateLimiter, FakeShareManager,
    FakeNearbyStopsRepository, FakeInfoTileManager,
    FakeNswParkRideSandook, FakeParkRideFacilityManager, FakeParkRideService,
    FakePlatformOps, FakeDiscoverCardSeenPreferences
  helpers/AnalyticsTestHelper
  builders/ParkRideTestData

Deliberately NOT brought across — they target interfaces that live in
:feature:trip-planner:ui itself, so per plan rule 3 ("single-feature double
stays feature-local") they're inlined into trip-planner/ui's commonTest
during the upcoming C2 migration:
  FakeStopResultsManager, FakeNearbyStopsManagerForMap,
  FakeInviteFriendsTileManager

New interface-module deps added to :core:testing commonMain (`api`):
  core.festival, core.share, core.maps.data, core.transport, info-tile.network.api,
  info-tile.state, feature.parkRide.network, platform.ops
  + libs.kotlinx.datetime (for FakeFestivalManager's LocalDate)

Detekt nits fixed while moving:
- @Suppress("TooManyFunctions") on FakeNswParkRideSandook (intrinsic to faking
  the production interface).
- @Suppress("LongParameterList") on buildCarParkFacilityDetailResponse
  (11 defaulted params mirror the production DTO contract).
- `throw Exception(msg)` -> `error(msg)` per TooGenericExceptionThrown.
- Extracted APPROX_KM_PER_DEGREE const in FakeNearbyStopsRepository.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>