### PR TITLE
test(trip-planner-ui): migrate 9 tests out of :core:test into the owning module

### DIFF
--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -135,6 +135,7 @@ kotlin {
                 implementation(projects.core.analytics)
                 implementation(projects.sandook)
                 implementation(projects.feature.departures.network)
+                implementation(projects.core.testing)
             }
         }
 

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
@@ -100,7 +100,7 @@ class StopSearchPipelineReproTest {
         // like the phone (these 15 major stops are seeded into the candidate pool
         // regardless of the trigram prefilter). Must stay in sync with
         // RemoteConfigDefaults.HIGH_PRIORITY_STOP_IDS.
-        val flag = FakeFlag(
+        val flag = MapBackedFakeFlag(
             mapOf(
                 FlagKeys.HIGH_PRIORITY_STOP_IDS.key to FlagValue.JsonValue(highPriorityJson),
                 FlagKeys.ENABLE_FUZZY_STOP_SEARCH.key to FlagValue.BooleanValue(true),

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertsViewModelTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.alerts
 
 import app.cash.turbine.test
 import kotlinx.coroutines.Dispatchers
@@ -8,9 +8,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import app.cash.turbine.test
 import kotlinx.collections.immutable.persistentSetOf
@@ -10,18 +10,18 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeAppVersionManager
-import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.core.test.fakes.FakeInfoTileManager
-import xyz.ksharma.core.test.fakes.FakeInviteFriendsTileManager
-import xyz.ksharma.core.test.fakes.FakeNswParkRideSandook
-import xyz.ksharma.core.test.fakes.FakeParkRideFacilityManager
-import xyz.ksharma.core.test.fakes.FakeParkRideService
-import xyz.ksharma.core.test.fakes.FakePlatformOps
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeSandookPreferences
-import xyz.ksharma.core.test.fakes.FakeStopResultsManager
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeAppVersionManager
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeInfoTileManager
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeInviteFriendsTileManager
+import xyz.ksharma.krail.core.testing.fakes.FakeNswParkRideSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideFacilityManager
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideService
+import xyz.ksharma.krail.core.testing.fakes.FakePlatformOps
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.info.tile.network.api.db.isInfoTileDismissed

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import app.cash.turbine.test
 import kotlinx.coroutines.Dispatchers
@@ -9,12 +9,12 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.core.test.fakes.FakeNearbyStopsManagerForMap
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeSandookPreferences
-import xyz.ksharma.core.test.fakes.FakeStopResultsManager
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeNearbyStopsManagerForMap
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import app.cash.turbine.test
 import kotlinx.collections.immutable.persistentListOf
@@ -9,14 +9,14 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.core.test.fakes.FakeNearbyStopsManagerForMap
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeSandookPreferences
-import xyz.ksharma.core.test.fakes.FakeStopResultsManager
-import xyz.ksharma.core.test.fakes.FakeTripPlanningService
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeNearbyStopsManagerForMap
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
+import xyz.ksharma.krail.core.testing.fakes.FakeTripPlanningService
+import xyz.ksharma.krail.core.testing.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManagerQueryBoundaryTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManagerQueryBoundaryTest.kt
@@ -154,7 +154,7 @@ class StopResultsManagerQueryBoundaryTest {
         highPriorityIds: List<String> = emptyList(),
     ): RealStopResultsManager {
         val idsJson = highPriorityIds.joinToString(",") { "\"$it\"" }
-        val fakeFlag = FakeFlag(
+        val fakeFlag = MapBackedFakeFlag(
             mapOf(
                 FlagKeys.HIGH_PRIORITY_STOP_IDS.key to FlagValue.JsonValue("""{"stop_ids":[$idsJson]}"""),
                 FlagKeys.ENABLE_FUZZY_STOP_SEARCH.key to FlagValue.BooleanValue(fuzzyEnabled),

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManagerTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManagerTest.kt
@@ -1,8 +1,8 @@
-package xyz.ksharma.core.test
+package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import kotlinx.collections.immutable.toImmutableList
-import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.core.test.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsPrioritisationTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsPrioritisationTest.kt
@@ -23,7 +23,7 @@ class StopResultsPrioritisationTest {
 
     private fun managerWithHighPriorityIds(vararg ids: String): RealStopResultsManager {
         val json = """{"stop_ids": [${ids.joinToString(",") { "\"$it\"" }}]}"""
-        val fakeFlag = FakeFlag(
+        val fakeFlag = MapBackedFakeFlag(
             mapOf(
                 FlagKeys.HIGH_PRIORITY_STOP_IDS.key to FlagValue.JsonValue(json),
                 FlagKeys.ENABLE_FUZZY_STOP_SEARCH.key to FlagValue.BooleanValue(false),

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchTestFakes.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchTestFakes.kt
@@ -7,10 +7,15 @@ import xyz.ksharma.krail.sandook.NswBusRoutesSandook
 import xyz.ksharma.krail.sandook.NswBusTripOptions
 import xyz.ksharma.krail.sandook.SelectStopsByTripId
 
-/** Map-backed [Flag] for tests. Throws on unregistered keys so missing setup fails loudly. */
-internal class FakeFlag(private val values: Map<String, FlagValue>) : Flag {
+/**
+ * Strict map-backed [Flag] for tests. Throws on unregistered keys so missing setup fails
+ * loudly — different shape from the canonical [xyz.ksharma.krail.core.testing.fakes.FakeFlag],
+ * which returns a default when a key is missing. Renamed so the canonical fake can also be
+ * imported into this package by the migrated ViewModel tests.
+ */
+internal class MapBackedFakeFlag(private val values: Map<String, FlagValue>) : Flag {
     override fun getFlagValue(key: String): FlagValue =
-        values[key] ?: error("FakeFlag: no value registered for key '$key'")
+        values[key] ?: error("MapBackedFakeFlag: no value registered for key '$key'")
 }
 
 /** Bus-routes sandook that errors on every call. Use when the test path doesn't touch routes. */

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryviewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryviewModelTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.settings.story
 
 import app.cash.molecule.RecompositionMode
 import app.cash.molecule.moleculeFlow
@@ -11,8 +11,8 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
 import xyz.ksharma.krail.trip.planner.ui.settings.story.OurStoryViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryEvent
 import kotlin.test.AfterTest

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeInviteFriendsTileManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeInviteFriendsTileManager.kt
@@ -1,0 +1,22 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.InviteFriendsTileManager
+
+class FakeInviteFriendsTileManager : InviteFriendsTileManager {
+
+    private var hasSeenTile: Boolean = false
+
+    override fun hasSeenInviteFriendsTile(): Boolean {
+        return hasSeenTile
+    }
+
+    override fun markAsSeen() {
+        hasSeenTile = true
+    }
+
+    // Test helper to reset state
+    fun reset() {
+        hasSeenTile = false
+    }
+}
+

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeNearbyStopsManagerForMap.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeNearbyStopsManagerForMap.kt
@@ -1,0 +1,130 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import kotlinx.coroutines.CoroutineScope
+import xyz.ksharma.krail.core.maps.data.model.NearbyStop
+import xyz.ksharma.krail.trip.planner.ui.searchstop.map.NearbyStopsManager
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+
+/**
+ * Fake implementation of [NearbyStopsManager] for testing.
+ * Allows control over behavior and verification of interactions.
+ */
+class FakeNearbyStopsManagerForMap : NearbyStopsManager {
+
+    // State tracking
+    var loadNearbyStopsCallCount = 0
+        private set
+    var invalidateCacheCallCount = 0
+        private set
+    var cancelOngoingQueryCallCount = 0
+        private set
+
+    // Last call parameters
+    var lastMapState: MapUiState.Ready? = null
+        private set
+    var lastCenter: LatLng? = null
+        private set
+    var lastScope: CoroutineScope? = null
+        private set
+
+    // Configurable behavior
+    var stopsToReturn: List<NearbyStop> = emptyList()
+    var shouldUseCachedResults: Boolean = false
+    var errorToThrow: Throwable? = null
+    var delayBeforeResult: Long = 0
+
+    // Captured callbacks
+    private var onLoadingStateChanged: ((Boolean) -> Unit)? = null
+    private var onStopsLoaded: ((List<NearbyStop>) -> Unit)? = null
+    private var onError: ((Throwable) -> Unit)? = null
+
+    override fun loadNearbyStops(
+        mapState: MapUiState.Ready,
+        center: LatLng,
+        scope: CoroutineScope,
+        onLoadingStateChanged: (Boolean) -> Unit,
+        onStopsLoaded: (List<NearbyStop>) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        loadNearbyStopsCallCount++
+        lastMapState = mapState
+        lastCenter = center
+        lastScope = scope
+        this.onLoadingStateChanged = onLoadingStateChanged
+        this.onStopsLoaded = onStopsLoaded
+        this.onError = onError
+
+        if (shouldUseCachedResults) {
+            // Do nothing - simulate cache hit
+            return
+        }
+
+        // Simulate loading state
+        onLoadingStateChanged(true)
+
+        // Simulate async behavior if needed
+        if (delayBeforeResult > 0) {
+            // In real tests, you'd use TestCoroutineScope and advanceTimeBy
+            // For now, just invoke callbacks immediately
+        }
+
+        errorToThrow?.let {
+            onLoadingStateChanged(false)
+            onError(it)
+        } ?: run {
+            onStopsLoaded(stopsToReturn)
+            onLoadingStateChanged(false)
+        }
+    }
+
+    override fun invalidateCache() {
+        invalidateCacheCallCount++
+        shouldUseCachedResults = false
+    }
+
+    override fun cancelOngoingQuery() {
+        cancelOngoingQueryCallCount++
+    }
+
+    /**
+     * Manually trigger loading state change (for testing)
+     */
+    fun triggerLoadingStateChange(isLoading: Boolean) {
+        onLoadingStateChanged?.invoke(isLoading)
+    }
+
+    /**
+     * Manually trigger stops loaded (for testing)
+     */
+    fun triggerStopsLoaded(stops: List<NearbyStop>) {
+        onStopsLoaded?.invoke(stops)
+    }
+
+    /**
+     * Manually trigger error (for testing)
+     */
+    fun triggerError(error: Throwable) {
+        onError?.invoke(error)
+    }
+
+    /**
+     * Reset all state for next test
+     */
+    fun reset() {
+        loadNearbyStopsCallCount = 0
+        invalidateCacheCallCount = 0
+        cancelOngoingQueryCallCount = 0
+        lastMapState = null
+        lastCenter = null
+        lastScope = null
+        stopsToReturn = emptyList()
+        shouldUseCachedResults = false
+        errorToThrow = null
+        delayBeforeResult = 0
+        onLoadingStateChanged = null
+        onStopsLoaded = null
+        onError = null
+    }
+}
+

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeStopResultsManager.kt
@@ -1,0 +1,148 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+class FakeStopResultsManager : StopResultsManager {
+    // Add a flag to control whether fetchStopResults should throw an exception
+    var shouldThrowError = false
+
+    // Track selected stops
+    private var _selectedFromStop: StopItem? = null
+    private var _selectedToStop: StopItem? = null
+
+    // Track recent search stops for testing
+    private val _recentSearchStops = mutableListOf<SearchStopState.StopResult>()
+
+    private val testStopResults = listOf(
+        SearchStopState.SearchResult.Stop(
+            stopId = "10101",
+            stopName = "Central Station",
+            transportModeType = persistentListOf(NswTransportMode.Train, NswTransportMode.Bus)
+        ),
+        SearchStopState.SearchResult.Stop(
+            stopId = "10102",
+            stopName = "Town Hall",
+            transportModeType = persistentListOf(NswTransportMode.Train)
+        ),
+        SearchStopState.SearchResult.Stop(
+            stopId = "10103",
+            stopName = "Parramatta Station",
+            transportModeType = persistentListOf(NswTransportMode.Train, NswTransportMode.Bus)
+        ),
+        SearchStopState.SearchResult.Stop(
+            stopId = "10104",
+            stopName = "Sydney Airport",
+            transportModeType = persistentListOf(NswTransportMode.Train)
+        )
+    )
+
+    override val selectedFromStop: StopItem?
+        get() = _selectedFromStop
+
+    override val selectedToStop: StopItem?
+        get() = _selectedToStop
+
+    override suspend fun fetchStopResults(
+        query: String,
+        searchRoutesEnabled: Boolean,
+    ): List<SearchStopState.SearchResult> {
+        // Throw an exception if shouldThrowError is true
+        if (shouldThrowError) {
+            throw RuntimeException("Error fetching stop results")
+        }
+
+        return if (query.isBlank()) {
+            testStopResults
+        } else {
+            testStopResults.filter {
+                it.stopName.contains(query, ignoreCase = true)
+            }
+        }
+    }
+
+    override fun prioritiseStops(stopResults: List<SearchStopState.SearchResult.Stop>): List<SearchStopState.SearchResult.Stop> {
+        return stopResults.sortedByDescending { it.transportModeType.size }
+    }
+
+    override fun fetchLocalStopName(stopId: String): String? {
+        return testStopResults.firstOrNull { it.stopId == stopId }?.stopName
+    }
+
+    override fun setSelectedFromStop(stopItem: StopItem?) {
+        _selectedFromStop = stopItem
+        // Add to recent search stops when a stop is selected (like the real implementation)
+        if (stopItem != null) {
+            addRecentSearchStopFromStopItem(stopItem)
+        }
+    }
+
+    override fun setSelectedToStop(stopItem: StopItem?) {
+        _selectedToStop = stopItem
+        // Add to recent search stops when a stop is selected (like the real implementation)
+        if (stopItem != null) {
+            addRecentSearchStopFromStopItem(stopItem)
+        }
+    }
+
+    override fun reverseSelectedStops() {
+        val tempFrom = _selectedFromStop
+        _selectedFromStop = _selectedToStop
+        _selectedToStop = tempFrom
+    }
+
+    override fun clearSelectedStops() {
+        _selectedFromStop = null
+        _selectedToStop = null
+    }
+
+    override suspend fun recentSearchStops(): List<SearchStopState.StopResult> {
+        return _recentSearchStops.toList()
+    }
+
+    override fun clearRecentSearchStops() {
+        _recentSearchStops.clear()
+    }
+
+    // Helper methods for testing
+    fun reset() {
+        _selectedFromStop = null
+        _selectedToStop = null
+        _recentSearchStops.clear()
+        shouldThrowError = false
+    }
+
+    // Helper method to add recent stops for testing
+    fun addRecentSearchStop(stopResult: SearchStopState.StopResult) {
+        _recentSearchStops.removeAll { it.stopId == stopResult.stopId }
+        _recentSearchStops.add(0, stopResult)
+        if (_recentSearchStops.size > 5) {
+            _recentSearchStops.removeAt(_recentSearchStops.size - 1)
+        }
+    }
+
+    // Helper method to convert StopItem to StopResult and add to recent stops
+    private fun addRecentSearchStopFromStopItem(stopItem: StopItem) {
+        // Find the corresponding test stop result and convert to legacy StopResult format
+        val searchResultStop = testStopResults.find { it.stopId == stopItem.stopId }
+        val stopResult = if (searchResultStop != null) {
+            SearchStopState.StopResult(
+                stopId = searchResultStop.stopId,
+                stopName = searchResultStop.stopName,
+                transportModeType = searchResultStop.transportModeType
+            )
+        } else {
+            SearchStopState.StopResult(
+                stopId = stopItem.stopId,
+                stopName = stopItem.stopName,
+                transportModeType = persistentListOf(NswTransportMode.Train) // Default transport mode
+            )
+        }
+
+        addRecentSearchStop(stopResult)
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModelTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.themeselection
 
 import app.cash.turbine.test
 import kotlinx.coroutines.Dispatchers
@@ -8,10 +8,10 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeSandookPreferences
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.core.testing.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelCacheTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelCacheTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.timetable
 
 /**
  * Comprehensive tests for TimeTableViewModel's three-cache architecture and staleness-pruning
@@ -24,15 +24,15 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeFestivalManager
-import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.core.test.fakes.FakeRateLimiter
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeShareManager
-import xyz.ksharma.core.test.fakes.FakeTripPlanningService
-import xyz.ksharma.core.test.fakes.FakeTripResponseBuilder
-import xyz.ksharma.core.test.fakes.FakeTripResponseBuilder.buildTripResponse
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeRateLimiter
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeShareManager
+import xyz.ksharma.krail.core.testing.fakes.FakeTripPlanningService
+import xyz.ksharma.krail.core.testing.fakes.FakeTripResponseBuilder
+import xyz.ksharma.krail.core.testing.fakes.FakeTripResponseBuilder.buildTripResponse
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.viewmodels
+package xyz.ksharma.krail.trip.planner.ui.timetable
 
 import app.cash.turbine.test
 import kotlinx.collections.immutable.persistentListOf
@@ -12,17 +12,17 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.TimeZone.Companion.currentSystemDefault
 import kotlinx.datetime.toLocalDateTime
-import xyz.ksharma.core.test.fakes.FakeAnalytics
-import xyz.ksharma.core.test.fakes.FakeFestivalManager
-import xyz.ksharma.core.test.fakes.FakeFlag
-import xyz.ksharma.core.test.fakes.FakeRateLimiter
-import xyz.ksharma.core.test.fakes.FakeSandook
-import xyz.ksharma.core.test.fakes.FakeShareManager
-import xyz.ksharma.core.test.fakes.FakeTripPlanningService
-import xyz.ksharma.core.test.fakes.FakeTripResponseBuilder
-import xyz.ksharma.core.test.fakes.FakeTripResponseBuilder.buildTripResponse
-import xyz.ksharma.core.test.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
-import xyz.ksharma.core.test.fakes.FakeImageBitmap
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeRateLimiter
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeShareManager
+import xyz.ksharma.krail.core.testing.fakes.FakeTripPlanningService
+import xyz.ksharma.krail.core.testing.fakes.FakeTripResponseBuilder
+import xyz.ksharma.krail.core.testing.fakes.FakeTripResponseBuilder.buildTripResponse
+import xyz.ksharma.krail.core.testing.helpers.AnalyticsTestHelper.assertScreenViewEventTracked
+import xyz.ksharma.krail.core.testing.fakes.FakeImageBitmap
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent


### PR DESCRIPTION
Largest single C-stack migration — every ViewModel/manager test that lives
in feature/trip-planner/ui now sits in that module's own commonTest, against
the canonical :core:testing fakes.

Tests moved (out of core/test/src/commonTest/kotlin/xyz/ksharma/core/test/):
  viewmodels/TimeTableViewModelTest             -> ui/timetable/
  viewmodels/TimeTableViewModelCacheTest        -> ui/timetable/
  viewmodels/SearchStopViewModelTest            -> ui/searchstop/
  viewmodels/SearchStopViewModelLabelHandlersTest -> ui/searchstop/
  viewmodels/SavedTripViewModelsTest            -> ui/savedtrips/
  viewmodels/ServiceAlertsViewModelTest         -> ui/alerts/
  viewmodels/ThemeSelectionViewModelTest        -> ui/themeselection/
  viewmodels/OurStoryviewModelTest              -> ui/settings/story/
  StopResultsManagerTest                        -> ui/searchstop/
Each got its package rewritten and its `xyz.ksharma.core.test.fakes.Fake*`
imports redirected to either `xyz.ksharma.krail.core.testing.fakes.*` (the
canonical fakes) or `xyz.ksharma.krail.trip.planner.ui.testfakes.*` (the
three trip-planner-internal ones — see below).

Per the plan's rule-3, three fakes target interfaces that live inside
:feature:trip-planner:ui itself and therefore stay feature-local instead of
bloating :core:testing's classpath with a :ui dep:
  testfakes/FakeStopResultsManager
  testfakes/FakeNearbyStopsManagerForMap
  testfakes/FakeInviteFriendsTileManager

Local-class rename to break a name clash: `internal class FakeFlag` in
searchstop/StopSearchTestFakes.kt is now `MapBackedFakeFlag` (it's a stricter,
throw-on-missing variant — different shape from canonical FakeFlag). Updated
3 callsites (StopResultsPrioritisationTest, StopResultsManagerQueryBoundaryTest,
StopSearchPipelineReproTest). Frees the `FakeFlag` name for the migrated
tests' canonical import.

build.gradle.kts: `implementation(projects.core.testing)` added to commonTest.
:core:test still compiles (loses 9 test files but its build deps were
unrelated). Final core/test cleanup is Stack D2 after the last C migrations.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>