### PR TITLE
test(discover): migrate Real discover tests out of :core:test

### DIFF
--- a/discover/network/real/build.gradle.kts
+++ b/discover/network/real/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
             dependencies {
                 implementation(libs.test.kotlin)
                 implementation(libs.test.kotlinxCoroutineTest)
+                implementation(projects.core.testing)
             }
         }
     }

--- a/discover/network/real/src/commonTest/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverCardOrderingEngineTest.kt
+++ b/discover/network/real/src/commonTest/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverCardOrderingEngineTest.kt
@@ -1,4 +1,4 @@
-package xyz.ksharma.core.test.discover
+package xyz.ksharma.krail.discover.network.real
 
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.DateTimeUnit
@@ -7,7 +7,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import xyz.ksharma.core.test.fakes.FakeDiscoverCardSeenPreferences
+import xyz.ksharma.krail.core.testing.fakes.FakeDiscoverCardSeenPreferences
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
 import xyz.ksharma.krail.discover.network.real.db.RealDiscoverCardOrderingEngine
 import xyz.ksharma.krail.discover.state.DiscoverCardType

--- a/discover/network/real/src/commonTest/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManagerTest.kt
+++ b/discover/network/real/src/commonTest/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManagerTest.kt
@@ -1,10 +1,10 @@
 @file:Suppress("VisibleForTests")
-package xyz.ksharma.core.test.discover
+package xyz.ksharma.krail.discover.network.real
 
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import xyz.ksharma.core.test.fakes.FakeDiscoverCardSeenPreferences
+import xyz.ksharma.krail.core.testing.fakes.FakeDiscoverCardSeenPreferences
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue


### PR DESCRIPTION
Both Real* discover tests now live next to the production code they test:
  RealDiscoverSydneyManagerTest      -> :discover:network:real
  RealDiscoverCardOrderingEngineTest -> :discover:network:real (db/ package)

Package rewritten and the FakeDiscoverCardSeenPreferences import redirected
to :core:testing. :discover:network:real's commonTest now also depends on
:core:testing.

The existing private FakeFlag inside DiscoverJsonValidationTest.kt is left
alone — it's in the verifyNoAdHocBoundaryFakes baseline and gets cleaned in
a separate detekt-cleanup PR (out of scope here to keep this migration
focused).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>