### PR TITLE
fix(timetable): cache raw journey data for load-more & previous trips + tests

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -344,6 +344,9 @@ class TimeTableViewModel(
             journeys.clear()
             loadMoreJourneys.clear()
             previousJourneysCache.clear()
+            // Old-mode raw journey data must not survive into the re-fetched list
+            // (this path clears caches inline instead of via resetPaginationCaches()).
+            rawJourneyDataByJourneyId.clear()
             loadMoreCount = 0
 
             // call api
@@ -577,6 +580,11 @@ class TimeTableViewModel(
     private fun resetPaginationCaches() {
         loadMoreJourneys.clear()
         previousJourneysCache.clear()
+        // Raw journey data backs the journey map. Every caller of this also clears
+        // `journeys` and triggers a re-fetch (which repopulates initial raw data via
+        // updateTripsCache), so clearing here prevents the map from leaking or serving
+        // stale load-more/previous journeys after a date-time or reverse-trip reset.
+        rawJourneyDataByJourneyId.clear()
         loadMoreCount = 0
         loadMoreFetchJob?.cancel()
         loadPreviousFetchJob?.cancel()
@@ -604,7 +612,10 @@ class TimeTableViewModel(
         loadMoreFetchJob?.cancel()
         loadMoreFetchJob = viewModelScope.launch(ioDispatcher) {
             loadTripAtTime(date = date, time = time).onSuccess { response ->
-                val (newJourneys, _) = response.buildJourneyListWithRawData()
+                val (newJourneys, newRawDataMap) = response.buildJourneyListWithRawData()
+                // Keep raw journey data so the journey map can resolve coordinates for
+                // load-more journeys via getRawJourneyById(). Without this the map is empty.
+                rawJourneyDataByJourneyId.putAll(newRawDataMap)
                 newJourneys?.forEach { journey ->
                     if (!loadMoreJourneys.containsKey(journey.journeyId) &&
                         !journeys.containsKey(journey.journeyId)
@@ -642,7 +653,10 @@ class TimeTableViewModel(
         loadPreviousFetchJob?.cancel()
         loadPreviousFetchJob = viewModelScope.launch(ioDispatcher) {
             loadTripAtTime(date = date, time = time).onSuccess { response ->
-                val (newJourneys, _) = response.buildJourneyListWithRawData()
+                val (newJourneys, newRawDataMap) = response.buildJourneyListWithRawData()
+                // Keep raw journey data so the journey map can resolve coordinates for
+                // previous journeys via getRawJourneyById(). Without this the map is empty.
+                rawJourneyDataByJourneyId.putAll(newRawDataMap)
                 newJourneys
                     ?.filter { Instant.parse(it.originUtcDateTime).isBefore(firstInstant) }
                     ?.forEach { journey ->

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -1442,6 +1442,119 @@ class TimeTableViewModelTest {
             assertTrue(viewModel.uiState.value.canLoadMore, "canLoadMore should be true when journeys loaded")
         }
 
+    // ── rawJourneyDataByJourneyId lifecycle (backs the journey map screen) ─────
+    //
+    // The map screen looks up coordinates via `viewModel.getRawJourneyById(id)`. That
+    // map is fed by `rawJourneyDataByJourneyId`. Before the fix:
+    //
+    //   - onLoadMoreTrips / onLoadPreviousTrips discarded the raw-data half of
+    //     `response.buildJourneyListWithRawData()` — tapping a load-more / previous
+    //     journey on the map showed an empty map.
+    //   - onModeSelectionChanged / resetPaginationCaches cleared everything *except*
+    //     raw-data, so a stale load-more entry could leak into a re-fetched list.
+
+    @Test
+    fun `GIVEN initial load WHEN LoadMoreTrips THEN raw journey data is cached for new journeys`() =
+        runTest {
+            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
+            tripPlanningService.isSuccess = true
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            // 2-journey response so dedup leaves at least one new load-more journey
+            // (the first overlaps the initial fetch; the second is fresh).
+            tripPlanningService.setResponseForCall(
+                tripPlanningService.tripCallCount,
+                FakeTripResponseBuilder.buildTripResponse(numberOfJourney = 2),
+            )
+
+            viewModel.onEvent(TimeTableUiEvent.LoadMoreTrips)
+            advanceUntilIdle()
+
+            assertTrue(
+                viewModel.loadMoreJourneys.isNotEmpty(),
+                "Sanity: load-more cache must hold the new journey",
+            )
+            viewModel.loadMoreJourneys.keys.forEach { id ->
+                assertNotNull(
+                    viewModel.getRawJourneyById(id),
+                    "Load-more journey '$id' must have raw data so the map can resolve coordinates",
+                )
+            }
+        }
+
+    @Test
+    fun `GIVEN journeys cached WHEN ModeSelectionChanged THEN raw journey data is cleared`() =
+        runTest {
+            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
+            tripPlanningService.isSuccess = true
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            val initialIds = viewModel.uiState.value.journeyList.map { it.journeyId }
+            assertTrue(initialIds.isNotEmpty(), "Sanity: initial journeys must be loaded")
+            initialIds.forEach { id ->
+                assertNotNull(viewModel.getRawJourneyById(id), "Sanity: initial raw data populated")
+            }
+
+            // ModeSelectionChanged inline-resets the caches AND clears rawJourneyDataByJourneyId,
+            // then triggers a re-fetch. Old journey IDs must no longer resolve.
+            viewModel.onEvent(TimeTableUiEvent.ModeSelectionChanged(unselectedModes = setOf(NswTransportMode.Bus.productClass)))
+            advanceUntilIdle()
+
+            initialIds.forEach { id ->
+                if (viewModel.uiState.value.journeyList.none { it.journeyId == id }) {
+                    // Only assert clearance for IDs that did NOT survive the re-fetch.
+                    // (If the re-fetch happens to produce the same ID, raw data is repopulated.)
+                    assertNull(
+                        viewModel.getRawJourneyById(id),
+                        "Stale raw data for journey '$id' must not survive a mode-selection reset",
+                    )
+                }
+            }
+        }
+
+    @Test
+    fun `GIVEN journeys cached WHEN DateTimeSelectionChanged THEN raw journey data is cleared via resetPaginationCaches`() =
+        runTest {
+            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
+            tripPlanningService.isSuccess = true
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            val initialIds = viewModel.uiState.value.journeyList.map { it.journeyId }
+            assertTrue(initialIds.isNotEmpty(), "Sanity: initial journeys must be loaded")
+            initialIds.forEach { id ->
+                assertNotNull(viewModel.getRawJourneyById(id), "Sanity: initial raw data populated")
+            }
+
+            // DateTimeSelectionChanged → resetPaginationCaches() (which now also clears
+            // rawJourneyDataByJourneyId per the fix) + journeys.clear() + re-fetch.
+            val newSelection = DateTimeSelectionItem(
+                date = Clock.System.now().toLocalDateTime(currentSystemDefault()).date,
+                option = JourneyTimeOptions.LEAVE,
+                hour = 12,
+                minute = 0,
+            )
+            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(dateTimeSelectionItem = newSelection))
+            advanceUntilIdle()
+
+            initialIds.forEach { id ->
+                if (viewModel.uiState.value.journeyList.none { it.journeyId == id }) {
+                    assertNull(
+                        viewModel.getRawJourneyById(id),
+                        "Stale raw data for journey '$id' must not survive a date-time reset",
+                    )
+                }
+            }
+        }
+
     // endregion
 
     @OptIn(ExperimentalTime::class)


### PR DESCRIPTION
Re-raise of #1606 (closed) — same fix, now with 3 unit tests on top of the new
testing infrastructure from #1618.

## Bug

Tapping the journey map for a "load more" or "previous" journey showed an empty
map. The map resolves coordinates via `TimeTableViewModel.getRawJourneyById()`,
which reads `rawJourneyDataByJourneyId`. That map was only populated for the
initial trip list (`updateTripsCache`); `onLoadMoreTrips()` and
`onLoadPreviousTrips()` discarded the raw-data half of
`buildJourneyListWithRawData()` (`val (newJourneys, _) = ...`), so past/extra
journeys had no raw data and the mapper produced an empty map.

## Fix (commit 1, unchanged from #1606)

- `onLoadMoreTrips` / `onLoadPreviousTrips`: capture `newRawDataMap` and
  `rawJourneyDataByJourneyId.putAll(...)` (mirrors `updateTripsCache`).
- Lifecycle consistency: clear `rawJourneyDataByJourneyId` in
  `resetPaginationCaches()` and the `onModeSelectionChanged()` inline reset.
  Every reset path also clears `journeys` and re-fetches (repopulating
  initial raw data), so the map can no longer leak or serve a stale
  load-more/previous journey after a date-time / reverse-trip / mode change.

## Tests (commit 2, new)

Three tests in `TimeTableViewModelTest`, each asserting via the public
`viewModel.getRawJourneyById(id)` accessor that production code calls:

| Test | Covers |
|---|---|
| `LoadMoreTrips → raw data cached for new journeys` | `onLoadMoreTrips`'s new `rawJourneyDataByJourneyId.putAll(...)`. The same fix lives in `onLoadPreviousTrips` — visual equivalence; constructing a fake that passes the `isBefore(firstInstant)` filter adds mechanical noise without strengthening the assertion. |
| `ModeSelectionChanged → raw data cleared` | The inline `rawJourneyDataByJourneyId.clear()` added next to `journeys.clear()` in `onModeSelectionChanged`. |
| `DateTimeSelectionChanged → raw data cleared via resetPaginationCaches` | The `resetPaginationCaches()` clear, which the date-time / reverse-trip / retry / load-previous paths all funnel through. |

Tests use the canonical fakes from `:core:testing` (shipped in #1618).

## Stacked on #1618

Base is `test-infra/testing-doc` (the testing-infrastructure consolidation PR).
Once #1618 merges, GitHub will auto-retarget this PR to `main` and the diff
will narrow to just these 2 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)