### PR TITLE
fix(ios): stop SQLITE_BUSY crash from multiple SQLite driver pools

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
-import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
@@ -53,21 +53,21 @@ class ThemeSelectionViewModel(
 
     private fun onThemeSelected(productClass: Int) {
         transportSelectionJob?.cancel()
-        transportSelectionJob = viewModelScope.launch(ioDispatcher) {
-            // Guard the DB write: a transient lock (e.g. a slow first-launch GTFS import still
-            // holding the writer) must never crash the app. The shared driver + raised busy
-            // timeout make this unlikely, but a caught failure degrades gracefully.
-            runCatching {
-                sandook.clearTheme() // Only one entry should exist at a time
-                sandook.insertOrReplaceTheme(productClass.toLong())
-            }.onSuccess {
-                updateUiState {
-                    copy(themeSelected = true)
-                }
-                analytics.trackThemeSelectionEvent(themeId = productClass)
-            }.onFailure { error ->
-                log("ThemeSelectionViewModel Failed to persist theme: $error")
+        // launchWithExceptionHandler (not runCatching): a transient DB lock (e.g. a slow
+        // first-launch GTFS import still holding the writer) must never crash the app, but
+        // runCatching also swallows CancellationException — and this job is cancelled on rapid
+        // re-selection above, so a caught cancellation would silently break structured
+        // concurrency. The handler ignores CancellationException and routes real failures to
+        // logError (Crashlytics).
+        transportSelectionJob = viewModelScope.launchWithExceptionHandler<ThemeSelectionViewModel>(
+            dispatcher = ioDispatcher,
+        ) {
+            sandook.clearTheme() // Only one entry should exist at a time
+            sandook.insertOrReplaceTheme(productClass.toLong())
+            updateUiState {
+                copy(themeSelected = true)
             }
+            analytics.trackThemeSelectionEvent(themeId = productClass)
         }
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
@@ -53,12 +54,20 @@ class ThemeSelectionViewModel(
     private fun onThemeSelected(productClass: Int) {
         transportSelectionJob?.cancel()
         transportSelectionJob = viewModelScope.launch(ioDispatcher) {
-            sandook.clearTheme() // Only one entry should exist at a time
-            sandook.insertOrReplaceTheme(productClass.toLong())
-            updateUiState {
-                copy(themeSelected = true)
+            // Guard the DB write: a transient lock (e.g. a slow first-launch GTFS import still
+            // holding the writer) must never crash the app. The shared driver + raised busy
+            // timeout make this unlikely, but a caught failure degrades gracefully.
+            runCatching {
+                sandook.clearTheme() // Only one entry should exist at a time
+                sandook.insertOrReplaceTheme(productClass.toLong())
+            }.onSuccess {
+                updateUiState {
+                    copy(themeSelected = true)
+                }
+                analytics.trackThemeSelectionEvent(themeId = productClass)
+            }.onFailure { error ->
+                log("ThemeSelectionViewModel Failed to persist theme: $error")
             }
-            analytics.trackThemeSelectionEvent(themeId = productClass)
         }
     }
 

--- a/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswbusroutes/NswBusRoutesManager.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswbusroutes/NswBusRoutesManager.kt
@@ -2,6 +2,8 @@ package xyz.ksharma.krail.io.gtfs.nswbusroutes
 
 import app.krail.kgtfs.proto.NswBusRouteList
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import krail.io.gtfs.generated.resources.Res
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
@@ -21,18 +23,24 @@ class NswBusRoutesManager(
     private val preferences: SandookPreferences,
 ) : StopsManager {
 
+    // Invoked from both RealAppStart and IntroViewModel; serialise so concurrent first-launch
+    // callers don't both run the full insert (see NswStopsManager for the same guard).
+    private val insertMutex = Mutex()
+
     init {
         log("NswBusRoutesManager Initialized with version: $NSW_BUS_ROUTES_VERSION")
     }
 
     override suspend fun insertStops() = runCatching {
-        log("NswBusRoutesManager Inserting NSW Bus Routes data if not already inserted")
-        if (shouldInsertBusRoutes()) {
-            insertNswBusRoutes()
-        } else {
-            log("NswBusRoutesManager Bus routes already inserted in the database.")
+        insertMutex.withLock {
+            log("NswBusRoutesManager Inserting NSW Bus Routes data if not already inserted")
+            if (shouldInsertBusRoutes()) {
+                insertNswBusRoutes()
+            } else {
+                log("NswBusRoutesManager Bus routes already inserted in the database.")
+            }
+            log("NswBusRoutesManager insertStops() completed successfully")
         }
-        log("NswBusRoutesManager insertStops() completed successfully")
     }.getOrElse { error ->
         logError("NswBusRoutesManager Error inserting bus routes: ${error.message}")
         error.printStackTrace()

--- a/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswstops/NswStopsManager.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswstops/NswStopsManager.kt
@@ -2,6 +2,8 @@ package xyz.ksharma.krail.io.gtfs.nswstops
 
 import app.krail.kgtfs.proto.NswStopList
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import krail.io.gtfs.generated.resources.Res
 import xyz.ksharma.krail.core.log.log
@@ -19,16 +21,25 @@ class NswStopsManager(
     private val preferences: SandookPreferences,
 ) : StopsManager {
 
+    // insertStops() is invoked from both RealAppStart and IntroViewModel and they can run
+    // concurrently on first launch. Without this lock both pass shouldInsertNswStops() (the stored
+    // version is only written after the transaction commits) and each runs the full ~37k-row
+    // insert, doubling the work and the time the DB write lock is held. Serialising here means the
+    // second caller re-checks after the first commits and skips.
+    private val insertMutex = Mutex()
+
     init {
         log("NswStopsManager Initialized with NSW Stops version: $NSW_STOPS_VERSION: $this")
     }
 
     override suspend fun insertStops() = runCatching {
-        log("NswStopsManager Inserting NSW Stops data if not already inserted: $this")
-        if (shouldInsertNswStops()) {
-            insertNswStops()
-        } else {
-            log("NswStopsManager Stops already inserted in the database.")
+        insertMutex.withLock {
+            log("NswStopsManager Inserting NSW Stops data if not already inserted: $this")
+            if (shouldInsertNswStops()) {
+                insertNswStops()
+            } else {
+                log("NswStopsManager Stops already inserted in the database.")
+            }
         }
     }.getOrElse { error ->
         log("NswStopsManager Error inserting stops: $error")

--- a/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/di/AndroidSandookModule.kt
+++ b/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/di/AndroidSandookModule.kt
@@ -1,24 +1,15 @@
 package xyz.ksharma.krail.sandook.di
 
-import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
-import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.sandook.AndroidSandookDriverFactory
-import xyz.ksharma.krail.sandook.RealSandook
 import xyz.ksharma.krail.sandook.SandookDriverFactory
 
 actual val sqlDriverModule = module {
+    // RealSandook (and the other repos) are bound in the shared sandookModule and consume the
+    // single shared KrailSandook, so they all share one driver / connection pool. Do not create
+    // additional drivers here: separate pools over the same db file race for write locks and
+    // throw SQLITE_BUSY under load.
     singleOf(::AndroidSandookDriverFactory) { bind<SandookDriverFactory>() }
-
-    single<RealSandook> {
-        RealSandook(
-            factory = AndroidSandookDriverFactory(
-                context = androidContext(),
-            ),
-            ioDispatcher = get(named(IODispatcher)),
-        )
-    }
 }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswStopsSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswStopsSandook.kt
@@ -115,10 +115,9 @@ interface NswStopsSandook {
  * Delegates to the SQLDelight generated queries.
  */
 internal class RealNswStopsSandook(
-    private val factory: SandookDriverFactory,
+    sandook: KrailSandook,
 ) : NswStopsSandook {
 
-    private val sandook = KrailSandook(factory.createDriver())
     private val nswStopsQueries = sandook.nswStopsQueries
 
     // region Query Operations

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealNswBusRoutesSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealNswBusRoutesSandook.kt
@@ -6,10 +6,9 @@ package xyz.ksharma.krail.sandook
  */
 @Suppress("TooManyFunctions")
 class RealNswBusRoutesSandook(
-    private val factory: SandookDriverFactory,
+    sandook: KrailSandook,
 ) : NswBusRoutesSandook {
 
-    private val sandook = KrailSandook(factory.createDriver())
     private val nswBusRoutesQueries = sandook.nswBusRoutesQueries
 
     // region Query Operations

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -7,11 +7,10 @@ import kotlinx.coroutines.flow.Flow
 import xyz.ksharma.krail.core.log.log
 
 internal class RealSandook(
-    factory: SandookDriverFactory,
+    sandook: KrailSandook,
     private val ioDispatcher: CoroutineDispatcher,
 ) : Sandook {
 
-    private val sandook = KrailSandook(factory.createDriver())
     private val query = sandook.krailSandookQueries
 
     private val nswStopsQueries = sandook.nswStopsQueries

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/di/SandookModule.kt
@@ -61,19 +61,19 @@ val sandookModule = module {
 
     single<NswBusRoutesSandook> {
         RealNswBusRoutesSandook(
-            factory = get(),
+            sandook = get<KrailSandook>(),
         )
     }
 
     single<NswStopsSandook> {
         RealNswStopsSandook(
-            factory = get(),
+            sandook = get<KrailSandook>(),
         )
     }
 
     single<Sandook> {
         RealSandook(
-            factory = get(),
+            sandook = get<KrailSandook>(),
             ioDispatcher = get(named(DispatchersComponent.IODispatcher)),
         )
     }

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.sandook
 import app.cash.sqldelight.db.AfterVersion
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
+import co.touchlab.sqliter.JournalMode
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter1
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter2
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter3
@@ -17,6 +18,20 @@ class IosSandookDriverFactory : SandookDriverFactory {
         return NativeSqliteDriver(
             schema = KrailSandook.Schema,
             name = "krailSandook.db",
+            onConfiguration = { config ->
+                // First-launch GTFS imports run multi-second write transactions. sqliter's
+                // default 5s busy timeout is shorter than those inserts, so a competing writer
+                // (e.g. theme selection) times out and crashes with SQLITE_BUSY. Raise the
+                // timeout well past worst-case insert time and keep WAL explicit so readers
+                // never block writers. The real fix for cross-pool contention is the single
+                // shared driver in the DI module; this is defence-in-depth.
+                config.copy(
+                    journalMode = JournalMode.WAL,
+                    extendedConfig = config.extendedConfig.copy(
+                        busyTimeout = BUSY_TIMEOUT_MS,
+                    ),
+                )
+            },
             callbacks = getMigrationCallbacks(),
         )
     }
@@ -32,4 +47,9 @@ class IosSandookDriverFactory : SandookDriverFactory {
         AfterVersion(7) { SandookMigrationAfter7.migrate(it) },
         AfterVersion(8) { SandookMigrationAfter8.migrate(it) },
     )
+
+    private companion object {
+        // Generous timeout (30s) so a slow first-launch GTFS insert never starves another writer.
+        const val BUSY_TIMEOUT_MS = 30_000
+    }
 }

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/di/IosSandookModule.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/di/IosSandookModule.kt
@@ -2,20 +2,14 @@ package xyz.ksharma.krail.sandook.di
 
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.singleOf
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
-import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.sandook.IosSandookDriverFactory
-import xyz.ksharma.krail.sandook.RealSandook
 import xyz.ksharma.krail.sandook.SandookDriverFactory
 
 actual val sqlDriverModule = module {
+    // RealSandook (and the other repos) are bound in the shared sandookModule and consume the
+    // single shared KrailSandook, so they all share one driver / connection pool. Do not create
+    // additional drivers here: separate pools over the same db file race for write locks and
+    // throw SQLITE_BUSY (this caused the iOS theme-selection crash during first-launch GTFS imports).
     singleOf(::IosSandookDriverFactory) { bind<SandookDriverFactory>() }
-
-    single<RealSandook> {
-        RealSandook(
-            factory = IosSandookDriverFactory(),
-            ioDispatcher = get(named(DispatchersComponent.IODispatcher)),
-        )
-    }
 }


### PR DESCRIPTION
The iOS app crashed with `SQLiteExceptionErrorCode: database is locked`
(SQLITE_BUSY) when selecting a theme during the first-launch GTFS import.

Root cause: the same `krailSandook.db` was opened by several independent
`NativeSqliteDriver` connection pools — each repo (`RealSandook`,
`RealNswStopsSandook`, `RealNswBusRoutesSandook`) called
`factory.createDriver()`, and both platform DI modules declared an extra
`single<RealSandook>` with its own factory. Separate pools cannot serialize
through SQLDelight's single-writer borrow, so they race for the file write
lock. sqliter already defaults to WAL + a 5s busy timeout, but the ~5.5s
first-launch stops insert outlives that timeout, so a competing writer (theme
selection) throws. Android masks the same bug via its busy handler + WAL.

Fix, in four layers:
- Share one driver: all repos now consume the shared `KrailSandook` from Koin;
  removed the duplicate `single<RealSandook>` in both platform modules. One
  pool = writes serialize on the Kotlin-side borrow, no cross-pool lock race.
- iOS driver: set WAL explicitly and raise busyTimeout to 30s (defence in depth).
- De-dup the import: `Mutex` in NswStopsManager and NswBusRoutesManager so the
  concurrent RealAppStart + IntroViewModel callers don't both run the full insert.
- Resilient theme write: wrap clearTheme/insertOrReplaceTheme in runCatching so a
  transient lock degrades gracefully instead of crashing.

Verified: detekt, :feature:trip-planner:ui:testAndroidHostTest, and iOS
simulator compile of :sandook and :io:gtfs all green.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>