### PR TITLE
docs(release-notes): add v1.22.0 Play Store + App Store notes

### DIFF
--- a/docs/release-notes/v1.22.0.md
+++ b/docs/release-notes/v1.22.0.md
@@ -1,0 +1,34 @@
+# KRAIL v1.22.0 — Release Notes
+
+## Android — Google Play Store
+
+v1.22.0
+
+Smarter search, sorted.
+
+🔍 Search now handles typos — type it roughly and KRAIL still finds your stop. Open search for curated quick-pick stops, with the best matches up top and buses sorted below trains and metro.
+
+☁️ Fresh new look on the search screen.
+
+🕐 Latest NSW timetables, stops and routes.
+
+Fixed: load-more and previous trips load reliably.
+
+Let's KRAIL.
+
+---
+
+## iOS — App Store
+
+v1.22.0
+
+Smarter search, top to bottom.
+
+1. Typo-friendly search: Type a stop name roughly and KRAIL still finds it, thanks to a new fuzzy search ranker.
+2. Quick-pick stops: Open search to see curated stops straight away, with the most relevant results first and bus stops sorted below trains and metro.
+3. Refreshed search screen: A new cloud gradient background gives the search screen a cleaner look.
+4. Latest NSW timetables: Updated stops and routes from Transport for NSW.
+
+Fixed: Load-more and previous trips now load reliably.
+
+Let's KRAIL.


### PR DESCRIPTION
Headline is the search overhaul: typo-tolerant fuzzy ranker, curated
quick-pick stops on first open, better relevance ordering, and buses
sorted below rail. Plus the refreshed cloud-gradient search screen and
latest NSW GTFS data.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>