### PR TITLE
fix(search): surface curated stops for single-letter queries

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -88,9 +88,16 @@ class RealStopResultsManager(
         // missing matches because LIKE 'X%' won't tolerate leading whitespace.
         val safeQuery = query.take(MAX_QUERY_LENGTH).trim()
 
-        // Don't search on 1-character queries. The exact path's substring LIKE returns
-        // a flood of accidental matches and the fuzzy path is too noisy to be useful.
-        if (safeQuery.length < MIN_QUERY_LENGTH) return@withContext emptyList()
+        if (safeQuery.isEmpty()) return@withContext emptyList()
+
+        // Single-letter queries can't use the substring LIKE / fuzzy paths: '%a%' floods
+        // the result set with thousands of accidental matches and trigram seeding has no
+        // signal from one character. Fall back to the curated high-priority list (major
+        // CBD / interchange stations) filtered to names whose words start with the letter
+        // so "c" surfaces Central / Circular Quay / Castle Hill instead of nothing.
+        if (safeQuery.length < MIN_QUERY_LENGTH) {
+            return@withContext shortQueryStopResults(safeQuery)
+        }
 
         val results = mutableListOf<SearchStopState.SearchResult>()
 
@@ -132,6 +139,21 @@ class RealStopResultsManager(
         }
 
         results
+    }
+
+    private fun shortQueryStopResults(query: String): List<SearchStopState.SearchResult.Stop> {
+        if (highPriorityStopIdList.isEmpty()) return emptyList()
+        val q = query.lowercase()
+        return sandook.selectStopsByIds(highPriorityStopIdList)
+            .map { it.toStopSearchResult() }
+            .filter { stop ->
+                val name = stop.stopName.lowercase()
+                // Word-prefix: matches "Central" for "c" and "Town Hall" for "h",
+                // but not "Macquarie" for "c" (which substring LIKE would surface).
+                name.startsWith(q) || name.contains(" $q")
+            }
+            .let(::prioritiseStops)
+            .take(MAX_STOP_SEARCH_RESULTS)
     }
 
     private fun fetchFuzzyResults(
@@ -358,7 +380,8 @@ class RealStopResultsManager(
         // by candidate-name length, not query length.
         private const val MAX_QUERY_LENGTH = 64
 
-        // Below this length the substring LIKE matches everything and the ranker is noise.
+        // Below this length the substring LIKE matches everything and the ranker is noise,
+        // so we drop to the curated short-query path instead of running the full search.
         private const val MIN_QUERY_LENGTH = 2
 
         private const val MIN_FUZZY_FALLBACK_THRESHOLD = 5

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManagerQueryBoundaryTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopResultsManagerQueryBoundaryTest.kt
@@ -29,17 +29,75 @@ import kotlin.test.assertTrue
 class StopResultsManagerQueryBoundaryTest {
 
     @Test
-    fun `single character query returns empty without DB call`() = runTest {
+    fun `single character query never triggers substring LIKE search`() = runTest {
+        // Whether the curated short-query path returns matches or not, single-letter
+        // queries must skip selectStops (the '%a%' path) to avoid the result-set flood.
         val sandook = RecordingSandook()
         val manager = manager(sandook)
+
+        manager.fetchStopResults("a", searchRoutesEnabled = false)
+
+        assertTrue(
+            sandook.selectStopsCalls.isEmpty(),
+            "Expected no substring LIKE call for 1-char query, got: ${sandook.selectStopsCalls}",
+        )
+    }
+
+    @Test
+    fun `single character query returns empty when no high-priority stops are configured`() = runTest {
+        val sandook = RecordingSandook()
+        val manager = manager(sandook, highPriorityIds = emptyList())
 
         val result = manager.fetchStopResults("a", searchRoutesEnabled = false)
 
         assertTrue(result.isEmpty())
         assertTrue(
-            sandook.selectStopsCalls.isEmpty(),
-            "Expected no DB call for 1-char query, got: ${sandook.selectStopsCalls}",
+            sandook.selectStopsByIdsCalls.isEmpty(),
+            "Expected no DB lookup when high-priority list is empty",
         )
+    }
+
+    @Test
+    fun `single character query surfaces high-priority stops whose words start with the letter`() = runTest {
+        val stops = listOf(
+            stopRow("HP1", "Central Station"),
+            stopRow("HP2", "Town Hall Station"),
+            stopRow("HP3", "Circular Quay"),
+            stopRow("HP4", "Macquarie University"),
+        )
+        val sandook = RecordingSandook(returns = stops)
+        val manager = manager(
+            sandook,
+            highPriorityIds = listOf("HP1", "HP2", "HP3", "HP4"),
+        )
+
+        val result = manager.fetchStopResults("c", searchRoutesEnabled = false)
+
+        val resultIds = result.filterIsInstance<SearchStopState.SearchResult.Stop>().map { it.stopId }
+        // Central + Circular Quay start with 'c'. Macquarie has no word starting with 'c'
+        // (substring LIKE would have wrongly surfaced it). Town Hall has none either.
+        assertEquals(setOf("HP1", "HP3"), resultIds.toSet())
+        assertEquals(
+            listOf(listOf("HP1", "HP2", "HP3", "HP4")),
+            sandook.selectStopsByIdsCalls,
+            "Expected one batch lookup of the configured high-priority list",
+        )
+    }
+
+    @Test
+    fun `single character query matches mid-name word prefix as well as leading prefix`() = runTest {
+        val stops = listOf(
+            stopRow("HP1", "Town Hall Station"),
+            stopRow("HP2", "Mascot"),
+        )
+        val sandook = RecordingSandook(returns = stops)
+        val manager = manager(sandook, highPriorityIds = listOf("HP1", "HP2"))
+
+        val result = manager.fetchStopResults("h", searchRoutesEnabled = false)
+
+        val resultIds = result.filterIsInstance<SearchStopState.SearchResult.Stop>().map { it.stopId }
+        // 'h' matches the second word "Hall" in Town Hall Station, not Mascot.
+        assertEquals(listOf("HP1"), resultIds)
     }
 
     @Test
@@ -201,7 +259,8 @@ private class RecordingSandook(
 
     override fun selectStopsByIds(stopIds: List<String>): List<SelectProductClassesForStop> {
         selectStopsByIdsCalls += stopIds
-        return emptyList()
+        val wanted = stopIds.toSet()
+        return returns.filter { it.stopId in wanted }
     }
 
     override fun observeStopLabels(): Flow<List<StopLabels>> = emptyFlow()


### PR DESCRIPTION
The single-letter path previously short-circuited to an empty list because
substring LIKE '%a%' floods the result set and trigram fuzzy seeding has no
signal from one character. Analytics show ~1,300 zero-result single-letter
searches across the top queries.

For length-1 queries, fall back to the curated high-priority stop list (the
~32 CBD / interchange stations already used to seed fuzzy candidates) and
keep only stops whose name has a word starting with the letter. "c" now
surfaces Central, Circular Quay, Castle Hill, Cherrybrook; "h" surfaces Town
Hall via the second-word prefix; "m" does not surface Macquarie for "c"
queries the way substring LIKE would have.

Reuses selectStopsByIds so no Sandook interface change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>