### PR TITLE
fix(searchstop): un-nest scene strategy and bound list pane width on tablets

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
@@ -1,7 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation.entries
 
-import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -18,16 +16,18 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 
 /**
- * Search Stop Entry - Detail Screen in List-Detail pattern
+ * Renders full-width on every form factor. SearchStopScreen owns its own
+ * list + map split internally via AdaptiveScreenContent, so this entry must
+ * not declare ListDetailSceneStrategy.listPane() — doing so would halve the
+ * window before the screen's own dual-pane halves it again, producing the
+ * cramped ~25 % / ~25 % layout on tablets and phone landscape.
+ * See docs/TABLET_FOLDABLE_UX.md §2.
  */
-@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 internal fun EntryProviderScope<NavKey>.SearchStopEntry(
     tripPlannerNavigator: TripPlannerNavigator,
 ) {
-    entry<SearchStopRoute>(
-        metadata = ListDetailSceneStrategy.listPane(),
-    ) { key ->
+    entry<SearchStopRoute> { key ->
         // ViewModel is scoped to this NavEntry and will be recreated each time
         // This ensures recent stops are refreshed when the screen is opened
         val viewModel: SearchStopViewModel = koinViewModel()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
@@ -67,6 +68,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_close
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -820,16 +822,18 @@ private fun SearchStopScreenDualPane(
                 .fillMaxSize()
                 .imePadding(),
         ) {
-            // Split view: List on left, Map on right
+            // Split view: List on left (bounded width), Map on right (fills the rest).
+            // See docs/TABLET_FOLDABLE_UX.md §2 for the ratio rationale.
             Row(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth(),
             ) {
-                // Left pane: List with search bar
+                // Left pane: list keeps phone-width proportions so stop rows stay readable;
+                // map then takes the remainder.
                 Column(
                     modifier = Modifier
-                        .weight(1f)
+                        .widthIn(min = SEARCH_STOP_LIST_PANE_MIN_WIDTH, max = SEARCH_STOP_LIST_PANE_MAX_WIDTH)
                         .fillMaxHeight(),
                 ) {
                     // Search top bar only spans the list width
@@ -1640,6 +1644,12 @@ private fun MapAutoInitEffect(
         }
     }
 }
+
+// Dual-pane list-column width bounds. Keeps the stops list at ≈ phone-width so
+// StopSearchListItem rows stay readable; map fills the remainder. See
+// docs/TABLET_FOLDABLE_UX.md §2 for the ratio table.
+private val SEARCH_STOP_LIST_PANE_MIN_WIDTH = 320.dp
+private val SEARCH_STOP_LIST_PANE_MAX_WIDTH = 480.dp
 
 // Pill scale factors used by LabelShortcutsRow's graphicsLayer transform — extracted
 // here so the call site reads as intent, not magic numbers.


### PR DESCRIPTION
## Summary

Fixes the cramped ~25 % / ~25 % SearchStopScreen layout that the user observed on tablets, foldable-unfolded, and phone landscape. Two changes:

1. **`SearchStopEntry`**: drop `ListDetailSceneStrategy.listPane()` metadata. SearchStopScreen already runs its own list+map split internally via `AdaptiveScreenContent`, so the Material 3 list-detail scaffold was halving the window before the screen's own dual-pane halved it again. Removing the metadata is the load-bearing fix — the route now renders full-width on every form factor.
2. **`SearchStopScreenDualPane`**: bound the list column to `widthIn(min = 320.dp, max = 480.dp)` instead of `weight(1f)`. With the parent now full-width, a 50/50 split would stretch stop rows uncomfortably wide on tablets and waste room the map can use. List stays phone-width, map takes the remainder. Constants extracted at file scope.

Stacked on top of #1629 (the spec doc). See [`docs/TABLET_FOLDABLE_UX.md` §2](https://github.com/ksharma-xyz/KRAIL/blob/docs/tablet-foldable-ux-rules/docs/TABLET_FOLDABLE_UX.md#2-searchstopscreen) for the breakpoint contract and ratio table.

## Test plan

- [x] `./gradlew :feature:trip-planner:ui:detekt --continue` — green
- [x] `./gradlew :feature:trip-planner:ui:testAndroidHostTest --continue` — green
- [ ] Manual verify on Android tablet (1280×800): list column ≈ 480 dp, map fills the rest, stops scroll smoothly, tapping a map stop selects it on the list side
- [ ] Manual verify on Pixel Fold unfolded (≈ 670 dp portrait): list ≈ 320 dp, map ≈ 350 dp, both usable
- [ ] Manual verify on phone landscape (≈ 720 dp): list ≈ 360 dp, map ≈ 360 dp
- [ ] Manual verify on phone portrait (compact): single-pane unchanged, list/map toggle still works
- [ ] Manual verify on iPad simulator (matching widths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)