### PR TITLE
feat(timetable): persistent JourneyMap pane on tablets / foldable / landscape

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -1,53 +1,66 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation.entries
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.koin.compose.viewmodel.koinViewModel
+import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.components.ModalBottomSheet
+import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertScreen
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorScreen
+import xyz.ksharma.krail.trip.planner.ui.journeymap.JourneyMap
+import xyz.ksharma.krail.trip.planner.ui.journeymap.business.JourneyMapMapper.toJourneyMapState
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.dateTimeSelectionSaver
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.serviceAlertSaver
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableScreen
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 
 /**
- * TimeTable Entry - Detail Screen in List-Detail pattern
+ * Renders full-width on every form factor. On tablets / foldable-unfolded / phone
+ * landscape (≥ 600 dp width), the screen splits internally: journey list on the left
+ * (capped width), persistent JourneyMap on the right. The per-card "Maps" button is
+ * suppressed in dual-pane because the map is always visible.
  *
- * Handles modal state for alerts and date/time selection.
- * Uses custom savers to preserve state across configuration changes.
+ * See docs/TABLET_FOLDABLE_UX.md §3.
  */
-@OptIn(ExperimentalMaterial3AdaptiveApi::class)
-@Suppress("UNUSED_VARIABLE")
+@Suppress("UNUSED_VARIABLE", "LongMethod")
 @Composable
 internal fun EntryProviderScope<NavKey>.TimeTableEntry(
     tripPlannerNavigator: TripPlannerNavigator,
 ) {
-    entry<TimeTableRoute>(
-        metadata = ListDetailSceneStrategy.detailPane(),
-    ) { key ->
+    entry<TimeTableRoute> { key ->
         LaunchedEffect(key) {
             log("🗺️ TimeTableEntry - key changed: from-${key.fromStopId}, to: ${key.toStopId}")
         }
@@ -100,8 +113,25 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
             )
         }
 
-        Box(modifier = Modifier.fillMaxSize()) {
-            // Main TimeTable Screen
+        // Adaptive layout — dual-pane on ≥ 600 dp width
+        val adaptiveLayoutInfo = rememberAdaptiveLayoutInfo()
+        val dualPane = adaptiveLayoutInfo.shouldShowDualPane
+
+        // Map state for the currently expanded journey. produceState recomputes whenever
+        // expandedJourneyId changes — the JourneyMap composable stays mounted in the right
+        // pane, only its data layer re-renders.
+        val journeyMapState by produceState<JourneyMapUiState?>(
+            initialValue = null,
+            key1 = expandedJourneyId,
+        ) {
+            value = expandedJourneyId?.let { id ->
+                withContext(Dispatchers.Default) {
+                    viewModel.getRawJourneyById(id)?.toJourneyMapState()
+                }
+            }
+        }
+
+        val timeTableScreen: @Composable (Modifier, Boolean) -> Unit = { mod, hideMapBtn ->
             TimeTableScreen(
                 timeTableState = timeTableState,
                 expandedJourneyId = expandedJourneyId,
@@ -140,7 +170,51 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                 onMapClick = { journeyId ->
                     tripPlannerNavigator.navigateToJourneyMap(journeyId)
                 },
+                hideMapButton = hideMapBtn,
+                modifier = mod,
             )
+        }
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (dualPane) {
+                Row(modifier = Modifier.fillMaxSize()) {
+                    timeTableScreen(
+                        Modifier
+                            .widthIn(max = TIMETABLE_PANE_MAX_WIDTH)
+                            .fillMaxHeight(),
+                        true,
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .background(color = KrailTheme.colors.surface),
+                    ) {
+                        when (val mapState = journeyMapState) {
+                            is JourneyMapUiState.Ready -> {
+                                JourneyMap(
+                                    journeyMapState = mapState,
+                                    modifier = Modifier.fillMaxSize(),
+                                )
+                            }
+                            else -> {
+                                Text(
+                                    text = "Tap a journey to see the route",
+                                    style = KrailTheme.typography.bodyLarge,
+                                    color = KrailTheme.colors.onSurface,
+                                    modifier = Modifier
+                                        .align(Alignment.Center)
+                                        .padding(KrailTheme.dimensions.spacingXL)
+                                        .fillMaxWidth(),
+                                )
+                            }
+                        }
+                    }
+                }
+            } else {
+                timeTableScreen(Modifier.fillMaxSize(), false)
+            }
 
             // Service Alerts Modal
             if (showAlertsModal) {
@@ -186,3 +260,7 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
         }
     }
 }
+
+// Left-pane width cap in dual-pane. Keeps journey cards at phone-width proportions
+// (≈ 520 dp) so they don't stretch awkwardly on tablets; map fills the remainder.
+private val TIMETABLE_PANE_MAX_WIDTH = 520.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -110,6 +110,9 @@ fun TimeTableScreen(
     onModeSelectionChanged: (Set<Int>) -> Unit = {},
     onModeClick: (Boolean) -> Unit = {},
     onMapClick: (String) -> Unit = {},
+    // When true, the per-card "Maps" button is suppressed because a persistent map pane
+    // is rendered alongside this screen (see docs/TABLET_FOLDABLE_UX.md §3).
+    hideMapButton: Boolean = false,
 ) {
     val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
@@ -385,6 +388,7 @@ fun TimeTableScreen(
                         onMapClick = onMapClick,
                     ),
                     onPlanTripClick = dateTimeSelectorClicked,
+                    hideMapButton = hideMapButton,
                 )
             } else { // Journey list is empty or null
                 item(key = "no-results") {
@@ -446,6 +450,7 @@ private fun LazyListScope.journeyListContent(
     themeColor: Color,
     callbacks: JourneyCallbacks,
     onPlanTripClick: () -> Unit,
+    hideMapButton: Boolean,
 ) {
     if (state.paginationEnabled) {
         paginationHeader(
@@ -459,6 +464,7 @@ private fun LazyListScope.journeyListContent(
             expandedJourneyId = expandedJourneyId,
             state = state,
             callbacks = callbacks,
+            hideMapButton = hideMapButton,
         )
     }
     journeyCardItems(
@@ -467,6 +473,7 @@ private fun LazyListScope.journeyListContent(
         expandedJourneyId = expandedJourneyId,
         state = state,
         callbacks = callbacks,
+        hideMapButton = hideMapButton,
     )
     if (state.paginationEnabled) {
         paginationFooter(
@@ -552,6 +559,7 @@ private fun LazyListScope.journeyCardItems(
     expandedJourneyId: String?,
     state: TimeTableState,
     callbacks: JourneyCallbacks,
+    hideMapButton: Boolean,
 ) {
     items(
         items = journeys,
@@ -577,7 +585,7 @@ private fun LazyListScope.journeyCardItems(
             onAlertClick = { callbacks.onAlertClick(journey.journeyId) },
             onLegClick = callbacks.onLegClick,
             onMapClick = { callbacks.onMapClick(journey.journeyId) },
-            isMapsAvailable = state.isMapsAvailable,
+            isMapsAvailable = state.isMapsAvailable && !hideMapButton,
             onShareJourney = { bitmap, shareText, isPastDeparture ->
                 callbacks.onEvent(
                     TimeTableUiEvent.ShareJourneyClicked(


### PR DESCRIPTION
## Summary

Implements [docs/TABLET_FOLDABLE_UX.md §3](https://github.com/ksharma-xyz/KRAIL/blob/docs/tablet-foldable-ux-rules/docs/TABLET_FOLDABLE_UX.md#3-timetablescreen). On ≥ 600 dp width the TimeTable screen splits internally: journey list on the left (capped at 520 dp), persistent `JourneyMap` on the right, keyed on the existing `TimeTableViewModel.expandedJourneyId` flow. The map composable stays mounted as the user expands different journeys — only its data layer (route polyline, leg stops, live vehicle) re-renders.

Changes:

- **`TimeTableEntry`**: drops `ListDetailSceneStrategy.detailPane()` metadata for the same reason the SearchStop fix dropped `listPane()` — TimeTable now owns its own internal list+map split, so letting the Material 3 scaffold halve the window again would cause the same cramped layout. Adds `rememberAdaptiveLayoutInfo()` + branches on `shouldShowDualPane`. In dual-pane: `Row` with `TimeTableScreen` (widthIn(max = 520.dp) + `hideMapButton = true`) on the left and a `JourneyMap` pane on the right. Right pane reads journey data via `produceState` keyed on `expandedJourneyId`, computing the map state on `Dispatchers.Default` to keep UI thread free. With no journey expanded, shows a "Tap a journey to see the route" placeholder.
- **`TimeTableScreen`**: new `hideMapButton: Boolean = false` parameter, threaded through `journeyListContent` → `journeyCardItems` to gate the per-card "Maps" button (`isMapsAvailable = state.isMapsAvailable && !hideMapButton`). On phone (COMPACT) the button stays and continues to navigate to the full-screen `JourneyMapScreen` — phone UX unchanged.

Spec deviation: §5 of the doc listed `TimeTableRoute` as `detailPane()` unchanged. The deviation (dropping that metadata) matches the SearchStop rationale and will be reflected in a doc update later when SavedTrips dual-pane lands and we have a unified picture of how list-detail vs internal-split routes should be marked.

Stacked on top of #1630 (SearchStop fix) and #1629 (spec doc).

## Test plan

- [x] `./gradlew :feature:trip-planner:ui:detekt --continue` — green
- [x] `./gradlew :feature:trip-planner:ui:testAndroidHostTest --continue` — green
- [ ] Manual verify on Android tablet landscape (1280×800): expand a journey → map renders on the right with the route polyline; tap another journey → map data swaps, composable stays mounted (no flicker)
- [ ] Manual verify on phone landscape (≈ 720 dp): same dual-pane behaviour at lower resolution
- [ ] Manual verify on phone portrait (compact): "Maps" button still appears on expanded cards, taps still navigate to full-screen JourneyMapScreen
- [ ] Verify Alerts modal + Date/Time selector modal still work in both single- and dual-pane
- [ ] Verify iOS simulator (iPad landscape) renders the dual-pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)