### PR TITLE
fix(analytics): remove redundant view_screen from dep board

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -14,5 +14,4 @@ sealed class AnalyticsScreen(val name: String) {
     // Map screens — used for ScreenViewEvent + BigQuery engagement_time_msec queries
     data object SearchStopMap : AnalyticsScreen(name = "SearchStopMap")
     data object JourneyMap : AnalyticsScreen(name = "JourneyMap")
-
 }

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -15,5 +15,4 @@ sealed class AnalyticsScreen(val name: String) {
     data object SearchStopMap : AnalyticsScreen(name = "SearchStopMap")
     data object JourneyMap : AnalyticsScreen(name = "JourneyMap")
 
-    data object DepartureBoard : AnalyticsScreen(name = "DepartureBoard")
 }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesAnalytics.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesAnalytics.kt
@@ -1,17 +1,14 @@
 package xyz.ksharma.krail.departures.ui
 
 import xyz.ksharma.krail.core.analytics.Analytics
-import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
-import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 
 internal fun Analytics.trackDepartureBoardScreenView(
     stopId: String,
     stopName: String,
     source: DepartureBoardSource,
 ) {
-    trackScreenViewEvent(AnalyticsScreen.DepartureBoard)
     track(AnalyticsEvent.DepartureBoardScreenViewEvent(stopId = stopId, stopName = stopName, source = source))
 }
 


### PR DESCRIPTION
dep_board_screen_view already captures stopId, stopName, and source —
the generic view_screen { name: "DepartureBoard" } alongside it adds
nothing. Departure board is a bottom sheet, not a nav screen, so
AnalyticsScreen.DepartureBoard was also a misnomer.

- Drop trackScreenViewEvent(AnalyticsScreen.DepartureBoard) call
- Remove unused AnalyticsScreen + trackScreenViewEvent imports
- Remove DepartureBoard entry from AnalyticsScreen sealed class

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>