### PR TITLE
fix(searchstoprow): apply display-cutout horizontal insets to pill and expanded row

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -27,11 +27,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -193,6 +197,7 @@ private fun CollapsedPill(
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal))
             .padding(
                 bottom = with(LocalDensity.current) { navBarPadding.dp } + dim.spacingXL,
                 start = dim.pageHorizontalPadding,
@@ -272,6 +277,7 @@ private fun ExpandedSearchRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal))
                 .padding(vertical = SearchRowVerticalPadding, horizontal = dim.pageHorizontalPadding)
                 .padding(
                     bottom = with(LocalDensity.current) { navBarPadding.dp },


### PR DESCRIPTION
In landscape on phones with a side camera notch, the SearchStopRow
content (pill button or From/To fields) could appear behind the cutout.

Add windowInsetsPadding(displayCutout.only(Horizontal)) to:
- CollapsedPill outer Box — shifts the pill button clear of the notch.
- ExpandedSearchRow inner Row — shifts From/To fields and action
  buttons clear of the notch; the background Column keeps edge-to-edge
  colour (no gap between the card and screen edge).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>