### PR TITLE
fix(map): camera never centers on user location after back-nav return

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -212,9 +212,12 @@ private fun MapContent(
 
         // Auto-center camera on the first non-null user location.
         // State-driven (recomposition-aware) so it survives the iOS permission dialog
-        // bouncing the activity through ON_STOP/ON_START, which used to cancel the
-        // animateTo before it could fire on the first grant.
-        var hasAutoCentered by rememberSaveable { mutableStateOf(false) }
+        // bouncing ON_STOP/ON_START without re-composing MapContent.
+        // remember (not rememberSaveable) — resets when the map is re-entered after
+        // navigation so the camera re-centers on each fresh open. rememberSaveable was
+        // persisting hasAutoCentered=true across back-nav returns, preventing centering
+        // even though location updates were arriving.
+        var hasAutoCentered by remember { mutableStateOf(false) }
         val firstUserLocation = mapState.mapDisplay.userLocation
         LaunchedEffect(firstUserLocation, hasAutoCentered) {
             if (firstUserLocation != null && !hasAutoCentered) {


### PR DESCRIPTION
rememberSaveable persisted hasAutoCentered=true across navigation. On a
return visit to the map, hasAutoCentered was already true so the
LaunchedEffect skipped the animateTo even though fresh location updates
were arriving — confirmed by [USER_LOCATION] logs showing correct
lat/lng but camera staying at Sydney default.

Switch to remember: resets on re-entry (fresh center each open) while
still surviving lifecycle bounces within a single composition session,
which was the original reason rememberSaveable was chosen.

Affects SearchStopMap (single-pane phone) and, through MapStopSelectionPane,
SavedTrips + SearchStop dual-pane right pane.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>