### PR TITLE
fix(mapstopselection): scope VM per nav entry, not as Koin singleton

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -1,8 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.di
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
@@ -124,14 +121,11 @@ val viewModelsModule = module {
         )
     }
 
-    // Shared right-pane map state — one Koin singleton reused by SavedTrips dual-pane
-    // (and SearchStop dual-pane in a follow-up PR). WhileSubscribed pattern inside the
-    // VM auto-cancels active queries when no consumer is collecting mapUiState.
-    single {
-        MapStopSelectionViewModel(
-            nearbyStopsManager = get(),
-            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-        )
+    // Per-entry map ViewModel — each nav entry (SavedTrips, SearchStop) gets its own
+    // instance so screens never share state or compete for NearbyStopsManager queries.
+    // NearbyStopsManager itself is a single so network/cache work is still deduplicated.
+    viewModel {
+        MapStopSelectionViewModel(nearbyStopsManager = get())
     }
 
     viewModelOf(::DepartureBoardViewModel)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionViewModel.kt
@@ -1,7 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.mapstopselection
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -18,23 +19,23 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
 
 /**
- * Shared owner of right-pane map state. One Koin singleton, reused by both
- * SavedTrips and SearchStop dual-pane (SearchStop migration lands in a follow-up PR).
+ * Owns right-pane map state for a single nav entry (SavedTrips or SearchStop dual-pane).
  *
- * State is **Ready from construction** — no initialise event needed, no race against
- * the first composition. Pane just collects.
+ * Scoped to the NavEntry ViewModel store — each screen gets its own instance so
+ * SavedTrips and SearchStop never share state or compete for NearbyStopsManager queries.
+ * The shared [NearbyStopsManager] (Koin single) still deduplcates network work under the hood.
  *
- * Lifecycle (mirrors TimeTableViewModel's WhileSubscribed pattern):
- * - Stops doing work as soon as the last consumer drops [mapUiState], with a small
- *   timeout to ride out config changes.
- * - Cancels any in-flight NearbyStopsManager query via [stopActiveWork].
- * - State is kept in-memory across attach/detach so the next consumer sees the last
- *   known map immediately (no flicker).
+ * State is **Ready from construction** — no initialise event needed.
+ *
+ * Lifecycle (WhileSubscribed pattern):
+ * - Stops work when the last UI consumer drops [mapUiState], with a 5-second timeout
+ *   to ride out rotation / config changes without cancelling in-flight queries.
+ * - viewModelScope is cancelled when the entry leaves the back stack.
  */
 class MapStopSelectionViewModel(
     private val nearbyStopsManager: NearbyStopsManager,
-    private val scope: CoroutineScope,
-) {
+) : ViewModel() {
+
     init {
         log("[MAP_STOP_SEL] VM init — seeded MapUiState.Ready")
     }
@@ -42,10 +43,10 @@ class MapStopSelectionViewModel(
     private val _mapUiState: MutableStateFlow<MapUiState> = MutableStateFlow(MapUiState.Ready())
 
     val mapUiState: StateFlow<MapUiState> = _mapUiState
-        .onStart { log("[MAP_STOP_SEL] consumer attached (subscriber count > 0)") }
-        .onCompletion { stopActiveWork() }
+        .onStart { log("[MAP_STOP_SEL] consumer attached") }
+        .onCompletion { log("[MAP_STOP_SEL] last consumer detached") }
         .stateIn(
-            scope = scope,
+            scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(SUBSCRIBER_TIMEOUT_MS),
             initialValue = MapUiState.Ready(),
         )
@@ -55,6 +56,12 @@ class MapStopSelectionViewModel(
             is MapStopSelectionEvent.UserLocationUpdated -> onUserLocationUpdated(event.location)
             is MapStopSelectionEvent.MapCenterChanged -> onMapCenterChanged(event.center)
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        nearbyStopsManager.cancelOngoingQuery()
+        log("[MAP_STOP_SEL] VM cleared — cancelled active queries")
     }
 
     private fun onUserLocationUpdated(location: LatLng?) {
@@ -79,7 +86,7 @@ class MapStopSelectionViewModel(
         nearbyStopsManager.loadNearbyStops(
             mapState = mapState,
             center = mapState.mapDisplay.mapCenter,
-            scope = scope,
+            scope = viewModelScope,
             onLoadingStateChanged = { isLoading ->
                 val ready = _mapUiState.value as? MapUiState.Ready ?: return@loadNearbyStops
                 _mapUiState.value = ready.copy(isLoadingNearbyStops = isLoading)
@@ -104,14 +111,7 @@ class MapStopSelectionViewModel(
         )
     }
 
-    private fun stopActiveWork() {
-        log("[MAP_STOP_SEL] last consumer detached — cancelling active queries")
-        nearbyStopsManager.cancelOngoingQuery()
-    }
-
     companion object {
-        // Matches the SearchStop pattern — long enough to ride out rotation, short
-        // enough that backgrounded screens stop work.
         private const val SUBSCRIBER_TIMEOUT_MS = 5000L
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.navigation.ResultEffect
 import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionPane
@@ -35,7 +34,7 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
     entry<SavedTripsRoute> {
         // Scoped ViewModel that survives navigation
         val viewModel: SavedTripsViewModel = koinViewModel(key = "SavedTripsNav")
-        val mapStopSelectionViewModel: MapStopSelectionViewModel = koinInject()
+        val mapStopSelectionViewModel: MapStopSelectionViewModel = koinViewModel()
         val mapUiState by mapStopSelectionViewModel.mapUiState.collectAsStateWithLifecycle()
         val savedTripState by viewModel.uiState.collectAsStateWithLifecycle()
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.navigation.LocalResultEventBusObj
 import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
@@ -37,7 +36,7 @@ internal fun EntryProviderScope<NavKey>.SearchStopEntry(
 
         // Shared singleton ViewModel for the dual-pane right-pane map. Injected here
         // (entry level) so the composable tree never touches Koin directly.
-        val mapStopSelectionViewModel: MapStopSelectionViewModel = koinInject()
+        val mapStopSelectionViewModel: MapStopSelectionViewModel = koinViewModel()
         val mapUiState by mapStopSelectionViewModel.mapUiState.collectAsStateWithLifecycle()
 
         // Refresh recent stops every time screen opens.


### PR DESCRIPTION
The singleton MapStopSelectionViewModel shared state between SavedTrips
and SearchStop dual-pane. When the user navigated from SavedTrips to
SearchStop in landscape (or vice versa), the second screen inherited
stale map state from the first — causing:
- Nearby stops for the wrong area (previous screen's center)
- NearbyStopsManager query conflicts (two callers, one manager)
- Location tracking thrash visible in [USER_LOCATION] start/stop loops
  as both entries competed for the single WhileSubscribed flow

Fix:
- MapStopSelectionViewModel extends ViewModel(), uses viewModelScope
  instead of an injected CoroutineScope. onCleared() cancels the
  NearbyStopsManager query (previously done via onCompletion).
- ViewModelModule: single{} -> viewModel{} so each NavEntry gets its
  own independent VM instance with isolated state and its own scope.
- Both entries: koinInject() -> koinViewModel() to consume the
  per-entry scoped instance.
- NearbyStopsManager remains a Koin single so network/cache work is
  still shared; only the in-memory map state is isolated.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>