### PR TITLE
fix(map): prevent camera drift back to Sydney on composition re-entry

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -1,5 +1,8 @@
 package xyz.ksharma.krail.trip.planner.ui.di
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -172,28 +172,22 @@ private fun MapContent(
     val scope = rememberCoroutineScope()
 
     Box(modifier = modifier.fillMaxSize()) {
-        // Start at default Sydney coordinates
+        // Seed from known user location so re-entry after a composition bounce
+        // (dual-pane layout shift, rotation) doesn't flash at Sydney default.
+        val knownLocation = mapState.mapDisplay.userLocation
         val cameraState = rememberCameraState(
-            firstPosition = CameraPosition(
-                target = Position(
-                    latitude = NearbyStopsConfig.DEFAULT_CENTER_LAT,
-                    longitude = NearbyStopsConfig.DEFAULT_CENTER_LON,
-                ),
-                zoom = NearbyStopsConfig.DEFAULT_ZOOM,
-            ),
+            firstPosition = initialCameraPosition(knownLocation),
         )
 
-        // Trigger initial load with default camera position
+        // Trigger initial nearby-stops load for the camera's starting position.
+        val initialCenter = knownLocation ?: LatLng(
+            NearbyStopsConfig.DEFAULT_CENTER_LAT,
+            NearbyStopsConfig.DEFAULT_CENTER_LON,
+        )
         LaunchedEffect(Unit) {
-            log("[NEARBY_STOPS_UI] Map initialized at default position")
-            onEvent(
-                SearchStopUiEvent.MapCenterChanged(
-                    LatLng(
-                        NearbyStopsConfig.DEFAULT_CENTER_LAT,
-                        NearbyStopsConfig.DEFAULT_CENTER_LON,
-                    ),
-                ),
-            )
+            val label = if (knownLocation != null) "user location" else "Sydney default"
+            log("[NEARBY_STOPS_UI] Map initialized at $label")
+            onEvent(SearchStopUiEvent.MapCenterChanged(initialCenter))
         }
 
         TrackUserLocation(
@@ -210,16 +204,14 @@ private fun MapContent(
             },
         )
 
-        // Auto-center camera on the first non-null user location.
-        // State-driven (recomposition-aware) so it survives the iOS permission dialog
-        // bouncing ON_STOP/ON_START without re-composing MapContent.
-        // remember (not rememberSaveable) — resets when the map is re-entered after
-        // navigation so the camera re-centers on each fresh open. rememberSaveable was
-        // persisting hasAutoCentered=true across back-nav returns, preventing centering
-        // even though location updates were arriving.
-        var hasAutoCentered by remember { mutableStateOf(false) }
+        // Auto-center on first user location.
+        // - hasAutoCentered seeds true if location is already known (re-entry case) —
+        //   no animation needed because cameraState already starts at userLoc above.
+        // - Keyed only on firstUserLocation, NOT on hasAutoCentered, so changing
+        //   hasAutoCentered false→true doesn't restart and cancel the animateTo.
         val firstUserLocation = mapState.mapDisplay.userLocation
-        LaunchedEffect(firstUserLocation, hasAutoCentered) {
+        var hasAutoCentered by remember { mutableStateOf(firstUserLocation != null) }
+        LaunchedEffect(firstUserLocation) {
             if (firstUserLocation != null && !hasAutoCentered) {
                 hasAutoCentered = true
                 cameraState.animateTo(
@@ -301,29 +293,16 @@ private fun MapContent(
                         SearchStopUiEvent.LocationButtonClicked(hadLocation = mapState.mapDisplay.userLocation != null),
                     )
                     scope.launch {
-                        val userLoc = mapState.mapDisplay.userLocation
-                        if (userLoc != null) {
-                            // Tracking is running — re-center camera on latest known position
-                            cameraState.animateTo(
-                                CameraPosition(
-                                    target = userLoc.toPosition(),
-                                    zoom = UserLocationConfig.RECENTER_ZOOM,
-                                ),
-                                duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-                            )
-                        } else {
-                            val status = userLocationManager.checkPermissionStatus()
-                            if (status is PermissionStatus.Denied) {
-                                // Cannot request — direct user to Settings instead
+                        handleLocationButtonClick(
+                            userLoc = mapState.mapDisplay.userLocation,
+                            cameraState = cameraState,
+                            userLocationManager = userLocationManager,
+                            onPermissionDenied = { status ->
                                 permissionStatus = status
                                 showPermissionBanner = true
-                            } else {
-                                // Flip the flag: TrackUserLocation's LifecycleStartEffect
-                                // relaunches immediately (key changed) and calls locationUpdates(),
-                                // which triggers the system permission dialog if not yet determined.
-                                allowPermissionRequest = true
-                            }
-                        }
+                            },
+                            onRequestPermission = { allowPermissionRequest = true },
+                        )
                     }
                 },
                 modifier = Modifier.align(Alignment.BottomStart),
@@ -424,6 +403,39 @@ private fun MapContent(
 }
 
 private fun LatLng.toPosition(): Position = Position(latitude = latitude, longitude = longitude)
+
+private suspend fun handleLocationButtonClick(
+    userLoc: LatLng?,
+    cameraState: org.maplibre.compose.camera.CameraState,
+    userLocationManager: xyz.ksharma.krail.core.maps.data.location.UserLocationManager,
+    onPermissionDenied: (xyz.ksharma.aagya.permission.PermissionStatus) -> Unit,
+    onRequestPermission: () -> Unit,
+) {
+    if (userLoc != null) {
+        cameraState.animateTo(
+            CameraPosition(target = userLoc.toPosition(), zoom = UserLocationConfig.RECENTER_ZOOM),
+            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
+        )
+    } else {
+        val status = userLocationManager.checkPermissionStatus()
+        if (status is xyz.ksharma.aagya.permission.PermissionStatus.Denied) {
+            onPermissionDenied(status)
+        } else {
+            onRequestPermission()
+        }
+    }
+}
+
+private fun initialCameraPosition(knownLocation: LatLng?): CameraPosition =
+    knownLocation?.let {
+        CameraPosition(target = it.toPosition(), zoom = UserLocationConfig.AUTO_CENTER_ZOOM)
+    } ?: CameraPosition(
+        target = Position(
+            latitude = NearbyStopsConfig.DEFAULT_CENTER_LAT,
+            longitude = NearbyStopsConfig.DEFAULT_CENTER_LON,
+        ),
+        zoom = NearbyStopsConfig.DEFAULT_ZOOM,
+    )
 
 // region Previews
 


### PR DESCRIPTION
Root cause: when MapContent briefly left and re-entered the composition
(dual-pane layout shift, rotation, lifecycle bounce), cameraState reset
to Sydney default and hasAutoCentered reset to false. Even though the VM
still had userLocation, the camera flashed at Sydney before animating back.

Two fixes:
1. Seed cameraState from mapState.mapDisplay.userLocation if non-null.
   On re-entry the camera starts at the user's position directly — no
   Sydney flash, no animation needed.
2. Seed hasAutoCentered = (userLocation != null). Re-entry with a known
   location skips the animateTo entirely.

Also remove hasAutoCentered from the LaunchedEffect key — it was
restarting (and cancelling animateTo mid-flight) when hasAutoCentered
changed false→true just after the animation started.

Also extracted handleLocationButtonClick (reduces MapContent cyclomatic
complexity to below detekt threshold) and initialCameraPosition helpers.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>