### PR TITLE
feat(adaptive): dual-pane maps for tablets + foldables + phone landscape

### DIFF
--- a/config/test-wiring-baseline.txt
+++ b/config/test-wiring-baseline.txt
@@ -15,3 +15,4 @@
 :feature:debug-settings:ui|src/commonTest/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsViewModelTest.kt
 :feature:track:ui|src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TrackTripViewModelTest.kt
 :feature:trip-planner:ui|src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
+:feature:trip-planner:ui|src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManagerCacheTest.kt

--- a/core/adaptive-ui/src/commonMain/kotlin/xyz/ksharma/krail/core/adaptiveui/AdaptiveLayoutInfo.kt
+++ b/core/adaptive-ui/src/commonMain/kotlin/xyz/ksharma/krail/core/adaptiveui/AdaptiveLayoutInfo.kt
@@ -148,6 +148,25 @@ data class AdaptiveLayoutInfo(
      */
     val shouldShowDualPane: Boolean
         get() = isTabletOrFoldable
+
+    /**
+     * Phone in landscape: any window with compact height (< 480 dp).
+     *
+     * Width alone can't distinguish phone-landscape from tablet — modern phones with
+     * edge-to-edge displays hit EXPANDED width (≥ 840 dp) in landscape. But no tablet
+     * has < 480 dp height in any orientation, so [isCompactHeight] is the reliable
+     * signal for "this is a phone rotated to landscape, treat vertical space as scarce".
+     */
+    val isPhoneLandscape: Boolean
+        get() = isCompactHeight
+
+    /**
+     * Tablet (or unfolded foldable) — wide enough for dual-pane AND tall enough that
+     * it isn't a phone in landscape. Used to gate adaptations that only make sense
+     * with both dimensions roomy (e.g. "always show the full bottom search row").
+     */
+    val isTablet: Boolean
+        get() = !isCompactHeight && widthSizeClass != WindowWidthSizeClass.COMPACT
 }
 
 /**

--- a/core/adaptive-ui/src/commonMain/kotlin/xyz/ksharma/krail/core/adaptiveui/DualPaneScaffold.kt
+++ b/core/adaptive-ui/src/commonMain/kotlin/xyz/ksharma/krail/core/adaptiveui/DualPaneScaffold.kt
@@ -9,12 +9,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import xyz.ksharma.krail.core.log.log
 
 /**
  * The one dual-pane split used by every screen (SavedTrips, SearchStop, …) so the two-pane
@@ -39,17 +35,12 @@ import xyz.ksharma.krail.core.log.log
  *     no offscreen ancestor.
  *
  * When [rightPane] is null the [listPane] fills the full width (no blank gap on the right).
- *
- * @param logTag temporary diagnostic label (e.g. "SavedTrips" / "SearchStop"). When non-null,
- *   the right pane logs its size + window position under the `[PANE_DIAG]` tag so two screens
- *   can be compared. Remove call-site tags once the layout is trusted.
  */
 @Composable
 fun DualPaneScaffold(
     listPane: @Composable BoxScope.() -> Unit,
     modifier: Modifier = Modifier,
     listPaneWidth: Dp = DUAL_PANE_LIST_WIDTH,
-    logTag: String? = null,
     rightPane: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     Row(modifier = modifier.fillMaxSize()) {
@@ -67,23 +58,7 @@ fun DualPaneScaffold(
             Box(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxHeight()
-                    .then(
-                        if (logTag != null) {
-                            Modifier
-                                .onSizeChanged {
-                                    log("[PANE_DIAG] $logTag rightPane size=${it.width}x${it.height}")
-                                }
-                                .onGloballyPositioned {
-                                    log(
-                                        "[PANE_DIAG] $logTag rightPane " +
-                                            "pos=${it.positionInWindow()} size=${it.size}",
-                                    )
-                                }
-                        } else {
-                            Modifier
-                        },
-                    ),
+                    .fillMaxHeight(),
             ) {
                 rightPane()
             }

--- a/core/adaptive-ui/src/commonMain/kotlin/xyz/ksharma/krail/core/adaptiveui/DualPaneScaffold.kt
+++ b/core/adaptive-ui/src/commonMain/kotlin/xyz/ksharma/krail/core/adaptiveui/DualPaneScaffold.kt
@@ -1,0 +1,98 @@
+package xyz.ksharma.krail.core.adaptiveui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.core.log.log
+
+/**
+ * The one dual-pane split used by every screen (SavedTrips, SearchStop, …) so the two-pane
+ * layout can never drift between screens again.
+ *
+ * Layout: a [Row] with a FIXED-width [listPane] on the left and a weight(1f) [rightPane]
+ * filling the remainder on the right.
+ *
+ * Two invariants are baked in because violating either produced iOS-only blank-map bugs that
+ * cost a long debugging saga:
+ *
+ *  1. **Fixed-width list pane.** The left pane is a hard [listPaneWidth], never a flexible
+ *     `widthIn`. A flexible-width sibling next to the map's `weight(1f)` gives iOS UIKitView
+ *     interop unstable, multi-pass constraints so the native MLNMapView frame never settles.
+ *     Fixed width makes the map's weight slot deterministic in a single measure pass.
+ *
+ *  2. **The right pane is a SIBLING of the list pane, never a descendant.** Callers must NOT
+ *     wrap both panes in a shared `CloudGradientBackground` (or any ancestor that uses
+ *     `graphicsLayer { compositingStrategy = Offscreen }`). On iOS a UIKitView (MapLibre's
+ *     MLNMapView) cannot composite into an offscreen GPU buffer and renders blank. Put any
+ *     gradient/background INSIDE the [listPane] lambda only; the map in [rightPane] then has
+ *     no offscreen ancestor.
+ *
+ * When [rightPane] is null the [listPane] fills the full width (no blank gap on the right).
+ *
+ * @param logTag temporary diagnostic label (e.g. "SavedTrips" / "SearchStop"). When non-null,
+ *   the right pane logs its size + window position under the `[PANE_DIAG]` tag so two screens
+ *   can be compared. Remove call-site tags once the layout is trusted.
+ */
+@Composable
+fun DualPaneScaffold(
+    listPane: @Composable BoxScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    listPaneWidth: Dp = DUAL_PANE_LIST_WIDTH,
+    logTag: String? = null,
+    rightPane: (@Composable BoxScope.() -> Unit)? = null,
+) {
+    Row(modifier = modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .then(
+                    if (rightPane != null) Modifier.width(listPaneWidth) else Modifier.fillMaxWidth(),
+                )
+                .fillMaxHeight(),
+        ) {
+            listPane()
+        }
+
+        if (rightPane != null) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+                    .then(
+                        if (logTag != null) {
+                            Modifier
+                                .onSizeChanged {
+                                    log("[PANE_DIAG] $logTag rightPane size=${it.width}x${it.height}")
+                                }
+                                .onGloballyPositioned {
+                                    log(
+                                        "[PANE_DIAG] $logTag rightPane " +
+                                            "pos=${it.positionInWindow()} size=${it.size}",
+                                    )
+                                }
+                        } else {
+                            Modifier
+                        },
+                    ),
+            ) {
+                rightPane()
+            }
+        }
+    }
+}
+
+/**
+ * Width of the list pane in a dual-pane layout. Keeps stop/trip rows at ≈ phone width so they
+ * stay readable while the map fills the rest. See docs/TABLET_FOLDABLE_UX.md §2.
+ */
+val DUAL_PANE_LIST_WIDTH: Dp = 480.dp

--- a/core/maps/state/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/state/NearbyStopsConfig.kt
+++ b/core/maps/state/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/state/NearbyStopsConfig.kt
@@ -6,7 +6,6 @@ package xyz.ksharma.krail.core.maps.state
  */
 object NearbyStopsConfig {
     const val MAX_NEARBY_RESULTS = 200
-    const val DEFAULT_RADIUS_KM = 1.0
 
     // Default Sydney coordinates (CBD)
     const val DEFAULT_CENTER_LAT = -33.8727

--- a/core/maps/state/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/state/SearchRadius.kt
+++ b/core/maps/state/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/state/SearchRadius.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.core.maps.state
+
+/**
+ * Valid search-radius options for the nearby-stops map query.
+ * Use [SearchRadius.entries] to iterate options in the UI and [DEFAULT] for initial state.
+ */
+enum class SearchRadius(val km: Double) {
+    ONE(1.0),
+    THREE(3.0),
+    FIVE(5.0),
+    ;
+
+    val label: String get() = "${km.toInt()}km"
+
+    companion object {
+        val DEFAULT: SearchRadius = ONE
+    }
+}

--- a/docs/MAPLIBRE_IOS_PITFALLS.md
+++ b/docs/MAPLIBRE_IOS_PITFALLS.md
@@ -1,0 +1,233 @@
+# MapLibre on iOS (Compose Multiplatform) — Pitfalls & Patterns
+
+Hard-won lessons from the dual-pane map work. Every bug below was **iOS-only** —
+Android rendered fine throughout — because MapLibre's map on iOS is a native
+`UIKitView` (`MLNMapView`) bridged into Compose, and UIKitView interop has rules
+Compose-on-Android doesn't.
+
+**If a map is blank, mis-centred, or zoomed wrong on iOS but fine on Android, start here.**
+
+> Scope: `feature/trip-planner/ui` maps — `searchstop/map/SearchStopMap.kt`
+> (the nearby-stops `MapContent`, shared by SavedTrips / SearchStop / TimeTable
+> dual-pane right panes and portrait "select on map") and
+> `journeymap/JourneyMap.kt` (the TimeTable route map). Layout via
+> `core/adaptive-ui/.../DualPaneScaffold.kt`.
+
+---
+
+## Golden rules (the short version)
+
+1. **Never nest a map under an offscreen-compositing ancestor.** No
+   `CloudGradientBackground` (or any `graphicsLayer { compositingStrategy = Offscreen }`)
+   above a `MaplibreMap`. Put the gradient inside the *list* pane only; keep the map a
+   **sibling**.
+2. **Never create a `MaplibreMap` at a 0-size frame.** Gate creation behind a
+   non-zero width **and** height, and **latch** that gate (never tear the map down on a
+   transient 0 during rotation).
+3. **Dual-pane = fixed-width list + weighted map**, never a flexible `widthIn` sibling
+   next to the map's `weight(1f)`. Use `DualPaneScaffold`.
+4. **Auto-center camera: key the effect on a stable boolean** (`hasUserLocation`), never
+   on the churning `LatLng`. And use **one** camera effect, not two that race.
+5. **Location-or-default:** centre on the user when a fix exists; fall back to the Sydney
+   default *only* when location permission is absent.
+
+---
+
+## 1. Blank map — nested under `CloudGradientBackground`
+
+**Symptom:** right-pane map blank on iOS; the identical composable rendered fine in
+another screen. Blank persisted across rotation. Pane size + window position were
+*identical* to the working screen, so it wasn't layout.
+
+**Cause:** `CloudGradientBackground` composites its whole subtree offscreen:
+
+```kotlin
+.graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+.drawBehind { /* blobs */ }
+```
+
+A `UIKitView` (native `MLNMapView`) **cannot composite into an offscreen GPU buffer on
+iOS** → invisible. Android has no such restriction. SearchStop had wrapped the *entire*
+dual-pane split (list **and** map) in the gradient; SavedTrips kept its map a sibling,
+which is why SavedTrips always worked. It was a regression from when the map loaded.
+
+**Fix:** gradient wraps **only the list pane**; the map is a **sibling** under the Row.
+
+**Diagnosis tip:** if `onSizeChanged` + `onGloballyPositioned` show the pane has identical
+size **and** window position to a working screen yet it's still blank — stop chasing
+layout. Look at ancestor compositing (`graphicsLayer` / offscreen / `drawBehind`).
+
+---
+
+## 2. Blank / zoomed-to-world — map created at a 0×0 frame
+
+**Symptom:** map blank, or (TimeTable) zoomed all the way out to the whole of Australia.
+
+**Logs (the fingerprint):**
+```
+🟢 Map will start loading
+CAMetalLayer ignoring invalid setDrawableSize width=0.000000 height=0.000000
+[CAMetalLayer nextDrawable] returning nil because allocation failed.
+🟢 frame = (0 0; 0 0)
+```
+
+**Cause:** on a dual-pane / rotation transient the container is briefly measured at a 0
+axis (the adaptive window flips through `840×0dp` / `0×480dp`). If `MaplibreMap` is
+instantiated then, the native `MLNMapView` is created at `(0 0; 0 0)`; its Metal layer
+fails to allocate a drawable and the camera projects against a dead viewport → blank or
+degenerate zoom.
+
+**Fix:** gate creation until the container reports non-zero **width AND height**:
+
+```kotlin
+var hasHadValidSize by remember { mutableStateOf(false) }
+Box(
+    modifier = Modifier
+        .fillMaxSize()
+        .onSizeChanged { if (it.width > 0 && it.height > 0) hasHadValidSize = true },
+) {
+    if (hasHadValidSize) {
+        MaplibreMap(/* … */)
+    }
+}
+```
+
+---
+
+## 3. Blank on FIRST rotate, map only on SECOND rotate — gate not latched
+
+**Symptom:** intermittent. Rotate → blank right pane; rotate again → map appears.
+Sometimes happened, sometimes not (timing-dependent).
+
+**Cause:** a naïve gate that reset to `false` on every 0 size. Rotation emits a burst of
+size callbacks: `…832×828` → transient `0×1792` → `…832×828`. If the last callback
+before a frame drew was a 0, the gate closed, the native `MLNMapView` was **torn down**,
+and recreated — blank until the next rotation re-opened it. Whether the 0 landed on a
+draw boundary was a race → "sometimes."
+
+**Fix:** **latch** the flag — set `hasHadValidSize = true` once and never reset it (see
+the snippet in §2). Once mounted, the map stays mounted; MapLibre resizes its own
+surface as the container settles. Removes the race entirely.
+
+---
+
+## 4. Dual-pane layout — fixed-width list, not flexible
+
+**Symptom:** map blank / native frame never settling on iOS in dual-pane.
+
+**Cause:** a flexible `widthIn(min, max)` list pane sitting next to the map's `weight(1f)`
+gives the iOS UIKitView interop unstable, multi-pass width constraints, so the native
+`MLNMapView` frame never settles.
+
+**Fix:** **fixed-width** list pane (`Modifier.width(...)`), map takes the remainder via
+`weight(1f)`. Encoded in `DualPaneScaffold` so screens can't diverge:
+
+- list pane = fixed `DUAL_PANE_LIST_WIDTH`,
+- right pane = `weight(1f)`, always a **sibling** of the list (never a descendant — see §1).
+
+Both SavedTrips and SearchStop now delegate their split to `DualPaneScaffold`. Use it for
+any new dual-pane screen.
+
+---
+
+## 5. Camera stuck at Sydney default until rotate — effect keyed on the wrong thing
+
+**Symptom:** fresh load showed the Sydney default even with location permission; rotating
+the device then showed the correct user location. On iOS the camera sometimes froze fully
+zoomed out.
+
+**Cause:** the "centre on user once" `LaunchedEffect` was keyed on the user-location
+`LatLng`. GPS emits a stream of slightly-different fixes, so the effect re-launched on
+every jitter and **cancelled the in-flight `animateTo`**. The once-guard had already
+flipped true, so it never re-fired — the camera froze wherever the cancelled animation
+stopped. Rotation only "fixed" it because `rememberCameraState(firstPosition = …)`
+re-seeds at the now-known location (a different path).
+
+**Fix:** key on a **stable boolean** that flips `false → true` once and stays true:
+
+```kotlin
+val hasUserLocation = userLocation != null
+var hasAutoCentered by remember { mutableStateOf(false) }   // seed false, NOT (userLocation != null)
+LaunchedEffect(hasUserLocation) {
+    val loc = userLocation
+    if (loc != null && !hasAutoCentered) {
+        hasAutoCentered = true
+        cameraState.animateTo(/* user location */)
+    }
+}
+```
+
+Seed the guard `false` — seeding it from `userLocation != null` lets a re-entry/rotation
+re-seed it `true` while the camera is still at the default, suppressing the animation.
+
+---
+
+## 6. Empty map randomly Sydney vs user — two camera effects racing
+
+**Symptom (TimeTable, no journey selected):** sometimes centred on Sydney, sometimes on
+the user — non-deterministic, worse when the GPS fix was slow.
+
+**Cause:** two `LaunchedEffect`s each called `cameraState.animateTo`:
+- one keyed on `cameraFocus + stops` → read `userLocation` at fire time → null on fresh
+  load → Sydney,
+- one keyed on `hasUserLocation` → user.
+
+Whichever ran last won.
+
+**Fix:** **one** effect, single source of truth:
+
+```kotlin
+val hasUserLocation = userLocation != null
+LaunchedEffect(mapState.cameraFocus, mapState.mapDisplay.stops, hasUserLocation) {
+    val target = cameraTargetForState(mapState, userLocation) // journey wins; else user; else Sydney
+    cameraState.animateTo(target, /* … */)
+}
+```
+
+---
+
+## 7. Content shoved down on iOS landscape — imePadding on the wrong node
+
+**Symptom:** in dual-pane, list content pushed down by the keyboard height on iOS
+landscape.
+
+**Cause:** the search top bar carried `windowInsetsPadding(WindowInsets.ime)`
+unconditionally. In single-pane it floats in a `Box` overlay (harmless); in dual-pane
+it's the first child of the list `Column`, so ime padding inflated its height and shoved
+the list down. Keyboard is at the bottom, top bar at the top — they never overlap, so the
+padding was pointless there.
+
+**Fix:** `SearchTopBar(applyImePadding = …)` — `false` in dual-pane. Also dropped
+`imePadding()` from the dual-pane root and stopped auto-showing the keyboard in dual-pane.
+
+---
+
+## Debugging method that actually worked
+
+The breakthrough was **comparison logging across a working screen and a broken one**, all
+under one grep tag, logging the things that *could* differ:
+
+- pane `onSizeChanged` (width × height),
+- pane `onGloballyPositioned` (`positionInWindow` + size),
+- the native `MLNMapView frame = (...)` lines MapLibre already prints,
+- the `CAMetalLayer` / `nextDrawable` warnings.
+
+When SavedTrips (works) and SearchStop (blank) logged **identical** size AND position yet
+behaved differently, layout was ruled out and the offscreen-compositing ancestor became
+the obvious suspect. Likewise the `frame = (0 0; 0 0)` + `CAMetalLayer width=0` lines
+pinned the 0-size-creation bug, and the repeated `Deallocating MLNMapView` mid-rotation
+pinned the un-latched gate.
+
+Diagnostic logging is fine to add temporarily — strip it before merge.
+
+---
+
+## Checklist for any new map / dual-pane screen on iOS
+
+- [ ] Map is **not** under `CloudGradientBackground` or any offscreen `graphicsLayer`.
+- [ ] Map creation gated behind non-zero width **and** height, **latched**.
+- [ ] Dual-pane via `DualPaneScaffold` (fixed-width list, sibling map).
+- [ ] Camera auto-center keyed on a stable boolean; one effect, not two.
+- [ ] No permission → Sydney default; fix present → user location.
+- [ ] Tested on iOS: fresh load, repeated rotations, journey select/deselect — not just
+      Android.

--- a/docs/TABLET_FOLDABLE_UX.md
+++ b/docs/TABLET_FOLDABLE_UX.md
@@ -41,22 +41,13 @@ Files:
   (`SearchStopScreenDualPane` around line 762)
 - Sister doc: [`feature/trip-planner/ui/SEARCH_STOP_UX.md`](../feature/trip-planner/ui/SEARCH_STOP_UX.md)
 
-### Why the old layout looked "squished"
-
-`SearchStopEntry` currently declares
-`metadata = ListDetailSceneStrategy.listPane()`. At ≥ 600 dp the Material 3
-`ListDetailSceneStrategy` confines SearchStop to roughly half the window
-(the list pane), and SearchStop's own internal dual-pane then splits that
-half again. Net result: ~25 % screen width for stops list, ~25 % for map,
-the remainder eaten by surrounding scaffold. This is the bug to fix first.
-
 ### Rules
 
-- **Drop `ListDetailSceneStrategy.listPane()` from `SearchStopEntry`.**
-  SearchStop owns its own list+map split — the scene strategy must not
-  split the window a second time. With this single change the screen
-  occupies the full window at every form factor and the existing
-  dual-pane code starts looking right.
+- `SearchStopEntry` declares **no `ListDetailSceneStrategy` metadata** —
+  SearchStop renders full-width and owns its own list+map split.
+  (The old `listPane()` declaration caused a double-split: scaffold halved
+  the window, then SearchStop's internal dual-pane halved it again,
+  leaving ~25 % each. That is fixed.)
 - Dual-pane at ≥ 600 dp width (`shouldShowDualPane`, unchanged).
   COMPACT widths keep the existing single-pane list/map toggle.
 - **Pane ratio** in dual-pane: list pane = `widthIn(min = 320.dp,
@@ -93,64 +84,53 @@ Files:
 
 - Left pane: existing TimeTable journey list, capped at
   `widthIn(max = 520.dp)` so cards keep phone-width proportions.
-- Right pane: a **persistent `JourneyMap`** instance keyed on
-  `expandedJourneyId` from `TimeTableViewModel`. The map composable
-  stays mounted; only its data layer (route polyline, leg stops, live
-  vehicle) re-renders as the user expands different journeys.
+- Right pane: a **persistent `JourneyMap`** instance that stays mounted
+  at all times — no appear/disappear flicker as journeys expand/collapse.
 - `JourneyCard`'s "Maps" button is **hidden** when `shouldShowDualPane`
   is true. COMPACT keeps the button + the existing navigation to a
   full-screen `JourneyMapScreen`.
-- With no journey expanded, the right pane shows a trip-overview map:
-  origin + destination markers, framed to fit both.
-- `JourneyMap` is already extensible via its `extraMapContent` slot —
-  no refactor needed, only new call-sites.
-- Phone landscape (`isCompactHeight` and width ≥ 600 dp): the
-  dual-pane layout still applies. Left-pane cards should switch to a
-  compact summary so 5–6 journeys fit above the fold.
+- **With no journey expanded**: right pane shows an empty map
+  (`JourneyMapDisplay()` — no route, no stops). Camera centres at user
+  location if GPS is available, else Sydney default. The map animates
+  smoothly to the route when the user expands a card (600 ms fly-to).
+- **With a journey expanded**: map shows the route polyline, stops, and
+  leg colours. Camera flies to the route bounds / origin stop.
+- Phone landscape (`isCompactHeight` and width ≥ 600 dp): dual-pane
+  layout still applies. Cards remain full-width; vertical scroll handles
+  density.
 
 ---
 
 ## 4. SavedTripsScreen
 
-File: [`SavedTripsScreen.kt`](../feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt)
+Files:
+- [`SavedTripsScreen.kt`](../feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt)
+- [`SavedTripsEntry.kt`](../feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt)
+- [`MapStopSelectionPane.kt`](../feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionPane.kt)
 
-`SavedTripsEntry` already declares `ListDetailSceneStrategy.listPane()` —
-SavedTrips genuinely is the list owner of the list-detail pair with
-`TimeTableRoute`. This stays.
+`SavedTripsEntry` has **no `ListDetailSceneStrategy` metadata** — it renders
+full-width and manages its own left/right split internally (same pattern as
+SearchStop). `TimeTableRoute` navigation still works via back-stack push.
 
 ### Width rules (≥ 600 dp)
 
-Detail-pane behaviour when no specific detail route is pushed:
-
-- **No saved trips, no recents** (first-open on tablet): detail pane
-  shows a hero block — emoji + "Let's Go! Sydney" + larger CTA layout,
-  plus an inline Discover preview if available. Phone (COMPACT) keeps
-  the smaller `ErrorMessage` empty state.
-- **Trip selected** (user taps a `SavedTripCard`): detail pane renders
-  `TimeTableScreen` inline, re-using the existing composable with the
-  current `TimeTableViewModel`. Phone (COMPACT) still navigates to a
-  full-screen `TimeTableScreen` — unchanged.
-- **No selection yet, has saved trips**: detail pane shows the
-  DepartureBoard accordion in its expanded form plus Discover content,
-  so the right column is never blank.
+- **Left pane** (≤ 480 dp): the saved-trips list, DepartureBoard, Park & Ride,
+  Discover tiles, and the SearchStopRow pill at the bottom — same as
+  portrait, just width-capped.
+- **Right pane** (`weight(1f)`): a **read-only nearby-stops map** powered by
+  `MapStopSelectionPane` (singleton `MapStopSelectionViewModel`). Users can
+  explore nearby stops and view stop details; tapping a stop has no
+  trip-planning side-effect. The right pane is purely contextual.
+- Trip planning is done via the SearchStopRow pill at the bottom of the left
+  pane (same flow as portrait — pill collapses/expands SearchStopRow).
 
 ### Compact-height rules (`isCompactHeight`, height < 480 dp)
 
-Phone landscape and similar tight-vertical contexts:
-
-- The current bottom `SearchStopRow` (From + reverse + To + Search +
-  Settings + Discover) eats ≥ 200 dp of vertical space. Collapse it
-  into a single-line variant pinned to the title bar:
-  - From and To as horizontally arranged `TextFieldButton`s.
-  - Reverse-direction icon button between them.
-  - Search action collapses to a small icon button on the right.
-- The saved-trips list becomes the dominant element.
-- `DepartureBoard` accordion stays collapsed by default; expanded
-  state still scrolls under the list.
-- Park & Ride and Discover info-tiles stay scroll-revealed, not
-  pinned.
-- These rules apply on every form factor that hits `isCompactHeight`,
-  independent of the width-based dual-pane treatment above.
+Phone landscape uses the **same pill + expand-SearchStopRow** behaviour as
+portrait. No special single-line collapsed bar is needed — the pill already
+collapses the row to a single button, and expanding it fills the remaining
+height acceptably. `showPill` logic is the same in both orientations
+(collapses when ≥ 2 saved trips, or 1 trip + Park & Ride).
 
 ---
 
@@ -161,12 +141,12 @@ File: [`KrailNavHost.kt`](../composeApp/src/commonMain/kotlin/xyz/ksharma/krail/
 `KrailNavHost` uses `ListDetailSceneStrategy` from Navigation 3.
 Per-route `metadata` decides which pane each route lands in:
 
-| Route               | Metadata today        | Should be                                         |
+| Route               | Metadata              | Notes                                             |
 |---------------------|-----------------------|---------------------------------------------------|
-| `SavedTripsRoute`   | `listPane()`          | unchanged                                         |
-| `SearchStopRoute`   | `listPane()`          | **none** (owns its own list+map; render full-width) |
-| `TimeTableRoute`    | `detailPane()`        | unchanged                                         |
-| `JourneyMapRoute`   | (none today)          | phone-only destination; tablet uses inline map    |
+| `SavedTripsRoute`   | **none**              | owns its own left/right split internally          |
+| `SearchStopRoute`   | **none**              | owns its own list+map split internally            |
+| `TimeTableRoute`    | **none**              | owns its own list+map split internally            |
+| `JourneyMapRoute`   | (none)                | phone-only; tablet uses JourneyMap inline in TimeTable |
 | `SettingsRoute`     | `detailPane()`        | unchanged                                         |
 | `IntroRoute`        | `detailPane()`        | unchanged                                         |
 | `DiscoverRoute`     | `detailPane()`        | unchanged                                         |
@@ -211,23 +191,15 @@ adding a custom `@Preview`.
 
 ---
 
-## 8. Implementation order
+## 8. Implementation status
 
-These are the suggested follow-up tickets. Each is independent and small
-enough to ship behind its own PR.
+Items 1–5 are **shipped**. Remaining work:
 
-1. **Drop `listPane()` metadata from `SearchStopEntry`.** Single-line
-   change; immediately removes the 25 % / 25 % cramped layout on
-   tablets and foldable-unfolded.
-2. Tighten the SearchStop pane ratio (320–480 dp list, map fills rest).
-   Validate on phone landscape, foldable-unfolded portrait, tablet
-   landscape.
-3. Wire the TimeTable dual-pane with a persistent `JourneyMap`; hide
-   the "Maps" button when `shouldShowDualPane`.
-4. Wire the SavedTrips dual-pane (inline TimeTable detail +
-   state-aware right pane).
-5. SavedTrips compact-height: collapse `SearchStopRow` into a
-   single-line bar pinned to the title bar.
+1. ~~Drop `listPane()` from `SearchStopEntry`.~~ ✓ Done
+2. ~~Tighten SearchStop pane ratio (320–480 dp list, map fills rest).~~ ✓ Done
+3. ~~Wire TimeTable dual-pane with persistent `JourneyMap`; hide "Maps" button.~~ ✓ Done
+4. ~~Wire SavedTrips dual-pane right pane.~~ ✓ Done — read-only nearby-stops map
+5. ~~SavedTrips compact-height SearchStopRow adaptation.~~ ✓ Done — same pill+expand as portrait
 6. Add `@TabletScreenPreview` (landscape) and `@CompactHeightPreview`
    (phone landscape) annotations; backfill previews on the screens
    touched above.

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/mapstopselection/MapStopSelectionEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/mapstopselection/MapStopSelectionEvent.kt
@@ -1,0 +1,16 @@
+package xyz.ksharma.krail.trip.planner.ui.state.mapstopselection
+
+import xyz.ksharma.krail.core.maps.state.LatLng
+
+/**
+ * Events handled by `MapStopSelectionViewModel`. Kept deliberately small — only the
+ * actions that mutate VM state. UI-internal events (sheet open/close, marker tap
+ * highlighting) live in the composable.
+ */
+sealed interface MapStopSelectionEvent {
+    /** User's GPS location updated. null = lost / not granted. Triggers nearby-stops reload. */
+    data class UserLocationUpdated(val location: LatLng?) : MapStopSelectionEvent
+
+    /** Map camera moved to a new center. Triggers nearby-stops reload for the new position. */
+    data class MapCenterChanged(val center: LatLng) : MapStopSelectionEvent
+}

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/MapUiState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/MapUiState.kt
@@ -7,6 +7,7 @@ import kotlinx.collections.immutable.toImmutableSet
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.maps.state.NearbyStopsConfig
 import xyz.ksharma.krail.core.maps.state.RouteFeature
+import xyz.ksharma.krail.core.maps.state.SearchRadius
 import xyz.ksharma.krail.core.maps.state.SelectedStopUi
 import xyz.ksharma.krail.core.maps.state.StopFeature
 import xyz.ksharma.krail.core.transport.TransportMode
@@ -49,7 +50,7 @@ data class MapDisplay(
         NearbyStopsConfig.DEFAULT_CENTER_LON,
     ),
     val userLocation: LatLng? = null, // User's current GPS location (null if unknown)
-    val searchRadiusKm: Double = NearbyStopsConfig.DEFAULT_RADIUS_KM,
+    val searchRadiusKm: Double = SearchRadius.DEFAULT.km,
     val showDistanceScale: Boolean = false,
     val showCompass: Boolean = true,
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -19,17 +19,23 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,14 +49,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_reverse
 import krail.feature.trip_planner.ui.generated.resources.ic_search
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.core.snapshot.ScreenshotTest
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Button
@@ -61,8 +65,6 @@ import xyz.ksharma.krail.taj.components.TextFieldButton
 import xyz.ksharma.krail.taj.components.ThemeTextFieldPlaceholderText
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
-import xyz.ksharma.krail.taj.theme.KrailThemeStyle
-import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 private val SearchRowTopRadius = 36.dp
@@ -79,6 +81,7 @@ fun SearchStopRow(
     isExpanded: Boolean = false,
     isFromHighlighted: Boolean = false,
     onExpandRequest: () -> Unit = {},
+    onCollapseRequest: (() -> Unit)? = null,
     onReverseButtonClick: () -> Unit = {},
     onSearchButtonClick: () -> Unit = {},
 ) {
@@ -135,6 +138,7 @@ fun SearchStopRow(
                 isFromHighlighted = isFromHighlighted,
                 fromButtonClick = fromButtonClick,
                 toButtonClick = toButtonClick,
+                onCollapseRequest = onCollapseRequest,
                 onReverseButtonClick = onReverseButtonClick,
                 onSearchButtonClick = onSearchButtonClick,
             )
@@ -189,6 +193,7 @@ private fun CollapsedPill(
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal))
             .padding(
                 bottom = with(LocalDensity.current) { navBarPadding.dp } + dim.spacingXL,
                 start = dim.pageHorizontalPadding,
@@ -233,6 +238,7 @@ private fun ExpandedSearchRow(
     onReverseButtonClick: () -> Unit,
     onSearchButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onCollapseRequest: (() -> Unit)? = null,
 ) {
     val dim = KrailTheme.dimensions
     var isReverseButtonRotated by rememberSaveable { mutableStateOf(false) }
@@ -249,216 +255,187 @@ private fun ExpandedSearchRow(
         label = "fromBorderAlpha",
     )
 
-    Row(
+    // Cutout inset on the outer box so the background itself doesn't draw behind
+    // the camera notch/punch-hole in landscape. Content and background are both
+    // constrained to the safe horizontal area.
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = themeColorHex.hexToComposeColor(),
-                shape = RoundedCornerShape(
-                    topStart = SearchRowTopRadius,
-                    topEnd = SearchRowTopRadius,
-                ),
-            )
-            .padding(vertical = SearchRowVerticalPadding, horizontal = dim.pageHorizontalPadding)
-            .padding(
-                bottom = with(LocalDensity.current) { navBarPadding.dp },
-                top = dim.spacingM,
-            ),
-        horizontalArrangement = Arrangement.SpaceBetween,
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
     ) {
         Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(SearchFieldSpacing),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = themeColorHex.hexToComposeColor(),
+                    shape = RoundedCornerShape(
+                        topStart = SearchRowTopRadius,
+                        topEnd = SearchRowTopRadius,
+                    ),
+                ),
         ) {
-            // From field — animates in when opened via a label pill tap
-            AnimatedVisibility(
-                visible = showFromField,
-                enter = expandVertically(
-                    expandFrom = Alignment.Top,
-                    animationSpec = tween(durationMillis = 450, easing = FastOutSlowInEasing),
-                ) + fadeIn(animationSpec = tween(350)),
+            if (onCollapseRequest != null) {
+                CollapseHandle(onClick = onCollapseRequest)
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        top = if (onCollapseRequest != null) 0.dp else SearchRowVerticalPadding + dim.spacingM,
+                        bottom = SearchRowVerticalPadding + with(LocalDensity.current) { navBarPadding.dp },
+                        start = dim.pageHorizontalPadding,
+                        end = dim.pageHorizontalPadding,
+                    ),
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                val fromFieldShape = RoundedCornerShape(50)
-                TextFieldButton(
-                    onClick = fromButtonClick,
-                    modifier = if (isFromHighlighted) {
-                        Modifier.border(
-                            width = dim.strokeRegular,
-                            color = KrailTheme.colors.surface.copy(alpha = borderAlpha),
-                            shape = fromFieldShape,
-                        )
-                    } else {
-                        Modifier
-                    },
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(SearchFieldSpacing),
                 ) {
-                    AnimatedContent(
-                        targetState = fromStopItem?.stopName ?: "Starting from",
-                        transitionSpec = {
-                            fadeIn(animationSpec = tween(200)) +
-                                slideInVertically(
-                                    initialOffsetY = { it / 2 },
-                                    animationSpec = tween(500, easing = FastOutSlowInEasing),
-                                ) togetherWith fadeOut(animationSpec = tween(200)) +
-                                slideOutVertically(
-                                    targetOffsetY = { -it / 2 },
-                                    animationSpec = tween(500),
+                    // From field — animates in when opened via a label pill tap
+                    AnimatedVisibility(
+                        visible = showFromField,
+                        enter = expandVertically(
+                            expandFrom = Alignment.Top,
+                            animationSpec = tween(durationMillis = 450, easing = FastOutSlowInEasing),
+                        ) + fadeIn(animationSpec = tween(350)),
+                    ) {
+                        val fromFieldShape = RoundedCornerShape(50)
+                        TextFieldButton(
+                            onClick = fromButtonClick,
+                            modifier = if (isFromHighlighted) {
+                                Modifier.border(
+                                    width = dim.strokeRegular,
+                                    color = KrailTheme.colors.surface.copy(alpha = borderAlpha),
+                                    shape = fromFieldShape,
                                 )
-                        },
-                        contentAlignment = Alignment.CenterStart,
-                        label = "startingFromText",
-                    ) { targetText ->
-                        ThemeTextFieldPlaceholderText(
-                            text = targetText,
-                            isActive = fromStopItem != null,
-                        )
+                            } else {
+                                Modifier
+                            },
+                        ) {
+                            AnimatedContent(
+                                targetState = fromStopItem?.stopName ?: "Starting from",
+                                transitionSpec = {
+                                    fadeIn(animationSpec = tween(200)) +
+                                        slideInVertically(
+                                            initialOffsetY = { it / 2 },
+                                            animationSpec = tween(500, easing = FastOutSlowInEasing),
+                                        ) togetherWith fadeOut(animationSpec = tween(200)) +
+                                        slideOutVertically(
+                                            targetOffsetY = { -it / 2 },
+                                            animationSpec = tween(500),
+                                        )
+                                },
+                                contentAlignment = Alignment.CenterStart,
+                                label = "startingFromText",
+                            ) { targetText ->
+                                ThemeTextFieldPlaceholderText(
+                                    text = targetText,
+                                    isActive = fromStopItem != null,
+                                )
+                            }
+                        }
+                    }
+
+                    // A small spacer replaces the From field gap when From is hidden,
+                    // so the To field doesn't jump when From animates in.
+                    if (!showFromField) {
+                        Spacer(modifier = Modifier.height(0.dp))
+                    }
+
+                    // To field — always visible when expanded
+                    TextFieldButton(onClick = toButtonClick) {
+                        AnimatedContent(
+                            targetState = toStopItem?.stopName ?: "Destination",
+                            transitionSpec = {
+                                fadeIn(animationSpec = tween(200)) +
+                                    slideInVertically(
+                                        initialOffsetY = { -it / 2 },
+                                        animationSpec = tween(500, easing = FastOutSlowInEasing),
+                                    ) togetherWith fadeOut(animationSpec = tween(200)) +
+                                    slideOutVertically(
+                                        targetOffsetY = { it / 2 },
+                                        animationSpec = tween(500),
+                                    )
+                            },
+                            contentAlignment = Alignment.CenterStart,
+                            label = "destinationText",
+                        ) { targetText ->
+                            ThemeTextFieldPlaceholderText(
+                                text = targetText,
+                                isActive = toStopItem != null,
+                            )
+                        }
                     }
                 }
-            }
 
-            // A small spacer replaces the From field gap when From is hidden,
-            // so the To field doesn't jump when From animates in.
-            if (!showFromField) {
-                Spacer(modifier = Modifier.height(0.dp))
-            }
+                // Action buttons (reverse + search)
+                Column(
+                    modifier = Modifier.padding(start = dim.spacingXL),
+                    verticalArrangement = Arrangement.spacedBy(SearchFieldSpacing),
+                ) {
+                    val rotation by animateFloatAsState(
+                        targetValue = if (isReverseButtonRotated) 180f else 0f,
+                        animationSpec = tween(durationMillis = 300),
+                        label = "reverseRotation",
+                    )
 
-            // To field — always visible when expanded
-            TextFieldButton(onClick = toButtonClick) {
-                AnimatedContent(
-                    targetState = toStopItem?.stopName ?: "Destination",
-                    transitionSpec = {
-                        fadeIn(animationSpec = tween(200)) +
-                            slideInVertically(
-                                initialOffsetY = { -it / 2 },
-                                animationSpec = tween(500, easing = FastOutSlowInEasing),
-                            ) togetherWith fadeOut(animationSpec = tween(200)) +
-                            slideOutVertically(
-                                targetOffsetY = { it / 2 },
-                                animationSpec = tween(500),
+                    RoundIconButton(
+                        content = {
+                            Image(
+                                painter = painterResource(Res.drawable.ic_reverse),
+                                contentDescription = "Reverse",
+                                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                                modifier = Modifier.size(dim.iconDefault),
                             )
-                    },
-                    contentAlignment = Alignment.CenterStart,
-                    label = "destinationText",
-                ) { targetText ->
-                    ThemeTextFieldPlaceholderText(
-                        text = targetText,
-                        isActive = toStopItem != null,
+                        },
+                        onClick = {
+                            isReverseButtonRotated = !isReverseButtonRotated
+                            onReverseButtonClick()
+                        },
+                        modifier = Modifier.graphicsLayer { rotationZ = rotation },
+                    )
+
+                    RoundIconButton(
+                        content = {
+                            Image(
+                                painter = painterResource(Res.drawable.ic_search),
+                                contentDescription = "Search",
+                                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                                modifier = Modifier.size(dim.iconDefault),
+                            )
+                        },
+                        onClick = onSearchButtonClick,
                     )
                 }
             }
         }
-
-        // Action buttons (reverse + search)
-        Column(
-            modifier = Modifier.padding(start = dim.spacingXL),
-            verticalArrangement = Arrangement.spacedBy(SearchFieldSpacing),
-        ) {
-            val rotation by animateFloatAsState(
-                targetValue = if (isReverseButtonRotated) 180f else 0f,
-                animationSpec = tween(durationMillis = 300),
-                label = "reverseRotation",
-            )
-
-            RoundIconButton(
-                content = {
-                    Image(
-                        painter = painterResource(Res.drawable.ic_reverse),
-                        contentDescription = "Reverse",
-                        colorFilter = ColorFilter.tint(LocalContentColor.current),
-                        modifier = Modifier.size(dim.iconDefault),
-                    )
-                },
-                onClick = {
-                    isReverseButtonRotated = !isReverseButtonRotated
-                    onReverseButtonClick()
-                },
-                modifier = Modifier.graphicsLayer { rotationZ = rotation },
-            )
-
-            RoundIconButton(
-                content = {
-                    Image(
-                        painter = painterResource(Res.drawable.ic_search),
-                        contentDescription = "Search",
-                        colorFilter = ColorFilter.tint(LocalContentColor.current),
-                        modifier = Modifier.size(dim.iconDefault),
-                    )
-                },
-                onClick = onSearchButtonClick,
-            )
-        }
-    }
+    } // closes cutout Box
 }
 
-// region Previews
-
-@ScreenshotTest
-@Preview(name = "1. Collapsed pill - Train theme")
 @Composable
-private fun PreviewSearchStopRow_Collapsed_Train() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
-        SearchStopRow(
-            fromButtonClick = {},
-            toButtonClick = {},
-            isExpanded = false,
+private fun CollapseHandle(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(40.dp)
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(width = 36.dp, height = 4.dp)
+                .background(
+                    color = KrailTheme.colors.surface,
+                    shape = RoundedCornerShape(2.dp),
+                ),
         )
     }
 }
 
-@ScreenshotTest
-@Preview(name = "2. Expanded - both fields empty")
-@Composable
-private fun PreviewSearchStopRow_Expanded_Empty() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
-        SearchStopRow(
-            fromButtonClick = {},
-            toButtonClick = {},
-            isExpanded = true,
-            isFromHighlighted = false,
-        )
-    }
-}
-
-@ScreenshotTest
-@Preview(name = "3. Expanded - To pre-filled, From highlighted (label pill flow)")
-@Composable
-private fun PreviewSearchStopRow_Expanded_LabelPill() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
-        SearchStopRow(
-            fromButtonClick = {},
-            toButtonClick = {},
-            isExpanded = true,
-            isFromHighlighted = true,
-            toStopItem = StopItem(stopId = "2000001", stopName = "Central Station"),
-        )
-    }
-}
-
-@ScreenshotTest
-@Preview(name = "4. Expanded - both stops set")
-@Composable
-private fun PreviewSearchStopRow_Expanded_BothSet() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
-        SearchStopRow(
-            fromButtonClick = {},
-            toButtonClick = {},
-            isExpanded = true,
-            fromStopItem = StopItem(stopId = "2000002", stopName = "Town Hall Station"),
-            toStopItem = StopItem(stopId = "2000001", stopName = "Central Station"),
-        )
-    }
-}
-
-// @ScreenshotTest disabled: missing baseline (recording timed out, see README)
-@Preview(name = "5. Collapsed pill - Ferry theme")
-@Composable
-private fun PreviewSearchStopRow_Collapsed_Ferry() {
-    PreviewTheme(themeStyle = KrailThemeStyle.Ferry) {
-        SearchStopRow(
-            fromButtonClick = {},
-            toButtonClick = {},
-            isExpanded = false,
-        )
-    }
-}
-
-// endregion
+// Previews live in SearchStopRowPreviews.kt (kept separate to stay under TooManyFunctions limit)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -15,6 +15,7 @@ import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertsViewModel
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewModel
 import xyz.ksharma.krail.trip.planner.ui.discover.DiscoverViewModel
 import xyz.ksharma.krail.trip.planner.ui.intro.IntroViewModel
+import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.DepartureBoardViewModel
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.InviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.RealInviteFriendsTileManager
@@ -121,6 +122,13 @@ val viewModelsModule = module {
             repository = get(),
             ioDispatcher = get(named(IODispatcher)),
         )
+    }
+
+    // Per-entry map ViewModel — each nav entry (SavedTrips, SearchStop) gets its own
+    // instance so screens never share state or compete for NearbyStopsManager queries.
+    // NearbyStopsManager itself is a single so network/cache work is still deduplicated.
+    viewModel {
+        MapStopSelectionViewModel(nearbyStopsManager = get())
     }
 
     viewModelOf(::DepartureBoardViewModel)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -8,10 +8,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -110,8 +115,10 @@ fun DiscoverScreenCompact(
 
     val dim = KrailTheme.dimensions
     Box(
-        modifier = Modifier.fillMaxSize()
-            .background(color = KrailTheme.colors.surface),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = KrailTheme.colors.surface)
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
     ) {
         if (isLargeFontScale()) {
             LazyColumn(
@@ -203,7 +210,8 @@ fun DiscoverScreenTablet(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(KrailTheme.colors.surface),
+            .background(KrailTheme.colors.surface)
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
     ) {
         Column {
             val dim = KrailTheme.dimensions

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -13,12 +13,17 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -100,7 +105,8 @@ fun IntroScreen(
         modifier = modifier
             .fillMaxSize()
             .background(color = KrailTheme.colors.surface)
-            .statusBarsPadding(),
+            .statusBarsPadding()
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
     ) {
         Column(modifier = Modifier.align(Alignment.TopCenter)) {
             // Overlapped titles that fade based on the animated alphas.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -89,6 +89,9 @@ fun JourneyMap(
 /**
  * The actual map content when data is ready.
  */
+@Suppress("CyclomaticComplexMethod")
+// Complexity is dominated by Compose state wiring (location/permission/freshness/camera effects
+// + the map's stop and route layers); splitting it fragments shared map state across composables.
 @Composable
 private fun JourneyMapContent(
     mapState: JourneyMapUiState.Ready,
@@ -138,6 +141,30 @@ private fun JourneyMapContent(
     LaunchedEffect(mapState.cameraFocus, mapState.mapDisplay.stops) {
         val target = cameraTargetForState(mapState, userLocation)
         cameraState.animateTo(target, duration = CAMERA_TRANSITION_MS.milliseconds)
+    }
+
+    // Empty-state (no journey) auto-centre on the user's first location fix.
+    // The effect above is keyed on cameraFocus + stops, NOT userLocation, so on a fresh
+    // load where the GPS fix arrives AFTER it runs, the camera stayed at the Sydney default
+    // until a rotation re-ran composition. Key this one on a STABLE boolean (flips
+    // false->true once) so GPS jitter can't re-launch and cancel the animateTo. Only acts
+    // while empty so it never yanks the camera off a selected journey; no location
+    // permission -> userLocation stays null -> camera stays at the Sydney default.
+    val hasUserLocation = userLocation != null
+    var hasCenteredOnUser by remember { mutableStateOf(false) }
+    LaunchedEffect(hasUserLocation) {
+        val loc = userLocation
+        val isEmpty = mapState.mapDisplay.stops.isEmpty() && mapState.cameraFocus == null
+        if (loc != null && isEmpty && !hasCenteredOnUser) {
+            hasCenteredOnUser = true
+            cameraState.animateTo(
+                CameraPosition(
+                    target = Position(latitude = loc.latitude, longitude = loc.longitude),
+                    zoom = UserLocationConfig.RECENTER_ZOOM,
+                ),
+                duration = CAMERA_TRANSITION_MS.milliseconds,
+            )
+        }
     }
 
     TrackUserLocation(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -128,11 +128,17 @@ private fun JourneyMapContent(
         else -> "Map showing scheduled times only."
     }
 
-    val cameraPosition = remember(mapState.cameraFocus, mapState.mapDisplay.stops) {
-        calculateInitialCameraPosition(mapState)
-    }
+    val initialCameraPosition = remember { calculateInitialCameraPosition(mapState) }
+    val cameraState = rememberCameraState(firstPosition = initialCameraPosition)
 
-    val cameraState = rememberCameraState(firstPosition = cameraPosition)
+    // Smooth camera animation when the displayed journey changes (different card
+    // expanded, journey collapsed back to empty). Reads userLocation at the moment
+    // the state changes — for the empty state, flies to user location if GPS is
+    // available, else falls back to Sydney default coordinates.
+    LaunchedEffect(mapState.cameraFocus, mapState.mapDisplay.stops) {
+        val target = cameraTargetForState(mapState, userLocation)
+        cameraState.animateTo(target, duration = CAMERA_TRANSITION_MS.milliseconds)
+    }
 
     TrackUserLocation(
         userLocationManager = userLocationManager,
@@ -247,6 +253,17 @@ private fun JourneyMapContent(
     }
 }
 
+private fun cameraTargetForState(mapState: JourneyMapUiState.Ready, userLocation: LatLng?): CameraPosition {
+    val isEmpty = mapState.mapDisplay.stops.isEmpty() && mapState.cameraFocus == null
+    if (isEmpty && userLocation != null) {
+        return CameraPosition(
+            target = Position(latitude = userLocation.latitude, longitude = userLocation.longitude),
+            zoom = UserLocationConfig.RECENTER_ZOOM,
+        )
+    }
+    return calculateInitialCameraPosition(mapState)
+}
+
 private fun calculateInitialCameraPosition(mapState: JourneyMapUiState.Ready): CameraPosition {
     val originStop = mapState.mapDisplay.stops.firstOrNull { it.stopType == StopType.ORIGIN }
 
@@ -266,3 +283,7 @@ private fun calculateInitialCameraPosition(mapState: JourneyMapUiState.Ready): C
 
     return CameraPosition(target = target, zoom = zoom)
 }
+
+// Duration for smooth camera fly-to when switching between journey routes or
+// returning to the empty (no-journey-selected) state.
+private const val CAMERA_TRANSITION_MS = 600L

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -135,37 +135,24 @@ private fun JourneyMapContent(
     val initialCameraPosition = remember { calculateInitialCameraPosition(mapState) }
     val cameraState = rememberCameraState(firstPosition = initialCameraPosition)
 
-    // Smooth camera animation when the displayed journey changes (different card
-    // expanded, journey collapsed back to empty). Reads userLocation at the moment
-    // the state changes — for the empty state, flies to user location if GPS is
-    // available, else falls back to Sydney default coordinates.
-    LaunchedEffect(mapState.cameraFocus, mapState.mapDisplay.stops) {
+    // Single source of truth for the camera target. ONE effect, so the journey-change case
+    // and the empty-state user-location case can't race two competing animateTo calls (the
+    // bug where the empty TimeTable map landed on Sydney sometimes and the user location other
+    // times, depending on which effect won).
+    //
+    // Keyed on:
+    //  - cameraFocus + stops → re-fit when the displayed journey changes.
+    //  - hasUserLocation (a STABLE boolean, NOT the churning LatLng) → re-evaluate once a fix
+    //    first arrives. Keying on the boolean (not the value) means GPS jitter can't re-launch
+    //    and cancel the in-flight animateTo.
+    //
+    // Priority inside cameraTargetForState: a selected journey wins; otherwise (empty) it flies
+    // to the user location if known, else the Sydney default. So with no location permission the
+    // empty map stays at Sydney; with a fix it centres on the user — deterministically, no race.
+    val hasUserLocation = userLocation != null
+    LaunchedEffect(mapState.cameraFocus, mapState.mapDisplay.stops, hasUserLocation) {
         val target = cameraTargetForState(mapState, userLocation)
         cameraState.animateTo(target, duration = CAMERA_TRANSITION_MS.milliseconds)
-    }
-
-    // Empty-state (no journey) auto-centre on the user's first location fix.
-    // The effect above is keyed on cameraFocus + stops, NOT userLocation, so on a fresh
-    // load where the GPS fix arrives AFTER it runs, the camera stayed at the Sydney default
-    // until a rotation re-ran composition. Key this one on a STABLE boolean (flips
-    // false->true once) so GPS jitter can't re-launch and cancel the animateTo. Only acts
-    // while empty so it never yanks the camera off a selected journey; no location
-    // permission -> userLocation stays null -> camera stays at the Sydney default.
-    val hasUserLocation = userLocation != null
-    var hasCenteredOnUser by remember { mutableStateOf(false) }
-    LaunchedEffect(hasUserLocation) {
-        val loc = userLocation
-        val isEmpty = mapState.mapDisplay.stops.isEmpty() && mapState.cameraFocus == null
-        if (loc != null && isEmpty && !hasCenteredOnUser) {
-            hasCenteredOnUser = true
-            cameraState.animateTo(
-                CameraPosition(
-                    target = Position(latitude = loc.latitude, longitude = loc.longitude),
-                    zoom = UserLocationConfig.RECENTER_ZOOM,
-                ),
-                duration = CAMERA_TRANSITION_MS.milliseconds,
-            )
-        }
     }
 
     TrackUserLocation(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -186,13 +185,20 @@ private fun JourneyMapContent(
     // native MLNMapView's Metal layer fail to allocate a drawable ("CAMetalLayer ... width=0" /
     // "nextDrawable returning nil") and the camera projects against a dead viewport, leaving it
     // zoomed all the way out (whole-of-Australia). Same gate as MapContent in SearchStopMap.
-    var mapContainerSize by remember { mutableStateOf(IntSize.Zero) }
+    //
+    // LATCH the flag — never reset it to false. During a rotation the container momentarily
+    // reports a 0 axis (the adaptive window flips through 840×0dp); tearing the map down on that
+    // transient and recreating it leaves the pane blank until a SECOND rotation. Once we've seen
+    // a valid size we keep the map mounted; MapLibre resizes its own surface as it settles.
+    var hasHadValidSize by remember { mutableStateOf(false) }
     Box(
         modifier = modifier
             .fillMaxSize()
-            .onSizeChanged { mapContainerSize = it },
+            .onSizeChanged {
+                if (it.width > 0 && it.height > 0) hasHadValidSize = true
+            },
     ) {
-        if (mapContainerSize.width > 0 && mapContainerSize.height > 0) {
+        if (hasHadValidSize) {
             MaplibreMap(
                 modifier = Modifier.fillMaxSize(),
                 cameraState = cameraState,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -19,6 +19,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -179,29 +181,41 @@ private fun JourneyMapContent(
         },
     )
 
-    Box(modifier = modifier.fillMaxSize()) {
-        MaplibreMap(
-            modifier = Modifier.fillMaxSize(),
-            cameraState = cameraState,
-            baseStyle = BaseStyle.Uri(MapTileProvider.DEFAULT),
-            options = MapOptions(
-                ornamentOptions = OrnamentOptions(
-                    padding = PaddingValues(MapConfig.Ornaments.DEFAULT_PADDING_DP.dp),
-                    isLogoEnabled = MapConfig.Ornaments.LOGO_ENABLED,
-                    isAttributionEnabled = MapConfig.Ornaments.ATTRIBUTION_ENABLED,
-                    attributionAlignment = Alignment.BottomEnd,
-                    isCompassEnabled = MapConfig.Ornaments.COMPASS_ENABLED,
-                    compassAlignment = Alignment.TopEnd,
-                    isScaleBarEnabled = MapConfig.Ornaments.SCALE_BAR_ENABLED,
+    // Gate MaplibreMap creation until the container has a real non-zero size.
+    // On iOS (dual-pane / rotation transients) instantiating it at a 0x0 frame makes the
+    // native MLNMapView's Metal layer fail to allocate a drawable ("CAMetalLayer ... width=0" /
+    // "nextDrawable returning nil") and the camera projects against a dead viewport, leaving it
+    // zoomed all the way out (whole-of-Australia). Same gate as MapContent in SearchStopMap.
+    var mapContainerSize by remember { mutableStateOf(IntSize.Zero) }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { mapContainerSize = it },
+    ) {
+        if (mapContainerSize.width > 0 && mapContainerSize.height > 0) {
+            MaplibreMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraState = cameraState,
+                baseStyle = BaseStyle.Uri(MapTileProvider.DEFAULT),
+                options = MapOptions(
+                    ornamentOptions = OrnamentOptions(
+                        padding = PaddingValues(MapConfig.Ornaments.DEFAULT_PADDING_DP.dp),
+                        isLogoEnabled = MapConfig.Ornaments.LOGO_ENABLED,
+                        isAttributionEnabled = MapConfig.Ornaments.ATTRIBUTION_ENABLED,
+                        attributionAlignment = Alignment.BottomEnd,
+                        isCompassEnabled = MapConfig.Ornaments.COMPASS_ENABLED,
+                        compassAlignment = Alignment.TopEnd,
+                        isScaleBarEnabled = MapConfig.Ornaments.SCALE_BAR_ENABLED,
+                    ),
                 ),
-            ),
-        ) {
-            JourneyMapLayers(
-                mapState = mapState,
-                userLocation = userLocation,
-                onStopSelect = { selectedStop = it },
-            )
-            extraMapContent()
+            ) {
+                JourneyMapLayers(
+                    mapState = mapState,
+                    userLocation = userLocation,
+                    onStopSelect = { selectedStop = it },
+                )
+                extraMapContent()
+            }
         }
 
         // User location button (bottom-end corner)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionPane.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionPane.kt
@@ -1,0 +1,84 @@
+package xyz.ksharma.krail.trip.planner.ui.mapstopselection
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import xyz.ksharma.krail.core.snapshot.ScreenshotTest
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.preview.PreviewScreen
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.searchstop.map.SearchStopMap
+import xyz.ksharma.krail.trip.planner.ui.state.mapstopselection.MapStopSelectionEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Edge-to-edge map pane showing nearby stops. Reusable by any screen.
+ *
+ * - [mapUiState] is collected by the entry and passed in — the pane holds no VM reference.
+ * - [onEvent] forwards map interactions (center change, user location) back to the caller.
+ * - [onStopSelected] fires when the user confirms a stop pick from the map's bottom sheet.
+ *   Defaults to a no-op — callers that don't need stop-picking can omit it (read-only map).
+ *
+ * See docs/TABLET_FOLDABLE_UX.md §4.
+ */
+@Composable
+fun MapStopSelectionPane(
+    mapUiState: MapUiState,
+    onEvent: (MapStopSelectionEvent) -> Unit,
+    modifier: Modifier = Modifier,
+    onStopSelected: (StopItem) -> Unit = {},
+) {
+    val statusBarTopPadding = WindowInsets.statusBars
+        .asPaddingValues()
+        .calculateTopPadding()
+
+    SearchStopMap(
+        modifier = modifier.fillMaxSize(),
+        mapUiState = mapUiState,
+        ornamentTopPadding = statusBarTopPadding,
+        onEvent = { sse ->
+            when (sse) {
+                is SearchStopUiEvent.MapCenterChanged ->
+                    onEvent(MapStopSelectionEvent.MapCenterChanged(sse.center))
+                is SearchStopUiEvent.UserLocationUpdated ->
+                    onEvent(MapStopSelectionEvent.UserLocationUpdated(sse.location))
+                else -> Unit
+            }
+        },
+        onStopSelect = onStopSelected,
+    )
+}
+
+// region Previews
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewMapStopSelectionPane_Loading() {
+    PreviewTheme {
+        MapStopSelectionPane(
+            mapUiState = MapUiState.Loading,
+            onEvent = {},
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewScreen
+@Composable
+private fun PreviewMapStopSelectionPane_Ready() {
+    PreviewTheme {
+        MapStopSelectionPane(
+            mapUiState = MapUiState.Ready(mapDisplay = MapDisplay()),
+            onEvent = {},
+        )
+    }
+}
+
+// endregion

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionViewModel.kt
@@ -1,0 +1,117 @@
+package xyz.ksharma.krail.trip.planner.ui.mapstopselection
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.trip.planner.ui.searchstop.map.NearbyStopsManager
+import xyz.ksharma.krail.trip.planner.ui.state.mapstopselection.MapStopSelectionEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
+
+/**
+ * Owns right-pane map state for a single nav entry (SavedTrips or SearchStop dual-pane).
+ *
+ * Scoped to the NavEntry ViewModel store — each screen gets its own instance so
+ * SavedTrips and SearchStop never share state or compete for NearbyStopsManager queries.
+ * The shared [NearbyStopsManager] (Koin single) still deduplcates network work under the hood.
+ *
+ * State is **Ready from construction** — no initialise event needed.
+ *
+ * Lifecycle (WhileSubscribed pattern):
+ * - Stops work when the last UI consumer drops [mapUiState], with a 5-second timeout
+ *   to ride out rotation / config changes without cancelling in-flight queries.
+ * - viewModelScope is cancelled when the entry leaves the back stack.
+ */
+class MapStopSelectionViewModel(
+    private val nearbyStopsManager: NearbyStopsManager,
+) : ViewModel() {
+
+    init {
+        log("[MAP_STOP_SEL] VM init — seeded MapUiState.Ready")
+    }
+
+    private val _mapUiState: MutableStateFlow<MapUiState> = MutableStateFlow(MapUiState.Ready())
+
+    val mapUiState: StateFlow<MapUiState> = _mapUiState
+        .onStart { log("[MAP_STOP_SEL] consumer attached") }
+        .onCompletion { log("[MAP_STOP_SEL] last consumer detached") }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SUBSCRIBER_TIMEOUT_MS),
+            initialValue = MapUiState.Ready(),
+        )
+
+    fun onEvent(event: MapStopSelectionEvent) {
+        when (event) {
+            is MapStopSelectionEvent.UserLocationUpdated -> onUserLocationUpdated(event.location)
+            is MapStopSelectionEvent.MapCenterChanged -> onMapCenterChanged(event.center)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        nearbyStopsManager.cancelOngoingQuery()
+        log("[MAP_STOP_SEL] VM cleared — cancelled active queries")
+    }
+
+    private fun onUserLocationUpdated(location: LatLng?) {
+        updateMapDisplay { copy(userLocation = location) }
+        loadNearbyStops()
+    }
+
+    private fun onMapCenterChanged(center: LatLng) {
+        updateMapDisplay { copy(mapCenter = center) }
+        loadNearbyStops()
+    }
+
+    private inline fun updateMapDisplay(block: MapDisplay.() -> MapDisplay) {
+        val ready = _mapUiState.value as? MapUiState.Ready ?: return
+        _mapUiState.update {
+            ready.copy(mapDisplay = ready.mapDisplay.block())
+        }
+    }
+
+    private fun loadNearbyStops() {
+        val mapState = _mapUiState.value as? MapUiState.Ready ?: return
+        nearbyStopsManager.loadNearbyStops(
+            mapState = mapState,
+            center = mapState.mapDisplay.mapCenter,
+            scope = viewModelScope,
+            onLoadingStateChanged = { isLoading ->
+                val ready = _mapUiState.value as? MapUiState.Ready ?: return@loadNearbyStops
+                _mapUiState.value = ready.copy(isLoadingNearbyStops = isLoading)
+            },
+            onStopsLoaded = { stops ->
+                updateMapDisplay {
+                    copy(
+                        nearbyStops = stops.map { nearby ->
+                            NearbyStopFeature(
+                                stopId = nearby.stopId,
+                                stopName = nearby.stopName,
+                                position = LatLng(nearby.latitude, nearby.longitude),
+                                transportModes = nearby.transportModes.toImmutableList(),
+                            )
+                        }.toImmutableList(),
+                    )
+                }
+            },
+            onError = { error ->
+                log("[MAP_STOP_SEL] loadNearbyStops error: ${error.message}")
+            },
+        )
+    }
+
+    companion object {
+        private const val SUBSCRIBER_TIMEOUT_MS = 5000L
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -1,7 +1,5 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation.entries
 
-import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -10,6 +8,8 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.navigation.ResultEffect
+import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionPane
+import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
@@ -21,18 +21,21 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 /**
- * Saved Trips Entry - List Screen in List-Detail pattern
+ * Saved Trips Entry - List Screen in List-Detail pattern.
+ *
+ * Right-pane content on tablet / foldable / phone-landscape is supplied as a slot
+ * (`rightPane`). Pending follow-up: plug in MapStopSelectionPane backed by a shared
+ * Koin singleton ViewModel.
  */
-@OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
     tripPlannerNavigator: TripPlannerNavigator,
 ) {
-    entry<SavedTripsRoute>(
-        metadata = ListDetailSceneStrategy.listPane(),
-    ) {
+    entry<SavedTripsRoute> {
         // Scoped ViewModel that survives navigation
         val viewModel: SavedTripsViewModel = koinViewModel(key = "SavedTripsNav")
+        val mapStopSelectionViewModel: MapStopSelectionViewModel = koinViewModel()
+        val mapUiState by mapStopSelectionViewModel.mapUiState.collectAsStateWithLifecycle()
         val savedTripState by viewModel.uiState.collectAsStateWithLifecycle()
 
         val departureBoardViewModel: DepartureBoardViewModel = koinViewModel()
@@ -92,25 +95,12 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
                 }
             },
             onSearchButtonClick = {
-                val fromStopItem = savedTripState.fromStop
-                val toStopItem = savedTripState.toStop
-
-                if (fromStopItem != null && toStopItem != null &&
-                    fromStopItem.stopId != toStopItem.stopId
-                ) {
-                    viewModel.onEvent(
-                        SavedTripUiEvent.AnalyticsLoadTimeTableClick(
-                            fromStopId = fromStopItem.stopId,
-                            toStopId = toStopItem.stopId,
-                        ),
-                    )
-                    tripPlannerNavigator.navigateToTimeTable(
-                        fromStopId = fromStopItem.stopId,
-                        fromStopName = fromStopItem.stopName,
-                        toStopId = toStopItem.stopId,
-                        toStopName = toStopItem.stopName,
-                    )
-                }
+                triggerTripSearch(
+                    fromStop = savedTripState.fromStop,
+                    toStop = savedTripState.toStop,
+                    viewModel = viewModel,
+                    tripPlannerNavigator = tripPlannerNavigator,
+                )
             },
             onSettingsButtonClick = {
                 viewModel.onEvent(SavedTripUiEvent.AnalyticsSettingsButtonClick)
@@ -124,6 +114,37 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
             departureBoardEntries = departureBoardEntries,
             expandedDepartureBoardStopId = expandedDepartureBoardStopId,
             onDepartureBoardEvent = departureBoardViewModel::onEvent,
+            rightPane = {
+                MapStopSelectionPane(
+                    mapUiState = mapUiState,
+                    onEvent = mapStopSelectionViewModel::onEvent,
+                    onStopSelected = { stop ->
+                        viewModel.onEvent(SavedTripUiEvent.ToStopChanged(stop.toJsonString()))
+                    },
+                )
+            },
+        )
+    }
+}
+
+private fun triggerTripSearch(
+    fromStop: StopItem?,
+    toStop: StopItem?,
+    viewModel: SavedTripsViewModel,
+    tripPlannerNavigator: TripPlannerNavigator,
+) {
+    if (fromStop != null && toStop != null && fromStop.stopId != toStop.stopId) {
+        viewModel.onEvent(
+            SavedTripUiEvent.AnalyticsLoadTimeTableClick(
+                fromStopId = fromStop.stopId,
+                toStopId = toStop.stopId,
+            ),
+        )
+        tripPlannerNavigator.navigateToTimeTable(
+            fromStopId = fromStop.stopId,
+            fromStopName = fromStop.stopName,
+            toStopId = toStop.stopId,
+            toStopName = toStop.stopName,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
@@ -8,6 +8,7 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.navigation.LocalResultEventBusObj
+import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
@@ -32,6 +33,11 @@ internal fun EntryProviderScope<NavKey>.SearchStopEntry(
         // This ensures recent stops are refreshed when the screen is opened
         val viewModel: SearchStopViewModel = koinViewModel()
         val searchStopState by viewModel.uiState.collectAsStateWithLifecycle()
+
+        // Shared singleton ViewModel for the dual-pane right-pane map. Injected here
+        // (entry level) so the composable tree never touches Koin directly.
+        val mapStopSelectionViewModel: MapStopSelectionViewModel = koinViewModel()
+        val mapUiState by mapStopSelectionViewModel.mapUiState.collectAsStateWithLifecycle()
 
         // Refresh recent stops every time screen opens.
         // Note: Cannot rely on StateFlow's onStart because WhileSubscribed(5000) keeps the
@@ -67,6 +73,8 @@ internal fun EntryProviderScope<NavKey>.SearchStopEntry(
                 tripPlannerNavigator.goBack()
             },
             onEvent = { event -> viewModel.onEvent(event) },
+            dualPaneMapUiState = mapUiState,
+            onDualPaneMapEvent = mapStopSelectionViewModel::onEvent,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -1,53 +1,62 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation.entries
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.navigation3.ListDetailSceneStrategy
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toPersistentSet
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.viewmodel.koinViewModel
+import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.components.ModalBottomSheet
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertScreen
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorScreen
+import xyz.ksharma.krail.trip.planner.ui.journeymap.JourneyMap
+import xyz.ksharma.krail.trip.planner.ui.journeymap.business.JourneyMapMapper.toJourneyMapState
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.dateTimeSelectionSaver
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.serviceAlertSaver
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableScreen
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
 
 /**
- * TimeTable Entry - Detail Screen in List-Detail pattern
+ * Renders full-width on every form factor. On tablets / foldable-unfolded / phone
+ * landscape (≥ 600 dp width), the screen splits internally: journey list on the left
+ * (capped width), persistent JourneyMap on the right. The per-card "Maps" button is
+ * suppressed in dual-pane because the map is always visible.
  *
- * Handles modal state for alerts and date/time selection.
- * Uses custom savers to preserve state across configuration changes.
+ * See docs/TABLET_FOLDABLE_UX.md §3.
  */
-@OptIn(ExperimentalMaterial3AdaptiveApi::class)
-@Suppress("UNUSED_VARIABLE")
 @Composable
 internal fun EntryProviderScope<NavKey>.TimeTableEntry(
     tripPlannerNavigator: TripPlannerNavigator,
 ) {
-    entry<TimeTableRoute>(
-        metadata = ListDetailSceneStrategy.detailPane(),
-    ) { key ->
+    entry<TimeTableRoute> { key ->
         LaunchedEffect(key) {
             log("🗺️ TimeTableEntry - key changed: from-${key.fromStopId}, to: ${key.toStopId}")
         }
@@ -57,10 +66,13 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
         val timeTableState by viewModel.uiState.collectAsStateWithLifecycle()
         val expandedJourneyId by viewModel.expandedJourneyId.collectAsStateWithLifecycle()
 
-        // CRITICAL: Must collect these to trigger flows' onStart blocks
-        val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
-        val isActive by viewModel.isActive.collectAsStateWithLifecycle()
-        val autoRefreshTimeTable by viewModel.autoRefreshTimeTable.collectAsStateWithLifecycle()
+        // Collect these flows to trigger their onStart side-effects (polling, lifecycle
+        // gating) without exposing the values as unused local variables.
+        LaunchedEffect(viewModel) {
+            launch { viewModel.isLoading.collect {} }
+            launch { viewModel.isActive.collect {} }
+            launch { viewModel.autoRefreshTimeTable.collect {} }
+        }
 
         // Modal visibility state
         var showAlertsModal by rememberSaveable { mutableStateOf(false) }
@@ -100,8 +112,29 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
             )
         }
 
-        Box(modifier = Modifier.fillMaxSize()) {
-            // Main TimeTable Screen
+        // Adaptive layout — dual-pane on ≥ 600 dp width
+        val adaptiveLayoutInfo = rememberAdaptiveLayoutInfo()
+        val dualPane = adaptiveLayoutInfo.shouldShowDualPane
+
+        // Empty map state — used when no journey is expanded. Sydney coordinates via
+        // JourneyMapDisplay defaults; JourneyMap's internal TrackUserLocation will
+        // re-center to user location once the first GPS fix arrives.
+        val emptyMapState = remember { JourneyMapUiState.Ready(mapDisplay = JourneyMapDisplay()) }
+
+        // Map state for the currently expanded journey. Falls back to emptyMapState
+        // so JourneyMap stays mounted at all times (no appear/disappear flicker).
+        val journeyMapState by produceState<JourneyMapUiState>(
+            initialValue = emptyMapState,
+            key1 = expandedJourneyId,
+        ) {
+            value = expandedJourneyId?.let { id ->
+                withContext(Dispatchers.Default) {
+                    viewModel.getRawJourneyById(id)?.toJourneyMapState()
+                }
+            } ?: emptyMapState
+        }
+
+        val timeTableScreen: @Composable (Modifier, Boolean) -> Unit = { mod, hideMapBtn ->
             TimeTableScreen(
                 timeTableState = timeTableState,
                 expandedJourneyId = expandedJourneyId,
@@ -140,7 +173,31 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                 onMapClick = { journeyId ->
                     tripPlannerNavigator.navigateToJourneyMap(journeyId)
                 },
+                hideMapButton = hideMapBtn,
+                modifier = mod,
             )
+        }
+
+        Box(modifier = Modifier.fillMaxSize()) {
+            if (dualPane) {
+                Row(modifier = Modifier.fillMaxSize()) {
+                    timeTableScreen(
+                        Modifier
+                            .widthIn(max = TIMETABLE_PANE_MAX_WIDTH)
+                            .fillMaxHeight(),
+                        true,
+                    )
+
+                    JourneyMap(
+                        journeyMapState = journeyMapState,
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                    )
+                }
+            } else {
+                timeTableScreen(Modifier.fillMaxSize(), false)
+            }
 
             // Service Alerts Modal
             if (showAlertsModal) {
@@ -186,3 +243,7 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
         }
     }
 }
+
+// Left-pane width cap in dual-pane. Keeps journey cards at phone-width proportions
+// (≈ 520 dp) so they don't stretch awkwardly on tablets; map fills the remainder.
+private val TIMETABLE_PANE_MAX_WIDTH = 520.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -22,16 +22,24 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
@@ -54,6 +62,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -66,6 +75,8 @@ import org.jetbrains.compose.resources.painterResource
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
+import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.feature.track.TrackedJourney
 import xyz.ksharma.krail.feature.track.ui.components.TrackingCard
 import xyz.ksharma.krail.info.tile.state.InfoTileData
@@ -115,6 +126,9 @@ fun SavedTripsScreen(
     departureBoardEntries: ImmutableList<StopDepartureBoardEntry> = persistentListOf(),
     expandedDepartureBoardStopId: String? = null,
     onDepartureBoardEvent: (DepartureBoardUiEvent) -> Unit = {},
+    // Slot for the dual-pane right side. SavedTrips knows nothing about its content —
+    // entry passes a MapStopSelectionPane (or anything else). Empty slot = blank pane.
+    rightPane: @Composable BoxScope.() -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
     val iconColor = if (isAppInDarkMode().not()) themeColor() else KrailTheme.colors.onSurface
@@ -126,15 +140,29 @@ fun SavedTripsScreen(
         }.random()
     }
 
-    // Pill only shown when there's enough saved content above to justify collapsing
-    // the search row out of the way:
+    // Pill (phone-portrait only) is shown when there's enough saved content above
+    // to justify collapsing the search row out of the way:
     //   • 2+ saved trips, OR
     //   • 1 saved trip + at least one Park & Ride entry.
     // Anything less and the expanded row stays — first-time and lightly-used
     // accounts still get the full search affordance front-and-centre.
     val savedTripsCount = savedTripsState.savedTrips.size
     val hasParkRide = savedTripsState.parkRideUiState.isNotEmpty()
-    val showPill = savedTripsCount >= 2 || (savedTripsCount >= 1 && hasParkRide)
+
+    // Adaptive layout:
+    //   - Tablet / foldable-unfolded (isTablet): SearchStopRow always expanded.
+    //   - Phone portrait + phone landscape: pill collapses SearchStopRow when
+    //     enough content is present. Same behaviour in both orientations.
+    // See docs/TABLET_FOLDABLE_UX.md §4.
+    val adaptiveLayoutInfo = rememberAdaptiveLayoutInfo()
+    val dualPane = adaptiveLayoutInfo.shouldShowDualPane
+    val isPhoneLandscape = adaptiveLayoutInfo.isPhoneLandscape
+    val isTablet = adaptiveLayoutInfo.isTablet
+
+    val showPill = when {
+        isTablet -> false
+        else -> savedTripsCount >= 2 || (savedTripsCount >= 1 && hasParkRide)
+    }
 
     // Search row expand / from-highlight state — rememberSaveable survives rotation.
     var isSearchExpanded by rememberSaveable { mutableStateOf(false) }
@@ -160,157 +188,204 @@ fun SavedTripsScreen(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KrailTheme.colors.surface),
+            .background(color = KrailTheme.colors.surface)
+            .onSizeChanged { log("[MAP_STOP_SEL] outerBox size=${it.width}x${it.height}") },
     ) {
-        Column {
-            TitleBar(
-                title = {
-                    Text(text = "KRAIL", color = themeColor())
-                },
-                actions = {
-                    if (editing) {
-                        Button(
-                            onClick = { editing = false },
-                            colors = ButtonDefaults.monochromeButtonColors(),
-                            dimensions = ButtonDefaults.chipButtonSize(),
-                            modifier = Modifier.padding(horizontal = dim.spacingM),
-                        ) {
-                            Text(text = "Done")
-                        }
-                    } else {
-                        if (savedTripsState.isDiscoverAvailable) {
-                            RoundIconButton(
-                                showBadge = savedTripsState.displayDiscoverBadge,
-                                onClick = onDiscoverButtonClick,
+        val body: @Composable BoxScope.() -> Unit = {
+            // Push content away from a side display cutout in landscape. Horizontal-only
+            // inset means portrait is untouched (cutout there is already covered by the
+            // status bar inset that TitleBar handles internally), but in landscape the
+            // whole column shifts right of the camera notch.
+            Column(
+                modifier = Modifier.windowInsetsPadding(
+                    WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
+                ),
+            ) {
+                TitleBar(
+                    title = {
+                        Text(text = "KRAIL", color = themeColor())
+                    },
+                    actions = {
+                        if (editing) {
+                            Button(
+                                onClick = { editing = false },
+                                colors = ButtonDefaults.monochromeButtonColors(),
+                                dimensions = ButtonDefaults.chipButtonSize(),
+                                modifier = Modifier.padding(horizontal = dim.spacingM),
                             ) {
-                                CityCodeText("SYD")
+                                Text(text = "Done")
+                            }
+                        } else {
+                            if (savedTripsState.isDiscoverAvailable) {
+                                RoundIconButton(
+                                    showBadge = savedTripsState.displayDiscoverBadge,
+                                    onClick = onDiscoverButtonClick,
+                                ) {
+                                    CityCodeText("SYD")
+                                }
+                            }
+
+                            RoundIconButton(
+                                onClick = onSettingsButtonClick,
+                            ) {
+                                Image(
+                                    painter = painterResource(Res.drawable.ic_settings),
+                                    contentDescription = "Settings",
+                                    colorFilter = ColorFilter.tint(LocalContentColor.current),
+                                    modifier = Modifier.size(dim.spacingXXXL),
+                                )
+                            }
+                        }
+                    },
+                )
+
+                val expandedMap = remember { mutableStateMapOf<String, Boolean>() }
+
+                LazyColumn(
+                    state = lazyListState,
+                    contentPadding = PaddingValues(bottom = LAZY_COLUMN_BOTTOM_PADDING.dp),
+                ) {
+                    when {
+                        savedTripsState.isSavedTripsLoading -> Unit
+
+                        savedTripsState.savedTrips.isEmpty() -> {
+                            savedTripsState.infoTiles?.let { infoTiles ->
+                                infoTiles(
+                                    infoTiles = infoTiles,
+                                    onCtaClick = { tileData ->
+                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
+                                    },
+                                    onDismissClick = { tileData ->
+                                        onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
+                                    },
+                                    onTileExpand = {
+                                        onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
+                                    },
+                                )
+                            }
+
+                            item(key = "empty_state") {
+                                ErrorMessage(
+                                    emoji = "🌟",
+                                    title = "Let's Go! Sydney",
+                                    message = emptyStateTip,
+                                    modifier = Modifier
+                                        .padding(horizontal = dim.pageHorizontalPadding)
+                                        .animateItem(),
+                                )
                             }
                         }
 
-                        RoundIconButton(
-                            onClick = onSettingsButtonClick,
-                        ) {
-                            Image(
-                                painter = painterResource(Res.drawable.ic_settings),
-                                contentDescription = "Settings",
-                                colorFilter = ColorFilter.tint(LocalContentColor.current),
-                                modifier = Modifier.size(dim.spacingXXXL),
+                        savedTripsState.savedTrips.isNotEmpty() -> {
+                            savedTripsState.infoTiles?.let { infoTiles ->
+                                infoTiles(
+                                    infoTiles = infoTiles,
+                                    onCtaClick = { tileData ->
+                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
+                                    },
+                                    onDismissClick = { tileData ->
+                                        onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
+                                    },
+                                    onTileExpand = {
+                                        onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
+                                    },
+                                )
+                            }
+
+                            savedTripsContent(
+                                savedTripsState = savedTripsState,
+                                trackedJourney = trackedJourney,
+                                iconColor = iconColor,
+                                onEvent = onEvent,
+                                onSavedTripCardClick = onSavedTripCardClick,
+                                onTrackingCardClick = onTrackingCardClick,
+                                onStopTracking = onStopTracking,
+                                expandedMap = expandedMap,
+                                departureBoardEntries = departureBoardEntries,
+                                expandedDepartureBoardStopId = expandedDepartureBoardStopId,
+                                onDepartureBoardEvent = onDepartureBoardEvent,
+                                editing = editing,
+                                reorderState = reorderState,
+                                onEnterEditing = { editing = true },
                             )
                         }
-                    }
-                },
-            )
-
-            val expandedMap = remember { mutableStateMapOf<String, Boolean>() }
-
-            LazyColumn(
-                state = lazyListState,
-                contentPadding = PaddingValues(bottom = LAZY_COLUMN_BOTTOM_PADDING.dp),
-            ) {
-                when {
-                    savedTripsState.isSavedTripsLoading -> Unit
-
-                    savedTripsState.savedTrips.isEmpty() -> {
-                        savedTripsState.infoTiles?.let { infoTiles ->
-                            infoTiles(
-                                infoTiles = infoTiles,
-                                onCtaClick = { tileData ->
-                                    onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                },
-                                onDismissClick = { tileData ->
-                                    onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
-                                },
-                                onTileExpand = {
-                                    onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
-                                },
-                            )
-                        }
-
-                        item(key = "empty_state") {
-                            ErrorMessage(
-                                emoji = "🌟",
-                                title = "Let's Go! Sydney",
-                                message = emptyStateTip,
-                                modifier = Modifier
-                                    .padding(horizontal = dim.pageHorizontalPadding)
-                                    .animateItem(),
-                            )
-                        }
-                    }
-
-                    savedTripsState.savedTrips.isNotEmpty() -> {
-                        savedTripsState.infoTiles?.let { infoTiles ->
-                            infoTiles(
-                                infoTiles = infoTiles,
-                                onCtaClick = { tileData ->
-                                    onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                },
-                                onDismissClick = { tileData ->
-                                    onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
-                                },
-                                onTileExpand = {
-                                    onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
-                                },
-                            )
-                        }
-
-                        savedTripsContent(
-                            savedTripsState = savedTripsState,
-                            trackedJourney = trackedJourney,
-                            iconColor = iconColor,
-                            onEvent = onEvent,
-                            onSavedTripCardClick = onSavedTripCardClick,
-                            onTrackingCardClick = onTrackingCardClick,
-                            onStopTracking = onStopTracking,
-                            expandedMap = expandedMap,
-                            departureBoardEntries = departureBoardEntries,
-                            expandedDepartureBoardStopId = expandedDepartureBoardStopId,
-                            onDepartureBoardEvent = onDepartureBoardEvent,
-                            editing = editing,
-                            reorderState = reorderState,
-                            onEnterEditing = { editing = true },
-                        )
                     }
                 }
             }
-        }
 
-        // Hold the bottom row off-screen until the saved-trips load has emitted at
-        // least once. Without this gate, the row renders against an empty
-        // savedTrips list (pill condition false → expanded), then flips to the
-        // pill once the DB lands — a visible flash of the wrong UI.
-        //
-        // Reveal is a plain slide-up + fade for both the collapsed pill and the
-        // expanded search row. The pill's "alive" pulse lives inside CollapsedPill
-        // itself — keeping the row-level reveal calm avoids stacking two bouncy
-        // animations (parent scale + child pulse) on top of each other.
-        AnimatedVisibility(
-            visible = !savedTripsState.isSavedTripsLoading && !editing,
-            enter = slideInVertically(
-                initialOffsetY = { it },
-                animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing),
-            ) + fadeIn(animationSpec = tween(durationMillis = 200)),
-            modifier = Modifier.align(Alignment.BottomCenter),
-        ) {
-            SearchStopRow(
-                fromStopItem = savedTripsState.fromStop,
-                toStopItem = savedTripsState.toStop,
-                isExpanded = effectiveIsExpanded,
-                isFromHighlighted = isFromHighlighted,
-                onExpandRequest = {
-                    isSearchExpanded = true
-                    isFromHighlighted = false
-                },
-                fromButtonClick = {
-                    isFromHighlighted = false
-                    fromButtonClick()
-                },
-                toButtonClick = toButtonClick,
-                onReverseButtonClick = {
-                    onEvent(SavedTripUiEvent.ReverseStopClick)
-                },
-                onSearchButtonClick = { onSearchButtonClick() },
-            )
+            // Hold the bottom row off-screen until the saved-trips load has emitted at
+            // least once. Without this gate, the row renders against an empty
+            // savedTrips list (pill condition false → expanded), then flips to the
+            // pill once the DB lands — a visible flash of the wrong UI.
+            //
+            // Reveal is a plain slide-up + fade for both the collapsed pill and the
+            // expanded search row. The pill's "alive" pulse lives inside CollapsedPill
+            // itself — keeping the row-level reveal calm avoids stacking two bouncy
+            // animations (parent scale + child pulse) on top of each other.
+            AnimatedVisibility(
+                visible = !savedTripsState.isSavedTripsLoading && !editing,
+                enter = slideInVertically(
+                    initialOffsetY = { it },
+                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing),
+                ) + fadeIn(animationSpec = tween(durationMillis = 200)),
+                modifier = Modifier.align(Alignment.BottomCenter),
+            ) {
+                SearchStopRow(
+                    fromStopItem = savedTripsState.fromStop,
+                    toStopItem = savedTripsState.toStop,
+                    isExpanded = effectiveIsExpanded,
+                    isFromHighlighted = isFromHighlighted,
+                    onExpandRequest = {
+                        isSearchExpanded = true
+                        isFromHighlighted = false
+                    },
+                    onCollapseRequest = if (showPill) {
+                        {
+                            isSearchExpanded = false
+                            isFromHighlighted = false
+                        }
+                    } else {
+                        null
+                    },
+                    fromButtonClick = {
+                        isFromHighlighted = false
+                        fromButtonClick()
+                    },
+                    toButtonClick = toButtonClick,
+                    onReverseButtonClick = {
+                        onEvent(SavedTripUiEvent.ReverseStopClick)
+                    },
+                    onSearchButtonClick = { onSearchButtonClick() },
+                )
+            }
+        }
+        log(
+            "[MAP_STOP_SEL] SavedTripsScreen dualPane=$dualPane " +
+                "isTablet=$isTablet isPhoneLandscape=$isPhoneLandscape",
+        )
+        if (dualPane) {
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onSizeChanged { log("[MAP_STOP_SEL] Row size=${it.width}x${it.height}") },
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(SAVED_TRIPS_PANE_MAX_WIDTH)
+                        .fillMaxHeight()
+                        .onSizeChanged { log("[MAP_STOP_SEL] leftPane size=${it.width}x${it.height}") },
+                ) {
+                    body()
+                }
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                    content = rightPane,
+                )
+            }
+        } else {
+            body()
         }
     }
 }
@@ -619,6 +694,11 @@ private const val WIGGLE_DURATION_VARIANCE_BUCKETS = 4
 private const val WIGGLE_DURATION_VARIANCE_STEP_MS = 70
 private const val WIGGLE_OFFSET_MULTIPLIER = 47
 private const val WIGGLE_OFFSET_MAX_MS = 200
+
+// Left-pane width cap when SavedTrips is rendered in dual-pane (≥ 600 dp width).
+// Keeps the saved-trips list at phone-width proportions; map fills the rest.
+// See docs/TABLET_FOLDABLE_UX.md §4.
+private val SAVED_TRIPS_PANE_MAX_WIDTH = 480.dp
 
 // region Previews
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -368,7 +368,6 @@ fun SavedTripsScreen(
             // two-pane layouts can't drift. Right pane (map) is a sibling of the list, never
             // nested under it; see DualPaneScaffold for the iOS compositing invariant.
             DualPaneScaffold(
-                logTag = "SavedTrips",
                 listPane = { body() },
                 rightPane = rightPane,
             )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -62,7 +62,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -380,7 +382,16 @@ fun SavedTripsScreen(
                 Box(
                     modifier = Modifier
                         .weight(1f)
-                        .fillMaxHeight(),
+                        .fillMaxHeight()
+                        .onSizeChanged {
+                            log("[PANE_DIAG] SavedTrips rightPane size=${it.width}x${it.height}")
+                        }
+                        .onGloballyPositioned {
+                            log(
+                                "[PANE_DIAG] SavedTrips rightPane " +
+                                    "pos=${it.positionInWindow()} size=${it.size}",
+                            )
+                        },
                     content = rightPane,
                 )
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -62,9 +61,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -77,6 +74,7 @@ import org.jetbrains.compose.resources.painterResource
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
+import xyz.ksharma.krail.core.adaptiveui.DualPaneScaffold
 import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.feature.track.TrackedJourney
@@ -366,35 +364,14 @@ fun SavedTripsScreen(
                 "isTablet=$isTablet isPhoneLandscape=$isPhoneLandscape",
         )
         if (dualPane) {
-            Row(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .onSizeChanged { log("[MAP_STOP_SEL] Row size=${it.width}x${it.height}") },
-            ) {
-                Box(
-                    modifier = Modifier
-                        .width(SAVED_TRIPS_PANE_MAX_WIDTH)
-                        .fillMaxHeight()
-                        .onSizeChanged { log("[MAP_STOP_SEL] leftPane size=${it.width}x${it.height}") },
-                ) {
-                    body()
-                }
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .onSizeChanged {
-                            log("[PANE_DIAG] SavedTrips rightPane size=${it.width}x${it.height}")
-                        }
-                        .onGloballyPositioned {
-                            log(
-                                "[PANE_DIAG] SavedTrips rightPane " +
-                                    "pos=${it.positionInWindow()} size=${it.size}",
-                            )
-                        },
-                    content = rightPane,
-                )
-            }
+            // Shared dual-pane split — same component SearchStop uses, so the two screens'
+            // two-pane layouts can't drift. Right pane (map) is a sibling of the list, never
+            // nested under it; see DualPaneScaffold for the iOS compositing invariant.
+            DualPaneScaffold(
+                logTag = "SavedTrips",
+                listPane = { body() },
+                rightPane = rightPane,
+            )
         } else {
             body()
         }
@@ -709,7 +686,6 @@ private const val WIGGLE_OFFSET_MAX_MS = 200
 // Left-pane width cap when SavedTrips is rendered in dual-pane (≥ 600 dp width).
 // Keeps the saved-trips list at phone-width proportions; map fills the rest.
 // See docs/TABLET_FOLDABLE_UX.md §4.
-private val SAVED_TRIPS_PANE_MAX_WIDTH = 480.dp
 
 // region Previews
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -812,7 +812,6 @@ private fun SearchStopScreenDualPane(
     // gradient must wrap ONLY the list. See DualPaneScaffold + docs/TABLET_FOLDABLE_UX.md §2.
     DualPaneScaffold(
         modifier = modifier,
-        logTag = "SearchStop",
         listPane = {
             CloudGradientBackground(
                 modifier = Modifier

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -809,10 +809,12 @@ private fun SearchStopScreenDualPane(
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .imePadding(),
+                .fillMaxSize(),
         ) {
             // Split view: List on left (bounded width), Map on right (fills the rest).
+            // No imePadding here — the keyboard appears at the bottom and the search bar
+            // is at the top; they don't overlap. imePadding would eat landscape height on
+            // iOS and collapse the map pane to zero.
             // See docs/TABLET_FOLDABLE_UX.md §2 for the ratio rationale.
             Row(
                 modifier = Modifier

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -66,6 +66,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -797,47 +799,50 @@ private fun SearchStopScreenDualPane(
     dualPaneMapUiState: MapUiState? = null,
     onDualPaneMapEvent: (MapStopSelectionEvent) -> Unit = {},
 ) {
-    // Focus and keyboard are one-shot — only needed on first entry.
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-        keyboard?.show()
-    }
+    // Dual-pane (tablet / foldable / phone landscape): do NOT auto-show the keyboard.
+    // On iOS the soft keyboard covers ~50% of the landscape height and, more critically,
+    // its show/hide drives a layout-resize storm. Combined with the fixed-width list pane,
+    // the map's weight(1f) gets transiently measured at 0 width, which makes MapLibre's iOS
+    // UIKitView project a degenerate frame — the camera target runs away to invalid coords
+    // (e.g. longitude > 180) and the map renders blank. SavedTrips' dual-pane map is stable
+    // precisely because it never auto-shows the keyboard. The map is the primary interaction
+    // here; the user taps the search field when they actually want to type.
 
-    CloudGradientBackground(
+    // Split view: List on left (fixed width), Map on right (fills the rest).
+    // CRITICAL (iOS): the map must NOT be a descendant of CloudGradientBackground. That
+    // component paints via Modifier.drawBehind; on iOS a MaplibreMap (a UIKitView interop
+    // node) nested under a drawBehind ancestor is composited BEHIND that draw layer and
+    // never becomes visible — blank forever, even across rotation. SavedTrips keeps its map
+    // outside the gradient for exactly this reason, which is why its map always worked.
+    // So the gradient wraps ONLY the left list pane; the map pane is a sibling under the Row.
+    // See docs/TABLET_FOLDABLE_UX.md §2 for the ratio rationale.
+    Column(
         modifier = modifier.fillMaxSize(),
-        themeColor = themeColor.hexToComposeColor(),
     ) {
-        Column(
+        Row(
             modifier = Modifier
-                .fillMaxSize(),
+                .weight(1f)
+                .fillMaxWidth(),
         ) {
-            // Split view: List on left (bounded width), Map on right (fills the rest).
-            // No imePadding here — the keyboard appears at the bottom and the search bar
-            // is at the top; they don't overlap. imePadding would eat landscape height on
-            // iOS and collapse the map pane to zero.
-            // See docs/TABLET_FOLDABLE_UX.md §2 for the ratio rationale.
-            Row(
+            // Left pane: FIXED width when right pane is present (mirrors SavedTrips dual-pane).
+            // A flexible widthIn() sibling next to the map's weight(1f) gives the iOS UIKitView
+            // interop unstable constraints. A fixed width makes the map's weight(1f) deterministic
+            // in a single measure pass. Gradient spans full width when the shared map VM has no
+            // state yet (no blank right gap).
+            CloudGradientBackground(
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
+                    .then(
+                        if (dualPaneMapUiState != null) {
+                            Modifier.width(SEARCH_STOP_LIST_PANE_MAX_WIDTH)
+                        } else {
+                            Modifier.fillMaxWidth()
+                        },
+                    )
+                    .fillMaxHeight()
+                    .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
+                themeColor = themeColor.hexToComposeColor(),
             ) {
-                // Left pane: bounded width when right pane is present so stop rows stay readable;
-                // fills full width when the shared map VM has no state yet (no blank space on right).
-                Column(
-                    modifier = Modifier
-                        .then(
-                            if (dualPaneMapUiState != null) {
-                                Modifier.widthIn(
-                                    min = SEARCH_STOP_LIST_PANE_MIN_WIDTH,
-                                    max = SEARCH_STOP_LIST_PANE_MAX_WIDTH,
-                                )
-                            } else {
-                                Modifier.fillMaxWidth()
-                            },
-                        )
-                        .fillMaxHeight()
-                        .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
-                ) {
+                Column(modifier = Modifier.fillMaxSize()) {
                     // Search top bar only spans the list width
                     SearchTopBar(
                         placeholderText = placeholderText,
@@ -849,6 +854,10 @@ private fun SearchStopScreenDualPane(
                         onMapToggle = { },
                         onBackClick = onBackClick,
                         onTextChange = onTextChange,
+                        // Dual-pane: top bar is the first child of the left Column, not a floating
+                        // overlay. ime padding here would push the list content down by the keyboard
+                        // height (the "content moved down" bug, worst on iOS landscape).
+                        applyImePadding = false,
                     )
 
                     SearchStopListContent(
@@ -872,16 +881,31 @@ private fun SearchStopScreenDualPane(
                         onOpenMap = {},
                     )
                 }
+            }
 
-                // Right pane: shared MapStopSelectionPane (same VM as SavedTrips dual-pane).
-                // The shared singleton ViewModel owns location tracking and nearby-stops state —
-                // no init event or isMapsAvailable check needed here.
-                if (dualPaneMapUiState != null) {
+            // Right pane: shared MapStopSelectionPane (same VM as SavedTrips dual-pane).
+            // Sibling of the gradient, NOT a child — see the iOS note above. The
+            // weight(1f).fillMaxHeight() lives on a wrapper Box (pane gets default Modifier),
+            // mirroring SavedTrips' dual-pane exactly.
+            if (dualPaneMapUiState != null) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .onSizeChanged {
+                            log("[PANE_DIAG] SearchStop rightPane size=${it.width}x${it.height}")
+                        }
+                        .onGloballyPositioned {
+                            log(
+                                "[PANE_DIAG] SearchStop rightPane " +
+                                    "pos=${it.positionInWindow()} size=${it.size}",
+                            )
+                        },
+                ) {
                     MapStopSelectionPane(
                         mapUiState = dualPaneMapUiState,
                         onEvent = onDualPaneMapEvent,
                         onStopSelected = onStopSelect,
-                        modifier = Modifier.weight(1f).fillMaxHeight(),
                     )
                 }
             }
@@ -1644,7 +1668,6 @@ private fun MapAutoInitEffect(
 // Dual-pane list-column width bounds. Keeps the stops list at ≈ phone-width so
 // StopSearchListItem rows stay readable; map fills the remainder. See
 // docs/TABLET_FOLDABLE_UX.md §2 for the ratio table.
-private val SEARCH_STOP_LIST_PANE_MIN_WIDTH = 320.dp
 private val SEARCH_STOP_LIST_PANE_MAX_WIDTH = 480.dp
 
 // Pill scale factors used by LabelShortcutsRow's graphicsLayer transform — extracted

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -27,16 +27,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
@@ -113,8 +115,10 @@ import xyz.ksharma.krail.trip.planner.ui.components.StopSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.TripSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.TripSearchListItemState
 import xyz.ksharma.krail.trip.planner.ui.components.UnsetLabelPill
+import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionPane
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.SearchStopMap
+import xyz.ksharma.krail.trip.planner.ui.state.mapstopselection.MapStopSelectionEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
@@ -139,6 +143,8 @@ fun SearchStopScreen(
     goBack: () -> Unit = {},
     onStopSelect: (StopItem) -> Unit = {},
     onEvent: (SearchStopUiEvent) -> Unit = {},
+    dualPaneMapUiState: MapUiState? = null,
+    onDualPaneMapEvent: (MapStopSelectionEvent) -> Unit = {},
 ) {
     SideEffect { log("[SEARCH_STOP_SCREEN] recomposed") }
 
@@ -304,6 +310,8 @@ fun SearchStopScreen(
                 onAddLabelClick = { showAddLabelSheet = true },
                 onDoneEditing = { editingLabels = false },
                 onEvent = onEvent,
+                dualPaneMapUiState = dualPaneMapUiState,
+                onDualPaneMapEvent = onDualPaneMapEvent,
             )
         },
     )
@@ -689,7 +697,9 @@ private fun SearchStopScreenSinglePane(
             modifier = Modifier.fillMaxSize(),
         ) {
             CloudGradientBackground(
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
                 themeColor = themeColor.hexToComposeColor(),
             ) {
                 SearchStopListContent(
@@ -750,6 +760,7 @@ private fun SearchStopScreenSinglePane(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.TopStart)
+                .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal))
                 .onGloballyPositioned { coords -> topBarHeightPx = coords.size.height },
         )
     }
@@ -783,34 +794,13 @@ private fun SearchStopScreenDualPane(
     onDoneEditing: () -> Unit,
     onEvent: (SearchStopUiEvent) -> Unit,
     modifier: Modifier = Modifier,
+    dualPaneMapUiState: MapUiState? = null,
+    onDualPaneMapEvent: (MapStopSelectionEvent) -> Unit = {},
 ) {
-    // Dual-pane always shows the list — request focus on every fresh composition
-    // (including after rotation). Single-pane handles its own focus via LaunchedEffect(showMap).
-    SideEffect {
-        log(
-            "[SEARCH_STOP_DUAL_PANE] isMapsAvailable=${searchStopState.isMapsAvailable} " +
-                "| mapUiState=${searchStopState.mapUiState?.let { it::class.simpleName } ?: "null"}",
-        )
-    }
-
     // Focus and keyboard are one-shot — only needed on first entry.
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
         keyboard?.show()
-    }
-
-    // Map init is keyed on isMapsAvailable so it re-runs if the remote config flag arrives
-    // after the first composition (the flag defaults to false in the initial state).
-    LaunchedEffect(searchStopState.isMapsAvailable) {
-        log(
-            "[SEARCH_STOP_DUAL_PANE] LaunchedEffect(isMapsAvailable): " +
-                "isMapsAvailable=${searchStopState.isMapsAvailable} " +
-                "mapUiState=${searchStopState.mapUiState?.let { it::class.simpleName } ?: "null"} " +
-                "→ willInitMap=${searchStopState.mapUiState == null && searchStopState.isMapsAvailable}",
-        )
-        if (searchStopState.mapUiState == null && searchStopState.isMapsAvailable) {
-            onEvent(SearchStopUiEvent.InitializeMap)
-        }
     }
 
     CloudGradientBackground(
@@ -829,12 +819,22 @@ private fun SearchStopScreenDualPane(
                     .weight(1f)
                     .fillMaxWidth(),
             ) {
-                // Left pane: list keeps phone-width proportions so stop rows stay readable;
-                // map then takes the remainder.
+                // Left pane: bounded width when right pane is present so stop rows stay readable;
+                // fills full width when the shared map VM has no state yet (no blank space on right).
                 Column(
                     modifier = Modifier
-                        .widthIn(min = SEARCH_STOP_LIST_PANE_MIN_WIDTH, max = SEARCH_STOP_LIST_PANE_MAX_WIDTH)
-                        .fillMaxHeight(),
+                        .then(
+                            if (dualPaneMapUiState != null) {
+                                Modifier.widthIn(
+                                    min = SEARCH_STOP_LIST_PANE_MIN_WIDTH,
+                                    max = SEARCH_STOP_LIST_PANE_MAX_WIDTH,
+                                )
+                            } else {
+                                Modifier.fillMaxWidth()
+                            },
+                        )
+                        .fillMaxHeight()
+                        .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
                 ) {
                     // Search top bar only spans the list width
                     SearchTopBar(
@@ -871,21 +871,15 @@ private fun SearchStopScreenDualPane(
                     )
                 }
 
-                // Right pane: Map (edge-to-edge)
-                // Show map if available and initialized
-                searchStopState.mapUiState?.let { mapState ->
-                    // Push compass/scale bar below the status bar so they don't sit behind it.
-                    val statusBarTopPadding = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-                    SearchStopMap(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight(),
-                        mapUiState = mapState,
-                        keyboard = keyboard,
-                        focusRequester = focusRequester,
-                        ornamentTopPadding = statusBarTopPadding,
-                        onEvent = onEvent,
-                        onStopSelect = onStopSelect,
+                // Right pane: shared MapStopSelectionPane (same VM as SavedTrips dual-pane).
+                // The shared singleton ViewModel owns location tracking and nearby-stops state —
+                // no init event or isMapsAvailable check needed here.
+                if (dualPaneMapUiState != null) {
+                    MapStopSelectionPane(
+                        mapUiState = dualPaneMapUiState,
+                        onEvent = onDualPaneMapEvent,
+                        onStopSelected = onStopSelect,
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
                     )
                 }
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -37,7 +36,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -66,13 +64,10 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_close
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -92,6 +87,7 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import xyz.ksharma.aagya.permission.PermissionStatus
 import xyz.ksharma.krail.core.adaptiveui.AdaptiveScreenContent
+import xyz.ksharma.krail.core.adaptiveui.DualPaneScaffold
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.transport.TransportMode
@@ -808,42 +804,23 @@ private fun SearchStopScreenDualPane(
     // precisely because it never auto-shows the keyboard. The map is the primary interaction
     // here; the user taps the search field when they actually want to type.
 
-    // Split view: List on left (fixed width), Map on right (fills the rest).
-    // CRITICAL (iOS): the map must NOT be a descendant of CloudGradientBackground. That
-    // component paints via Modifier.drawBehind; on iOS a MaplibreMap (a UIKitView interop
-    // node) nested under a drawBehind ancestor is composited BEHIND that draw layer and
-    // never becomes visible — blank forever, even across rotation. SavedTrips keeps its map
-    // outside the gradient for exactly this reason, which is why its map always worked.
-    // So the gradient wraps ONLY the left list pane; the map pane is a sibling under the Row.
-    // See docs/TABLET_FOLDABLE_UX.md §2 for the ratio rationale.
-    Column(
-        modifier = modifier.fillMaxSize(),
-    ) {
-        Row(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth(),
-        ) {
-            // Left pane: FIXED width when right pane is present (mirrors SavedTrips dual-pane).
-            // A flexible widthIn() sibling next to the map's weight(1f) gives the iOS UIKitView
-            // interop unstable constraints. A fixed width makes the map's weight(1f) deterministic
-            // in a single measure pass. Gradient spans full width when the shared map VM has no
-            // state yet (no blank right gap).
+    // Dual-pane split via the shared DualPaneScaffold so SavedTrips and SearchStop can't drift.
+    // The scaffold owns the fixed-width-list / weighted-right-pane contract AND the invariant
+    // that the right-pane map is a SIBLING of the list — never nested under the list's
+    // CloudGradientBackground. The gradient uses an offscreen graphicsLayer; on iOS a UIKitView
+    // (MapLibre's MLNMapView) can't composite into an offscreen buffer and renders blank, so the
+    // gradient must wrap ONLY the list. See DualPaneScaffold + docs/TABLET_FOLDABLE_UX.md §2.
+    DualPaneScaffold(
+        modifier = modifier,
+        logTag = "SearchStop",
+        listPane = {
             CloudGradientBackground(
                 modifier = Modifier
-                    .then(
-                        if (dualPaneMapUiState != null) {
-                            Modifier.width(SEARCH_STOP_LIST_PANE_MAX_WIDTH)
-                        } else {
-                            Modifier.fillMaxWidth()
-                        },
-                    )
-                    .fillMaxHeight()
+                    .fillMaxSize()
                     .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
                 themeColor = themeColor.hexToComposeColor(),
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
-                    // Search top bar only spans the list width
                     SearchTopBar(
                         placeholderText = placeholderText,
                         initialText = initialText,
@@ -882,35 +859,17 @@ private fun SearchStopScreenDualPane(
                     )
                 }
             }
-
-            // Right pane: shared MapStopSelectionPane (same VM as SavedTrips dual-pane).
-            // Sibling of the gradient, NOT a child — see the iOS note above. The
-            // weight(1f).fillMaxHeight() lives on a wrapper Box (pane gets default Modifier),
-            // mirroring SavedTrips' dual-pane exactly.
-            if (dualPaneMapUiState != null) {
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .onSizeChanged {
-                            log("[PANE_DIAG] SearchStop rightPane size=${it.width}x${it.height}")
-                        }
-                        .onGloballyPositioned {
-                            log(
-                                "[PANE_DIAG] SearchStop rightPane " +
-                                    "pos=${it.positionInWindow()} size=${it.size}",
-                            )
-                        },
-                ) {
-                    MapStopSelectionPane(
-                        mapUiState = dualPaneMapUiState,
-                        onEvent = onDualPaneMapEvent,
-                        onStopSelected = onStopSelect,
-                    )
-                }
+        },
+        rightPane = dualPaneMapUiState?.let { mapState ->
+            {
+                MapStopSelectionPane(
+                    mapUiState = mapState,
+                    onEvent = onDualPaneMapEvent,
+                    onStopSelected = onStopSelect,
+                )
             }
-        }
-    }
+        },
+    )
 }
 
 /**
@@ -1664,11 +1623,6 @@ private fun MapAutoInitEffect(
         }
     }
 }
-
-// Dual-pane list-column width bounds. Keeps the stops list at ≈ phone-width so
-// StopSearchListItem rows stay readable; map fills the remainder. See
-// docs/TABLET_FOLDABLE_UX.md §2 for the ratio table.
-private val SEARCH_STOP_LIST_PANE_MAX_WIDTH = 480.dp
 
 // Pill scale factors used by LabelShortcutsRow's graphicsLayer transform — extracted
 // here so the call site reads as intent, not magic numbers.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
@@ -66,6 +66,7 @@ fun SearchTopBar(
     isMapAvailable: Boolean = false,
     isMapSelected: Boolean = false,
     animateMapButton: Boolean? = null,
+    applyImePadding: Boolean = true,
 ) {
     // rememberSaveable survives rotation so the slide-in plays only on first appearance,
     // not again after every configuration change.
@@ -87,7 +88,13 @@ fun SearchTopBar(
         modifier = modifier
             .fillMaxWidth()
             .statusBarsPadding()
-            .windowInsetsPadding(WindowInsets.ime)
+            // Single-pane: the top bar floats in a Box over the content, so ime padding keeps it
+            // clear of the keyboard. Dual-pane: the top bar is the FIRST child of the left Column,
+            // so ime padding inflates its height by the keyboard height and shoves the list content
+            // down (severe on iOS landscape where the keyboard is ~50% of the height). The keyboard
+            // is at the bottom and the top bar at the top — they never overlap — so dual-pane opts
+            // out via applyImePadding = false.
+            .then(if (applyImePadding) Modifier.windowInsetsPadding(WindowInsets.ime) else Modifier)
             .padding(horizontal = dim.spacingXL, vertical = dim.spacingL)
             .background(
                 color = Color.Transparent,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapActionButtons.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapActionButtons.kt
@@ -44,7 +44,7 @@ internal fun MapActionButtons(
         modifier = modifier
             .fillMaxWidth()
             .navigationBarsPadding()
-            .padding(horizontal = dim.spacingXL, vertical = dim.spacingM),
+            .padding(horizontal = dim.spacingXL, vertical = dim.spacingXL),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toPersistentSet
-import xyz.ksharma.krail.core.maps.state.NearbyStopsConfig
+import xyz.ksharma.krail.core.maps.state.SearchRadius
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.TransportModeSortOrder
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
@@ -260,21 +260,20 @@ private fun SearchRadiusChips(
     onRadiusSelect: (Double) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val radiusOptions = remember { listOf(1.0, 3.0, 5.0) }
     val themeColor = LocalThemeColor.current.value.hexToComposeColor()
 
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(KrailTheme.dimensions.spacingM),
     ) {
-        radiusOptions.forEach { radius ->
+        SearchRadius.entries.forEach { radius ->
             FilterChip(
-                selected = selectedRadiusKm == radius,
-                onClick = { onRadiusSelect(radius) },
+                selected = selectedRadiusKm == radius.km,
+                onClick = { onRadiusSelect(radius.km) },
                 label = {
                     Text(
-                        text = "${radius.toInt()}km",
-                        color = if (selectedRadiusKm == radius) {
+                        text = radius.label,
+                        color = if (selectedRadiusKm == radius.km) {
                             KrailTheme.colors.surface
                         } else {
                             KrailTheme.colors.onSurface
@@ -361,7 +360,7 @@ private fun MapControlToggle(
 private fun PreviewMapOptionsBottomSheet() {
     PreviewTheme {
         MapOptionsBottomSheet(
-            searchRadiusKm = NearbyStopsConfig.DEFAULT_RADIUS_KM,
+            searchRadiusKm = SearchRadius.DEFAULT.km,
             selectedTransportModes = NswTransportConfig.allProductClasses().toPersistentSet(),
             showDistanceScale = false,
             showCompass = true,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManager.kt
@@ -77,7 +77,11 @@ internal class RealNearbyStopsManager(
     ) {
         log("[NEARBY_STOPS] loadNearbyStops() called")
 
-        if (shouldUseCachedResults(center)) {
+        // Always fetch when the caller has no stops yet — a prior consumer may have
+        // populated the cache at this center, but this consumer's own state is empty
+        // and needs its own data (each consumer owns its own MapUiState store).
+        val callerHasStops = mapState.mapDisplay.nearbyStops.isNotEmpty()
+        if (callerHasStops && shouldUseCachedResults(center)) {
             log("[NEARBY_STOPS] Using cached nearby stops")
             return
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
@@ -415,13 +414,20 @@ private fun MapSurface(
     onStopSelected: (NearbyStopFeature) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var mapContainerSize by remember { mutableStateOf(IntSize.Zero) }
+    // LATCH the "has had a real size" flag — never reset it to false. During a rotation the
+    // container momentarily reports a 0 axis (the adaptive window flips through 840×0dp);
+    // tearing the map down on that transient and recreating it leaves the right pane blank
+    // until a SECOND rotation. Once we've seen a valid size we keep the map mounted; MapLibre
+    // resizes its own surface as the container settles.
+    var hasHadValidSize by remember { mutableStateOf(false) }
     Box(
         modifier = modifier
             .fillMaxSize()
-            .onSizeChanged { mapContainerSize = it },
+            .onSizeChanged {
+                if (it.width > 0 && it.height > 0) hasHadValidSize = true
+            },
     ) {
-        if (mapContainerSize.width > 0 && mapContainerSize.height > 0) {
+        if (hasHadValidSize) {
             MaplibreMap(
                 modifier = Modifier.fillMaxSize(),
                 cameraState = cameraState,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -73,6 +73,7 @@ fun SearchStopMap(
     onShowOptionsSheet: () -> Unit = {},
     onEvent: (SearchStopUiEvent) -> Unit = {},
     onStopSelect: (StopItem) -> Unit = {},
+    onPermissionBannerVisibilityChanged: (Boolean) -> Unit = {},
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         when (mapUiState) {
@@ -92,6 +93,7 @@ fun SearchStopMap(
                     onShowOptionsSheet = onShowOptionsSheet,
                     onEvent = onEvent,
                     onStopSelect = onStopSelect,
+                    onPermissionBannerVisibilityChanged = onPermissionBannerVisibilityChanged,
                     modifier = Modifier.fillMaxSize(),
                 )
             }
@@ -130,6 +132,7 @@ private fun MapContent(
     ornamentTopPadding: Dp = 0.dp,
     autoShowOptionsSheet: Boolean = false,
     onShowOptionsSheet: () -> Unit = {},
+    onPermissionBannerVisibilityChanged: (Boolean) -> Unit = {},
 ) {
     log(
         "[NEARBY_STOPS_UI] MapContent rendered: nearbyStops.size=${mapState.mapDisplay.nearbyStops.size}, " +
@@ -150,6 +153,9 @@ private fun MapContent(
     // User location state
     var permissionStatus by remember { mutableStateOf<PermissionStatus>(PermissionStatus.NotDetermined) }
     var showPermissionBanner by remember { mutableStateOf(false) }
+    LaunchedEffect(showPermissionBanner) {
+        onPermissionBannerVisibilityChanged(showPermissionBanner)
+    }
     // False until the user explicitly taps the location button.
     // When true, TrackUserLocation is allowed to trigger the system permission dialog.
     var allowPermissionRequest by remember { mutableStateOf(false) }
@@ -166,28 +172,22 @@ private fun MapContent(
     val scope = rememberCoroutineScope()
 
     Box(modifier = modifier.fillMaxSize()) {
-        // Start at default Sydney coordinates
+        // Seed from known user location so re-entry after a composition bounce
+        // (dual-pane layout shift, rotation) doesn't flash at Sydney default.
+        val knownLocation = mapState.mapDisplay.userLocation
         val cameraState = rememberCameraState(
-            firstPosition = CameraPosition(
-                target = Position(
-                    latitude = NearbyStopsConfig.DEFAULT_CENTER_LAT,
-                    longitude = NearbyStopsConfig.DEFAULT_CENTER_LON,
-                ),
-                zoom = NearbyStopsConfig.DEFAULT_ZOOM,
-            ),
+            firstPosition = initialCameraPosition(knownLocation),
         )
 
-        // Trigger initial load with default camera position
+        // Trigger initial nearby-stops load for the camera's starting position.
+        val initialCenter = knownLocation ?: LatLng(
+            NearbyStopsConfig.DEFAULT_CENTER_LAT,
+            NearbyStopsConfig.DEFAULT_CENTER_LON,
+        )
         LaunchedEffect(Unit) {
-            log("[NEARBY_STOPS_UI] Map initialized at default position")
-            onEvent(
-                SearchStopUiEvent.MapCenterChanged(
-                    LatLng(
-                        NearbyStopsConfig.DEFAULT_CENTER_LAT,
-                        NearbyStopsConfig.DEFAULT_CENTER_LON,
-                    ),
-                ),
-            )
+            val label = if (knownLocation != null) "user location" else "Sydney default"
+            log("[NEARBY_STOPS_UI] Map initialized at $label")
+            onEvent(SearchStopUiEvent.MapCenterChanged(initialCenter))
         }
 
         TrackUserLocation(
@@ -204,13 +204,14 @@ private fun MapContent(
             },
         )
 
-        // Auto-center camera on the first non-null user location.
-        // State-driven (recomposition-aware) so it survives the iOS permission dialog
-        // bouncing the activity through ON_STOP/ON_START, which used to cancel the
-        // animateTo before it could fire on the first grant.
-        var hasAutoCentered by rememberSaveable { mutableStateOf(false) }
+        // Auto-center on first user location.
+        // - hasAutoCentered seeds true if location is already known (re-entry case) —
+        //   no animation needed because cameraState already starts at userLoc above.
+        // - Keyed only on firstUserLocation, NOT on hasAutoCentered, so changing
+        //   hasAutoCentered false→true doesn't restart and cancel the animateTo.
         val firstUserLocation = mapState.mapDisplay.userLocation
-        LaunchedEffect(firstUserLocation, hasAutoCentered) {
+        var hasAutoCentered by remember { mutableStateOf(firstUserLocation != null) }
+        LaunchedEffect(firstUserLocation) {
             if (firstUserLocation != null && !hasAutoCentered) {
                 hasAutoCentered = true
                 cameraState.animateTo(
@@ -292,29 +293,16 @@ private fun MapContent(
                         SearchStopUiEvent.LocationButtonClicked(hadLocation = mapState.mapDisplay.userLocation != null),
                     )
                     scope.launch {
-                        val userLoc = mapState.mapDisplay.userLocation
-                        if (userLoc != null) {
-                            // Tracking is running — re-center camera on latest known position
-                            cameraState.animateTo(
-                                CameraPosition(
-                                    target = userLoc.toPosition(),
-                                    zoom = UserLocationConfig.RECENTER_ZOOM,
-                                ),
-                                duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-                            )
-                        } else {
-                            val status = userLocationManager.checkPermissionStatus()
-                            if (status is PermissionStatus.Denied) {
-                                // Cannot request — direct user to Settings instead
+                        handleLocationButtonClick(
+                            userLoc = mapState.mapDisplay.userLocation,
+                            cameraState = cameraState,
+                            userLocationManager = userLocationManager,
+                            onPermissionDenied = { status ->
                                 permissionStatus = status
                                 showPermissionBanner = true
-                            } else {
-                                // Flip the flag: TrackUserLocation's LifecycleStartEffect
-                                // relaunches immediately (key changed) and calls locationUpdates(),
-                                // which triggers the system permission dialog if not yet determined.
-                                allowPermissionRequest = true
-                            }
-                        }
+                            },
+                            onRequestPermission = { allowPermissionRequest = true },
+                        )
                     }
                 },
                 modifier = Modifier.align(Alignment.BottomStart),
@@ -415,6 +403,39 @@ private fun MapContent(
 }
 
 private fun LatLng.toPosition(): Position = Position(latitude = latitude, longitude = longitude)
+
+private suspend fun handleLocationButtonClick(
+    userLoc: LatLng?,
+    cameraState: org.maplibre.compose.camera.CameraState,
+    userLocationManager: xyz.ksharma.krail.core.maps.data.location.UserLocationManager,
+    onPermissionDenied: (xyz.ksharma.aagya.permission.PermissionStatus) -> Unit,
+    onRequestPermission: () -> Unit,
+) {
+    if (userLoc != null) {
+        cameraState.animateTo(
+            CameraPosition(target = userLoc.toPosition(), zoom = UserLocationConfig.RECENTER_ZOOM),
+            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
+        )
+    } else {
+        val status = userLocationManager.checkPermissionStatus()
+        if (status is xyz.ksharma.aagya.permission.PermissionStatus.Denied) {
+            onPermissionDenied(status)
+        } else {
+            onRequestPermission()
+        }
+    }
+}
+
+private fun initialCameraPosition(knownLocation: LatLng?): CameraPosition =
+    knownLocation?.let {
+        CameraPosition(target = it.toPosition(), zoom = UserLocationConfig.AUTO_CENTER_ZOOM)
+    } ?: CameraPosition(
+        target = Position(
+            latitude = NearbyStopsConfig.DEFAULT_CENTER_LAT,
+            longitude = NearbyStopsConfig.DEFAULT_CENTER_LON,
+        ),
+        zoom = NearbyStopsConfig.DEFAULT_ZOOM,
+    )
 
 // region Previews
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -207,24 +207,32 @@ private fun MapContent(
             },
         )
 
-        // Auto-center on first user location.
-        // - hasAutoCentered seeds true if location is already known (re-entry case) —
-        //   no animation needed because cameraState already starts at userLoc above.
-        // - Keyed only on firstUserLocation, NOT on hasAutoCentered, so changing
-        //   hasAutoCentered false→true doesn't restart and cancel the animateTo.
-        val firstUserLocation = mapState.mapDisplay.userLocation
+        // Auto-center on first user location, exactly once, smoothly.
+        //
+        // CRITICAL: key the effect on a STABLE boolean (hasUserLocation), NOT on the changing
+        // LatLng. GPS emits a stream of slightly-different fixes; keying on the value re-launched
+        // this effect on every jitter, which CANCELLED the in-flight animateTo. Because
+        // hasAutoCentered had already flipped true, it never re-fired — so the camera was left
+        // frozen wherever the cancelled animation stopped: at the Sydney seed, or (on iOS) at an
+        // intermediate zoomed-all-the-way-out frame. Rotating "fixed" it only because
+        // rememberCameraState re-seeded firstPosition at the now-known location (the seed path,
+        // not this animate path). hasUserLocation flips false→true once and then stays true, so
+        // subsequent jitter no longer re-keys the effect and the animation runs to completion.
+        //
+        // If location permission is absent, userLocation stays null → no animation → the camera
+        // stays at the Sydney default seed. Only when a real fix arrives do we move to it.
+        val userLocation = mapState.mapDisplay.userLocation
+        val hasUserLocation = userLocation != null
         var hasAutoCentered by remember { mutableStateOf(false) }
-        LaunchedEffect(firstUserLocation) {
-            log(
-                "[CAMERA_DIAG] auto-center check: firstUserLocation=$firstUserLocation " +
-                    "hasAutoCentered=$hasAutoCentered",
-            )
-            if (firstUserLocation != null && !hasAutoCentered) {
+        LaunchedEffect(hasUserLocation) {
+            log("[CAMERA_DIAG] auto-center check: hasUserLocation=$hasUserLocation hasAutoCentered=$hasAutoCentered")
+            val target = userLocation
+            if (target != null && !hasAutoCentered) {
                 hasAutoCentered = true
-                log("[CAMERA_DIAG] animating camera to user location $firstUserLocation")
+                log("[CAMERA_DIAG] animating camera to user location $target")
                 cameraState.animateTo(
                     CameraPosition(
-                        target = firstUserLocation.toPosition(),
+                        target = target.toPosition(),
                         zoom = UserLocationConfig.AUTO_CENTER_ZOOM,
                     ),
                     duration = UserLocationConfig.AUTO_CENTER_ANIMATION_MS.milliseconds,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -224,11 +224,9 @@ private fun MapContent(
         val hasUserLocation = userLocation != null
         var hasAutoCentered by remember { mutableStateOf(false) }
         LaunchedEffect(hasUserLocation) {
-            log("[CAMERA_DIAG] auto-center check: hasUserLocation=$hasUserLocation hasAutoCentered=$hasAutoCentered")
             val target = userLocation
             if (target != null && !hasAutoCentered) {
                 hasAutoCentered = true
-                log("[CAMERA_DIAG] animating camera to user location $target")
                 cameraState.animateTo(
                     CameraPosition(
                         target = target.toPosition(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -21,14 +21,17 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
@@ -229,6 +232,11 @@ private fun MapContent(
         LaunchedEffect(cameraState) {
             snapshotFlow { cameraState.position.target }
                 .debounce(NearbyStopsConfig.CAMERA_PAN_DEBOUNCE_MS)
+                // Defensive: during an iOS resize transient MapLibre can briefly report a
+                // projected target outside valid lat/lon bounds. Dropping those stops the
+                // runaway nearby-stops query (and its "Invalid longitude" errors) instead of
+                // feeding garbage coordinates downstream.
+                .filter { it.latitude in -90.0..90.0 && it.longitude in -180.0..180.0 }
                 .collect { target ->
                     onEvent(
                         SearchStopUiEvent.MapCenterChanged(
@@ -239,46 +247,15 @@ private fun MapContent(
         }
 
         Box(modifier = Modifier.fillMaxSize()) {
-            MaplibreMap(
-                modifier = Modifier.fillMaxSize(),
+            MapSurface(
+                mapState = mapState,
                 cameraState = cameraState,
-                baseStyle = BaseStyle.Uri(OPEN_FREE_MAP_LIBERTY),
-                options = MapOptions(
-                    ornamentOptions = OrnamentOptions(
-                        padding = PaddingValues(top = ornamentTopPadding),
-                        isLogoEnabled = LOGO_ENABLED,
-                        isAttributionEnabled = ATTRIBUTION_ENABLED,
-                        attributionAlignment = Alignment.BottomEnd,
-                        isCompassEnabled = mapState.mapDisplay.showCompass,
-                        compassAlignment = Alignment.TopEnd,
-                        isScaleBarEnabled = mapState.mapDisplay.showDistanceScale,
-                        scaleBarAlignment = Alignment.TopStart,
-                    ),
-                ),
-            ) {
-                // Render nearby stops
-                if (mapState.mapDisplay.nearbyStops.isNotEmpty()) {
-                    log(
-                        "[NEARBY_STOPS_UI] Rendering ${mapState.mapDisplay.nearbyStops.size} " +
-                            "stops on map",
-                    )
-                    NearbyStopsLayer(
-                        stops = mapState.mapDisplay.nearbyStops,
-                        onStopClick = { stop ->
-                            log("[NEARBY_STOPS_UI] Stop clicked: ${stop.stopName}")
-                            selectedStop = stop
-                            onEvent(SearchStopUiEvent.NearbyStopClicked(stop))
-                        },
-                    )
-                } else {
-                    log("[NEARBY_STOPS_UI] No stops to render")
-                }
-
-                // Render user location as red circle (always on top)
-                UserLocationLayer(
-                    userLocation = mapState.mapDisplay.userLocation,
-                )
-            }
+                ornamentTopPadding = ornamentTopPadding,
+                onStopSelected = { stop ->
+                    selectedStop = stop
+                    onEvent(SearchStopUiEvent.NearbyStopClicked(stop))
+                },
+            )
 
             // Bottom left action buttons (Options and Location).
             // All location business logic lives here, not inside MapActionButtons.
@@ -396,6 +373,76 @@ private fun MapContent(
                             },
                         )
                     },
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The MapLibre GL surface plus its on-map layers (nearby stops, user location).
+ *
+ * iOS UIKitView interop: if [MaplibreMap] is instantiated while EITHER axis of the container
+ * is 0, the native MLNMapView is created with a degenerate frame. With both axes 0 the Metal
+ * layer fails to allocate a drawable ("CAMetalLayer ... width=0 height=0" / "nextDrawable
+ * returning nil") and the map is blank. With one axis 0 (the adaptive window reports a
+ * transient `840×0dp` / `0×480dp` during rotation) MapLibre projects camera moves against a
+ * zero-area viewport and the camera target runs away to invalid coords (e.g. longitude > 180,
+ * mid-Pacific), so the map pans off the world AND the nearby-stops query errors out.
+ *
+ * Gate creation until BOTH width and height are non-zero so the native view always initialises
+ * with a valid frame. Android is unaffected (AndroidView re-lays-out cleanly) but the gate is
+ * harmless there.
+ */
+@Composable
+private fun MapSurface(
+    mapState: MapUiState.Ready,
+    cameraState: org.maplibre.compose.camera.CameraState,
+    ornamentTopPadding: Dp,
+    onStopSelected: (NearbyStopFeature) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var mapContainerSize by remember { mutableStateOf(IntSize.Zero) }
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .onSizeChanged { mapContainerSize = it },
+    ) {
+        if (mapContainerSize.width > 0 && mapContainerSize.height > 0) {
+            MaplibreMap(
+                modifier = Modifier.fillMaxSize(),
+                cameraState = cameraState,
+                baseStyle = BaseStyle.Uri(OPEN_FREE_MAP_LIBERTY),
+                options = MapOptions(
+                    ornamentOptions = OrnamentOptions(
+                        padding = PaddingValues(top = ornamentTopPadding),
+                        isLogoEnabled = LOGO_ENABLED,
+                        isAttributionEnabled = ATTRIBUTION_ENABLED,
+                        attributionAlignment = Alignment.BottomEnd,
+                        isCompassEnabled = mapState.mapDisplay.showCompass,
+                        compassAlignment = Alignment.TopEnd,
+                        isScaleBarEnabled = mapState.mapDisplay.showDistanceScale,
+                        scaleBarAlignment = Alignment.TopStart,
+                    ),
+                ),
+            ) {
+                if (mapState.mapDisplay.nearbyStops.isNotEmpty()) {
+                    log(
+                        "[NEARBY_STOPS_UI] Rendering ${mapState.mapDisplay.nearbyStops.size} " +
+                            "stops on map",
+                    )
+                    NearbyStopsLayer(
+                        stops = mapState.mapDisplay.nearbyStops,
+                        onStopClick = { stop ->
+                            log("[NEARBY_STOPS_UI] Stop clicked: ${stop.stopName}")
+                            onStopSelected(stop)
+                        },
+                    )
+                }
+
+                // Render user location as red circle (always on top)
+                UserLocationLayer(
+                    userLocation = mapState.mapDisplay.userLocation,
                 )
             }
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -213,10 +213,15 @@ private fun MapContent(
         // - Keyed only on firstUserLocation, NOT on hasAutoCentered, so changing
         //   hasAutoCentered false→true doesn't restart and cancel the animateTo.
         val firstUserLocation = mapState.mapDisplay.userLocation
-        var hasAutoCentered by remember { mutableStateOf(firstUserLocation != null) }
+        var hasAutoCentered by remember { mutableStateOf(false) }
         LaunchedEffect(firstUserLocation) {
+            log(
+                "[CAMERA_DIAG] auto-center check: firstUserLocation=$firstUserLocation " +
+                    "hasAutoCentered=$hasAutoCentered",
+            )
             if (firstUserLocation != null && !hasAutoCentered) {
                 hasAutoCentered = true
+                log("[CAMERA_DIAG] animating camera to user location $firstUserLocation")
                 cameraState.animateTo(
                     CameraPosition(
                         target = firstUserLocation.toPosition(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -8,12 +8,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -64,7 +69,8 @@ fun SettingsScreen(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.TopCenter),
+                .align(Alignment.TopCenter)
+                .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
         ) {
             TitleBar(
                 modifier = Modifier.fillMaxWidth(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryScreen.kt
@@ -4,9 +4,14 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -26,7 +31,8 @@ fun OurStoryScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .background(color = KrailTheme.colors.surface),
+            .background(color = KrailTheme.colors.surface)
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
             TitleBar(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionScreen.kt
@@ -7,11 +7,16 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -55,7 +60,11 @@ fun ThemeSelectionScreen(
         )
 
         val dim = KrailTheme.dimensions
-        Column {
+        Column(
+            modifier = Modifier.windowInsetsPadding(
+                WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal),
+            ),
+        ) {
             TitleBar(
                 onNavActionClick = onBackClick,
                 title = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -14,13 +14,18 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
@@ -110,6 +115,9 @@ fun TimeTableScreen(
     onModeSelectionChanged: (Set<Int>) -> Unit = {},
     onModeClick: (Boolean) -> Unit = {},
     onMapClick: (String) -> Unit = {},
+    // When true, the per-card "Maps" button is suppressed because a persistent map pane
+    // is rendered alongside this screen (see docs/TABLET_FOLDABLE_UX.md §3).
+    hideMapButton: Boolean = false,
 ) {
     val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
@@ -128,7 +136,10 @@ fun TimeTableScreen(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
     ) {
         LazyColumn(
-            modifier = Modifier.fillMaxSize().statusBarsPadding(),
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
             contentPadding = PaddingValues(bottom = dim.spacingXL),
         ) {
             stickyHeader(key = "title-bar") {
@@ -383,6 +394,7 @@ fun TimeTableScreen(
                         onAlertClick = onAlertClick,
                         onLegClick = onJourneyLegClick,
                         onMapClick = onMapClick,
+                        hideMapButton = hideMapButton,
                     ),
                     onPlanTripClick = dateTimeSelectorClicked,
                 )
@@ -438,6 +450,7 @@ private data class JourneyCallbacks(
     val onAlertClick: (String) -> Unit,
     val onLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit,
     val onMapClick: (String) -> Unit,
+    val hideMapButton: Boolean = false,
 )
 
 private fun LazyListScope.journeyListContent(
@@ -577,7 +590,7 @@ private fun LazyListScope.journeyCardItems(
             onAlertClick = { callbacks.onAlertClick(journey.journeyId) },
             onLegClick = callbacks.onLegClick,
             onMapClick = { callbacks.onMapClick(journey.journeyId) },
-            isMapsAvailable = state.isMapsAvailable,
+            isMapsAvailable = state.isMapsAvailable && !callbacks.hideMapButton,
             onShareJourney = { bitmap, shareText, isPastDeparture ->
                 callbacks.onEvent(
                     TimeTableUiEvent.ShareJourneyClicked(

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/mapstopselection/MapStopSelectionViewModelTest.kt
@@ -1,0 +1,149 @@
+package xyz.ksharma.krail.trip.planner.ui.mapstopselection
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.trip.planner.ui.state.mapstopselection.MapStopSelectionEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeNearbyStopsManagerForMap
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MapStopSelectionViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var fakeNearbyStopsManager: FakeNearbyStopsManagerForMap
+    private lateinit var viewModel: MapStopSelectionViewModel
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        fakeNearbyStopsManager = FakeNearbyStopsManagerForMap()
+        viewModel = MapStopSelectionViewModel(
+            nearbyStopsManager = fakeNearbyStopsManager,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        fakeNearbyStopsManager.reset()
+    }
+
+    @Test
+    fun `initial state is Ready`() = runTest {
+        viewModel.mapUiState.test {
+            assertIs<MapUiState.Ready>(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `UserLocationUpdated updates userLocation in state`() = runTest {
+        val location = LatLng(latitude = -33.87, longitude = 151.21)
+
+        viewModel.mapUiState.test {
+            awaitItem() // initial Ready
+
+            viewModel.onEvent(MapStopSelectionEvent.UserLocationUpdated(location))
+            advanceUntilIdle()
+
+            val state = awaitItem() as MapUiState.Ready
+            assertEquals(location, state.mapDisplay.userLocation)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `UserLocationUpdated triggers nearby stops load`() = runTest {
+        val location = LatLng(latitude = -33.87, longitude = 151.21)
+
+        viewModel.mapUiState.test {
+            awaitItem() // activate WhileSubscribed
+
+            viewModel.onEvent(MapStopSelectionEvent.UserLocationUpdated(location))
+            advanceUntilIdle()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(1, fakeNearbyStopsManager.loadNearbyStopsCallCount)
+    }
+
+    @Test
+    fun `MapCenterChanged updates mapCenter in state`() = runTest {
+        val center = LatLng(latitude = -33.90, longitude = 151.18)
+
+        viewModel.mapUiState.test {
+            awaitItem() // initial Ready
+
+            viewModel.onEvent(MapStopSelectionEvent.MapCenterChanged(center))
+            advanceUntilIdle()
+
+            val state = awaitItem() as MapUiState.Ready
+            assertEquals(center, state.mapDisplay.mapCenter)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `MapCenterChanged triggers nearby stops load`() = runTest {
+        val center = LatLng(latitude = -33.90, longitude = 151.18)
+
+        viewModel.mapUiState.test {
+            awaitItem() // activate WhileSubscribed
+
+            viewModel.onEvent(MapStopSelectionEvent.MapCenterChanged(center))
+            advanceUntilIdle()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(1, fakeNearbyStopsManager.loadNearbyStopsCallCount)
+        assertEquals(center, fakeNearbyStopsManager.lastCenter)
+    }
+
+    @Test
+    fun `MapCenterChanged uses updated center for load, not stale default`() = runTest {
+        val center = LatLng(latitude = -33.90, longitude = 151.18)
+
+        viewModel.mapUiState.test {
+            awaitItem()
+
+            viewModel.onEvent(MapStopSelectionEvent.MapCenterChanged(center))
+            advanceUntilIdle()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // The center passed to NearbyStopsManager must match the updated mapCenter,
+        // not the Sydney default from initial state.
+        assertEquals(center, fakeNearbyStopsManager.lastCenter)
+    }
+
+    @Test
+    fun `UserLocationUpdated with null does not persist non-null location`() = runTest {
+        viewModel.mapUiState.test {
+            awaitItem() // initial Ready — userLocation is null by default
+
+            viewModel.onEvent(MapStopSelectionEvent.UserLocationUpdated(null))
+            advanceUntilIdle()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Verify null was passed through to the NearbyStopsManager's mapState
+        val passedState = fakeNearbyStopsManager.lastMapState
+        assertEquals(null, passedState?.mapDisplay?.userLocation)
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManagerCacheTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManagerCacheTest.kt
@@ -1,0 +1,140 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.map
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.krail.core.maps.data.model.NearbyStop
+import xyz.ksharma.krail.core.maps.data.repository.NearbyStopsRepository
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests the cache-bypass rule: when the caller's MapUiState has no stops yet,
+ * [NearbyStopsManager.loadNearbyStops] must always fetch, even if a prior consumer
+ * already populated the cache for the same center.
+ *
+ * Regression test for the SavedTrips MapStopSelectionPane poisoning the cache shared
+ * with SearchStopViewModel, causing SearchStop's initial load to be skipped.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NearbyStopsManagerCacheTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var fakeRepository: FakeNearbyStopsRepository
+    private lateinit var manager: NearbyStopsManager
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        fakeRepository = FakeNearbyStopsRepository()
+        manager = createNearbyStopsManager(
+            repository = fakeRepository,
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `fetches when caller has no stops even if cache is warm for same center`() = runTest {
+        val center = LatLng(-33.87, 151.21)
+        val scope = CoroutineScope(testDispatcher)
+
+        // First consumer loads stops — warms cache for center.
+        manager.loadNearbyStops(
+            mapState = MapUiState.Ready(mapDisplay = MapDisplay(mapCenter = center)),
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(1, fakeRepository.callCount, "first consumer should fetch")
+
+        // Second consumer at same center but EMPTY stops (fresh ViewModel state) —
+        // must NOT use cache; must fetch its own data.
+        manager.loadNearbyStops(
+            mapState = MapUiState.Ready(mapDisplay = MapDisplay(nearbyStops = persistentListOf(), mapCenter = center)),
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(2, fakeRepository.callCount, "second consumer with empty state should fetch despite warm cache")
+    }
+
+    @Test
+    fun `skips fetch when caller already has stops and cache is warm`() = runTest {
+        val center = LatLng(-33.87, 151.21)
+        val scope = CoroutineScope(testDispatcher)
+        val existingStop = NearbyStopFeature(
+            stopId = "stop-1",
+            stopName = "Town Hall",
+            position = center,
+            transportModes = persistentListOf(),
+        )
+
+        // First load warms cache.
+        manager.loadNearbyStops(
+            mapState = MapUiState.Ready(mapDisplay = MapDisplay(mapCenter = center)),
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(1, fakeRepository.callCount)
+
+        // Same consumer, same center, already has stops in state → cache used, no re-fetch.
+        manager.loadNearbyStops(
+            mapState = MapUiState.Ready(
+                mapDisplay = MapDisplay(
+                    nearbyStops = persistentListOf(existingStop),
+                    mapCenter = center,
+                ),
+            ),
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(1, fakeRepository.callCount, "caller with stops should reuse warm cache")
+    }
+}
+
+private class FakeNearbyStopsRepository : NearbyStopsRepository {
+    var callCount = 0
+        private set
+
+    override suspend fun getStopsNearby(
+        centerLat: Double,
+        centerLon: Double,
+        radiusKm: Double,
+        productClasses: Set<Int>,
+        maxResults: Int,
+    ): List<NearbyStop> {
+        callCount++
+        return emptyList()
+    }
+}


### PR DESCRIPTION
Combines SavedTrips dual-pane hero, SearchStop dual-pane migration to
shared map, and all follow-up map/camera bug fixes into one PR.

SavedTrips dual-pane
- Full List+Map layout on tablets, foldables, and phone landscape.
- Left pane: saved trips list capped at 480 dp; right pane: shared
  MapStopSelectionPane showing nearby stops.
- Compact-height pill on phone landscape navigates to SearchStop instead
  of expanding inline.
- Collapse handle on the SearchStopRow expanded card (surface token,
  40 dp touch target) lets users dismiss it back to pill.
- SearchStopRow: display-cutout horizontal insets applied to both pill
  and expanded card; background constrained to safe area.
- Tapping a nearby stop on the right-pane map fires ToStopChanged so
  it appears in the destination field.
- Default nearby-stops radius: 1 km (was 3 km).

SearchStop dual-pane (tablet/foldable/phone-landscape)
- Right pane now uses the same MapStopSelectionPane as SavedTrips.
  Eliminates the duplicate map-state path in SearchStopViewModel;
  any bug fixed in the shared VM fixes both screens.
- Removed isMapsAvailable + InitializeMap event from dual-pane path;
  shared VM is Ready from construction.
- Placeholder Box holds right-pane space during async map init so the
  list doesn't jump to full width then back.

MapStopSelectionViewModel
- Converted from Koin singleton to per-entry ViewModel (viewModel {},
  koinViewModel()) so SavedTrips and SearchStop each own independent
  map state, scope, and NearbyStopsManager query slots.
- Uses viewModelScope; onCleared() cancels in-flight queries.

Camera fixes
- hasAutoCentered: remember (not rememberSaveable) so camera re-centers
  on each fresh open; rememberSaveable was persisting true across nav.
- Camera seeds from mapState.mapDisplay.userLocation if already known,
  eliminating Sydney flash on composition re-entry (rotation,
  dual-pane layout shift).
- LaunchedEffect keyed only on firstUserLocation, not on hasAutoCentered,
  so animateTo is never cancelled by the flag flip mid-animation.
- initialCameraPosition / handleLocationButtonClick extracted to reduce
  MapContent cyclomatic complexity.

Architecture / shared code
- SearchStopRow previews extracted to SearchStopRowPreviews.kt
  (TooManyFunctions limit).
- New @PreviewComponent + @ScreenshotTest previews for collapse-handle
  states and MapStopSelectionPane (Loading / Ready).
- NearbyStopsManagerCacheTest baseline added (FakeNearbyStopsRepository
  migration to :core:testing is a follow-up).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>