### PR TITLE
feat(savedtrips): collapse search row to button only in phone-landscape

### DIFF
--- a/docs/TABLET_FOLDABLE_UX.md
+++ b/docs/TABLET_FOLDABLE_UX.md
@@ -121,16 +121,18 @@ SearchStop). `TimeTableRoute` navigation still works via back-stack push.
   `MapStopSelectionPane` (singleton `MapStopSelectionViewModel`). Users can
   explore nearby stops and view stop details; tapping a stop has no
   trip-planning side-effect. The right pane is purely contextual.
-- Trip planning is done via the SearchStopRow pill at the bottom of the left
-  pane (same flow as portrait — pill collapses/expands SearchStopRow).
+- Trip planning is done via the SearchStopRow at the bottom of the left pane.
+  On tablet and foldable-unfolded the row is **always expanded**; only
+  phone-landscape collapses it to a button (see compact-height rules below).
 
 ### Compact-height rules (`isCompactHeight`, height < 480 dp)
 
-Phone landscape uses the **same pill + expand-SearchStopRow** behaviour as
-portrait. No special single-line collapsed bar is needed — the pill already
-collapses the row to a single button, and expanding it fills the remaining
-height acceptably. `showPill` logic is the same in both orientations
-(collapses when ≥ 2 saved trips, or 1 trip + Park & Ride).
+Phone landscape is the **only** form factor that collapses SearchStopRow to a
+"Plan a trip" button — vertical space is too scarce to keep the full row open.
+Tapping the button expands the full SearchStopRow; the collapse handle returns
+to the button. Phone portrait, tablet, and foldable-unfolded always show the
+expanded row. The rule is simply `showPill = isPhoneLandscape` — it no longer
+depends on saved-trip count or Park & Ride.
 
 ---
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -131,29 +131,21 @@ fun SavedTripsScreen(
         }.random()
     }
 
-    // Pill (phone-portrait only) is shown when there's enough saved content above
-    // to justify collapsing the search row out of the way:
-    //   • 2+ saved trips, OR
-    //   • 1 saved trip + at least one Park & Ride entry.
-    // Anything less and the expanded row stays — first-time and lightly-used
-    // accounts still get the full search affordance front-and-centre.
-    val savedTripsCount = savedTripsState.savedTrips.size
-    val hasParkRide = savedTripsState.parkRideUiState.isNotEmpty()
-
-    // Adaptive layout:
-    //   - Tablet / foldable-unfolded (isTablet): SearchStopRow always expanded.
-    //   - Phone portrait + phone landscape: pill collapses SearchStopRow when
-    //     enough content is present. Same behaviour in both orientations.
+    // Adaptive search-row presentation:
+    //   - Phone portrait, tablet, foldable-unfolded: SearchStopRow is ALWAYS expanded —
+    //     these form factors have the vertical room, so the full search affordance stays
+    //     front-and-centre.
+    //   - Phone landscape (compact height): vertical space is scarce, so the row collapses
+    //     to a "Plan a trip" button. Tapping it expands the full SearchStopRow; the
+    //     collapse handle returns to the button.
     // See docs/TABLET_FOLDABLE_UX.md §4.
     val adaptiveLayoutInfo = rememberAdaptiveLayoutInfo()
     val dualPane = adaptiveLayoutInfo.shouldShowDualPane
     val isPhoneLandscape = adaptiveLayoutInfo.isPhoneLandscape
     val isTablet = adaptiveLayoutInfo.isTablet
 
-    val showPill = when {
-        isTablet -> false
-        else -> savedTripsCount >= 2 || (savedTripsCount >= 1 && hasParkRide)
-    }
+    // Collapse to the button only in phone-landscape; everything else stays expanded.
+    val showPill = isPhoneLandscape
 
     // Search row expand / from-highlight state — rememberSaveable survives rotation.
     var isSearchExpanded by rememberSaveable { mutableStateOf(false) }


### PR DESCRIPTION
Previously the SearchStopRow collapsed to a "Plan a trip" pill on phones in
both portrait and landscape once enough saved content was present (2+ trips,
or 1 trip + Park & Ride). That hid the primary search affordance on portrait
phones with a couple of saved trips.

Now the rule is purely form-factor driven:

- Phone portrait, tablet, foldable-unfolded: SearchStopRow is always expanded.
- Phone landscape (compact height): collapses to the "Plan a trip" button to
  reclaim scarce vertical space; tapping it expands the full row, and the
  collapse handle returns to the button.

`showPill = isPhoneLandscape` — no longer depends on saved-trip count or
Park & Ride. Updates docs/TABLET_FOLDABLE_UX.md §4 to match.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>