### PR TITLE
chore: fix compiler deprecation and redundancy warnings

### DIFF
--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -289,7 +289,7 @@ object DateTimeHelper {
                         .take(DATE_LABEL_ABBREV_LENGTH)
                         .lowercase()
                         .replaceFirstChar { it.uppercase() }
-                    "$day ${departureDate.dayOfMonth} $month"
+                    "$day ${departureDate.day} $month"
                 }
             }
         }.getOrDefault("")

--- a/core/festival/src/commonTest/kotlin/xyz/ksharma/krail/core/festival/RealFestivalManagerTest.kt
+++ b/core/festival/src/commonTest/kotlin/xyz/ksharma/krail/core/festival/RealFestivalManagerTest.kt
@@ -78,7 +78,7 @@ class RealFestivalManagerTest {
         val result = manager.festivalOnDate(LocalDate.parse("2024-06-05"))
         assertNotNull(result)
         assertTrue(result is VariableDateFestival)
-        assertEquals("Ongoing Festival", (result as VariableDateFestival).greeting)
+        assertEquals("Ongoing Festival", result.greeting)
     }
 
     @Test

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeSandook.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeSandook.kt
@@ -268,12 +268,7 @@ class FakeSandook : Sandook {
     override fun selectStopCoordinatesBatch(stopIds: List<String>): Map<String, Pair<Double, Double>> {
         return stops
             .filter { it.stopId in stopIds }
-            .mapNotNull { stop ->
-                val lat = stop.stopLat ?: return@mapNotNull null
-                val lon = stop.stopLon ?: return@mapNotNull null
-                stop.stopId to Pair(lat, lon)
-            }
-            .toMap()
+            .associate { stop -> stop.stopId to Pair(stop.stopLat, stop.stopLon) }
     }
 
     private companion object {


### PR DESCRIPTION
- FakeSandook: stopLat/stopLon are non-null Double, drop redundant elvis
  and collapse mapNotNull/toMap into associate
- RealFestivalManagerTest: drop redundant cast (result already smart-cast)
- DateTimeHelper: kotlinx-datetime dayOfMonth is deprecated, use day

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>