### PR TITLE
fix(timetable): keep journeys on screen when a refresh fails

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -420,7 +420,13 @@ class TimeTableViewModel(
                     updateTripsCache(response)
                     updateUiStateWithFilteredTrips()
                 }.onFailure {
-                    updateUiState { copy(isLoading = false, isError = true) }
+                    // fetchTrip() runs on every screen-visible (onStart) and every auto-refresh.
+                    // A failure on one of those silent/background refreshes must NOT blow away
+                    // journeys already on screen, otherwise returning to the app or a flaky
+                    // 30s refresh flips the whole screen to the error state. Only surface the
+                    // full error screen when there is nothing to show.
+                    val hasData = _uiState.value.journeyList.isNotEmpty()
+                    updateUiState { copy(isLoading = false, isError = !hasData) }
                 }
             }
         }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -229,6 +229,48 @@ class TimeTableViewModelTest {
             }
         }
 
+    @Test
+    fun `GIVEN loaded journeys WHEN a later refresh fails THEN error screen is not shown and journeys are preserved`() =
+        runTest {
+            // GIVEN a trip whose first load succeeds and populates the list
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2"
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.uiState.test {
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                viewModel.fetchTrip()
+
+                // Drain until journeys are loaded.
+                var loaded = awaitItem()
+                while (loaded.journeyList.isEmpty()) loaded = awaitItem()
+                assertFalse(loaded.isError)
+                assertTrue(loaded.journeyList.isNotEmpty())
+
+                // WHEN a later (silent/auto) refresh fails
+                tripPlanningService.isSuccess = false
+                viewModel.fetchTrip()
+
+                // THEN no emission flips to the error screen while data is present,
+                // and the loaded journeys survive the failed refresh.
+                var settled = awaitItem()
+                while (settled.silentLoading) {
+                    assertFalse(settled.isError)
+                    settled = awaitItem()
+                }
+                settled.run {
+                    assertFalse(isError)
+                    assertTrue(journeyList.isNotEmpty())
+                }
+
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
     // endregion
 
     // region Test for updateTripsCache


### PR DESCRIPTION
fetchTrip() runs on every screen-visible (onStart) and every 30s auto-
refresh. Previously any failure set isError=true, wiping already-loaded
journeys and showing the full error screen. On resume the cold-network
re-fetch fails and the list is replaced by the error screen; the 30s auto-
refresh then re-fails, so the error screen keeps reappearing.

Only surface the error screen when there is no data to show. A failed
silent/background refresh now leaves the existing journey list visible.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>