### PR TITLE
feat(timetable): track error-screen views and API retries

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -4,6 +4,9 @@ sealed class AnalyticsScreen(val name: String) {
     data object Settings : AnalyticsScreen(name = "Settings")
     data object SavedTrips : AnalyticsScreen(name = "SavedTrips")
     data object TimeTable : AnalyticsScreen(name = "TimeTable")
+
+    // Shown when the timetable load fails with no data to display (full error screen).
+    data object TimeTableError : AnalyticsScreen(name = "TimeTableError")
     data object PlanTrip : AnalyticsScreen(name = "PlanTrip")
     data object ThemeSelection : AnalyticsScreen(name = "ThemeSelection")
     data object SearchStop : AnalyticsScreen(name = "SearchStop")

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -46,6 +46,21 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
+    /**
+     * User taps Retry after an API/load failure. Unified across surfaces to stay within the
+     * Firebase 500-event budget: [source] identifies where the retry happened rather than
+     * minting a per-screen event.
+     */
+    data class RetryApiEvent(val source: Source) :
+        AnalyticsEvent(
+            name = "retry_api",
+            properties = mapOf(PROP_SOURCE to source.value),
+        ) {
+        enum class Source(val value: String) {
+            TIMETABLE("timetable"),
+        }
+    }
+
     data object SettingsClickEvent : AnalyticsEvent(name = "settings_click")
 
     data object FromFieldClickEvent : AnalyticsEvent(name = "from_field_click")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -252,7 +252,14 @@ class TimeTableViewModel(
 
             TimeTableUiEvent.ReverseTripButtonClicked -> onReverseTripButtonClicked()
 
-            TimeTableUiEvent.RetryButtonClicked -> onLoadTimeTable(tripInfo!!)
+            TimeTableUiEvent.RetryButtonClicked -> {
+                analytics.track(
+                    AnalyticsEvent.RetryApiEvent(
+                        source = AnalyticsEvent.RetryApiEvent.Source.TIMETABLE,
+                    ),
+                )
+                onLoadTimeTable(tripInfo!!)
+            }
 
             is TimeTableUiEvent.DateTimeSelectionChanged -> {
                 onDateTimeSelectionChanged(item = event.dateTimeSelectionItem)
@@ -426,6 +433,11 @@ class TimeTableViewModel(
                     // 30s refresh flips the whole screen to the error state. Only surface the
                     // full error screen when there is nothing to show.
                     val hasData = _uiState.value.journeyList.isNotEmpty()
+                    // Track the error screen as a screen view, but only on the transition
+                    // into the error state (not on every failed auto-refresh while errored).
+                    if (!hasData && !_uiState.value.isError) {
+                        analytics.trackScreenViewEvent(screen = AnalyticsScreen.TimeTableError)
+                    }
                     updateUiState { copy(isLoading = false, isError = !hasData) }
                 }
             }


### PR DESCRIPTION
- Add AnalyticsScreen.TimeTableError; fire a screen_view on the transition
  into the error state (once per error, not per failed auto-refresh).
- Add unified RetryApiEvent(source) — fired on Retry tap with source=timetable.
  Unified across surfaces to respect the Firebase 500-event budget instead of
  a per-screen retry event.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>