### PR TITLE
fix(timetable): filter de-selected modes on the client

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -24,6 +24,11 @@ data class TimeTableState(
     val previousJourneyList: ImmutableList<JourneyCardInfo> = persistentListOf(),
     val trip: Trip? = null,
     val isError: Boolean = false,
+    /**
+     * True when the API returned journeys but the user's mode selection filtered all of them
+     * out. Lets the screen show a mode-specific hint instead of the generic "no route found".
+     */
+    val emptyDueToModeFilter: Boolean = false,
     val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
     // has to be null, otherwise it will switch from default to a festival.
     // It should load only once whether it is a festival or not.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableEmptyResultMessage.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableEmptyResultMessage.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+/**
+ * Title + message for the empty timetable state.
+ *
+ * When [emptyDueToModeFilter] is true the API returned trips but the user's mode selection hid
+ * them all, so we point them at the modes button instead of saying no route exists.
+ *
+ * Lives in its own file so the choice does not add to [TimeTableScreen]'s cyclomatic complexity
+ * or file function count, both of which already sit at their detekt limit.
+ */
+internal fun timeTableEmptyResultMessage(emptyDueToModeFilter: Boolean): Pair<String, String> =
+    if (emptyDueToModeFilter) {
+        "Nothing right now" to
+            "No trips running for the transport modes you picked. Tap the modes button to show more."
+    } else {
+        "No route found!" to "Search for another stop or check back later."
+    }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -398,11 +398,13 @@ fun TimeTableScreen(
                     ),
                     onPlanTripClick = dateTimeSelectorClicked,
                 )
-            } else { // Journey list is empty or null
+            } else { // Journey list is empty — either no results, or mode filter removed them all.
                 item(key = "no-results") {
+                    val (title, message) =
+                        timeTableEmptyResultMessage(timeTableState.emptyDueToModeFilter)
                     ErrorMessage(
-                        title = "No route found!",
-                        message = "Search for another stop or check back later.",
+                        title = title,
+                        message = message,
                         modifier = Modifier.fillMaxWidth().animateItem(),
                     )
                 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -521,16 +521,38 @@ class TimeTableViewModel(
         }
     }
 
+    /**
+     * Drops journeys that use any de-selected transport mode.
+     *
+     * The NSW trip API does not reliably honour the `exclMOT` exclusion params we send — it
+     * still returns excluded modes (e.g. de-selecting Train still yields train journeys). We
+     * therefore filter defensively on the client so the user's mode selection is always
+     * respected. A multi-modal journey is dropped if ANY of its legs uses an excluded mode.
+     *
+     * Footpath/walk (productClass 99) is not a selectable mode and never appears in
+     * [TimeTableState.JourneyCardInfo.transportModeLines], so it is never excluded.
+     */
+    private fun List<TimeTableState.JourneyCardInfo>.excludeUnselectedModes(): List<TimeTableState.JourneyCardInfo> =
+        if (unselectedModes.isEmpty()) {
+            this
+        } else {
+            filterNot { journey ->
+                journey.transportModeLines.any { it.transportMode.productClass in unselectedModes }
+            }
+        }
+
     private fun updateUiStateWithFilteredTrips() {
         // Main list = current-window journeys + load-more (future) journeys, sorted chronologically.
         val mergedJourneys = (journeys.values + loadMoreJourneys.values)
             .distinctBy { it.journeyId }
         val journeyList = updateJourneyCardInfoTimeText(mergedJourneys)
+            .excludeUnselectedModes()
             .sortedBy { it.originUtcDateTime.utcToLocalDateTimeAEST() }
             .toImmutableList()
 
         // Previous list = past journeys fetched via "Show Previous".
         val previousJourneyList = updateJourneyCardInfoTimeText(previousJourneysCache.values.toList())
+            .excludeUnselectedModes()
             .sortedBy { it.originUtcDateTime.utcToLocalDateTimeAEST() }
             .toImmutableList()
 
@@ -555,12 +577,19 @@ class TimeTableViewModel(
         }
         log("[SHARE] deep link URLs computed — ${deepLinkUrls?.size ?: 0} journeys encoded for sharing")
 
+        // The API returned journeys but the user's mode selection filtered them all out.
+        // Distinct from "API returned nothing" so the UI can show a mode-specific hint
+        // instead of the generic "no route found" message.
+        val emptyDueToModeFilter = unselectedModes.isNotEmpty() &&
+            mergedJourneys.isNotEmpty() && journeyList.isEmpty()
+
         updateUiState {
             copy(
                 isLoading = false,
                 journeyList = journeyList,
                 previousJourneyList = previousJourneyList,
                 isError = false,
+                emptyDueToModeFilter = emptyDueToModeFilter,
                 deepLinkUrls = deepLinkUrls ?: this.deepLinkUrls,
                 canLoadMore = PAGINATION_ENABLED && journeyList.isNotEmpty() &&
                     loadMoreCount < MAX_LOAD_MORE_COUNT,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -784,6 +784,37 @@ class TimeTableViewModelTest {
             assertEquals(initialUnselectedModes, viewModel.uiState.value.unselectedModes)
             assertTrue((fakeAnalytics as FakeAnalytics).isEventTracked("mode_selection_done"))
         }
+
+    @Test
+    fun `GIVEN train-only journeys WHEN Train is de-selected THEN journeys are filtered out client-side and emptyDueToModeFilter is true`() =
+        runTest {
+            // GIVEN a loaded trip — the fake builder returns train-only journeys (productClass 1).
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2"
+            )
+            tripPlanningService.isSuccess = true
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.journeyList.isNotEmpty())
+            assertFalse(viewModel.uiState.value.emptyDueToModeFilter)
+
+            // WHEN Train (productClass 1) is de-selected and the trip re-fetches. The NSW API
+            // still returns train journeys, so the client-side filter must drop them.
+            viewModel.onEvent(TimeTableUiEvent.ModeSelectionChanged(setOf(1)))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            // THEN all train journeys are filtered out and the mode-specific empty hint is set.
+            viewModel.uiState.value.run {
+                assertTrue(journeyList.isEmpty())
+                assertTrue(emptyDueToModeFilter)
+                assertFalse(isError)
+            }
+        }
     // endregion
 
     // region Test for ShareJourneyClicked


### PR DESCRIPTION
The NSW trip API does not honour our exclMOT exclusion params — de-selecting
Train still returns train journeys (confirmed in logs: 'Exclude transport
mode - [1]' followed by Sydney Trains journeys). We relied entirely on
server-side exclusion, so the user's mode selection was effectively ignored.

Filter journeys on the client: drop any journey that uses a de-selected mode
(a multi-modal journey is dropped if ANY leg uses an excluded mode). When the
filter empties the list, surface a mode-specific hint ('Nothing right now …
tap the modes button') instead of the generic 'no route found'.

emptyResultMessage lives in its own file so the screen stays within its
cyclomatic-complexity and function-count limits without any suppression.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>