### PR TITLE
fix(timetable): Retry preserves selected Leave/Arrive time

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -258,7 +258,7 @@ class TimeTableViewModel(
                         source = AnalyticsEvent.RetryApiEvent.Source.TIMETABLE,
                     ),
                 )
-                onLoadTimeTable(tripInfo!!)
+                onRetry()
             }
 
             is TimeTableUiEvent.DateTimeSelectionChanged -> {
@@ -834,6 +834,19 @@ class TimeTableViewModel(
             legCount = legCount,
             transportModes = transportModes,
         )
+    }
+
+    /**
+     * Re-runs the current request after a failure. Unlike [onLoadTimeTable], retry must NOT
+     * reset trip params: it preserves the selected date/time (Leave at / Arrive by) and the
+     * mode filter, then simply re-fetches. Routing retry through onLoadTimeTable used to null
+     * dateTimeSelectionItem whenever the VM had no previousTripId yet (e.g. a fresh VM after
+     * process death or re-navigation), so retry silently fell back to "now".
+     */
+    private fun onRetry() {
+        if (tripInfo == null) return
+        updateUiState { copy(isLoading = true, isError = false) }
+        fetchTrip()
     }
 
     private fun onLoadTimeTable(trip: Trip) {

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -29,6 +29,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -1265,6 +1266,39 @@ class TimeTableViewModelTest {
 
             assertEquals("0915", tripPlanningService.lastCalledTime)
             assertNotNull(tripPlanningService.lastCalledDate)
+        }
+
+    @Test
+    fun `GIVEN a selected Arrive-by time WHEN Retry is clicked THEN the re-fetch keeps that time`() =
+        runTest {
+            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
+
+            @OptIn(ExperimentalTime::class)
+            val selection = DateTimeSelectionItem(
+                date = Clock.System.now().toLocalDateTime(currentSystemDefault()).date,
+                option = JourneyTimeOptions.ARRIVE,
+                hour = 9,
+                minute = 15,
+            )
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(selection))
+
+            // First fetch fails -> error screen.
+            tripPlanningService.isSuccess = false
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.isError)
+
+            // WHEN Retry is clicked
+            tripPlanningService.isSuccess = true
+            viewModel.onEvent(TimeTableUiEvent.RetryButtonClicked)
+            advanceUntilIdle()
+
+            // THEN the retried request keeps the selected Arrive-by time, not "now".
+            assertEquals("0915", tripPlanningService.lastCalledTime)
+            assertEquals(DepArr.ARR, tripPlanningService.lastCalledDepArr)
+            assertNotNull(viewModel.dateTimeSelectionItem)
         }
 
     // endregion


### PR DESCRIPTION
Retry routed through onLoadTimeTable, which resets dateTimeSelectionItem to
null in its different-trip branch. On a fresh VM (process death / re-nav)
previousTripId is null, so retry took that branch and silently fell back to
'now', ignoring the user's Arrive-by / Leave-at selection.

Add onRetry(): keep all current request params (date/time + mode filter) and
just re-fetch.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>