### PR TITLE
refactor: remove all CyclomaticComplexMethod suppressions (8 files)

### DIFF
--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
@@ -113,7 +113,7 @@ internal fun DepartureMonitorResponse.StopEvent.toStopDeparture(): StopDeparture
 //     return the raw platform code only  (e.g. "F1").
 //   unknown:
 //     try regex on platformName, then disassembledName.
-@Suppress("MagicNumber", "CyclomaticComplexMethod")
+@Suppress("MagicNumber")
 private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: Int?): String? {
     // Without a parent, this location IS the stop itself — no platform sub-label.
     parent ?: return null
@@ -127,29 +127,12 @@ private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: 
         TransportMode.Train.productClass,
         TransportMode.Metro.productClass,
         TransportMode.Coach.productClass,
-        -> {
-            if (pName != null && pName != pCode) {
-                // Normal case: "Platform 17", "Platform 26"
-                extractPlatformText(pName)
-            } else if (pCode != null) {
-                // Bad case: platformName == "THL6" → derive "Platform 6" from code
-                val num = Regex("\\d+").find(pCode)?.value
-                num?.let { "Platform $it" }
-            } else {
-                // No properties at all — fall back to regex on disassembledName
-                disassembledName?.let { extractPlatformText(it) }
-            }
-        }
+        -> resolveNumberedPlatform(pName, pCode, disassembledName)
 
         // ── Light Rail (4) ───────────────────────────────────────────────────────
         // Show code AND name: "LR1 · Central Chalmers Street Light Rail"
         // If the platform field is absent, just show the name.
-        TransportMode.LightRail.productClass -> when {
-            pCode != null && pName != null && pCode != pName -> "$pCode · $pName"
-            pName != null -> pName
-            pCode != null -> pCode
-            else -> null
-        }
+        TransportMode.LightRail.productClass -> resolveLightRailPlatform(pName, pCode)
 
         // ── Bus (5), School Bus (11) ─────────────────────────────────────────────
         // Extract "Stand X" from compound platformName:
@@ -162,10 +145,38 @@ private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: 
         TransportMode.Ferry.productClass -> pCode
 
         // ── Unknown / fallback ───────────────────────────────────────────────────
-        else -> pName?.let { extractPlatformText(it) ?: it }
-            ?: disassembledName?.let { extractPlatformText(it) }
+        else -> resolveFallbackPlatform(pName, disassembledName)
     }
 }
+
+// Train / Metro / Coach: prefer "Platform N" name, else derive number from a code that
+// echoes the raw API value, else fall back to regex on disassembledName.
+@Suppress("MagicNumber")
+private fun resolveNumberedPlatform(pName: String?, pCode: String?, disassembledName: String?): String? =
+    if (pName != null && pName != pCode) {
+        // Normal case: "Platform 17", "Platform 26"
+        extractPlatformText(pName)
+    } else if (pCode != null) {
+        // Bad case: platformName == "THL6" → derive "Platform 6" from code
+        val num = Regex("\\d+").find(pCode)?.value
+        num?.let { "Platform $it" }
+    } else {
+        // No properties at all — fall back to regex on disassembledName
+        disassembledName?.let { extractPlatformText(it) }
+    }
+
+// Light Rail: show code AND name when both present and differ, else whichever exists.
+private fun resolveLightRailPlatform(pName: String?, pCode: String?): String? = when {
+    pCode != null && pName != null && pCode != pName -> "$pCode · $pName"
+    pName != null -> pName
+    pCode != null -> pCode
+    else -> null
+}
+
+// Unknown mode: try regex on platformName (keep raw on miss), then disassembledName.
+private fun resolveFallbackPlatform(pName: String?, disassembledName: String?): String? =
+    pName?.let { extractPlatformText(it) ?: it }
+        ?: disassembledName?.let { extractPlatformText(it) }
 
 // Resolves the hex colour for a line badge via NswTransportConfig:
 // line-specific lookup first, then product-class fallback, then Bus colour.

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMapper.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMapper.kt
@@ -12,13 +12,11 @@ import xyz.ksharma.krail.core.transport.nsw.NswTransportLine
 import xyz.ksharma.krail.feature.track.DepartureDeviation
 import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
 import xyz.ksharma.krail.feature.track.TrackedLeg
-import xyz.ksharma.krail.feature.track.TrackedStop
 import xyz.ksharma.krail.feature.track.TripDeepLink
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.departureDeviationMinutes
 import xyz.ksharma.krail.trip.planner.network.api.model.isWalkingLeg
 import kotlin.math.absoluteValue
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -46,7 +44,6 @@ internal object TripResponseMapper {
      * (rather than restructuring it), this function returns null and the state transitions
      * to [xyz.ksharma.krail.feature.track.TrackTripState.NotFound].
      */
-    @Suppress("CyclomaticComplexMethod")
     @OptIn(ExperimentalTime::class)
     fun TripResponse.findMatchingJourney(deepLink: TripDeepLink): TripResponse.Journey? {
         val deepLinkInstant = runCatching { Instant.parse(deepLink.departureUtcDateTime) }.getOrNull()
@@ -57,29 +54,7 @@ internal object TripResponseMapper {
         )
 
         val match = journeys?.firstOrNull { journey ->
-            val publicLegs = journey.legs
-                ?.filter { it.transportation != null && !it.isWalkingLeg() }
-                ?: return@firstOrNull false
-
-            val legIds = publicLegs.mapNotNull { it.transportation?.id }
-            val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
-
-            // All deep-link transportation IDs must appear in the journey legs.
-            val idsMatch = deepLink.legs.all { dl -> legIds.contains(dl.transportationId) }
-            if (!idsMatch) return@firstOrNull false
-
-            // Departure time: parse both as Instant so string-format differences don't break the
-            // match (e.g. "2026-04-22T22:35:00Z" vs "2026-04-22T22:35:00.000Z").
-            // Allow 60 s tolerance for any minor rounding in the API response.
-            val timeMatch = if (deepLinkInstant != null && firstDep != null) {
-                val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
-                legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
-            } else {
-                firstDep == deepLink.departureUtcDateTime
-            }
-
-            log("TrackTrip:   journey ids=$legIds firstDep=$firstDep → idsMatch=$idsMatch timeMatch=$timeMatch")
-            timeMatch
+            journey.matchesDeepLinkStrict(deepLink, deepLinkInstant)
         }
 
         if (match != null) {
@@ -96,28 +71,7 @@ internal object TripResponseMapper {
         // and terminating at the same destination are the same trip, just restructured.
         log("TrackTrip: findMatchingJourney — strict match failed, trying fallback (time + destination)")
         val fallback = journeys?.firstOrNull { journey ->
-            val publicLegs = journey.legs
-                ?.filter { it.transportation != null && !it.isWalkingLeg() }
-                ?: return@firstOrNull false
-
-            val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
-            val lastDestId = publicLegs.lastOrNull()?.destination?.parent?.id
-                ?: publicLegs.lastOrNull()?.destination?.id
-
-            val timeMatch = if (deepLinkInstant != null && firstDep != null) {
-                val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
-                legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
-            } else {
-                false
-            }
-
-            val destMatch = lastDestId == deepLink.toStopId
-
-            log(
-                "TrackTrip:   fallback journey firstDep=$firstDep " +
-                    "lastDestId=$lastDestId → time=$timeMatch dest=$destMatch",
-            )
-            timeMatch && destMatch
+            journey.matchesDeepLinkFallback(deepLink, deepLinkInstant)
         }
 
         if (fallback == null) {
@@ -174,7 +128,6 @@ internal object TripResponseMapper {
         )
     }
 
-    @Suppress("CyclomaticComplexMethod")
     fun TripResponse.Leg.toTrackedTransportLeg(): TrackedLeg.Transport? {
         val productClass = transportation?.product?.productClass?.toInt() ?: return null
         val mode = NswTransportConfig.modeFromProductClass(productClass) ?: return null
@@ -183,23 +136,7 @@ internal object TripResponseMapper {
             ?: mode.colorCode
 
         val stops = stopSequence?.mapNotNull { stop ->
-            val name = stop.disassembledName ?: stop.name ?: return@mapNotNull null
-            val scheduledUtc = stop.departureTimePlanned ?: stop.arrivalTimePlanned
-            val estimatedUtc = stop.departureTimeEstimated ?: stop.arrivalTimeEstimated
-            val timeUtc = estimatedUtc ?: scheduledUtc ?: return@mapNotNull null
-            TrackedStop(
-                stopId = stop.id.orEmpty(),
-                name = name,
-                scheduledTime = (scheduledUtc ?: timeUtc).utcToDisplayTime(),
-                estimatedTime = estimatedUtc
-                    ?.takeIf { it != scheduledUtc }
-                    ?.utcToDisplayTime(),
-                utcTime = timeUtc,
-                scheduledUtcTime = scheduledUtc ?: timeUtc,
-                // API coord is [latitude, longitude]
-                lat = stop.coord?.getOrNull(0),
-                lon = stop.coord?.getOrNull(1),
-            )
+            stop.toTrackedStop()
         }?.toImmutableList() ?: return null
 
         val routePathCoordinates = coords

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMatchers.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMatchers.kt
@@ -1,0 +1,104 @@
+package xyz.ksharma.krail.feature.track.ui
+
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.feature.track.TrackedStop
+import xyz.ksharma.krail.feature.track.TripDeepLink
+import xyz.ksharma.krail.feature.track.ui.TripResponseMapper.utcToDisplayTime
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.model.isWalkingLeg
+import kotlin.math.absoluteValue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Strict deep-link match: all deep-link transportation IDs must appear in the journey legs
+ * AND the first leg's planned departure must match the deep link's departure time (±60 s).
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Journey.matchesDeepLinkStrict(
+    deepLink: TripDeepLink,
+    deepLinkInstant: Instant?,
+): Boolean {
+    val publicLegs = legs
+        ?.filter { it.transportation != null && !it.isWalkingLeg() }
+        ?: return false
+
+    val legIds = publicLegs.mapNotNull { it.transportation?.id }
+    val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
+
+    // All deep-link transportation IDs must appear in the journey legs.
+    val idsMatch = deepLink.legs.all { dl -> legIds.contains(dl.transportationId) }
+    if (!idsMatch) return false
+
+    // Departure time: parse both as Instant so string-format differences don't break the
+    // match (e.g. "2026-04-22T22:35:00Z" vs "2026-04-22T22:35:00.000Z").
+    // Allow 60 s tolerance for any minor rounding in the API response.
+    val timeMatch = if (deepLinkInstant != null && firstDep != null) {
+        val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
+        legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
+    } else {
+        firstDep == deepLink.departureUtcDateTime
+    }
+
+    log("TrackTrip:   journey ids=$legIds firstDep=$firstDep → idsMatch=$idsMatch timeMatch=$timeMatch")
+    return timeMatch
+}
+
+/**
+ * Fallback deep-link match when TfNSW restructures a service mid-disruption and the original
+ * leg IDs no longer appear. Matches only by departure time (±60 s) from the same origin and
+ * the same destination stop parent ID.
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Journey.matchesDeepLinkFallback(
+    deepLink: TripDeepLink,
+    deepLinkInstant: Instant?,
+): Boolean {
+    val publicLegs = legs
+        ?.filter { it.transportation != null && !it.isWalkingLeg() }
+        ?: return false
+
+    val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
+    val lastDestId = publicLegs.lastOrNull()?.destination?.parent?.id
+        ?: publicLegs.lastOrNull()?.destination?.id
+
+    val timeMatch = if (deepLinkInstant != null && firstDep != null) {
+        val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
+        legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
+    } else {
+        false
+    }
+
+    val destMatch = lastDestId == deepLink.toStopId
+
+    log(
+        "TrackTrip:   fallback journey firstDep=$firstDep " +
+            "lastDestId=$lastDestId → time=$timeMatch dest=$destMatch",
+    )
+    return timeMatch && destMatch
+}
+
+/**
+ * Maps a single API stop in a leg's stop sequence into a [TrackedStop], or null when the stop
+ * lacks a usable name or time.
+ */
+internal fun TripResponse.StopSequence.toTrackedStop(): TrackedStop? {
+    val name = disassembledName ?: name ?: return null
+    val scheduledUtc = departureTimePlanned ?: arrivalTimePlanned
+    val estimatedUtc = departureTimeEstimated ?: arrivalTimeEstimated
+    val timeUtc = estimatedUtc ?: scheduledUtc ?: return null
+    return TrackedStop(
+        stopId = id.orEmpty(),
+        name = name,
+        scheduledTime = (scheduledUtc ?: timeUtc).utcToDisplayTime(),
+        estimatedTime = estimatedUtc
+            ?.takeIf { it != scheduledUtc }
+            ?.utcToDisplayTime(),
+        utcTime = timeUtc,
+        scheduledUtcTime = scheduledUtc ?: timeUtc,
+        // API coord is [latitude, longitude]
+        lat = coord?.getOrNull(0),
+        lon = coord?.getOrNull(1),
+    )
+}

--- a/feature/trip-planner/ui/baseline.xml
+++ b/feature/trip-planner/ui/baseline.xml
@@ -31,10 +31,7 @@
     <ID>ComposableParamOrder:JourneyTimeOptionsGroup.kt$JourneyTimeOptionsGroup</ID>
     <ID>ComposableParamOrder:TagLineWithEmoji.kt$TagLineWithEmoji</ID>
     <ID>ComposableParamOrder:TimeTableScreen.kt$JourneyCardItem</ID>
-    <ID>CyclomaticComplexMethod:JourneyCard.kt$@Composable private fun ResponsiveJourneyInfoRow( destinationTime: String, totalTravelTime: String, totalWalkTime: String?, departureDeviation: TimeTableState.JourneyCardInfo.DepartureDeviation?, )</ID>
     <ID>CyclomaticComplexMethod:SearchStopScreen.kt$@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class, ExperimentalTime::class) @Composable fun SearchStopScreen( searchStopState: SearchStopState, modifier: Modifier = Modifier, searchQuery: String = "", goBack: () -&gt; Unit = {}, onStopSelect: (StopItem) -&gt; Unit = {}, onEvent: (SearchStopUiEvent) -&gt; Unit = {}, )</ID>
-    <ID>CyclomaticComplexMethod:ThemeSelectionRadioButton.kt$@Composable fun ThemeSelectionRadioButton( themeStyle: KrailThemeStyle, onClick: (KrailThemeStyle) -&gt; Unit, modifier: Modifier = Modifier, selected: Boolean = false, )</ID>
-    <ID>CyclomaticComplexMethod:TripResponseMapper.kt$@Suppress("ComplexCondition") private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg?</ID>
     <ID>FinalNewline:DiscoverScreen.kt$xyz.ksharma.krail.trip.planner.ui.discover.DiscoverScreen.kt</ID>
     <ID>FinalNewline:IntroContentPlanTrip.kt$xyz.ksharma.krail.trip.planner.ui.intro.IntroContentPlanTrip.kt</ID>
     <ID>FinalNewline:ParkRideCard.kt$xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard.kt</ID>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardBody.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardBody.kt
@@ -1,4 +1,4 @@
-@file:Suppress("MagicNumber", "CyclomaticComplexMethod")
+@file:Suppress("MagicNumber")
 
 package xyz.ksharma.krail.trip.planner.ui.components
 
@@ -19,8 +19,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
 import xyz.ksharma.krail.taj.components.AnimatedDots
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextButton
@@ -96,95 +98,142 @@ internal fun DepartureBoardBody(
 
             state.isError -> DeparturesErrorContent(onRetry = onRetry)
 
-            else -> {
-                if (state.departures.isNotEmpty()) {
-                    LinesServedRow(
-                        departures = state.departures,
-                        selectedLine = selectedLine,
-                        onLineSelect = { newLine ->
-                            // Capture the previously selected line BEFORE updating state so
-                            // we can report it when the filter is being cleared (deselected).
-                            val previousLine = selectedLine
-                            selectedLineKey = newLine ?: ""
-                            val affectedLine = newLine ?: previousLine
-                            val transportMode = affectedLine?.let { line ->
-                                state.departures.firstOrNull { it.lineNumber == line }?.transportModeName
-                            }
-                            onLineFilterChange?.invoke(affectedLine, transportMode, newLine != null)
-                        },
-                    )
-                }
-
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = dim.spacingM, bottom = dim.spacingL),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    TextButton(
-                        onClick = {
-                            showPrevious = !showPrevious
-                            onShowPreviousToggle?.invoke(showPrevious)
-                            if (showPrevious &&
-                                state.previousDepartures.isEmpty() &&
-                                !state.isPreviousLoading
-                            ) {
-                                previousRequested = true
-                                onLoadPreviousDepartures()
-                            }
-                        },
+            else -> DepartureBoardSuccessContent(
+                state = state,
+                selectedLine = selectedLine,
+                showPrevious = showPrevious,
+                previousRequested = previousRequested,
+                filteredDepartures = filteredDepartures,
+                filteredPreviousDepartures = filteredPreviousDepartures,
+                maxItems = maxItems,
+                onLineSelect = { newLine ->
+                    // Capture the previously selected line BEFORE updating state so
+                    // we can report it when the filter is being cleared (deselected).
+                    val previousLine = selectedLine
+                    selectedLineKey = newLine ?: ""
+                    val affectedLine = newLine ?: previousLine
+                    val transportMode = affectedLine?.let { line ->
+                        state.departures.firstOrNull { it.lineNumber == line }?.transportModeName
+                    }
+                    onLineFilterChange?.invoke(affectedLine, transportMode, newLine != null)
+                },
+                onTogglePrevious = {
+                    showPrevious = !showPrevious
+                    onShowPreviousToggle?.invoke(showPrevious)
+                    if (showPrevious &&
+                        state.previousDepartures.isEmpty() &&
+                        !state.isPreviousLoading
                     ) {
-                        Text(
-                            text = if (showPrevious) {
-                                "Hide previous departures"
-                            } else {
-                                "Show previous departures"
-                            },
-                        )
+                        previousRequested = true
+                        onLoadPreviousDepartures()
                     }
-                }
-
-                when {
-                    // Previous fetch in-flight (or requested but not yet acknowledged) —
-                    // show inline loader above any upcoming departures.
-                    showPrevious && (state.isPreviousLoading || previousRequested) -> {
-                        DepartureBoardLoadingContent()
-                        when {
-                            filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
-                            else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
-                        }
-                    }
-
-                    // Previous fetched but none match the current filter —
-                    // show message then the upcoming list.
-                    showPrevious && filteredPreviousDepartures.isEmpty() -> {
-                        Text(
-                            text = "No previous departures in the last ${state.previousWindowMinutes} minutes.",
-                            style = KrailTheme.typography.bodyMedium,
-                            color = KrailTheme.colors.softLabel,
-                            modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingL),
-                        )
-                        when {
-                            filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
-                            else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
-                        }
-                    }
-
-                    // Previous + upcoming combined as one unified list with date labels.
-                    showPrevious -> DepartureRowList(
-                        departures = remember(filteredPreviousDepartures, filteredDepartures) {
-                            (filteredPreviousDepartures + filteredDepartures).toImmutableList()
-                        },
-                        maxItems = maxItems,
-                    )
-
-                    state.departures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = false)
-                    filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
-                    else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
-                }
-            }
+                },
+            )
         }
         Spacer(modifier = Modifier.height(dim.spacingM))
+    }
+}
+
+@Composable
+private fun DepartureBoardSuccessContent(
+    state: DeparturesState,
+    selectedLine: String?,
+    showPrevious: Boolean,
+    previousRequested: Boolean,
+    filteredDepartures: ImmutableList<StopDeparture>,
+    filteredPreviousDepartures: ImmutableList<StopDeparture>,
+    maxItems: Int?,
+    onLineSelect: (String?) -> Unit,
+    onTogglePrevious: () -> Unit,
+) {
+    val dim = KrailTheme.dimensions
+    if (state.departures.isNotEmpty()) {
+        LinesServedRow(
+            departures = state.departures,
+            selectedLine = selectedLine,
+            onLineSelect = onLineSelect,
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = dim.spacingM, bottom = dim.spacingL),
+        contentAlignment = Alignment.Center,
+    ) {
+        TextButton(onClick = onTogglePrevious) {
+            Text(
+                text = if (showPrevious) {
+                    "Hide previous departures"
+                } else {
+                    "Show previous departures"
+                },
+            )
+        }
+    }
+
+    DepartureBoardDeparturesSection(
+        state = state,
+        showPrevious = showPrevious,
+        previousRequested = previousRequested,
+        filteredDepartures = filteredDepartures,
+        filteredPreviousDepartures = filteredPreviousDepartures,
+        maxItems = maxItems,
+    )
+}
+
+@Composable
+private fun DepartureBoardDeparturesSection(
+    state: DeparturesState,
+    showPrevious: Boolean,
+    previousRequested: Boolean,
+    filteredDepartures: ImmutableList<StopDeparture>,
+    filteredPreviousDepartures: ImmutableList<StopDeparture>,
+    maxItems: Int?,
+) {
+    val dim = KrailTheme.dimensions
+    when {
+        // Previous fetch in-flight (or requested but not yet acknowledged) —
+        // show inline loader above any upcoming departures.
+        showPrevious && (state.isPreviousLoading || previousRequested) -> {
+            DepartureBoardLoadingContent()
+            UpcomingDeparturesOrEmpty(filteredDepartures = filteredDepartures, maxItems = maxItems)
+        }
+
+        // Previous fetched but none match the current filter —
+        // show message then the upcoming list.
+        showPrevious && filteredPreviousDepartures.isEmpty() -> {
+            Text(
+                text = "No previous departures in the last ${state.previousWindowMinutes} minutes.",
+                style = KrailTheme.typography.bodyMedium,
+                color = KrailTheme.colors.softLabel,
+                modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingL),
+            )
+            UpcomingDeparturesOrEmpty(filteredDepartures = filteredDepartures, maxItems = maxItems)
+        }
+
+        // Previous + upcoming combined as one unified list with date labels.
+        showPrevious -> DepartureRowList(
+            departures = remember(filteredPreviousDepartures, filteredDepartures) {
+                (filteredPreviousDepartures + filteredDepartures).toImmutableList()
+            },
+            maxItems = maxItems,
+        )
+
+        state.departures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = false)
+        filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
+        else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
+    }
+}
+
+@Composable
+private fun UpcomingDeparturesOrEmpty(
+    filteredDepartures: ImmutableList<StopDeparture>,
+    maxItems: Int?,
+) {
+    when {
+        filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
+        else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegTimeline.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegTimeline.kt
@@ -1,0 +1,202 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import xyz.ksharma.krail.feature.track.TrackedStop
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Shared per-stop colours/radii/segment data computed once in [TrackedLegView] and threaded
+ * through the timeline section composables. Keeping this immutable holder out of the big
+ * composable keeps each section's branching local to its own function.
+ */
+@Suppress("LongParameterList")
+internal class TrackedLegTimeline(
+    val currentStopIndex: Int?,
+    val currentSegmentFraction: Float?,
+    val nextStopIndex: Int?,
+    val pulseScale: Float,
+    val lineColor: Color,
+    val pendingColor: Color,
+    val circleRadius: Dp,
+    val strokeWidth: Dp,
+) {
+    // A segment starting at fromIdx is "completed" when the vehicle has left that stop.
+    // Using >= so the current stop's BELOW line also flows in lineColor, matching the split spacer.
+    fun segmentColor(fromIdx: Int): Color = when {
+        currentStopIndex == null -> pendingColor
+        currentStopIndex >= fromIdx -> lineColor
+        else -> pendingColor
+    }
+
+    fun stopCircleColor(stopIdx: Int): Color = when {
+        currentStopIndex == null -> pendingColor
+        stopIdx <= currentStopIndex -> lineColor
+        else -> pendingColor
+    }
+
+    fun stopCircleRadius(stopIdx: Int): Dp =
+        if (currentStopIndex == stopIdx) circleRadius * pulseScale else circleRadius
+
+    fun isActiveSegment(fromIdx: Int): Boolean =
+        currentStopIndex == fromIdx && currentSegmentFraction != null
+}
+
+@OptIn(ExperimentalTime::class)
+internal fun approachingText(effective: Instant?, now: Instant): String? {
+    val stopInstant = effective ?: return null
+    val secs = (stopInstant - now).inWholeSeconds
+    return when {
+        secs <= 0L -> "arriving now"
+        secs < SECONDS_PER_MINUTE -> "in ${secs}s"
+        else -> {
+            val mins = secs / SECONDS_PER_MINUTE
+            val rem = secs % SECONDS_PER_MINUTE
+            if (rem > 0L) "in ${mins}m ${rem}s" else "in ${mins}m"
+        }
+    }
+}
+
+@Composable
+internal fun TrackedLegFirstStop(
+    timeline: TrackedLegTimeline,
+    firstStop: TrackedStop,
+    isArrived: Boolean,
+) {
+    val dim = KrailTheme.dimensions
+    TrackedStopRow(
+        time = firstStop.estimatedTime ?: firstStop.scheduledTime,
+        scheduledTime = firstStop.estimatedTime?.let { firstStop.scheduledTime },
+        stopName = firstStop.name,
+        isPast = timeline.currentStopIndex != null,
+        isApproaching = false,
+        isArrived = isArrived,
+        lineColor = timeline.lineColor,
+        modifier = Modifier
+            .timeLineTop(
+                color = timeline.segmentColor(0),
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(0),
+                circleColor = timeline.stopCircleColor(0),
+            )
+            .padding(start = dim.spacingXL),
+    )
+
+    TrackedLegSegmentSpacer(timeline = timeline, fromIdx = 0, collapsedHeight = dim.spacingL)
+}
+
+@Composable
+internal fun TrackedLegIntermediateStop(
+    timeline: TrackedLegTimeline,
+    stop: TrackedStop,
+    stopIdx: Int,
+    isArrived: Boolean,
+    approachingTimeText: String?,
+) {
+    val dim = KrailTheme.dimensions
+    val isPast = timeline.currentStopIndex != null && stopIdx <= timeline.currentStopIndex
+    val isApproaching = stopIdx == timeline.nextStopIndex
+
+    // The approaching stop's ABOVE line must be pendingColor so it connects
+    // flush with the split spacer's pendingColor tail, not a jarring lineColor flash.
+    val aboveColor =
+        if (isApproaching) timeline.pendingColor else timeline.segmentColor(stopIdx - 1)
+
+    TrackedStopRow(
+        time = stop.estimatedTime ?: stop.scheduledTime,
+        scheduledTime = stop.estimatedTime?.let { stop.scheduledTime },
+        stopName = stop.name,
+        isPast = isPast,
+        isApproaching = isApproaching,
+        isArrived = isArrived,
+        lineColor = timeline.lineColor,
+        approachingTimeText = if (isApproaching) approachingTimeText else null,
+        modifier = Modifier
+            .timeLineCenterWithStop(
+                color = aboveColor,
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(stopIdx),
+                circleColor = timeline.stopCircleColor(stopIdx),
+            )
+            .timeLineTop(
+                color = timeline.segmentColor(stopIdx),
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(stopIdx),
+                circleColor = timeline.stopCircleColor(stopIdx),
+            )
+            .padding(start = dim.spacingXL),
+    )
+
+    TrackedLegSegmentSpacer(timeline = timeline, fromIdx = stopIdx, collapsedHeight = dim.spacingXL)
+}
+
+@Composable
+internal fun TrackedLegLastStop(
+    timeline: TrackedLegTimeline,
+    lastStop: TrackedStop,
+    lastIdx: Int,
+    isArrived: Boolean,
+    approachingTimeText: String?,
+) {
+    val dim = KrailTheme.dimensions
+    val isLastApproaching = lastIdx == timeline.nextStopIndex
+    // Same rule: if last stop is approaching, its incoming line must be pendingColor.
+    val lastIncomingColor =
+        if (isLastApproaching) timeline.pendingColor else timeline.segmentColor(lastIdx - 1)
+    TrackedStopRow(
+        time = lastStop.estimatedTime ?: lastStop.scheduledTime,
+        scheduledTime = lastStop.estimatedTime?.let { lastStop.scheduledTime },
+        stopName = lastStop.name,
+        isPast = timeline.currentStopIndex != null && lastIdx <= timeline.currentStopIndex,
+        isApproaching = isLastApproaching,
+        isArrived = isArrived,
+        isDestination = true,
+        lineColor = timeline.lineColor,
+        approachingTimeText = if (isLastApproaching) approachingTimeText else null,
+        modifier = Modifier
+            .timeLineBottom(
+                color = lastIncomingColor,
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(lastIdx),
+                circleColor = timeline.stopCircleColor(lastIdx),
+            )
+            .padding(start = dim.spacingXL),
+    )
+}
+
+@Composable
+private fun TrackedLegSegmentSpacer(
+    timeline: TrackedLegTimeline,
+    fromIdx: Int,
+    collapsedHeight: Dp,
+) {
+    val dim = KrailTheme.dimensions
+    if (timeline.isActiveSegment(fromIdx)) {
+        Spacer(
+            modifier = Modifier.height(dim.spacingXL)
+                .timeLineCenterSplit(
+                    completedColor = timeline.lineColor,
+                    pendingColor = timeline.pendingColor,
+                    strokeWidth = timeline.strokeWidth,
+                    fraction = timeline.currentSegmentFraction ?: 0f,
+                ),
+        )
+    } else {
+        Spacer(
+            modifier = Modifier.height(collapsedHeight)
+                .timeLineCenter(
+                    color = timeline.segmentColor(fromIdx),
+                    strokeWidth = timeline.strokeWidth,
+                ),
+        )
+    }
+}
+
+private const val SECONDS_PER_MINUTE = 60L

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
@@ -9,9 +9,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.core.transport.TransportMode
@@ -38,7 +35,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-@Suppress("CyclomaticComplexMethod")
 @OptIn(ExperimentalTime::class)
 @Composable
 internal fun TrackedLegView(
@@ -49,40 +45,28 @@ internal fun TrackedLegView(
     stopDelays: Map<String, Int> = emptyMap(),
 ) {
     val dim = KrailTheme.dimensions
-    val circleRadius = dim.spacingM
-    val strokeWidth = dim.strokeThick
     val lineColor = remember(leg.lineColorCode) { leg.lineColorCode.hexToComposeColor() }
     val pendingColor = KrailTheme.colors.softLabel
 
-    // Compute the authoritative real-time instant for a stop.
-    // When GTFS-RT delay is available, apply it to the scheduled time — this is the most
-    // up-to-date signal between trip API re-polls. Falls back to the trip API estimated time.
-    fun effectiveInstant(stop: TrackedStop): Instant? {
-        val delay = stopDelays[stop.stopId]
-        return if (delay != null) {
-            runCatching {
-                Instant.parse(stop.scheduledUtcTime) + delay.seconds
-            }.getOrNull()
-        } else {
-            runCatching { Instant.parse(stop.utcTime) }.getOrNull()
-        }
+    val effectiveInstants: List<Instant?> = remember(leg.stops, stopDelays) {
+        leg.stops.map { stop -> effectiveInstant(stop, stopDelays) }
     }
 
     // Last stop index whose real-time adjusted arrival is <= now.
     // Using GTFS-RT delay means we only advance past a stop when the API confirms it.
-    val currentStopIndex: Int? = remember(leg.stops, stopDelays, now) {
-        leg.stops.indexOfLast { stop ->
-            (effectiveInstant(stop) ?: return@indexOfLast false) <= now
+    val currentStopIndex: Int? = remember(effectiveInstants, now) {
+        effectiveInstants.indexOfLast { instant ->
+            (instant ?: return@indexOfLast false) <= now
         }.takeIf { it >= 0 }
     }
 
     // How far (0..1) through the active segment (from currentStopIndex to currentStopIndex+1)
-    val currentSegmentFraction: Float? = remember(currentStopIndex, stopDelays, now) {
+    val currentSegmentFraction: Float? = remember(currentStopIndex, effectiveInstants, now) {
         currentStopIndex?.let { idx ->
             val nextIdx = idx + 1
-            if (nextIdx < leg.stops.size) {
-                val prev = effectiveInstant(leg.stops[idx])
-                val next = effectiveInstant(leg.stops[nextIdx])
+            if (nextIdx < effectiveInstants.size) {
+                val prev = effectiveInstants[idx]
+                val next = effectiveInstants[nextIdx]
                 if (prev != null && next != null) {
                     val total = (next - prev).inWholeMilliseconds.toFloat()
                     val elapsed = (now - prev).inWholeMilliseconds.toFloat()
@@ -109,39 +93,16 @@ internal fun TrackedLegView(
         label = "pulseScale",
     )
 
-    // A segment starting at fromIdx is "completed" when the vehicle has left that stop
-    // Using >= so the current stop's BELOW line also flows in lineColor, matching the split spacer
-    fun segmentColor(fromIdx: Int): Color = when {
-        currentStopIndex == null -> pendingColor
-        currentStopIndex >= fromIdx -> lineColor
-        else -> pendingColor
-    }
-
-    fun stopCircleColor(stopIdx: Int): Color = when {
-        currentStopIndex == null -> pendingColor
-        stopIdx <= currentStopIndex -> lineColor
-        else -> pendingColor
-    }
-
-    fun stopCircleRadius(stopIdx: Int): Dp =
-        if (currentStopIndex == stopIdx) circleRadius * pulseScale else circleRadius
-
-    fun isActiveSegment(fromIdx: Int) =
-        currentStopIndex == fromIdx && currentSegmentFraction != null
-
-    fun approachingText(stop: TrackedStop): String? {
-        val stopInstant = effectiveInstant(stop) ?: return null
-        val secs = (stopInstant - now).inWholeSeconds
-        return when {
-            secs <= 0L -> "arriving now"
-            secs < 60L -> "in ${secs}s"
-            else -> {
-                val mins = secs / 60L
-                val rem = secs % 60L
-                if (rem > 0L) "in ${mins}m ${rem}s" else "in ${mins}m"
-            }
-        }
-    }
+    val timeline = TrackedLegTimeline(
+        currentStopIndex = currentStopIndex,
+        currentSegmentFraction = currentSegmentFraction,
+        nextStopIndex = nextStopIndex,
+        pulseScale = pulseScale,
+        lineColor = lineColor,
+        pendingColor = pendingColor,
+        circleRadius = dim.spacingM,
+        strokeWidth = dim.strokeThick,
+    )
 
     Column(modifier = modifier.fillMaxWidth()) {
         // Route header: badge + headsign
@@ -166,129 +127,54 @@ internal fun TrackedLegView(
 
         Column(modifier = Modifier.fillMaxWidth().padding(start = dim.spacingXS)) {
             // First stop (always prominent — origin)
-            val firstStop = leg.stops.first()
-            TrackedStopRow(
-                time = firstStop.estimatedTime ?: firstStop.scheduledTime,
-                scheduledTime = firstStop.estimatedTime?.let { firstStop.scheduledTime },
-                stopName = firstStop.name,
-                isPast = currentStopIndex != null,
-                isApproaching = false,
+            TrackedLegFirstStop(
+                timeline = timeline,
+                firstStop = leg.stops.first(),
                 isArrived = isArrived,
-                lineColor = lineColor,
-                modifier = Modifier
-                    .timeLineTop(
-                        color = segmentColor(0),
-                        strokeWidth = strokeWidth,
-                        circleRadius = stopCircleRadius(0),
-                        circleColor = stopCircleColor(0),
-                    )
-                    .padding(start = dim.spacingXL),
             )
-
-            if (isActiveSegment(0)) {
-                Spacer(
-                    modifier = Modifier.height(dim.spacingXL)
-                        .timeLineCenterSplit(
-                            completedColor = lineColor,
-                            pendingColor = pendingColor,
-                            strokeWidth = strokeWidth,
-                            fraction = currentSegmentFraction ?: 0f,
-                        ),
-                )
-            } else {
-                Spacer(
-                    modifier = Modifier.height(dim.spacingL)
-                        .timeLineCenter(color = segmentColor(0), strokeWidth = strokeWidth),
-                )
-            }
 
             // Intermediate stops
             leg.stops.drop(1).dropLast(1).forEachIndexed { idx, stop ->
                 val stopIdx = idx + 1
-                val isPast = currentStopIndex != null && stopIdx <= currentStopIndex
-                val isApproaching = stopIdx == nextStopIndex
-
-                // The approaching stop's ABOVE line must be pendingColor so it connects
-                // flush with the split spacer's pendingColor tail, not a jarring lineColor flash.
-                val aboveColor = if (isApproaching) pendingColor else segmentColor(stopIdx - 1)
-
-                TrackedStopRow(
-                    time = stop.estimatedTime ?: stop.scheduledTime,
-                    scheduledTime = stop.estimatedTime?.let { stop.scheduledTime },
-                    stopName = stop.name,
-                    isPast = isPast,
-                    isApproaching = isApproaching,
+                TrackedLegIntermediateStop(
+                    timeline = timeline,
+                    stop = stop,
+                    stopIdx = stopIdx,
                     isArrived = isArrived,
-                    lineColor = lineColor,
-                    approachingTimeText = if (isApproaching) approachingText(stop) else null,
-                    modifier = Modifier
-                        .timeLineCenterWithStop(
-                            color = aboveColor,
-                            strokeWidth = strokeWidth,
-                            circleRadius = stopCircleRadius(stopIdx),
-                            circleColor = stopCircleColor(stopIdx),
-                        )
-                        .timeLineTop(
-                            color = segmentColor(stopIdx),
-                            strokeWidth = strokeWidth,
-                            circleRadius = stopCircleRadius(stopIdx),
-                            circleColor = stopCircleColor(stopIdx),
-                        )
-                        .padding(start = dim.spacingXL),
+                    approachingTimeText = approachingText(effectiveInstants[stopIdx], now),
                 )
-
-                if (isActiveSegment(stopIdx)) {
-                    Spacer(
-                        modifier = Modifier.height(dim.spacingXL)
-                            .timeLineCenterSplit(
-                                lineColor,
-                                pendingColor,
-                                strokeWidth,
-                                currentSegmentFraction ?: 0f,
-                            ),
-                    )
-                } else {
-                    Spacer(
-                        modifier = Modifier.height(dim.spacingXL).timeLineCenter(
-                            color = segmentColor(stopIdx),
-                            strokeWidth = strokeWidth,
-                        ),
-                    )
-                }
             }
 
             // Last stop (always prominent — destination)
             val lastIdx = leg.stops.size - 1
-            val lastStop = leg.stops.last()
-            val isLastApproaching = lastIdx == nextStopIndex
-            // Same rule: if last stop is approaching, its incoming line must be pendingColor
-            val lastIncomingColor =
-                if (isLastApproaching) pendingColor else segmentColor(lastIdx - 1)
-            TrackedStopRow(
-                time = lastStop.estimatedTime ?: lastStop.scheduledTime,
-                scheduledTime = lastStop.estimatedTime?.let { lastStop.scheduledTime },
-                stopName = lastStop.name,
-                isPast = currentStopIndex != null && lastIdx <= currentStopIndex,
-                isApproaching = isLastApproaching,
+            TrackedLegLastStop(
+                timeline = timeline,
+                lastStop = leg.stops.last(),
+                lastIdx = lastIdx,
                 isArrived = isArrived,
-                isDestination = true,
-                lineColor = lineColor,
-                approachingTimeText = if (isLastApproaching) approachingText(lastStop) else null,
-                modifier = Modifier
-                    .timeLineBottom(
-                        color = lastIncomingColor,
-                        strokeWidth = strokeWidth,
-                        circleRadius = stopCircleRadius(lastIdx),
-                        circleColor = stopCircleColor(lastIdx),
-                    )
-                    .padding(start = dim.spacingXL),
+                approachingTimeText = approachingText(effectiveInstants[lastIdx], now),
             )
         }
     }
 }
 
+// Compute the authoritative real-time instant for a stop.
+// When GTFS-RT delay is available, apply it to the scheduled time — this is the most
+// up-to-date signal between trip API re-polls. Falls back to the trip API estimated time.
+@OptIn(ExperimentalTime::class)
+private fun effectiveInstant(stop: TrackedStop, stopDelays: Map<String, Int>): Instant? {
+    val delay = stopDelays[stop.stopId]
+    return if (delay != null) {
+        runCatching {
+            Instant.parse(stop.scheduledUtcTime) + delay.seconds
+        }.getOrNull()
+    } else {
+        runCatching { Instant.parse(stop.utcTime) }.getOrNull()
+    }
+}
+
 @Composable
-private fun TrackedStopRow(
+internal fun TrackedStopRow(
     time: String,
     scheduledTime: String?,
     stopName: String,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -31,6 +31,7 @@ import org.maplibre.compose.map.OrnamentOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
 import xyz.ksharma.aagya.permission.PermissionStatus
+import xyz.ksharma.krail.core.maps.data.location.UserLocationManager
 import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.maps.state.UserLocationConfig
@@ -90,9 +91,6 @@ fun JourneyMap(
 /**
  * The actual map content when data is ready.
  */
-@Suppress("CyclomaticComplexMethod")
-// Complexity is dominated by Compose state wiring (location/permission/freshness/camera effects
-// + the map's stop and route layers); splitting it fragments shared map state across composables.
 @Composable
 private fun JourneyMapContent(
     mapState: JourneyMapUiState.Ready,
@@ -216,25 +214,13 @@ private fun JourneyMapContent(
             onClick = {
                 onLocationButtonClick(userLocation != null)
                 scope.launch {
-                    val userLoc = userLocation
-                    if (userLoc != null) {
-                        // Re-center camera on latest known position
-                        cameraState.animateTo(
-                            CameraPosition(
-                                target = Position(latitude = userLoc.latitude, longitude = userLoc.longitude),
-                                zoom = UserLocationConfig.RECENTER_ZOOM,
-                            ),
-                            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-                        )
-                    } else {
-                        val status = userLocationManager.checkPermissionStatus()
-                        if (status is PermissionStatus.Denied) {
-                            showPermissionBanner = true
-                        } else {
-                            // Trigger system permission dialog via TrackUserLocation
-                            allowPermissionRequest = true
-                        }
-                    }
+                    onUserLocationButtonClick(
+                        userLocation = userLocation,
+                        userLocationManager = userLocationManager,
+                        cameraState = cameraState,
+                        onShowPermissionBanner = { showPermissionBanner = true },
+                        onRequestPermission = { allowPermissionRequest = true },
+                    )
                 }
             },
             isActive = userLocation != null,
@@ -244,38 +230,17 @@ private fun JourneyMapContent(
                 .padding(KrailTheme.dimensions.spacingXL),
         )
 
-        // Top overlays — permission banner (if shown) then freshness badge directly below it.
-        // fillMaxWidth + horizontal padding here so both children get consistent spacingXL screen
-        // margins without each child needing to specify it individually.
-        if (showPermissionBanner || (showFreshnessBadge && badgeText != null)) {
-            Column(
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .fillMaxWidth()
-                    .padding(horizontal = KrailTheme.dimensions.spacingXL)
-                    .padding(top = KrailTheme.dimensions.spacingM),
-            ) {
-                if (showPermissionBanner) {
-                    LocationPermissionBanner(
-                        onGoToSettings = {
-                            onPermissionSettingsClick()
-                            userLocationManager.openAppSettings()
-                        },
-                    )
-                }
-                if (showFreshnessBadge) {
-                    badgeText?.let { text ->
-                        MapTimetableDataBadge(
-                            text = text,
-                            isStale = isStale,
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .padding(vertical = KrailTheme.dimensions.spacingM),
-                        )
-                    }
-                }
-            }
-        }
+        JourneyMapTopOverlays(
+            showPermissionBanner = showPermissionBanner,
+            showFreshnessBadge = showFreshnessBadge,
+            badgeText = badgeText,
+            isStale = isStale,
+            onGoToSettings = {
+                onPermissionSettingsClick()
+                userLocationManager.openAppSettings()
+            },
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
 
         // Stop Details Bottom Sheet
         selectedStop?.let { stop ->
@@ -283,6 +248,75 @@ private fun JourneyMapContent(
                 stop = stop,
                 onDismiss = { selectedStop = null },
             )
+        }
+    }
+}
+
+/**
+ * Top overlays — permission banner (if shown) then freshness badge directly below it.
+ * fillMaxWidth + horizontal padding here so both children get consistent spacingXL screen
+ * margins without each child needing to specify it individually.
+ */
+@Composable
+private fun JourneyMapTopOverlays(
+    showPermissionBanner: Boolean,
+    showFreshnessBadge: Boolean,
+    badgeText: String?,
+    isStale: Boolean,
+    onGoToSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (!showPermissionBanner && !(showFreshnessBadge && badgeText != null)) return
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = KrailTheme.dimensions.spacingXL)
+            .padding(top = KrailTheme.dimensions.spacingM),
+    ) {
+        if (showPermissionBanner) {
+            LocationPermissionBanner(onGoToSettings = onGoToSettings)
+        }
+        if (showFreshnessBadge) {
+            badgeText?.let { text ->
+                MapTimetableDataBadge(
+                    text = text,
+                    isStale = isStale,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(vertical = KrailTheme.dimensions.spacingM),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Handles a tap on the user-location button: re-centre on a known fix, otherwise resolve
+ * permission state (show banner when denied, else request).
+ */
+private suspend fun onUserLocationButtonClick(
+    userLocation: LatLng?,
+    userLocationManager: UserLocationManager,
+    cameraState: org.maplibre.compose.camera.CameraState,
+    onShowPermissionBanner: () -> Unit,
+    onRequestPermission: () -> Unit,
+) {
+    if (userLocation != null) {
+        // Re-center camera on latest known position
+        cameraState.animateTo(
+            CameraPosition(
+                target = Position(latitude = userLocation.latitude, longitude = userLocation.longitude),
+                zoom = UserLocationConfig.RECENTER_ZOOM,
+            ),
+            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
+        )
+    } else {
+        val status = userLocationManager.checkPermissionStatus()
+        if (status is PermissionStatus.Denied) {
+            onShowPermissionBanner()
+        } else {
+            // Trigger system permission dialog via TrackUserLocation
+            onRequestPermission()
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,9 +1,8 @@
-@file:Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
+@file:Suppress("LongMethod", "LongParameterList")
 
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.StartOffset
@@ -16,7 +15,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -58,18 +56,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_close
 import kotlinx.collections.immutable.ImmutableList
-import krail.feature.trip_planner.ui.generated.resources.Res
-import krail.feature.trip_planner.ui.generated.resources.ic_settings
 import org.jetbrains.compose.resources.painterResource
-import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import xyz.ksharma.krail.core.adaptiveui.DualPaneScaffold
@@ -79,26 +71,15 @@ import xyz.ksharma.krail.feature.track.TrackedJourney
 import xyz.ksharma.krail.feature.track.ui.components.TrackingCard
 import xyz.ksharma.krail.info.tile.state.InfoTileData
 import xyz.ksharma.krail.info.tiles.ui.InfoTile
-import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalTextStyle
-import xyz.ksharma.krail.taj.components.Button
-import xyz.ksharma.krail.taj.components.ButtonDefaults
-import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeColor
-import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
-import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
-import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
-import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
-import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
-import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.fromStopDisplay
-import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.toStopDisplay
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import app.krail.taj.resources.Res as TajRes
 
@@ -189,36 +170,14 @@ fun SavedTripsScreen(
                         Text(text = "KRAIL", color = themeColor())
                     },
                     actions = {
-                        if (editing) {
-                            Button(
-                                onClick = { editing = false },
-                                colors = ButtonDefaults.monochromeButtonColors(),
-                                dimensions = ButtonDefaults.chipButtonSize(),
-                                modifier = Modifier.padding(horizontal = dim.spacingM),
-                            ) {
-                                Text(text = "Done")
-                            }
-                        } else {
-                            if (savedTripsState.isDiscoverAvailable) {
-                                RoundIconButton(
-                                    showBadge = savedTripsState.displayDiscoverBadge,
-                                    onClick = onDiscoverButtonClick,
-                                ) {
-                                    CityCodeText("SYD")
-                                }
-                            }
-
-                            RoundIconButton(
-                                onClick = onSettingsButtonClick,
-                            ) {
-                                Image(
-                                    painter = painterResource(Res.drawable.ic_settings),
-                                    contentDescription = "Settings",
-                                    colorFilter = ColorFilter.tint(LocalContentColor.current),
-                                    modifier = Modifier.size(dim.spacingXXXL),
-                                )
-                            }
-                        }
+                        SavedTripsTitleBarActions(
+                            editing = editing,
+                            isDiscoverAvailable = savedTripsState.isDiscoverAvailable,
+                            displayDiscoverBadge = savedTripsState.displayDiscoverBadge,
+                            onDoneClick = { editing = false },
+                            onDiscoverButtonClick = onDiscoverButtonClick,
+                            onSettingsButtonClick = onSettingsButtonClick,
+                        )
                     },
                 )
 
@@ -228,67 +187,20 @@ fun SavedTripsScreen(
                     state = lazyListState,
                     contentPadding = PaddingValues(bottom = LAZY_COLUMN_BOTTOM_PADDING.dp),
                 ) {
-                    when {
-                        savedTripsState.isSavedTripsLoading -> Unit
-
-                        savedTripsState.savedTrips.isEmpty() -> {
-                            savedTripsState.infoTiles?.let { infoTiles ->
-                                infoTiles(
-                                    infoTiles = infoTiles,
-                                    onCtaClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                    },
-                                    onDismissClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
-                                    },
-                                    onTileExpand = {
-                                        onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
-                                    },
-                                )
-                            }
-
-                            item(key = "empty_state") {
-                                ErrorMessage(
-                                    emoji = "🌟",
-                                    title = "Let's Go! Sydney",
-                                    message = emptyStateTip,
-                                    modifier = Modifier
-                                        .padding(horizontal = dim.pageHorizontalPadding)
-                                        .animateItem(),
-                                )
-                            }
-                        }
-
-                        savedTripsState.savedTrips.isNotEmpty() -> {
-                            savedTripsState.infoTiles?.let { infoTiles ->
-                                infoTiles(
-                                    infoTiles = infoTiles,
-                                    onCtaClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                    },
-                                    onDismissClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
-                                    },
-                                    onTileExpand = {
-                                        onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
-                                    },
-                                )
-                            }
-
-                            savedTripsContent(
-                                savedTripsState = savedTripsState,
-                                trackedJourney = trackedJourney,
-                                onEvent = onEvent,
-                                onSavedTripCardClick = onSavedTripCardClick,
-                                onTrackingCardClick = onTrackingCardClick,
-                                onStopTracking = onStopTracking,
-                                expandedMap = expandedMap,
-                                editing = editing,
-                                reorderState = reorderState,
-                                onEnterEditing = { editing = true },
-                            )
-                        }
-                    }
+                    savedTripsListBody(
+                        savedTripsState = savedTripsState,
+                        trackedJourney = trackedJourney,
+                        emptyStateTip = emptyStateTip,
+                        pageHorizontalPadding = dim.pageHorizontalPadding,
+                        onEvent = onEvent,
+                        onSavedTripCardClick = onSavedTripCardClick,
+                        onTrackingCardClick = onTrackingCardClick,
+                        onStopTracking = onStopTracking,
+                        expandedMap = expandedMap,
+                        editing = editing,
+                        reorderState = reorderState,
+                        onEnterEditing = { editing = true },
+                    )
                 }
             }
 
@@ -301,42 +213,30 @@ fun SavedTripsScreen(
             // expanded search row. The pill's "alive" pulse lives inside CollapsedPill
             // itself — keeping the row-level reveal calm avoids stacking two bouncy
             // animations (parent scale + child pulse) on top of each other.
-            AnimatedVisibility(
+            SavedTripsBottomSearchRow(
                 visible = !savedTripsState.isSavedTripsLoading && !editing,
-                enter = slideInVertically(
-                    initialOffsetY = { it },
-                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing),
-                ) + fadeIn(animationSpec = tween(durationMillis = 200)),
+                fromStopItem = savedTripsState.fromStop,
+                toStopItem = savedTripsState.toStop,
+                isExpanded = effectiveIsExpanded,
+                isFromHighlighted = isFromHighlighted,
+                showPill = showPill,
+                onExpandRequest = {
+                    isSearchExpanded = true
+                    isFromHighlighted = false
+                },
+                onCollapseRequest = {
+                    isSearchExpanded = false
+                    isFromHighlighted = false
+                },
+                fromButtonClick = {
+                    isFromHighlighted = false
+                    fromButtonClick()
+                },
+                toButtonClick = toButtonClick,
+                onReverseButtonClick = { onEvent(SavedTripUiEvent.ReverseStopClick) },
+                onSearchButtonClick = { onSearchButtonClick() },
                 modifier = Modifier.align(Alignment.BottomCenter),
-            ) {
-                SearchStopRow(
-                    fromStopItem = savedTripsState.fromStop,
-                    toStopItem = savedTripsState.toStop,
-                    isExpanded = effectiveIsExpanded,
-                    isFromHighlighted = isFromHighlighted,
-                    onExpandRequest = {
-                        isSearchExpanded = true
-                        isFromHighlighted = false
-                    },
-                    onCollapseRequest = if (showPill) {
-                        {
-                            isSearchExpanded = false
-                            isFromHighlighted = false
-                        }
-                    } else {
-                        null
-                    },
-                    fromButtonClick = {
-                        isFromHighlighted = false
-                        fromButtonClick()
-                    },
-                    toButtonClick = toButtonClick,
-                    onReverseButtonClick = {
-                        onEvent(SavedTripUiEvent.ReverseStopClick)
-                    },
-                    onSearchButtonClick = { onSearchButtonClick() },
-                )
-            }
+            )
         }
         log(
             "[MAP_STOP_SEL] SavedTripsScreen dualPane=$dualPane " +
@@ -356,7 +256,7 @@ fun SavedTripsScreen(
     }
 }
 
-private fun LazyListScope.infoTiles(
+internal fun LazyListScope.infoTiles(
     infoTiles: ImmutableList<InfoTileData>,
     onCtaClick: (InfoTileData) -> Unit,
     onDismissClick: (InfoTileData) -> Unit,
@@ -389,7 +289,7 @@ private fun LazyListScope.infoTiles(
     }
 }
 
-private fun LazyListScope.savedTripsContent(
+internal fun LazyListScope.savedTripsContent(
     savedTripsState: SavedTripsState,
     trackedJourney: TrackedJourney?,
     onEvent: (SavedTripUiEvent) -> Unit,
@@ -470,99 +370,26 @@ private fun LazyListScope.savedTripsContent(
         items = savedTripsState.savedTrips,
         key = { trip -> trip.tripId },
     ) { trip ->
-        val dim = KrailTheme.dimensions
-        val haptic = LocalHapticFeedback.current
-
-        ReorderableItem(reorderState, key = trip.tripId) { isDragging ->
-            val rotation = rememberWiggleRotation(
-                active = editing && !isDragging,
-                seed = trip.tripId.hashCode(),
-            )
-
-            Column(modifier = Modifier.padding(top = if (editing) dim.spacingS else dim.spacingNone)) {
-                Box(
-                    modifier = Modifier
-                        .graphicsLayer { rotationZ = rotation }
-                        .padding(horizontal = dim.pageHorizontalPadding),
-                ) {
-                    SavedTripCard(
-                        fromDisplay = trip.fromStopDisplay(savedTripsState.stopLabels),
-                        toDisplay = trip.toStopDisplay(savedTripsState.stopLabels),
-                        onCardClick = {
-                            if (!editing) {
-                                onSavedTripCardClick(
-                                    StopItem(stopId = trip.fromStopId, stopName = trip.fromStopName),
-                                    StopItem(stopId = trip.toStopId, stopName = trip.toStopName),
-                                )
-                            }
-                        },
-                        editing = editing,
-                        onLongClick = if (!editing) {
-                            {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                onEnterEditing()
-                            }
-                        } else {
-                            null
-                        },
-                        modifier = Modifier.longPressDraggableHandle(
-                            enabled = editing,
-                            onDragStarted = {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                            },
-                        ),
-                    )
-
-                    if (editing) {
-                        TripDeleteOverlay(
-                            onClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
-                            modifier = Modifier.align(Alignment.TopEnd),
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(dim.spacingXL))
-            }
-        }
+        SavedTripItem(
+            trip = trip,
+            stopLabels = savedTripsState.stopLabels,
+            editing = editing,
+            reorderState = reorderState,
+            onSavedTripCardClick = onSavedTripCardClick,
+            onEnterEditing = onEnterEditing,
+            onDelete = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
+        )
     }
 
-    if (savedTripsState.parkRideUiState.isNotEmpty()) {
-        stickyHeader(key = "park_ride_title") {
-            SavedTripsTitle {
-                Text(text = "Park & Ride")
-            }
-        }
-
-        items(
-            items = savedTripsState.parkRideUiState,
-            key = { parkRide -> parkRide.stopId },
-        ) { parkRide ->
-            val dim = KrailTheme.dimensions
-            val isExpanded = expandedMap[parkRide.stopId] ?: false
-
-            ParkRideCard(
-                isExpanded = isExpanded,
-                modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding),
-                onClick = {
-                    val newExpanded = !isExpanded
-                    expandedMap[parkRide.stopId] = newExpanded
-                    onEvent(
-                        SavedTripUiEvent.ParkRideCardClick(
-                            parkRideState = parkRide,
-                            isExpanded = newExpanded,
-                        ),
-                    )
-                },
-                parkRideUiState = parkRide,
-            )
-
-            Spacer(modifier = Modifier.height(dim.spacingXL))
-        }
-    }
+    parkRideSection(
+        savedTripsState = savedTripsState,
+        expandedMap = expandedMap,
+        onEvent = onEvent,
+    )
 }
 
 @Composable
-private fun TripDeleteOverlay(
+internal fun TripDeleteOverlay(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -586,7 +413,7 @@ private fun TripDeleteOverlay(
 }
 
 @Composable
-private fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
+internal fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
     val transition = rememberInfiniteTransition(label = "trip-wiggle")
     val seedAbs = kotlin.math.abs(seed)
     val angle by transition.animateFloat(
@@ -610,7 +437,7 @@ private fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
 }
 
 @Composable
-private fun SavedTripsTitle(
+internal fun SavedTripsTitle(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -1,0 +1,308 @@
+@file:Suppress("LongMethod", "LongParameterList")
+
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
+import kotlinx.collections.immutable.ImmutableList
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_settings
+import org.jetbrains.compose.resources.painterResource
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.ReorderableLazyListState
+import xyz.ksharma.krail.feature.track.TrackedJourney
+import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.components.Button
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.RoundIconButton
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
+import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
+import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
+import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
+import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.fromStopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.toStopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+
+/**
+ * Full LazyColumn body for [SavedTripsScreen] — picks the empty / populated branch and renders the
+ * matching content. Pure extraction of the original `when` block; behaviour is identical.
+ */
+internal fun LazyListScope.savedTripsListBody(
+    savedTripsState: SavedTripsState,
+    trackedJourney: TrackedJourney?,
+    emptyStateTip: String,
+    pageHorizontalPadding: Dp,
+    onEvent: (SavedTripUiEvent) -> Unit,
+    onSavedTripCardClick: (StopItem?, StopItem?) -> Unit,
+    onTrackingCardClick: () -> Unit,
+    onStopTracking: () -> Unit,
+    expandedMap: SnapshotStateMap<String, Boolean>,
+    editing: Boolean,
+    reorderState: ReorderableLazyListState,
+    onEnterEditing: () -> Unit,
+) {
+    when {
+        savedTripsState.isSavedTripsLoading -> Unit
+
+        savedTripsState.savedTrips.isEmpty() -> {
+            savedTripsInfoTiles(savedTripsState, onEvent)
+            item(key = "empty_state") {
+                ErrorMessage(
+                    emoji = "🌟",
+                    title = "Let's Go! Sydney",
+                    message = emptyStateTip,
+                    modifier = Modifier
+                        .padding(horizontal = pageHorizontalPadding)
+                        .animateItem(),
+                )
+            }
+        }
+
+        savedTripsState.savedTrips.isNotEmpty() -> {
+            savedTripsInfoTiles(savedTripsState, onEvent)
+            savedTripsContent(
+                savedTripsState = savedTripsState,
+                trackedJourney = trackedJourney,
+                onEvent = onEvent,
+                onSavedTripCardClick = onSavedTripCardClick,
+                onTrackingCardClick = onTrackingCardClick,
+                onStopTracking = onStopTracking,
+                expandedMap = expandedMap,
+                editing = editing,
+                reorderState = reorderState,
+                onEnterEditing = onEnterEditing,
+            )
+        }
+    }
+}
+
+private fun LazyListScope.savedTripsInfoTiles(
+    savedTripsState: SavedTripsState,
+    onEvent: (SavedTripUiEvent) -> Unit,
+) {
+    savedTripsState.infoTiles?.let { infoTiles ->
+        infoTiles(
+            infoTiles = infoTiles,
+            onCtaClick = { tileData -> onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData)) },
+            onDismissClick = { tileData -> onEvent(SavedTripUiEvent.DismissInfoTile(tileData)) },
+            onTileExpand = { onEvent(SavedTripUiEvent.InfoTileExpand(it.key)) },
+        )
+    }
+}
+
+internal fun LazyListScope.parkRideSection(
+    savedTripsState: SavedTripsState,
+    expandedMap: SnapshotStateMap<String, Boolean>,
+    onEvent: (SavedTripUiEvent) -> Unit,
+) {
+    if (savedTripsState.parkRideUiState.isEmpty()) return
+
+    stickyHeader(key = "park_ride_title") {
+        SavedTripsTitle {
+            Text(text = "Park & Ride")
+        }
+    }
+
+    items(
+        items = savedTripsState.parkRideUiState,
+        key = { parkRide -> parkRide.stopId },
+    ) { parkRide ->
+        val dim = KrailTheme.dimensions
+        val isExpanded = expandedMap[parkRide.stopId] ?: false
+
+        ParkRideCard(
+            isExpanded = isExpanded,
+            modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding),
+            onClick = {
+                val newExpanded = !isExpanded
+                expandedMap[parkRide.stopId] = newExpanded
+                onEvent(
+                    SavedTripUiEvent.ParkRideCardClick(
+                        parkRideState = parkRide,
+                        isExpanded = newExpanded,
+                    ),
+                )
+            },
+            parkRideUiState = parkRide,
+        )
+
+        Spacer(modifier = Modifier.height(dim.spacingXL))
+    }
+}
+
+@Composable
+internal fun LazyItemScope.SavedTripItem(
+    trip: Trip,
+    stopLabels: ImmutableList<StopLabel>,
+    editing: Boolean,
+    reorderState: ReorderableLazyListState,
+    onSavedTripCardClick: (StopItem?, StopItem?) -> Unit,
+    onEnterEditing: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val dim = KrailTheme.dimensions
+    val haptic = LocalHapticFeedback.current
+
+    ReorderableItem(reorderState, key = trip.tripId) { isDragging ->
+        val rotation = rememberWiggleRotation(
+            active = editing && !isDragging,
+            seed = trip.tripId.hashCode(),
+        )
+
+        Column(modifier = Modifier.padding(top = if (editing) dim.spacingS else dim.spacingNone)) {
+            Box(
+                modifier = Modifier
+                    .graphicsLayer { rotationZ = rotation }
+                    .padding(horizontal = dim.pageHorizontalPadding),
+            ) {
+                SavedTripCard(
+                    fromDisplay = trip.fromStopDisplay(stopLabels),
+                    toDisplay = trip.toStopDisplay(stopLabels),
+                    onCardClick = {
+                        if (!editing) {
+                            onSavedTripCardClick(
+                                StopItem(stopId = trip.fromStopId, stopName = trip.fromStopName),
+                                StopItem(stopId = trip.toStopId, stopName = trip.toStopName),
+                            )
+                        }
+                    },
+                    editing = editing,
+                    onLongClick = if (!editing) {
+                        {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onEnterEditing()
+                        }
+                    } else {
+                        null
+                    },
+                    modifier = Modifier.longPressDraggableHandle(
+                        enabled = editing,
+                        onDragStarted = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        },
+                    ),
+                )
+
+                if (editing) {
+                    TripDeleteOverlay(
+                        onClick = onDelete,
+                        modifier = Modifier.align(Alignment.TopEnd),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(dim.spacingXL))
+        }
+    }
+}
+
+@Composable
+internal fun SavedTripsTitleBarActions(
+    editing: Boolean,
+    isDiscoverAvailable: Boolean,
+    displayDiscoverBadge: Boolean,
+    onDoneClick: () -> Unit,
+    onDiscoverButtonClick: () -> Unit,
+    onSettingsButtonClick: () -> Unit,
+) {
+    val dim = KrailTheme.dimensions
+    if (editing) {
+        Button(
+            onClick = onDoneClick,
+            colors = ButtonDefaults.monochromeButtonColors(),
+            dimensions = ButtonDefaults.chipButtonSize(),
+            modifier = Modifier.padding(horizontal = dim.spacingM),
+        ) {
+            Text(text = "Done")
+        }
+    } else {
+        if (isDiscoverAvailable) {
+            RoundIconButton(
+                showBadge = displayDiscoverBadge,
+                onClick = onDiscoverButtonClick,
+            ) {
+                CityCodeText("SYD")
+            }
+        }
+
+        RoundIconButton(
+            onClick = onSettingsButtonClick,
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.ic_settings),
+                contentDescription = "Settings",
+                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                modifier = Modifier.size(dim.spacingXXXL),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun BoxScope.SavedTripsBottomSearchRow(
+    visible: Boolean,
+    fromStopItem: StopItem?,
+    toStopItem: StopItem?,
+    isExpanded: Boolean,
+    isFromHighlighted: Boolean,
+    showPill: Boolean,
+    onExpandRequest: () -> Unit,
+    onCollapseRequest: () -> Unit,
+    fromButtonClick: () -> Unit,
+    toButtonClick: () -> Unit,
+    onReverseButtonClick: () -> Unit,
+    onSearchButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(
+            initialOffsetY = { it },
+            animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing),
+        ) + fadeIn(animationSpec = tween(durationMillis = 200)),
+        modifier = modifier,
+    ) {
+        SearchStopRow(
+            fromStopItem = fromStopItem,
+            toStopItem = toStopItem,
+            isExpanded = isExpanded,
+            isFromHighlighted = isFromHighlighted,
+            onExpandRequest = onExpandRequest,
+            onCollapseRequest = if (showPill) onCollapseRequest else null,
+            fromButtonClick = fromButtonClick,
+            toButtonClick = toButtonClick,
+            onReverseButtonClick = onReverseButtonClick,
+            onSearchButtonClick = onSearchButtonClick,
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
@@ -26,9 +26,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.platform.LocalDensity
@@ -114,35 +116,12 @@ fun ThemeSelectionRadioButton(
             .scalingKlickable { onClick(themeStyle) },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier = Modifier
-                .size(COLOR_SWATCH_OUTER_SIZE)
-                .then(
-                    if (selected) {
-                        Modifier.drawBehind {
-                            val color = themeStyle.hexColorCode.hexToComposeColor()
-                            withTransform({
-                                scale(pulseScale, pulseScale, pivot = center)
-                            }) {
-                                drawCircle(
-                                    color = color.copy(alpha = pulseAlpha),
-                                    radius = size.minDimension / 2,
-                                )
-                            }
-                        }
-                    } else {
-                        Modifier
-                    },
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(dim.iconL)
-                    .clip(CircleShape)
-                    .background(color = themeStyle.hexColorCode.hexToComposeColor()),
-            )
-        }
+        ThemeColorSwatch(
+            themeStyle = themeStyle,
+            selected = selected,
+            pulseScale = pulseScale,
+            pulseAlpha = pulseAlpha,
+        )
 
         Box(
             modifier = Modifier
@@ -155,54 +134,11 @@ fun ThemeSelectionRadioButton(
                         .width(textWidth)
                         .padding(horizontal = dim.spacingL),
                 ) {
-                    val layout = textLayoutResult!!
-                    val lineCount = layout.lineCount
-                    val strokeWidth = WAVE_STROKE_WIDTH.toPx()
-                    val amplitude = WAVE_AMPLITUDE.toPx()
-                    val waveLength = WAVE_LENGTH.toPx()
-                    var remaining = currentPathLength
-
-                    for (line in 0 until lineCount) {
-                        val left = layout.getLineLeft(line)
-                        val right = layout.getLineRight(line)
-                        val lineWidth = right - left
-                        if (remaining <= 0f) break
-                        val highlightEnd = left + remaining.coerceAtMost(lineWidth)
-                        val top = layout.getLineTop(line)
-                        val bottom = layout.getLineBottom(line)
-                        val centerY = (top + bottom) / 2f
-
-                        val path = Path()
-                        var x = left
-                        var up = true
-                        path.moveTo(x, centerY)
-                        while (x < highlightEnd) {
-                            val nextX = (x + waveLength).coerceAtMost(highlightEnd)
-                            val controlX1 = x + waveLength / 3
-                            val controlX2 = x + 2 * waveLength / 3
-                            val endY = if (up) centerY - amplitude else centerY + amplitude
-                            path.cubicTo(
-                                controlX1,
-                                centerY,
-                                controlX2,
-                                endY,
-                                nextX,
-                                endY,
-                            )
-                            x = nextX
-                            up = !up
-                        }
-                        drawPath(
-                            path = path,
-                            color = highlightColor,
-                            style = Stroke(
-                                width = strokeWidth,
-                                cap = StrokeCap.Round,
-                                join = StrokeJoin.Round,
-                            ),
-                        )
-                        remaining -= lineWidth
-                    }
+                    drawWaveHighlight(
+                        layout = textLayoutResult!!,
+                        currentPathLength = currentPathLength,
+                        highlightColor = highlightColor,
+                    )
                 }
             }
 
@@ -218,6 +154,109 @@ fun ThemeSelectionRadioButton(
             )
         }
     }
+}
+
+@Composable
+private fun ThemeColorSwatch(
+    themeStyle: KrailThemeStyle,
+    selected: Boolean,
+    pulseScale: Float,
+    pulseAlpha: Float,
+) {
+    val dim = KrailTheme.dimensions
+    Box(
+        modifier = Modifier
+            .size(COLOR_SWATCH_OUTER_SIZE)
+            .then(
+                if (selected) {
+                    Modifier.drawBehind {
+                        val color = themeStyle.hexColorCode.hexToComposeColor()
+                        withTransform({
+                            scale(pulseScale, pulseScale, pivot = center)
+                        }) {
+                            drawCircle(
+                                color = color.copy(alpha = pulseAlpha),
+                                radius = size.minDimension / 2,
+                            )
+                        }
+                    }
+                } else {
+                    Modifier
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(dim.iconL)
+                .clip(CircleShape)
+                .background(color = themeStyle.hexColorCode.hexToComposeColor()),
+        )
+    }
+}
+
+private fun DrawScope.drawWaveHighlight(
+    layout: TextLayoutResult,
+    currentPathLength: Float,
+    highlightColor: Color,
+) {
+    val strokeWidth = WAVE_STROKE_WIDTH.toPx()
+    val amplitude = WAVE_AMPLITUDE.toPx()
+    val waveLength = WAVE_LENGTH.toPx()
+    var remaining = currentPathLength
+
+    for (line in 0 until layout.lineCount) {
+        val left = layout.getLineLeft(line)
+        val lineWidth = layout.getLineRight(line) - left
+        if (remaining <= 0f) break
+        val highlightEnd = left + remaining.coerceAtMost(lineWidth)
+        val centerY = (layout.getLineTop(line) + layout.getLineBottom(line)) / 2f
+
+        drawPath(
+            path = buildWavePath(
+                left = left,
+                highlightEnd = highlightEnd,
+                centerY = centerY,
+                amplitude = amplitude,
+                waveLength = waveLength,
+            ),
+            color = highlightColor,
+            style = Stroke(
+                width = strokeWidth,
+                cap = StrokeCap.Round,
+                join = StrokeJoin.Round,
+            ),
+        )
+        remaining -= lineWidth
+    }
+}
+
+private fun buildWavePath(
+    left: Float,
+    highlightEnd: Float,
+    centerY: Float,
+    amplitude: Float,
+    waveLength: Float,
+): Path {
+    val path = Path()
+    var x = left
+    var up = true
+    path.moveTo(x, centerY)
+    while (x < highlightEnd) {
+        val nextX = (x + waveLength).coerceAtMost(highlightEnd)
+        val endY = if (up) centerY - amplitude else centerY + amplitude
+        path.cubicTo(
+            x + waveLength / 3,
+            centerY,
+            x + 2 * waveLength / 3,
+            endY,
+            nextX,
+            endY,
+        )
+        x = nextX
+        up = !up
+    }
+    return path
 }
 
 @Preview

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
@@ -1,0 +1,75 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import kotlinx.collections.immutable.toImmutableList
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeString
+import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+
+/**
+ * Builds a [TimeTableState.JourneyCardInfo.Leg.WalkingLeg] for a walking leg, or null when the
+ * walking leg has no display duration or its footpath info is redundant.
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Leg.toWalkingLegUiModel(): TimeTableState.JourneyCardInfo.Leg? {
+    // duration can be null for some legs; resolveDurationSeconds() falls back to dep/arr times.
+    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
+    return if (displayDuration != null && footPathInfoRedundant != true) {
+        TimeTableState.JourneyCardInfo.Leg.WalkingLeg(duration = displayDuration)
+    } else {
+        null
+    }
+}
+
+/**
+ * Builds a [TimeTableState.JourneyCardInfo.Leg.TransportLeg] for a public transport leg, or null
+ * (and logs which field was null) when any required field is missing.
+ */
+@OptIn(ExperimentalTime::class)
+@Suppress("ComplexCondition")
+internal fun TripResponse.Leg.toTransportLegUiModel(): TimeTableState.JourneyCardInfo.Leg? {
+    val transportMode = transportation?.product?.productClass?.toInt()
+        ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
+    val lineName = transportation?.disassembledName
+    val displayText = NswTransportConfig.resolveServiceDisplayText(
+        productClass = transportation?.product?.productClass?.toInt(),
+        destinationName = transportation?.destination?.name,
+        description = transportation?.description,
+    )
+    val numberOfStops = stopSequence?.size
+    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
+    val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
+    val alerts = infos?.mapNotNull { it.toAlert() }?.toImmutableList()
+
+    if (transportMode == null || lineName == null || displayText == null ||
+        numberOfStops == null || stops == null || displayDuration == null
+    ) {
+        logError(
+            "Something is null - NOT adding Transport LEG: " +
+                "TransportMode: $transportMode, lineName: $lineName, displayText: $displayText, " +
+                "numberOfStops: $numberOfStops, stops: $stops, displayDuration: $displayDuration",
+        )
+        return null
+    }
+
+    return TimeTableState.JourneyCardInfo.Leg.TransportLeg(
+        transportModeLine = TransportModeLine(
+            transportMode = transportMode,
+            lineName = lineName,
+        ),
+        displayText = displayText,
+        totalDuration = displayDuration,
+        stops = stops,
+        serviceAlertList = alerts,
+        walkInterchange = footPathInfo?.firstOrNull()?.run {
+            duration?.seconds?.toFormattedDurationTimeString()
+                ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
+        },
+        tripId = transportation?.id + transportation?.properties?.realtimeTripId,
+        transportationId = transportation?.id,
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -17,7 +17,6 @@ import xyz.ksharma.krail.trip.planner.network.api.model.isWalkingLeg
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import kotlin.math.absoluteValue
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -162,65 +161,10 @@ private fun List<TripResponse.Leg>.getLegsList() = mapNotNull { it.toUiModel() }
 @OptIn(ExperimentalTime::class)
 private fun String.getTimeText() = toDepartureRelativeString()
 
-@OptIn(ExperimentalTime::class)
-@Suppress("ComplexCondition", "CyclomaticComplexMethod")
-private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
-    val transportMode =
-        transportation?.product?.productClass?.toInt()
-            ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
-    val lineName = transportation?.disassembledName
-
-    val displayText = NswTransportConfig.resolveServiceDisplayText(
-        productClass = transportation?.product?.productClass?.toInt(),
-        destinationName = transportation?.destination?.name,
-        description = transportation?.description,
-    )
-    val numberOfStops = stopSequence?.size
-    // duration can be null for some legs (e.g. first bus leg in a multi-leg journey).
-    // Fall back to calculating duration from departure/arrival times via resolveDurationSeconds().
-    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
-    val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
-    val alerts = infos?.mapNotNull { it.toAlert() }?.toImmutableList()
-
-    return when {
-        // Walking Leg - Always check before public transport leg
-        isWalkingLeg() -> if (displayDuration != null && this.footPathInfoRedundant != true) {
-            TimeTableState.JourneyCardInfo.Leg.WalkingLeg(duration = displayDuration)
-        } else {
-            null
-        }
-
-        else -> { // Public Transport Leg
-            if (transportMode != null && lineName != null && displayText != null &&
-                numberOfStops != null && stops != null && displayDuration != null
-            ) {
-                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
-                    transportModeLine = TransportModeLine(
-                        transportMode = transportMode,
-                        lineName = lineName,
-                    ),
-                    displayText = displayText,
-                    totalDuration = displayDuration,
-                    stops = stops,
-                    serviceAlertList = alerts,
-                    walkInterchange = footPathInfo?.firstOrNull()?.run {
-                        duration?.seconds?.toFormattedDurationTimeString()
-                            ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
-                    },
-                    tripId = transportation?.id + transportation?.properties?.realtimeTripId,
-                    transportationId = transportation?.id,
-                )
-            } else {
-                logError(
-                    "Something is null - NOT adding Transport LEG: " +
-                        "TransportMode: $transportMode, lineName: $lineName, displayText: $displayText, " +
-                        "numberOfStops: $numberOfStops, stops: $stops, displayDuration: $displayDuration",
-                )
-                null
-            }
-        }
-    }
-}
+private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? =
+    // Walking Leg - Always check before public transport leg. Both builders compute their
+    // own fields from this leg; see TripResponseLegMapper.kt.
+    if (isWalkingLeg()) toWalkingLegUiModel() else toTransportLegUiModel()
 
 /**
  * Resolves the duration of a leg in seconds.
@@ -280,7 +224,7 @@ internal fun TripResponse.FootPathInfo.toWalkInterchange(
     }
 }
 
-private fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInfo.Stop? {
+internal fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInfo.Stop? {
     val stopName = disassembledName ?: name
     // For last leg there is no departure time, so using arrival time
     // For first leg there is no arrival time, so using departure time.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -1,4 +1,4 @@
-@file:Suppress("LongMethod", "TooManyFunctions", "CyclomaticComplexMethod", "StringLiteralDuplication")
+@file:Suppress("LongMethod", "TooManyFunctions", "StringLiteralDuplication")
 
 package xyz.ksharma.krail.trip.planner.ui.tracktrip
 
@@ -139,30 +139,13 @@ fun TrackTripScreen(
                 title = { Text(text = "Track Trip") },
                 onNavActionClick = onBack,
                 actions = {
-                    AnimatedVisibility(
-                        visible = isRefreshing,
-                        enter = fadeIn(),
-                        exit = fadeOut(),
-                    ) {
-                        val dim = KrailTheme.dimensions
-                        AnimatedDots(modifier = Modifier.size(dim.buttonRoundSize, dim.iconXS))
-                    }
-                    if (isJourneyActive) {
-                        TextButton(onClick = { mapExpanded = !mapExpanded }) {
-                            Text(text = if (mapExpanded) "Hide Map" else "Map")
-                        }
-                        ActionButton(
-                            onClick = { triggerShare = true },
-                            contentDescription = "Share journey",
-                        ) {
-                            Image(
-                                painter = rememberShareIconPainter(),
-                                contentDescription = null,
-                                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(KrailTheme.dimensions.iconM),
-                            )
-                        }
-                    }
+                    TrackTripActions(
+                        isRefreshing = isRefreshing,
+                        isJourneyActive = isJourneyActive,
+                        mapExpanded = mapExpanded,
+                        onToggleMap = { mapExpanded = !mapExpanded },
+                        onShare = { triggerShare = true },
+                    )
                 },
             )
 
@@ -216,59 +199,95 @@ fun TrackTripScreen(
                     },
                 )
 
-                TrackTripState.NotFound -> Column(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Service not found",
-                        message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
-                        emoji = "\uD83D\uDEAB",
-                        actionData = ActionData("Retry") { viewModel.retry() },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {
-                            viewModel.onStopTracking()
-                            onBack()
-                        },
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.NotFound -> TrackTripErrorContent(
+                    title = "Service not found",
+                    message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
+                    emoji = "\uD83D\uDEAB",
+                    onRetry = { viewModel.retry() },
+                    onStopTracking = {
+                        viewModel.onStopTracking()
+                        onBack()
+                    },
+                )
 
-                TrackTripState.Error -> Column(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Something went wrong",
-                        message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
-                        actionData = ActionData("Retry") { viewModel.retry() },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {
-                            viewModel.onStopTracking()
-                            onBack()
-                        },
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.Error -> TrackTripErrorContent(
+                    title = "Something went wrong",
+                    message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
+                    emoji = null,
+                    onRetry = { viewModel.retry() },
+                    onStopTracking = {
+                        viewModel.onStopTracking()
+                        onBack()
+                    },
+                )
 
                 is TrackTripState.AlreadyTracking -> Unit // unreachable — deep link tap clears old tracking
             }
+        }
+    }
+}
+
+@Composable
+private fun TrackTripActions(
+    isRefreshing: Boolean,
+    isJourneyActive: Boolean,
+    mapExpanded: Boolean,
+    onToggleMap: () -> Unit,
+    onShare: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = isRefreshing,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        val dim = KrailTheme.dimensions
+        AnimatedDots(modifier = Modifier.size(dim.buttonRoundSize, dim.iconXS))
+    }
+    if (isJourneyActive) {
+        TextButton(onClick = onToggleMap) {
+            Text(text = if (mapExpanded) "Hide Map" else "Map")
+        }
+        ActionButton(
+            onClick = onShare,
+            contentDescription = "Share journey",
+        ) {
+            Image(
+                painter = rememberShareIconPainter(),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                modifier = Modifier.size(KrailTheme.dimensions.iconM),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrackTripErrorContent(
+    title: String,
+    message: String,
+    emoji: String?,
+    onRetry: () -> Unit,
+    onStopTracking: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        val dim = KrailTheme.dimensions
+        ErrorMessage(
+            title = title,
+            message = message,
+            emoji = emoji ?: "🐶",
+            actionData = ActionData("Retry") { onRetry() },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dim.spacingXL),
+        )
+        Button(
+            onClick = onStopTracking,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(bottom = dim.spacingXL),
+        ) {
+            Text("Stop Tracking")
         }
     }
 }
@@ -610,46 +629,21 @@ private fun TrackTripScreenPreview(state: TrackTripState) {
                     isArrived = true,
                 )
 
-                TrackTripState.NotFound -> Column(modifier = Modifier.fillMaxWidth()) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Service not found",
-                        message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
-                        emoji = "\uD83D\uDEAB",
-                        actionData = ActionData("Retry") { },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {},
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.NotFound -> TrackTripErrorContent(
+                    title = "Service not found",
+                    message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
+                    emoji = "\uD83D\uDEAB",
+                    onRetry = {},
+                    onStopTracking = {},
+                )
 
-                TrackTripState.Error -> Column(modifier = Modifier.fillMaxWidth()) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Something went wrong",
-                        message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
-                        actionData = ActionData("Retry") { },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {},
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.Error -> TrackTripErrorContent(
+                    title = "Something went wrong",
+                    message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
+                    emoji = null,
+                    onRetry = {},
+                    onStopTracking = {},
+                )
 
                 is TrackTripState.AlreadyTracking -> Unit // unreachable — deep link tap clears old tracking
 


### PR DESCRIPTION
Refactor every function that suppressed detekt CyclomaticComplexMethod
(via @Suppress, @file:Suppress, or baseline.xml) below the threshold by
extracting cohesive blocks into well-named helpers (top-level / sibling
files so detekt does not count their branches toward the caller, and to
avoid TooManyFunctions). Behavior preserved throughout.

- track/ui TripResponseMapper: findMatchingJourney + toTrackedTransportLeg
  -> new TripResponseMatchers.kt
- departures/ui DepartureMonitorMapper: platform-text resolution helpers
- journeymap/JourneyMap: extracted top overlays + location-button helper
- components/TrackedLegView: timeline sections -> new TrackedLegTimeline.kt
- timetable/business TripResponseMapper: toUiModel split into
  toWalkingLegUiModel/toTransportLegUiModel -> new TripResponseLegMapper.kt
- components/DepartureBoardBody: success-state body -> sub-composables
- savedtrips/SavedTripsScreen: item + sections -> new SavedTripsScreenSections.kt
- tracktrip/TrackTripScreen: actions + error content extracted
- baseline.xml: removed stale entries for JourneyCard.ResponsiveJourneyInfoRow,
  ThemeSelectionRadioButton, timetable TripResponseMapper.toUiModel

Non-cyclomatic suppressions (ComplexCondition, MagicNumber, LongMethod,
LongParameterList) are preserved as before.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>