### PR TITLE
fix(timetable): client-side mode filter, retry preserves date/time + fires immediately

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -24,6 +24,11 @@ data class TimeTableState(
     val previousJourneyList: ImmutableList<JourneyCardInfo> = persistentListOf(),
     val trip: Trip? = null,
     val isError: Boolean = false,
+    /**
+     * True when the API returned journeys but the user's mode selection filtered all of them
+     * out. Lets the screen show a mode-specific hint instead of the generic "no route found".
+     */
+    val emptyDueToModeFilter: Boolean = false,
     val unselectedModes: ImmutableSet<Int> = persistentSetOf(),
     // has to be null, otherwise it will switch from default to a festival.
     // It should load only once whether it is a festival or not.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableEmptyResultMessage.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableEmptyResultMessage.kt
@@ -1,0 +1,18 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+/**
+ * Title + message for the empty timetable state.
+ *
+ * When [emptyDueToModeFilter] is true the API returned trips but the user's mode selection hid
+ * them all, so we point them at the modes button instead of saying no route exists.
+ *
+ * Lives in its own file so the choice does not add to [TimeTableScreen]'s cyclomatic complexity
+ * or file function count, both of which already sit at their detekt limit.
+ */
+internal fun timeTableEmptyResultMessage(emptyDueToModeFilter: Boolean): Pair<String, String> =
+    if (emptyDueToModeFilter) {
+        "Nothing right now" to
+            "No trips for your selected modes. Tap the mode button to show more."
+    } else {
+        "No route found!" to "Search for another stop or check back later."
+    }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -398,11 +398,13 @@ fun TimeTableScreen(
                     ),
                     onPlanTripClick = dateTimeSelectorClicked,
                 )
-            } else { // Journey list is empty or null
+            } else { // Journey list is empty — either no results, or mode filter removed them all.
                 item(key = "no-results") {
+                    val (title, message) =
+                        timeTableEmptyResultMessage(timeTableState.emptyDueToModeFilter)
                     ErrorMessage(
-                        title = "No route found!",
-                        message = "Search for another stop or check back later.",
+                        title = title,
+                        message = message,
                         modifier = Modifier.fillMaxWidth().animateItem(),
                     )
                 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -258,7 +258,7 @@ class TimeTableViewModel(
                         source = AnalyticsEvent.RetryApiEvent.Source.TIMETABLE,
                     ),
                 )
-                onLoadTimeTable(tripInfo!!)
+                onRetry()
             }
 
             is TimeTableUiEvent.DateTimeSelectionChanged -> {
@@ -422,25 +422,33 @@ class TimeTableViewModel(
             }.catch { e ->
                 log("Error while fetching trip: $e")
             }.collectLatest { result ->
-                updateUiState { copy(silentLoading = false) }
-                result.onSuccess { response ->
-                    updateTripsCache(response)
-                    updateUiStateWithFilteredTrips()
-                }.onFailure {
-                    // fetchTrip() runs on every screen-visible (onStart) and every auto-refresh.
-                    // A failure on one of those silent/background refreshes must NOT blow away
-                    // journeys already on screen, otherwise returning to the app or a flaky
-                    // 30s refresh flips the whole screen to the error state. Only surface the
-                    // full error screen when there is nothing to show.
-                    val hasData = _uiState.value.journeyList.isNotEmpty()
-                    // Track the error screen as a screen view, but only on the transition
-                    // into the error state (not on every failed auto-refresh while errored).
-                    if (!hasData && !_uiState.value.isError) {
-                        analytics.trackScreenViewEvent(screen = AnalyticsScreen.TimeTableError)
-                    }
-                    updateUiState { copy(isLoading = false, isError = !hasData) }
-                }
+                handleTripResult(result)
             }
+        }
+    }
+
+    /**
+     * Applies a [loadTrip] result to UI state. Shared by the rate-limited [fetchTrip] auto-refresh
+     * path and the immediate [onRetry] path.
+     */
+    private suspend fun handleTripResult(result: Result<TripResponse>) {
+        updateUiState { copy(silentLoading = false) }
+        result.onSuccess { response ->
+            updateTripsCache(response)
+            updateUiStateWithFilteredTrips()
+        }.onFailure {
+            // fetchTrip() runs on every screen-visible (onStart) and every auto-refresh.
+            // A failure on one of those silent/background refreshes must NOT blow away
+            // journeys already on screen, otherwise returning to the app or a flaky
+            // 30s refresh flips the whole screen to the error state. Only surface the
+            // full error screen when there is nothing to show.
+            val hasData = _uiState.value.journeyList.isNotEmpty()
+            // Track the error screen as a screen view, but only on the transition
+            // into the error state (not on every failed auto-refresh while errored).
+            if (!hasData && !_uiState.value.isError) {
+                analytics.trackScreenViewEvent(screen = AnalyticsScreen.TimeTableError)
+            }
+            updateUiState { copy(isLoading = false, isError = !hasData) }
         }
     }
 
@@ -521,16 +529,38 @@ class TimeTableViewModel(
         }
     }
 
+    /**
+     * Drops journeys that use any de-selected transport mode.
+     *
+     * The NSW trip API does not reliably honour the `exclMOT` exclusion params we send — it
+     * still returns excluded modes (e.g. de-selecting Train still yields train journeys). We
+     * therefore filter defensively on the client so the user's mode selection is always
+     * respected. A multi-modal journey is dropped if ANY of its legs uses an excluded mode.
+     *
+     * Footpath/walk (productClass 99) is not a selectable mode and never appears in
+     * [TimeTableState.JourneyCardInfo.transportModeLines], so it is never excluded.
+     */
+    private fun List<TimeTableState.JourneyCardInfo>.excludeUnselectedModes(): List<TimeTableState.JourneyCardInfo> =
+        if (unselectedModes.isEmpty()) {
+            this
+        } else {
+            filterNot { journey ->
+                journey.transportModeLines.any { it.transportMode.productClass in unselectedModes }
+            }
+        }
+
     private fun updateUiStateWithFilteredTrips() {
         // Main list = current-window journeys + load-more (future) journeys, sorted chronologically.
         val mergedJourneys = (journeys.values + loadMoreJourneys.values)
             .distinctBy { it.journeyId }
         val journeyList = updateJourneyCardInfoTimeText(mergedJourneys)
+            .excludeUnselectedModes()
             .sortedBy { it.originUtcDateTime.utcToLocalDateTimeAEST() }
             .toImmutableList()
 
         // Previous list = past journeys fetched via "Show Previous".
         val previousJourneyList = updateJourneyCardInfoTimeText(previousJourneysCache.values.toList())
+            .excludeUnselectedModes()
             .sortedBy { it.originUtcDateTime.utcToLocalDateTimeAEST() }
             .toImmutableList()
 
@@ -555,12 +585,19 @@ class TimeTableViewModel(
         }
         log("[SHARE] deep link URLs computed — ${deepLinkUrls?.size ?: 0} journeys encoded for sharing")
 
+        // The API returned journeys but the user's mode selection filtered them all out.
+        // Distinct from "API returned nothing" so the UI can show a mode-specific hint
+        // instead of the generic "no route found" message.
+        val emptyDueToModeFilter = unselectedModes.isNotEmpty() &&
+            mergedJourneys.isNotEmpty() && journeyList.isEmpty()
+
         updateUiState {
             copy(
                 isLoading = false,
                 journeyList = journeyList,
                 previousJourneyList = previousJourneyList,
                 isError = false,
+                emptyDueToModeFilter = emptyDueToModeFilter,
                 deepLinkUrls = deepLinkUrls ?: this.deepLinkUrls,
                 canLoadMore = PAGINATION_ENABLED && journeyList.isNotEmpty() &&
                     loadMoreCount < MAX_LOAD_MORE_COUNT,
@@ -805,6 +842,28 @@ class TimeTableViewModel(
             legCount = legCount,
             transportModes = transportModes,
         )
+    }
+
+    /**
+     * Re-runs the current request after a failure. Unlike [onLoadTimeTable], retry must NOT
+     * reset trip params: it preserves the selected date/time (Leave at / Arrive by) and the
+     * mode filter, then simply re-fetches. Routing retry through onLoadTimeTable used to null
+     * dateTimeSelectionItem whenever the VM had no previousTripId yet (e.g. a fresh VM after
+     * process death or re-navigation), so retry silently fell back to "now".
+     */
+    private fun onRetry() {
+        if (tripInfo == null) return
+        log("onRetry: immediate fetch, bypassing rate limiter")
+        // Show the loading screen right away.
+        updateUiState { copy(isLoading = true, isError = false) }
+        // Retry must hit the API IMMEDIATELY. Routing through fetchTrip()'s rateLimitFlow
+        // debounces the call against the shared 30s auto-refresh trigger, so the user could
+        // wait up to a full refresh interval before anything happens. Call loadTrip() directly.
+        fetchTripJob?.cancel()
+        fetchTripJob = viewModelScope.launch(ioDispatcher) {
+            updateUiState { copy(silentLoading = true) }
+            handleTripResult(loadTrip())
+        }
     }
 
     private fun onLoadTimeTable(trip: Trip) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
@@ -1,0 +1,75 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import kotlinx.collections.immutable.toImmutableList
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeString
+import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+
+/**
+ * Builds a [TimeTableState.JourneyCardInfo.Leg.WalkingLeg] for a walking leg, or null when the
+ * walking leg has no display duration or its footpath info is redundant.
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Leg.toWalkingLegUiModel(): TimeTableState.JourneyCardInfo.Leg? {
+    // duration can be null for some legs; resolveDurationSeconds() falls back to dep/arr times.
+    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
+    return if (displayDuration != null && footPathInfoRedundant != true) {
+        TimeTableState.JourneyCardInfo.Leg.WalkingLeg(duration = displayDuration)
+    } else {
+        null
+    }
+}
+
+/**
+ * Builds a [TimeTableState.JourneyCardInfo.Leg.TransportLeg] for a public transport leg, or null
+ * (and logs which field was null) when any required field is missing.
+ */
+@OptIn(ExperimentalTime::class)
+@Suppress("ComplexCondition")
+internal fun TripResponse.Leg.toTransportLegUiModel(): TimeTableState.JourneyCardInfo.Leg? {
+    val transportMode = transportation?.product?.productClass?.toInt()
+        ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
+    val lineName = transportation?.disassembledName
+    val displayText = NswTransportConfig.resolveServiceDisplayText(
+        productClass = transportation?.product?.productClass?.toInt(),
+        destinationName = transportation?.destination?.name,
+        description = transportation?.description,
+    )
+    val numberOfStops = stopSequence?.size
+    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
+    val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
+    val alerts = infos?.mapNotNull { it.toAlert() }?.toImmutableList()
+
+    if (transportMode == null || lineName == null || displayText == null ||
+        numberOfStops == null || stops == null || displayDuration == null
+    ) {
+        logError(
+            "Something is null - NOT adding Transport LEG: " +
+                "TransportMode: $transportMode, lineName: $lineName, displayText: $displayText, " +
+                "numberOfStops: $numberOfStops, stops: $stops, displayDuration: $displayDuration",
+        )
+        return null
+    }
+
+    return TimeTableState.JourneyCardInfo.Leg.TransportLeg(
+        transportModeLine = TransportModeLine(
+            transportMode = transportMode,
+            lineName = lineName,
+        ),
+        displayText = displayText,
+        totalDuration = displayDuration,
+        stops = stops,
+        serviceAlertList = alerts,
+        walkInterchange = footPathInfo?.firstOrNull()?.run {
+            duration?.seconds?.toFormattedDurationTimeString()
+                ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
+        },
+        tripId = transportation?.id + transportation?.properties?.realtimeTripId,
+        transportationId = transportation?.id,
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -17,7 +17,6 @@ import xyz.ksharma.krail.trip.planner.network.api.model.isWalkingLeg
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import kotlin.math.absoluteValue
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -162,65 +161,10 @@ private fun List<TripResponse.Leg>.getLegsList() = mapNotNull { it.toUiModel() }
 @OptIn(ExperimentalTime::class)
 private fun String.getTimeText() = toDepartureRelativeString()
 
-@OptIn(ExperimentalTime::class)
-@Suppress("ComplexCondition", "CyclomaticComplexMethod")
-private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? {
-    val transportMode =
-        transportation?.product?.productClass?.toInt()
-            ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
-    val lineName = transportation?.disassembledName
-
-    val displayText = NswTransportConfig.resolveServiceDisplayText(
-        productClass = transportation?.product?.productClass?.toInt(),
-        destinationName = transportation?.destination?.name,
-        description = transportation?.description,
-    )
-    val numberOfStops = stopSequence?.size
-    // duration can be null for some legs (e.g. first bus leg in a multi-leg journey).
-    // Fall back to calculating duration from departure/arrival times via resolveDurationSeconds().
-    val displayDuration = resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
-    val stops = stopSequence?.mapNotNull { it.toUiModel() }?.toImmutableList()
-    val alerts = infos?.mapNotNull { it.toAlert() }?.toImmutableList()
-
-    return when {
-        // Walking Leg - Always check before public transport leg
-        isWalkingLeg() -> if (displayDuration != null && this.footPathInfoRedundant != true) {
-            TimeTableState.JourneyCardInfo.Leg.WalkingLeg(duration = displayDuration)
-        } else {
-            null
-        }
-
-        else -> { // Public Transport Leg
-            if (transportMode != null && lineName != null && displayText != null &&
-                numberOfStops != null && stops != null && displayDuration != null
-            ) {
-                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
-                    transportModeLine = TransportModeLine(
-                        transportMode = transportMode,
-                        lineName = lineName,
-                    ),
-                    displayText = displayText,
-                    totalDuration = displayDuration,
-                    stops = stops,
-                    serviceAlertList = alerts,
-                    walkInterchange = footPathInfo?.firstOrNull()?.run {
-                        duration?.seconds?.toFormattedDurationTimeString()
-                            ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
-                    },
-                    tripId = transportation?.id + transportation?.properties?.realtimeTripId,
-                    transportationId = transportation?.id,
-                )
-            } else {
-                logError(
-                    "Something is null - NOT adding Transport LEG: " +
-                        "TransportMode: $transportMode, lineName: $lineName, displayText: $displayText, " +
-                        "numberOfStops: $numberOfStops, stops: $stops, displayDuration: $displayDuration",
-                )
-                null
-            }
-        }
-    }
-}
+private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? =
+    // Walking Leg - Always check before public transport leg. Both builders compute their
+    // own fields from this leg; see TripResponseLegMapper.kt.
+    if (isWalkingLeg()) toWalkingLegUiModel() else toTransportLegUiModel()
 
 /**
  * Resolves the duration of a leg in seconds.
@@ -280,7 +224,7 @@ internal fun TripResponse.FootPathInfo.toWalkInterchange(
     }
 }
 
-private fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInfo.Stop? {
+internal fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInfo.Stop? {
     val stopName = disassembledName ?: name
     // For last leg there is no departure time, so using arrival time
     // For first leg there is no arrival time, so using departure time.

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -29,6 +29,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -784,6 +785,37 @@ class TimeTableViewModelTest {
             assertEquals(initialUnselectedModes, viewModel.uiState.value.unselectedModes)
             assertTrue((fakeAnalytics as FakeAnalytics).isEventTracked("mode_selection_done"))
         }
+
+    @Test
+    fun `GIVEN train-only journeys WHEN Train is de-selected THEN journeys are filtered out client-side and emptyDueToModeFilter is true`() =
+        runTest {
+            // GIVEN a loaded trip — the fake builder returns train-only journeys (productClass 1).
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2"
+            )
+            tripPlanningService.isSuccess = true
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.journeyList.isNotEmpty())
+            assertFalse(viewModel.uiState.value.emptyDueToModeFilter)
+
+            // WHEN Train (productClass 1) is de-selected and the trip re-fetches. The NSW API
+            // still returns train journeys, so the client-side filter must drop them.
+            viewModel.onEvent(TimeTableUiEvent.ModeSelectionChanged(setOf(1)))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            // THEN all train journeys are filtered out and the mode-specific empty hint is set.
+            viewModel.uiState.value.run {
+                assertTrue(journeyList.isEmpty())
+                assertTrue(emptyDueToModeFilter)
+                assertFalse(isError)
+            }
+        }
     // endregion
 
     // region Test for ShareJourneyClicked
@@ -1234,6 +1266,39 @@ class TimeTableViewModelTest {
 
             assertEquals("0915", tripPlanningService.lastCalledTime)
             assertNotNull(tripPlanningService.lastCalledDate)
+        }
+
+    @Test
+    fun `GIVEN a selected Arrive-by time WHEN Retry is clicked THEN the re-fetch keeps that time`() =
+        runTest {
+            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
+
+            @OptIn(ExperimentalTime::class)
+            val selection = DateTimeSelectionItem(
+                date = Clock.System.now().toLocalDateTime(currentSystemDefault()).date,
+                option = JourneyTimeOptions.ARRIVE,
+                hour = 9,
+                minute = 15,
+            )
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(selection))
+
+            // First fetch fails -> error screen.
+            tripPlanningService.isSuccess = false
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.isError)
+
+            // WHEN Retry is clicked
+            tripPlanningService.isSuccess = true
+            viewModel.onEvent(TimeTableUiEvent.RetryButtonClicked)
+            advanceUntilIdle()
+
+            // THEN the retried request keeps the selected Arrive-by time, not "now".
+            assertEquals("0915", tripPlanningService.lastCalledTime)
+            assertEquals(DepArr.ARR, tripPlanningService.lastCalledDepArr)
+            assertNotNull(viewModel.dateTimeSelectionItem)
         }
 
     // endregion


### PR DESCRIPTION
Squashes the timetable work: filter de-selected transport modes on the client,
retry preserves the selected Leave/Arrive time, retry calls the API immediately
(bypassing the auto-refresh rate limiter), plus the mapper extractions that cut
TimeTableViewModel / TripResponseMapper complexity below the detekt threshold.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>