### PR TITLE
fix(maps): center journey-map permission banner, drop freshness badge

### DIFF
--- a/core/maps/ui/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/ui/components/LocationPermissionBanner.kt
+++ b/core/maps/ui/src/commonMain/kotlin/xyz/ksharma/krail/core/maps/ui/components/LocationPermissionBanner.kt
@@ -32,6 +32,10 @@ fun LocationPermissionBanner(
     modifier: Modifier = Modifier,
 ) {
     Box(
+        // No window-inset padding here: the pill is positioned by the call site
+        // (ornamentTopPadding already clears the search bar / status bar in every pane and
+        // orientation). Adding statusBarsPadding here double-counted the status bar — fine in
+        // landscape where the top inset is ~0, but a large gap in portrait.
         modifier = modifier
             .clip(RoundedCornerShape(24.dp))
             .background(color = KrailTheme.colors.surface.copy(alpha = 0.9f))
@@ -40,7 +44,7 @@ fun LocationPermissionBanner(
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "Location off, tap to open Settings",
+            text = "Location permission required",
             style = KrailTheme.typography.bodySmall,
             color = KrailTheme.colors.onSurface,
         )

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
@@ -113,7 +113,7 @@ internal fun DepartureMonitorResponse.StopEvent.toStopDeparture(): StopDeparture
 //     return the raw platform code only  (e.g. "F1").
 //   unknown:
 //     try regex on platformName, then disassembledName.
-@Suppress("MagicNumber", "CyclomaticComplexMethod")
+@Suppress("MagicNumber")
 private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: Int?): String? {
     // Without a parent, this location IS the stop itself — no platform sub-label.
     parent ?: return null
@@ -127,29 +127,12 @@ private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: 
         TransportMode.Train.productClass,
         TransportMode.Metro.productClass,
         TransportMode.Coach.productClass,
-        -> {
-            if (pName != null && pName != pCode) {
-                // Normal case: "Platform 17", "Platform 26"
-                extractPlatformText(pName)
-            } else if (pCode != null) {
-                // Bad case: platformName == "THL6" → derive "Platform 6" from code
-                val num = Regex("\\d+").find(pCode)?.value
-                num?.let { "Platform $it" }
-            } else {
-                // No properties at all — fall back to regex on disassembledName
-                disassembledName?.let { extractPlatformText(it) }
-            }
-        }
+        -> resolveNumberedPlatform(pName, pCode, disassembledName)
 
         // ── Light Rail (4) ───────────────────────────────────────────────────────
         // Show code AND name: "LR1 · Central Chalmers Street Light Rail"
         // If the platform field is absent, just show the name.
-        TransportMode.LightRail.productClass -> when {
-            pCode != null && pName != null && pCode != pName -> "$pCode · $pName"
-            pName != null -> pName
-            pCode != null -> pCode
-            else -> null
-        }
+        TransportMode.LightRail.productClass -> resolveLightRailPlatform(pName, pCode)
 
         // ── Bus (5), School Bus (11) ─────────────────────────────────────────────
         // Extract "Stand X" from compound platformName:
@@ -162,10 +145,38 @@ private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: 
         TransportMode.Ferry.productClass -> pCode
 
         // ── Unknown / fallback ───────────────────────────────────────────────────
-        else -> pName?.let { extractPlatformText(it) ?: it }
-            ?: disassembledName?.let { extractPlatformText(it) }
+        else -> resolveFallbackPlatform(pName, disassembledName)
     }
 }
+
+// Train / Metro / Coach: prefer "Platform N" name, else derive number from a code that
+// echoes the raw API value, else fall back to regex on disassembledName.
+@Suppress("MagicNumber")
+private fun resolveNumberedPlatform(pName: String?, pCode: String?, disassembledName: String?): String? =
+    if (pName != null && pName != pCode) {
+        // Normal case: "Platform 17", "Platform 26"
+        extractPlatformText(pName)
+    } else if (pCode != null) {
+        // Bad case: platformName == "THL6" → derive "Platform 6" from code
+        val num = Regex("\\d+").find(pCode)?.value
+        num?.let { "Platform $it" }
+    } else {
+        // No properties at all — fall back to regex on disassembledName
+        disassembledName?.let { extractPlatformText(it) }
+    }
+
+// Light Rail: show code AND name when both present and differ, else whichever exists.
+private fun resolveLightRailPlatform(pName: String?, pCode: String?): String? = when {
+    pCode != null && pName != null && pCode != pName -> "$pCode · $pName"
+    pName != null -> pName
+    pCode != null -> pCode
+    else -> null
+}
+
+// Unknown mode: try regex on platformName (keep raw on miss), then disassembledName.
+private fun resolveFallbackPlatform(pName: String?, disassembledName: String?): String? =
+    pName?.let { extractPlatformText(it) ?: it }
+        ?: disassembledName?.let { extractPlatformText(it) }
 
 // Resolves the hex colour for a line badge via NswTransportConfig:
 // line-specific lookup first, then product-class fallback, then Bus colour.

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMapper.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMapper.kt
@@ -12,13 +12,11 @@ import xyz.ksharma.krail.core.transport.nsw.NswTransportLine
 import xyz.ksharma.krail.feature.track.DepartureDeviation
 import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
 import xyz.ksharma.krail.feature.track.TrackedLeg
-import xyz.ksharma.krail.feature.track.TrackedStop
 import xyz.ksharma.krail.feature.track.TripDeepLink
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.departureDeviationMinutes
 import xyz.ksharma.krail.trip.planner.network.api.model.isWalkingLeg
 import kotlin.math.absoluteValue
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -46,7 +44,6 @@ internal object TripResponseMapper {
      * (rather than restructuring it), this function returns null and the state transitions
      * to [xyz.ksharma.krail.feature.track.TrackTripState.NotFound].
      */
-    @Suppress("CyclomaticComplexMethod")
     @OptIn(ExperimentalTime::class)
     fun TripResponse.findMatchingJourney(deepLink: TripDeepLink): TripResponse.Journey? {
         val deepLinkInstant = runCatching { Instant.parse(deepLink.departureUtcDateTime) }.getOrNull()
@@ -57,29 +54,7 @@ internal object TripResponseMapper {
         )
 
         val match = journeys?.firstOrNull { journey ->
-            val publicLegs = journey.legs
-                ?.filter { it.transportation != null && !it.isWalkingLeg() }
-                ?: return@firstOrNull false
-
-            val legIds = publicLegs.mapNotNull { it.transportation?.id }
-            val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
-
-            // All deep-link transportation IDs must appear in the journey legs.
-            val idsMatch = deepLink.legs.all { dl -> legIds.contains(dl.transportationId) }
-            if (!idsMatch) return@firstOrNull false
-
-            // Departure time: parse both as Instant so string-format differences don't break the
-            // match (e.g. "2026-04-22T22:35:00Z" vs "2026-04-22T22:35:00.000Z").
-            // Allow 60 s tolerance for any minor rounding in the API response.
-            val timeMatch = if (deepLinkInstant != null && firstDep != null) {
-                val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
-                legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
-            } else {
-                firstDep == deepLink.departureUtcDateTime
-            }
-
-            log("TrackTrip:   journey ids=$legIds firstDep=$firstDep → idsMatch=$idsMatch timeMatch=$timeMatch")
-            timeMatch
+            journey.matchesDeepLinkStrict(deepLink, deepLinkInstant)
         }
 
         if (match != null) {
@@ -96,28 +71,7 @@ internal object TripResponseMapper {
         // and terminating at the same destination are the same trip, just restructured.
         log("TrackTrip: findMatchingJourney — strict match failed, trying fallback (time + destination)")
         val fallback = journeys?.firstOrNull { journey ->
-            val publicLegs = journey.legs
-                ?.filter { it.transportation != null && !it.isWalkingLeg() }
-                ?: return@firstOrNull false
-
-            val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
-            val lastDestId = publicLegs.lastOrNull()?.destination?.parent?.id
-                ?: publicLegs.lastOrNull()?.destination?.id
-
-            val timeMatch = if (deepLinkInstant != null && firstDep != null) {
-                val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
-                legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
-            } else {
-                false
-            }
-
-            val destMatch = lastDestId == deepLink.toStopId
-
-            log(
-                "TrackTrip:   fallback journey firstDep=$firstDep " +
-                    "lastDestId=$lastDestId → time=$timeMatch dest=$destMatch",
-            )
-            timeMatch && destMatch
+            journey.matchesDeepLinkFallback(deepLink, deepLinkInstant)
         }
 
         if (fallback == null) {
@@ -174,7 +128,6 @@ internal object TripResponseMapper {
         )
     }
 
-    @Suppress("CyclomaticComplexMethod")
     fun TripResponse.Leg.toTrackedTransportLeg(): TrackedLeg.Transport? {
         val productClass = transportation?.product?.productClass?.toInt() ?: return null
         val mode = NswTransportConfig.modeFromProductClass(productClass) ?: return null
@@ -183,23 +136,7 @@ internal object TripResponseMapper {
             ?: mode.colorCode
 
         val stops = stopSequence?.mapNotNull { stop ->
-            val name = stop.disassembledName ?: stop.name ?: return@mapNotNull null
-            val scheduledUtc = stop.departureTimePlanned ?: stop.arrivalTimePlanned
-            val estimatedUtc = stop.departureTimeEstimated ?: stop.arrivalTimeEstimated
-            val timeUtc = estimatedUtc ?: scheduledUtc ?: return@mapNotNull null
-            TrackedStop(
-                stopId = stop.id.orEmpty(),
-                name = name,
-                scheduledTime = (scheduledUtc ?: timeUtc).utcToDisplayTime(),
-                estimatedTime = estimatedUtc
-                    ?.takeIf { it != scheduledUtc }
-                    ?.utcToDisplayTime(),
-                utcTime = timeUtc,
-                scheduledUtcTime = scheduledUtc ?: timeUtc,
-                // API coord is [latitude, longitude]
-                lat = stop.coord?.getOrNull(0),
-                lon = stop.coord?.getOrNull(1),
-            )
+            stop.toTrackedStop()
         }?.toImmutableList() ?: return null
 
         val routePathCoordinates = coords

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMatchers.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripResponseMatchers.kt
@@ -1,0 +1,104 @@
+package xyz.ksharma.krail.feature.track.ui
+
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.feature.track.TrackedStop
+import xyz.ksharma.krail.feature.track.TripDeepLink
+import xyz.ksharma.krail.feature.track.ui.TripResponseMapper.utcToDisplayTime
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.network.api.model.isWalkingLeg
+import kotlin.math.absoluteValue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Strict deep-link match: all deep-link transportation IDs must appear in the journey legs
+ * AND the first leg's planned departure must match the deep link's departure time (±60 s).
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Journey.matchesDeepLinkStrict(
+    deepLink: TripDeepLink,
+    deepLinkInstant: Instant?,
+): Boolean {
+    val publicLegs = legs
+        ?.filter { it.transportation != null && !it.isWalkingLeg() }
+        ?: return false
+
+    val legIds = publicLegs.mapNotNull { it.transportation?.id }
+    val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
+
+    // All deep-link transportation IDs must appear in the journey legs.
+    val idsMatch = deepLink.legs.all { dl -> legIds.contains(dl.transportationId) }
+    if (!idsMatch) return false
+
+    // Departure time: parse both as Instant so string-format differences don't break the
+    // match (e.g. "2026-04-22T22:35:00Z" vs "2026-04-22T22:35:00.000Z").
+    // Allow 60 s tolerance for any minor rounding in the API response.
+    val timeMatch = if (deepLinkInstant != null && firstDep != null) {
+        val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
+        legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
+    } else {
+        firstDep == deepLink.departureUtcDateTime
+    }
+
+    log("TrackTrip:   journey ids=$legIds firstDep=$firstDep → idsMatch=$idsMatch timeMatch=$timeMatch")
+    return timeMatch
+}
+
+/**
+ * Fallback deep-link match when TfNSW restructures a service mid-disruption and the original
+ * leg IDs no longer appear. Matches only by departure time (±60 s) from the same origin and
+ * the same destination stop parent ID.
+ */
+@OptIn(ExperimentalTime::class)
+internal fun TripResponse.Journey.matchesDeepLinkFallback(
+    deepLink: TripDeepLink,
+    deepLinkInstant: Instant?,
+): Boolean {
+    val publicLegs = legs
+        ?.filter { it.transportation != null && !it.isWalkingLeg() }
+        ?: return false
+
+    val firstDep = publicLegs.firstOrNull()?.origin?.departureTimePlanned
+    val lastDestId = publicLegs.lastOrNull()?.destination?.parent?.id
+        ?: publicLegs.lastOrNull()?.destination?.id
+
+    val timeMatch = if (deepLinkInstant != null && firstDep != null) {
+        val legInstant = runCatching { Instant.parse(firstDep) }.getOrNull()
+        legInstant != null && (legInstant - deepLinkInstant).absoluteValue < 60.seconds
+    } else {
+        false
+    }
+
+    val destMatch = lastDestId == deepLink.toStopId
+
+    log(
+        "TrackTrip:   fallback journey firstDep=$firstDep " +
+            "lastDestId=$lastDestId → time=$timeMatch dest=$destMatch",
+    )
+    return timeMatch && destMatch
+}
+
+/**
+ * Maps a single API stop in a leg's stop sequence into a [TrackedStop], or null when the stop
+ * lacks a usable name or time.
+ */
+internal fun TripResponse.StopSequence.toTrackedStop(): TrackedStop? {
+    val name = disassembledName ?: name ?: return null
+    val scheduledUtc = departureTimePlanned ?: arrivalTimePlanned
+    val estimatedUtc = departureTimeEstimated ?: arrivalTimeEstimated
+    val timeUtc = estimatedUtc ?: scheduledUtc ?: return null
+    return TrackedStop(
+        stopId = id.orEmpty(),
+        name = name,
+        scheduledTime = (scheduledUtc ?: timeUtc).utcToDisplayTime(),
+        estimatedTime = estimatedUtc
+            ?.takeIf { it != scheduledUtc }
+            ?.utcToDisplayTime(),
+        utcTime = timeUtc,
+        scheduledUtcTime = scheduledUtc ?: timeUtc,
+        // API coord is [latitude, longitude]
+        lat = coord?.getOrNull(0),
+        lon = coord?.getOrNull(1),
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardBody.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/DepartureBoardBody.kt
@@ -1,4 +1,4 @@
-@file:Suppress("MagicNumber", "CyclomaticComplexMethod")
+@file:Suppress("MagicNumber")
 
 package xyz.ksharma.krail.trip.planner.ui.components
 
@@ -19,8 +19,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.departures.ui.state.DeparturesState
+import xyz.ksharma.krail.departures.ui.state.model.StopDeparture
 import xyz.ksharma.krail.taj.components.AnimatedDots
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextButton
@@ -96,95 +98,142 @@ internal fun DepartureBoardBody(
 
             state.isError -> DeparturesErrorContent(onRetry = onRetry)
 
-            else -> {
-                if (state.departures.isNotEmpty()) {
-                    LinesServedRow(
-                        departures = state.departures,
-                        selectedLine = selectedLine,
-                        onLineSelect = { newLine ->
-                            // Capture the previously selected line BEFORE updating state so
-                            // we can report it when the filter is being cleared (deselected).
-                            val previousLine = selectedLine
-                            selectedLineKey = newLine ?: ""
-                            val affectedLine = newLine ?: previousLine
-                            val transportMode = affectedLine?.let { line ->
-                                state.departures.firstOrNull { it.lineNumber == line }?.transportModeName
-                            }
-                            onLineFilterChange?.invoke(affectedLine, transportMode, newLine != null)
-                        },
-                    )
-                }
-
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = dim.spacingM, bottom = dim.spacingL),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    TextButton(
-                        onClick = {
-                            showPrevious = !showPrevious
-                            onShowPreviousToggle?.invoke(showPrevious)
-                            if (showPrevious &&
-                                state.previousDepartures.isEmpty() &&
-                                !state.isPreviousLoading
-                            ) {
-                                previousRequested = true
-                                onLoadPreviousDepartures()
-                            }
-                        },
+            else -> DepartureBoardSuccessContent(
+                state = state,
+                selectedLine = selectedLine,
+                showPrevious = showPrevious,
+                previousRequested = previousRequested,
+                filteredDepartures = filteredDepartures,
+                filteredPreviousDepartures = filteredPreviousDepartures,
+                maxItems = maxItems,
+                onLineSelect = { newLine ->
+                    // Capture the previously selected line BEFORE updating state so
+                    // we can report it when the filter is being cleared (deselected).
+                    val previousLine = selectedLine
+                    selectedLineKey = newLine ?: ""
+                    val affectedLine = newLine ?: previousLine
+                    val transportMode = affectedLine?.let { line ->
+                        state.departures.firstOrNull { it.lineNumber == line }?.transportModeName
+                    }
+                    onLineFilterChange?.invoke(affectedLine, transportMode, newLine != null)
+                },
+                onTogglePrevious = {
+                    showPrevious = !showPrevious
+                    onShowPreviousToggle?.invoke(showPrevious)
+                    if (showPrevious &&
+                        state.previousDepartures.isEmpty() &&
+                        !state.isPreviousLoading
                     ) {
-                        Text(
-                            text = if (showPrevious) {
-                                "Hide previous departures"
-                            } else {
-                                "Show previous departures"
-                            },
-                        )
+                        previousRequested = true
+                        onLoadPreviousDepartures()
                     }
-                }
-
-                when {
-                    // Previous fetch in-flight (or requested but not yet acknowledged) —
-                    // show inline loader above any upcoming departures.
-                    showPrevious && (state.isPreviousLoading || previousRequested) -> {
-                        DepartureBoardLoadingContent()
-                        when {
-                            filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
-                            else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
-                        }
-                    }
-
-                    // Previous fetched but none match the current filter —
-                    // show message then the upcoming list.
-                    showPrevious && filteredPreviousDepartures.isEmpty() -> {
-                        Text(
-                            text = "No previous departures in the last ${state.previousWindowMinutes} minutes.",
-                            style = KrailTheme.typography.bodyMedium,
-                            color = KrailTheme.colors.softLabel,
-                            modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingL),
-                        )
-                        when {
-                            filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
-                            else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
-                        }
-                    }
-
-                    // Previous + upcoming combined as one unified list with date labels.
-                    showPrevious -> DepartureRowList(
-                        departures = remember(filteredPreviousDepartures, filteredDepartures) {
-                            (filteredPreviousDepartures + filteredDepartures).toImmutableList()
-                        },
-                        maxItems = maxItems,
-                    )
-
-                    state.departures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = false)
-                    filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
-                    else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
-                }
-            }
+                },
+            )
         }
         Spacer(modifier = Modifier.height(dim.spacingM))
+    }
+}
+
+@Composable
+private fun DepartureBoardSuccessContent(
+    state: DeparturesState,
+    selectedLine: String?,
+    showPrevious: Boolean,
+    previousRequested: Boolean,
+    filteredDepartures: ImmutableList<StopDeparture>,
+    filteredPreviousDepartures: ImmutableList<StopDeparture>,
+    maxItems: Int?,
+    onLineSelect: (String?) -> Unit,
+    onTogglePrevious: () -> Unit,
+) {
+    val dim = KrailTheme.dimensions
+    if (state.departures.isNotEmpty()) {
+        LinesServedRow(
+            departures = state.departures,
+            selectedLine = selectedLine,
+            onLineSelect = onLineSelect,
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = dim.spacingM, bottom = dim.spacingL),
+        contentAlignment = Alignment.Center,
+    ) {
+        TextButton(onClick = onTogglePrevious) {
+            Text(
+                text = if (showPrevious) {
+                    "Hide previous departures"
+                } else {
+                    "Show previous departures"
+                },
+            )
+        }
+    }
+
+    DepartureBoardDeparturesSection(
+        state = state,
+        showPrevious = showPrevious,
+        previousRequested = previousRequested,
+        filteredDepartures = filteredDepartures,
+        filteredPreviousDepartures = filteredPreviousDepartures,
+        maxItems = maxItems,
+    )
+}
+
+@Composable
+private fun DepartureBoardDeparturesSection(
+    state: DeparturesState,
+    showPrevious: Boolean,
+    previousRequested: Boolean,
+    filteredDepartures: ImmutableList<StopDeparture>,
+    filteredPreviousDepartures: ImmutableList<StopDeparture>,
+    maxItems: Int?,
+) {
+    val dim = KrailTheme.dimensions
+    when {
+        // Previous fetch in-flight (or requested but not yet acknowledged) —
+        // show inline loader above any upcoming departures.
+        showPrevious && (state.isPreviousLoading || previousRequested) -> {
+            DepartureBoardLoadingContent()
+            UpcomingDeparturesOrEmpty(filteredDepartures = filteredDepartures, maxItems = maxItems)
+        }
+
+        // Previous fetched but none match the current filter —
+        // show message then the upcoming list.
+        showPrevious && filteredPreviousDepartures.isEmpty() -> {
+            Text(
+                text = "No previous departures in the last ${state.previousWindowMinutes} minutes.",
+                style = KrailTheme.typography.bodyMedium,
+                color = KrailTheme.colors.softLabel,
+                modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingL),
+            )
+            UpcomingDeparturesOrEmpty(filteredDepartures = filteredDepartures, maxItems = maxItems)
+        }
+
+        // Previous + upcoming combined as one unified list with date labels.
+        showPrevious -> DepartureRowList(
+            departures = remember(filteredPreviousDepartures, filteredDepartures) {
+                (filteredPreviousDepartures + filteredDepartures).toImmutableList()
+            },
+            maxItems = maxItems,
+        )
+
+        state.departures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = false)
+        filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
+        else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
+    }
+}
+
+@Composable
+private fun UpcomingDeparturesOrEmpty(
+    filteredDepartures: ImmutableList<StopDeparture>,
+    maxItems: Int?,
+) {
+    when {
+        filteredDepartures.isEmpty() -> DepartureBoardEmptyContent(hasActiveFilter = true)
+        else -> DepartureRowList(departures = filteredDepartures, maxItems = maxItems)
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegTimeline.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegTimeline.kt
@@ -1,0 +1,202 @@
+package xyz.ksharma.krail.trip.planner.ui.components
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import xyz.ksharma.krail.feature.track.TrackedStop
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Shared per-stop colours/radii/segment data computed once in [TrackedLegView] and threaded
+ * through the timeline section composables. Keeping this immutable holder out of the big
+ * composable keeps each section's branching local to its own function.
+ */
+@Suppress("LongParameterList")
+internal class TrackedLegTimeline(
+    val currentStopIndex: Int?,
+    val currentSegmentFraction: Float?,
+    val nextStopIndex: Int?,
+    val pulseScale: Float,
+    val lineColor: Color,
+    val pendingColor: Color,
+    val circleRadius: Dp,
+    val strokeWidth: Dp,
+) {
+    // A segment starting at fromIdx is "completed" when the vehicle has left that stop.
+    // Using >= so the current stop's BELOW line also flows in lineColor, matching the split spacer.
+    fun segmentColor(fromIdx: Int): Color = when {
+        currentStopIndex == null -> pendingColor
+        currentStopIndex >= fromIdx -> lineColor
+        else -> pendingColor
+    }
+
+    fun stopCircleColor(stopIdx: Int): Color = when {
+        currentStopIndex == null -> pendingColor
+        stopIdx <= currentStopIndex -> lineColor
+        else -> pendingColor
+    }
+
+    fun stopCircleRadius(stopIdx: Int): Dp =
+        if (currentStopIndex == stopIdx) circleRadius * pulseScale else circleRadius
+
+    fun isActiveSegment(fromIdx: Int): Boolean =
+        currentStopIndex == fromIdx && currentSegmentFraction != null
+}
+
+@OptIn(ExperimentalTime::class)
+internal fun approachingText(effective: Instant?, now: Instant): String? {
+    val stopInstant = effective ?: return null
+    val secs = (stopInstant - now).inWholeSeconds
+    return when {
+        secs <= 0L -> "arriving now"
+        secs < SECONDS_PER_MINUTE -> "in ${secs}s"
+        else -> {
+            val mins = secs / SECONDS_PER_MINUTE
+            val rem = secs % SECONDS_PER_MINUTE
+            if (rem > 0L) "in ${mins}m ${rem}s" else "in ${mins}m"
+        }
+    }
+}
+
+@Composable
+internal fun TrackedLegFirstStop(
+    timeline: TrackedLegTimeline,
+    firstStop: TrackedStop,
+    isArrived: Boolean,
+) {
+    val dim = KrailTheme.dimensions
+    TrackedStopRow(
+        time = firstStop.estimatedTime ?: firstStop.scheduledTime,
+        scheduledTime = firstStop.estimatedTime?.let { firstStop.scheduledTime },
+        stopName = firstStop.name,
+        isPast = timeline.currentStopIndex != null,
+        isApproaching = false,
+        isArrived = isArrived,
+        lineColor = timeline.lineColor,
+        modifier = Modifier
+            .timeLineTop(
+                color = timeline.segmentColor(0),
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(0),
+                circleColor = timeline.stopCircleColor(0),
+            )
+            .padding(start = dim.spacingXL),
+    )
+
+    TrackedLegSegmentSpacer(timeline = timeline, fromIdx = 0, collapsedHeight = dim.spacingL)
+}
+
+@Composable
+internal fun TrackedLegIntermediateStop(
+    timeline: TrackedLegTimeline,
+    stop: TrackedStop,
+    stopIdx: Int,
+    isArrived: Boolean,
+    approachingTimeText: String?,
+) {
+    val dim = KrailTheme.dimensions
+    val isPast = timeline.currentStopIndex != null && stopIdx <= timeline.currentStopIndex
+    val isApproaching = stopIdx == timeline.nextStopIndex
+
+    // The approaching stop's ABOVE line must be pendingColor so it connects
+    // flush with the split spacer's pendingColor tail, not a jarring lineColor flash.
+    val aboveColor =
+        if (isApproaching) timeline.pendingColor else timeline.segmentColor(stopIdx - 1)
+
+    TrackedStopRow(
+        time = stop.estimatedTime ?: stop.scheduledTime,
+        scheduledTime = stop.estimatedTime?.let { stop.scheduledTime },
+        stopName = stop.name,
+        isPast = isPast,
+        isApproaching = isApproaching,
+        isArrived = isArrived,
+        lineColor = timeline.lineColor,
+        approachingTimeText = if (isApproaching) approachingTimeText else null,
+        modifier = Modifier
+            .timeLineCenterWithStop(
+                color = aboveColor,
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(stopIdx),
+                circleColor = timeline.stopCircleColor(stopIdx),
+            )
+            .timeLineTop(
+                color = timeline.segmentColor(stopIdx),
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(stopIdx),
+                circleColor = timeline.stopCircleColor(stopIdx),
+            )
+            .padding(start = dim.spacingXL),
+    )
+
+    TrackedLegSegmentSpacer(timeline = timeline, fromIdx = stopIdx, collapsedHeight = dim.spacingXL)
+}
+
+@Composable
+internal fun TrackedLegLastStop(
+    timeline: TrackedLegTimeline,
+    lastStop: TrackedStop,
+    lastIdx: Int,
+    isArrived: Boolean,
+    approachingTimeText: String?,
+) {
+    val dim = KrailTheme.dimensions
+    val isLastApproaching = lastIdx == timeline.nextStopIndex
+    // Same rule: if last stop is approaching, its incoming line must be pendingColor.
+    val lastIncomingColor =
+        if (isLastApproaching) timeline.pendingColor else timeline.segmentColor(lastIdx - 1)
+    TrackedStopRow(
+        time = lastStop.estimatedTime ?: lastStop.scheduledTime,
+        scheduledTime = lastStop.estimatedTime?.let { lastStop.scheduledTime },
+        stopName = lastStop.name,
+        isPast = timeline.currentStopIndex != null && lastIdx <= timeline.currentStopIndex,
+        isApproaching = isLastApproaching,
+        isArrived = isArrived,
+        isDestination = true,
+        lineColor = timeline.lineColor,
+        approachingTimeText = if (isLastApproaching) approachingTimeText else null,
+        modifier = Modifier
+            .timeLineBottom(
+                color = lastIncomingColor,
+                strokeWidth = timeline.strokeWidth,
+                circleRadius = timeline.stopCircleRadius(lastIdx),
+                circleColor = timeline.stopCircleColor(lastIdx),
+            )
+            .padding(start = dim.spacingXL),
+    )
+}
+
+@Composable
+private fun TrackedLegSegmentSpacer(
+    timeline: TrackedLegTimeline,
+    fromIdx: Int,
+    collapsedHeight: Dp,
+) {
+    val dim = KrailTheme.dimensions
+    if (timeline.isActiveSegment(fromIdx)) {
+        Spacer(
+            modifier = Modifier.height(dim.spacingXL)
+                .timeLineCenterSplit(
+                    completedColor = timeline.lineColor,
+                    pendingColor = timeline.pendingColor,
+                    strokeWidth = timeline.strokeWidth,
+                    fraction = timeline.currentSegmentFraction ?: 0f,
+                ),
+        )
+    } else {
+        Spacer(
+            modifier = Modifier.height(collapsedHeight)
+                .timeLineCenter(
+                    color = timeline.segmentColor(fromIdx),
+                    strokeWidth = timeline.strokeWidth,
+                ),
+        )
+    }
+}
+
+private const val SECONDS_PER_MINUTE = 60L

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TrackedLegView.kt
@@ -9,9 +9,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.core.transport.TransportMode
@@ -38,7 +35,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-@Suppress("CyclomaticComplexMethod")
 @OptIn(ExperimentalTime::class)
 @Composable
 internal fun TrackedLegView(
@@ -49,40 +45,28 @@ internal fun TrackedLegView(
     stopDelays: Map<String, Int> = emptyMap(),
 ) {
     val dim = KrailTheme.dimensions
-    val circleRadius = dim.spacingM
-    val strokeWidth = dim.strokeThick
     val lineColor = remember(leg.lineColorCode) { leg.lineColorCode.hexToComposeColor() }
     val pendingColor = KrailTheme.colors.softLabel
 
-    // Compute the authoritative real-time instant for a stop.
-    // When GTFS-RT delay is available, apply it to the scheduled time — this is the most
-    // up-to-date signal between trip API re-polls. Falls back to the trip API estimated time.
-    fun effectiveInstant(stop: TrackedStop): Instant? {
-        val delay = stopDelays[stop.stopId]
-        return if (delay != null) {
-            runCatching {
-                Instant.parse(stop.scheduledUtcTime) + delay.seconds
-            }.getOrNull()
-        } else {
-            runCatching { Instant.parse(stop.utcTime) }.getOrNull()
-        }
+    val effectiveInstants: List<Instant?> = remember(leg.stops, stopDelays) {
+        leg.stops.map { stop -> effectiveInstant(stop, stopDelays) }
     }
 
     // Last stop index whose real-time adjusted arrival is <= now.
     // Using GTFS-RT delay means we only advance past a stop when the API confirms it.
-    val currentStopIndex: Int? = remember(leg.stops, stopDelays, now) {
-        leg.stops.indexOfLast { stop ->
-            (effectiveInstant(stop) ?: return@indexOfLast false) <= now
+    val currentStopIndex: Int? = remember(effectiveInstants, now) {
+        effectiveInstants.indexOfLast { instant ->
+            (instant ?: return@indexOfLast false) <= now
         }.takeIf { it >= 0 }
     }
 
     // How far (0..1) through the active segment (from currentStopIndex to currentStopIndex+1)
-    val currentSegmentFraction: Float? = remember(currentStopIndex, stopDelays, now) {
+    val currentSegmentFraction: Float? = remember(currentStopIndex, effectiveInstants, now) {
         currentStopIndex?.let { idx ->
             val nextIdx = idx + 1
-            if (nextIdx < leg.stops.size) {
-                val prev = effectiveInstant(leg.stops[idx])
-                val next = effectiveInstant(leg.stops[nextIdx])
+            if (nextIdx < effectiveInstants.size) {
+                val prev = effectiveInstants[idx]
+                val next = effectiveInstants[nextIdx]
                 if (prev != null && next != null) {
                     val total = (next - prev).inWholeMilliseconds.toFloat()
                     val elapsed = (now - prev).inWholeMilliseconds.toFloat()
@@ -109,39 +93,16 @@ internal fun TrackedLegView(
         label = "pulseScale",
     )
 
-    // A segment starting at fromIdx is "completed" when the vehicle has left that stop
-    // Using >= so the current stop's BELOW line also flows in lineColor, matching the split spacer
-    fun segmentColor(fromIdx: Int): Color = when {
-        currentStopIndex == null -> pendingColor
-        currentStopIndex >= fromIdx -> lineColor
-        else -> pendingColor
-    }
-
-    fun stopCircleColor(stopIdx: Int): Color = when {
-        currentStopIndex == null -> pendingColor
-        stopIdx <= currentStopIndex -> lineColor
-        else -> pendingColor
-    }
-
-    fun stopCircleRadius(stopIdx: Int): Dp =
-        if (currentStopIndex == stopIdx) circleRadius * pulseScale else circleRadius
-
-    fun isActiveSegment(fromIdx: Int) =
-        currentStopIndex == fromIdx && currentSegmentFraction != null
-
-    fun approachingText(stop: TrackedStop): String? {
-        val stopInstant = effectiveInstant(stop) ?: return null
-        val secs = (stopInstant - now).inWholeSeconds
-        return when {
-            secs <= 0L -> "arriving now"
-            secs < 60L -> "in ${secs}s"
-            else -> {
-                val mins = secs / 60L
-                val rem = secs % 60L
-                if (rem > 0L) "in ${mins}m ${rem}s" else "in ${mins}m"
-            }
-        }
-    }
+    val timeline = TrackedLegTimeline(
+        currentStopIndex = currentStopIndex,
+        currentSegmentFraction = currentSegmentFraction,
+        nextStopIndex = nextStopIndex,
+        pulseScale = pulseScale,
+        lineColor = lineColor,
+        pendingColor = pendingColor,
+        circleRadius = dim.spacingM,
+        strokeWidth = dim.strokeThick,
+    )
 
     Column(modifier = modifier.fillMaxWidth()) {
         // Route header: badge + headsign
@@ -166,129 +127,54 @@ internal fun TrackedLegView(
 
         Column(modifier = Modifier.fillMaxWidth().padding(start = dim.spacingXS)) {
             // First stop (always prominent — origin)
-            val firstStop = leg.stops.first()
-            TrackedStopRow(
-                time = firstStop.estimatedTime ?: firstStop.scheduledTime,
-                scheduledTime = firstStop.estimatedTime?.let { firstStop.scheduledTime },
-                stopName = firstStop.name,
-                isPast = currentStopIndex != null,
-                isApproaching = false,
+            TrackedLegFirstStop(
+                timeline = timeline,
+                firstStop = leg.stops.first(),
                 isArrived = isArrived,
-                lineColor = lineColor,
-                modifier = Modifier
-                    .timeLineTop(
-                        color = segmentColor(0),
-                        strokeWidth = strokeWidth,
-                        circleRadius = stopCircleRadius(0),
-                        circleColor = stopCircleColor(0),
-                    )
-                    .padding(start = dim.spacingXL),
             )
-
-            if (isActiveSegment(0)) {
-                Spacer(
-                    modifier = Modifier.height(dim.spacingXL)
-                        .timeLineCenterSplit(
-                            completedColor = lineColor,
-                            pendingColor = pendingColor,
-                            strokeWidth = strokeWidth,
-                            fraction = currentSegmentFraction ?: 0f,
-                        ),
-                )
-            } else {
-                Spacer(
-                    modifier = Modifier.height(dim.spacingL)
-                        .timeLineCenter(color = segmentColor(0), strokeWidth = strokeWidth),
-                )
-            }
 
             // Intermediate stops
             leg.stops.drop(1).dropLast(1).forEachIndexed { idx, stop ->
                 val stopIdx = idx + 1
-                val isPast = currentStopIndex != null && stopIdx <= currentStopIndex
-                val isApproaching = stopIdx == nextStopIndex
-
-                // The approaching stop's ABOVE line must be pendingColor so it connects
-                // flush with the split spacer's pendingColor tail, not a jarring lineColor flash.
-                val aboveColor = if (isApproaching) pendingColor else segmentColor(stopIdx - 1)
-
-                TrackedStopRow(
-                    time = stop.estimatedTime ?: stop.scheduledTime,
-                    scheduledTime = stop.estimatedTime?.let { stop.scheduledTime },
-                    stopName = stop.name,
-                    isPast = isPast,
-                    isApproaching = isApproaching,
+                TrackedLegIntermediateStop(
+                    timeline = timeline,
+                    stop = stop,
+                    stopIdx = stopIdx,
                     isArrived = isArrived,
-                    lineColor = lineColor,
-                    approachingTimeText = if (isApproaching) approachingText(stop) else null,
-                    modifier = Modifier
-                        .timeLineCenterWithStop(
-                            color = aboveColor,
-                            strokeWidth = strokeWidth,
-                            circleRadius = stopCircleRadius(stopIdx),
-                            circleColor = stopCircleColor(stopIdx),
-                        )
-                        .timeLineTop(
-                            color = segmentColor(stopIdx),
-                            strokeWidth = strokeWidth,
-                            circleRadius = stopCircleRadius(stopIdx),
-                            circleColor = stopCircleColor(stopIdx),
-                        )
-                        .padding(start = dim.spacingXL),
+                    approachingTimeText = approachingText(effectiveInstants[stopIdx], now),
                 )
-
-                if (isActiveSegment(stopIdx)) {
-                    Spacer(
-                        modifier = Modifier.height(dim.spacingXL)
-                            .timeLineCenterSplit(
-                                lineColor,
-                                pendingColor,
-                                strokeWidth,
-                                currentSegmentFraction ?: 0f,
-                            ),
-                    )
-                } else {
-                    Spacer(
-                        modifier = Modifier.height(dim.spacingXL).timeLineCenter(
-                            color = segmentColor(stopIdx),
-                            strokeWidth = strokeWidth,
-                        ),
-                    )
-                }
             }
 
             // Last stop (always prominent — destination)
             val lastIdx = leg.stops.size - 1
-            val lastStop = leg.stops.last()
-            val isLastApproaching = lastIdx == nextStopIndex
-            // Same rule: if last stop is approaching, its incoming line must be pendingColor
-            val lastIncomingColor =
-                if (isLastApproaching) pendingColor else segmentColor(lastIdx - 1)
-            TrackedStopRow(
-                time = lastStop.estimatedTime ?: lastStop.scheduledTime,
-                scheduledTime = lastStop.estimatedTime?.let { lastStop.scheduledTime },
-                stopName = lastStop.name,
-                isPast = currentStopIndex != null && lastIdx <= currentStopIndex,
-                isApproaching = isLastApproaching,
+            TrackedLegLastStop(
+                timeline = timeline,
+                lastStop = leg.stops.last(),
+                lastIdx = lastIdx,
                 isArrived = isArrived,
-                isDestination = true,
-                lineColor = lineColor,
-                approachingTimeText = if (isLastApproaching) approachingText(lastStop) else null,
-                modifier = Modifier
-                    .timeLineBottom(
-                        color = lastIncomingColor,
-                        strokeWidth = strokeWidth,
-                        circleRadius = stopCircleRadius(lastIdx),
-                        circleColor = stopCircleColor(lastIdx),
-                    )
-                    .padding(start = dim.spacingXL),
+                approachingTimeText = approachingText(effectiveInstants[lastIdx], now),
             )
         }
     }
 }
 
+// Compute the authoritative real-time instant for a stop.
+// When GTFS-RT delay is available, apply it to the scheduled time — this is the most
+// up-to-date signal between trip API re-polls. Falls back to the trip API estimated time.
+@OptIn(ExperimentalTime::class)
+private fun effectiveInstant(stop: TrackedStop, stopDelays: Map<String, Int>): Instant? {
+    val delay = stopDelays[stop.stopId]
+    return if (delay != null) {
+        runCatching {
+            Instant.parse(stop.scheduledUtcTime) + delay.seconds
+        }.getOrNull()
+    } else {
+        runCatching { Instant.parse(stop.utcTime) }.getOrNull()
+    }
+}
+
 @Composable
-private fun TrackedStopRow(
+internal fun TrackedStopRow(
     time: String,
     scheduledTime: String?,
     stopName: String,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -1,27 +1,23 @@
 package xyz.ksharma.krail.trip.planner.ui.journeymap
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.maplibre.compose.camera.CameraPosition
 import org.maplibre.compose.camera.rememberCameraState
@@ -31,11 +27,11 @@ import org.maplibre.compose.map.OrnamentOptions
 import org.maplibre.compose.style.BaseStyle
 import org.maplibre.spatialk.geojson.Position
 import xyz.ksharma.aagya.permission.PermissionStatus
+import xyz.ksharma.krail.core.maps.data.location.UserLocationManager
 import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.maps.state.LatLng
 import xyz.ksharma.krail.core.maps.state.UserLocationConfig
 import xyz.ksharma.krail.core.maps.ui.components.LocationPermissionBanner
-import xyz.ksharma.krail.core.maps.ui.components.MapTimetableDataBadge
 import xyz.ksharma.krail.core.maps.ui.components.UserLocationButton
 import xyz.ksharma.krail.core.maps.ui.config.MapConfig
 import xyz.ksharma.krail.core.maps.ui.config.MapTileProvider
@@ -46,8 +42,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyStopFeature
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.StopType
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.TimeSource
 
 /**
  * Main composable for displaying a journey on a map.
@@ -60,7 +54,6 @@ import kotlin.time.TimeSource
 fun JourneyMap(
     journeyMapState: JourneyMapUiState,
     modifier: Modifier = Modifier,
-    showFreshnessBadge: Boolean = true,
     onLocationButtonClick: (isLocationActive: Boolean) -> Unit = {},
     onPermissionSettingsClick: () -> Unit = {},
     extraMapContent: @Composable () -> Unit = {},
@@ -77,7 +70,6 @@ fun JourneyMap(
         is JourneyMapUiState.Ready -> {
             JourneyMapContent(
                 mapState = journeyMapState,
-                showFreshnessBadge = showFreshnessBadge,
                 onLocationButtonClick = onLocationButtonClick,
                 onPermissionSettingsClick = onPermissionSettingsClick,
                 extraMapContent = extraMapContent,
@@ -90,14 +82,10 @@ fun JourneyMap(
 /**
  * The actual map content when data is ready.
  */
-@Suppress("CyclomaticComplexMethod")
-// Complexity is dominated by Compose state wiring (location/permission/freshness/camera effects
-// + the map's stop and route layers); splitting it fragments shared map state across composables.
 @Composable
 private fun JourneyMapContent(
     mapState: JourneyMapUiState.Ready,
     modifier: Modifier = Modifier,
-    showFreshnessBadge: Boolean = true,
     onLocationButtonClick: (isLocationActive: Boolean) -> Unit = {},
     onPermissionSettingsClick: () -> Unit = {},
     extraMapContent: @Composable () -> Unit = {},
@@ -112,25 +100,6 @@ private fun JourneyMapContent(
     var allowPermissionRequest by remember { mutableStateOf(false) }
     val userLocationManager = rememberUserLocationManager()
     val scope = rememberCoroutineScope()
-
-    // Data freshness badge — survives rotation via rememberSaveable
-    // baseMinutes captures the saved value at composition time so the tick
-    // always adds fresh elapsed time on top of any previously accumulated minutes.
-    var elapsedMinutes by rememberSaveable { mutableLongStateOf(0L) }
-    val baseMinutes = remember { elapsedMinutes }
-    val loadedAt = remember { TimeSource.Monotonic.markNow() }
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(30.seconds)
-            elapsedMinutes = baseMinutes + loadedAt.elapsedNow().inWholeMinutes
-        }
-    }
-    val isStale = elapsedMinutes >= 2
-    val badgeText: String? = when {
-        elapsedMinutes < 1 -> null
-        elapsedMinutes < 5 -> "Updated $elapsedMinutes mins ago"
-        else -> "Map showing scheduled times only."
-    }
 
     val initialCameraPosition = remember { calculateInitialCameraPosition(mapState) }
     val cameraState = rememberCameraState(firstPosition = initialCameraPosition)
@@ -216,25 +185,13 @@ private fun JourneyMapContent(
             onClick = {
                 onLocationButtonClick(userLocation != null)
                 scope.launch {
-                    val userLoc = userLocation
-                    if (userLoc != null) {
-                        // Re-center camera on latest known position
-                        cameraState.animateTo(
-                            CameraPosition(
-                                target = Position(latitude = userLoc.latitude, longitude = userLoc.longitude),
-                                zoom = UserLocationConfig.RECENTER_ZOOM,
-                            ),
-                            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-                        )
-                    } else {
-                        val status = userLocationManager.checkPermissionStatus()
-                        if (status is PermissionStatus.Denied) {
-                            showPermissionBanner = true
-                        } else {
-                            // Trigger system permission dialog via TrackUserLocation
-                            allowPermissionRequest = true
-                        }
-                    }
+                    onUserLocationButtonClick(
+                        userLocation = userLocation,
+                        userLocationManager = userLocationManager,
+                        cameraState = cameraState,
+                        onShowPermissionBanner = { showPermissionBanner = true },
+                        onRequestPermission = { allowPermissionRequest = true },
+                    )
                 }
             },
             isActive = userLocation != null,
@@ -244,37 +201,22 @@ private fun JourneyMapContent(
                 .padding(KrailTheme.dimensions.spacingXL),
         )
 
-        // Top overlays — permission banner (if shown) then freshness badge directly below it.
-        // fillMaxWidth + horizontal padding here so both children get consistent spacingXL screen
-        // margins without each child needing to specify it individually.
-        if (showPermissionBanner || (showFreshnessBadge && badgeText != null)) {
-            Column(
+        // Location permission banner (shown when permission is denied).
+        // TopCenter so the pill is horizontally centred like the search-stop / saved-trip maps.
+        // statusBarsPadding clears the status bar (the pill carries no inset of its own),
+        // then spacingM adds a small gap below it. Horizontal padding gives edge breathing room.
+        if (showPermissionBanner) {
+            LocationPermissionBanner(
+                onGoToSettings = {
+                    onPermissionSettingsClick()
+                    userLocationManager.openAppSettings()
+                },
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .fillMaxWidth()
-                    .padding(horizontal = KrailTheme.dimensions.spacingXL)
-                    .padding(top = KrailTheme.dimensions.spacingM),
-            ) {
-                if (showPermissionBanner) {
-                    LocationPermissionBanner(
-                        onGoToSettings = {
-                            onPermissionSettingsClick()
-                            userLocationManager.openAppSettings()
-                        },
-                    )
-                }
-                if (showFreshnessBadge) {
-                    badgeText?.let { text ->
-                        MapTimetableDataBadge(
-                            text = text,
-                            isStale = isStale,
-                            modifier = Modifier
-                                .align(Alignment.CenterHorizontally)
-                                .padding(vertical = KrailTheme.dimensions.spacingM),
-                        )
-                    }
-                }
-            }
+                    .statusBarsPadding()
+                    .padding(top = KrailTheme.dimensions.spacingM)
+                    .padding(horizontal = KrailTheme.dimensions.spacingXL),
+            )
         }
 
         // Stop Details Bottom Sheet
@@ -283,6 +225,37 @@ private fun JourneyMapContent(
                 stop = stop,
                 onDismiss = { selectedStop = null },
             )
+        }
+    }
+}
+
+/**
+ * Handles a tap on the user-location button: re-centre on a known fix, otherwise resolve
+ * permission state (show banner when denied, else request).
+ */
+private suspend fun onUserLocationButtonClick(
+    userLocation: LatLng?,
+    userLocationManager: UserLocationManager,
+    cameraState: org.maplibre.compose.camera.CameraState,
+    onShowPermissionBanner: () -> Unit,
+    onRequestPermission: () -> Unit,
+) {
+    if (userLocation != null) {
+        // Re-center camera on latest known position
+        cameraState.animateTo(
+            CameraPosition(
+                target = Position(latitude = userLocation.latitude, longitude = userLocation.longitude),
+                zoom = UserLocationConfig.RECENTER_ZOOM,
+            ),
+            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
+        )
+    } else {
+        val status = userLocationManager.checkPermissionStatus()
+        if (status is PermissionStatus.Denied) {
+            onShowPermissionBanner()
+        } else {
+            // Trigger system permission dialog via TrackUserLocation
+            onRequestPermission()
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/tracktrip/TrackTripScreen.kt
@@ -1,4 +1,4 @@
-@file:Suppress("LongMethod", "TooManyFunctions", "CyclomaticComplexMethod", "StringLiteralDuplication")
+@file:Suppress("LongMethod", "TooManyFunctions", "StringLiteralDuplication")
 
 package xyz.ksharma.krail.trip.planner.ui.tracktrip
 
@@ -139,30 +139,13 @@ fun TrackTripScreen(
                 title = { Text(text = "Track Trip") },
                 onNavActionClick = onBack,
                 actions = {
-                    AnimatedVisibility(
-                        visible = isRefreshing,
-                        enter = fadeIn(),
-                        exit = fadeOut(),
-                    ) {
-                        val dim = KrailTheme.dimensions
-                        AnimatedDots(modifier = Modifier.size(dim.buttonRoundSize, dim.iconXS))
-                    }
-                    if (isJourneyActive) {
-                        TextButton(onClick = { mapExpanded = !mapExpanded }) {
-                            Text(text = if (mapExpanded) "Hide Map" else "Map")
-                        }
-                        ActionButton(
-                            onClick = { triggerShare = true },
-                            contentDescription = "Share journey",
-                        ) {
-                            Image(
-                                painter = rememberShareIconPainter(),
-                                contentDescription = null,
-                                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(KrailTheme.dimensions.iconM),
-                            )
-                        }
-                    }
+                    TrackTripActions(
+                        isRefreshing = isRefreshing,
+                        isJourneyActive = isJourneyActive,
+                        mapExpanded = mapExpanded,
+                        onToggleMap = { mapExpanded = !mapExpanded },
+                        onShare = { triggerShare = true },
+                    )
                 },
             )
 
@@ -216,59 +199,95 @@ fun TrackTripScreen(
                     },
                 )
 
-                TrackTripState.NotFound -> Column(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Service not found",
-                        message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
-                        emoji = "\uD83D\uDEAB",
-                        actionData = ActionData("Retry") { viewModel.retry() },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {
-                            viewModel.onStopTracking()
-                            onBack()
-                        },
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.NotFound -> TrackTripErrorContent(
+                    title = "Service not found",
+                    message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
+                    emoji = "\uD83D\uDEAB",
+                    onRetry = { viewModel.retry() },
+                    onStopTracking = {
+                        viewModel.onStopTracking()
+                        onBack()
+                    },
+                )
 
-                TrackTripState.Error -> Column(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Something went wrong",
-                        message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
-                        actionData = ActionData("Retry") { viewModel.retry() },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {
-                            viewModel.onStopTracking()
-                            onBack()
-                        },
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.Error -> TrackTripErrorContent(
+                    title = "Something went wrong",
+                    message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
+                    emoji = null,
+                    onRetry = { viewModel.retry() },
+                    onStopTracking = {
+                        viewModel.onStopTracking()
+                        onBack()
+                    },
+                )
 
                 is TrackTripState.AlreadyTracking -> Unit // unreachable — deep link tap clears old tracking
             }
+        }
+    }
+}
+
+@Composable
+private fun TrackTripActions(
+    isRefreshing: Boolean,
+    isJourneyActive: Boolean,
+    mapExpanded: Boolean,
+    onToggleMap: () -> Unit,
+    onShare: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = isRefreshing,
+        enter = fadeIn(),
+        exit = fadeOut(),
+    ) {
+        val dim = KrailTheme.dimensions
+        AnimatedDots(modifier = Modifier.size(dim.buttonRoundSize, dim.iconXS))
+    }
+    if (isJourneyActive) {
+        TextButton(onClick = onToggleMap) {
+            Text(text = if (mapExpanded) "Hide Map" else "Map")
+        }
+        ActionButton(
+            onClick = onShare,
+            contentDescription = "Share journey",
+        ) {
+            Image(
+                painter = rememberShareIconPainter(),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                modifier = Modifier.size(KrailTheme.dimensions.iconM),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrackTripErrorContent(
+    title: String,
+    message: String,
+    emoji: String?,
+    onRetry: () -> Unit,
+    onStopTracking: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        val dim = KrailTheme.dimensions
+        ErrorMessage(
+            title = title,
+            message = message,
+            emoji = emoji ?: "🐶",
+            actionData = ActionData("Retry") { onRetry() },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dim.spacingXL),
+        )
+        Button(
+            onClick = onStopTracking,
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(bottom = dim.spacingXL),
+        ) {
+            Text("Stop Tracking")
         }
     }
 }
@@ -391,7 +410,6 @@ private fun JourneyContent(
             Box(modifier = Modifier.fillMaxHeight(0.45f)) {
                 JourneyMap(
                     journeyMapState = journeyMapState,
-                    showFreshnessBadge = false,
                     modifier = Modifier.fillMaxSize(),
                     extraMapContent = {
                         liveOverlay?.let {
@@ -610,46 +628,21 @@ private fun TrackTripScreenPreview(state: TrackTripState) {
                     isArrived = true,
                 )
 
-                TrackTripState.NotFound -> Column(modifier = Modifier.fillMaxWidth()) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Service not found",
-                        message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
-                        emoji = "\uD83D\uDEAB",
-                        actionData = ActionData("Retry") { },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {},
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.NotFound -> TrackTripErrorContent(
+                    title = "Service not found",
+                    message = "This service wasn't found. It may have been cancelled or\u00A0changed.",
+                    emoji = "\uD83D\uDEAB",
+                    onRetry = {},
+                    onStopTracking = {},
+                )
 
-                TrackTripState.Error -> Column(modifier = Modifier.fillMaxWidth()) {
-                    val dim = KrailTheme.dimensions
-                    ErrorMessage(
-                        title = "Something went wrong",
-                        message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
-                        actionData = ActionData("Retry") { },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dim.spacingXL),
-                    )
-                    Button(
-                        onClick = {},
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = dim.spacingXL),
-                    ) {
-                        Text("Stop Tracking")
-                    }
-                }
+                TrackTripState.Error -> TrackTripErrorContent(
+                    title = "Something went wrong",
+                    message = "Couldn't reach transport services. Check your connection and try\u00A0again.",
+                    emoji = null,
+                    onRetry = {},
+                    onStopTracking = {},
+                )
 
                 is TrackTripState.AlreadyTracking -> Unit // unreachable — deep link tap clears old tracking
 


### PR DESCRIPTION
Remove the journey-map freshness badge, center the location permission banner
with consistent status-bar padding (matching search-stop / saved-trip maps), and
fix double status-bar padding in LocationPermissionBanner. Includes the track-trip
timeline / departure-board view extractions from the complexity refactor.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>