### PR TITLE
refactor: cut SearchStop/SavedTrips/Theme complexity below detekt threshold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,24 @@ If a module is missing `testAndroidHostTest`, add `withHostTest {}` inside its `
 Suppression rules:
 - Break long lines instead of suppressing `MaximumLineLength` / `MaxLineLength`
 - Extract constants instead of suppressing `MagicNumber` (unless truly no reuse value)
-- Only suppress `CyclomaticComplexMethod` / `LongMethod` when refactoring is genuinely not possible
+
+### `CyclomaticComplexMethod` — zero tolerance for suppression
+
+**Never** suppress `CyclomaticComplexMethod`. Not via `@Suppress`, not via `detekt.yml`
+config, and not via a `baseline.xml` entry (baselining is suppression). When a method
+trips the rule, **refactor it** until it passes:
+- Extract cohesive blocks into well-named private functions. If the file is also at its
+  `TooManyFunctions` limit, extract to a **separate file** so neither limit grows (note:
+  detekt counts branches inside nested/local functions toward the enclosing function, so a
+  local `fun` does **not** reduce complexity — a top-level function in another file does).
+- Replace if/else-if ladders with `when`, polymorphism, or a lookup map.
+- Split a Composable that renders many conditional sections into smaller Composables.
+
+If you genuinely believe a method cannot be refactored, stop and raise it with the
+maintainer rather than suppressing. There is no "genuinely not possible" escape hatch here.
+
+`LongMethod` is exempt only on `@Composable` functions (already configured); never suppress
+it elsewhere — refactor instead.
 
 ## LazyColumn / LazyRow item keys
 

--- a/feature/trip-planner/ui/baseline.xml
+++ b/feature/trip-planner/ui/baseline.xml
@@ -31,10 +31,6 @@
     <ID>ComposableParamOrder:JourneyTimeOptionsGroup.kt$JourneyTimeOptionsGroup</ID>
     <ID>ComposableParamOrder:TagLineWithEmoji.kt$TagLineWithEmoji</ID>
     <ID>ComposableParamOrder:TimeTableScreen.kt$JourneyCardItem</ID>
-    <ID>CyclomaticComplexMethod:JourneyCard.kt$@Composable private fun ResponsiveJourneyInfoRow( destinationTime: String, totalTravelTime: String, totalWalkTime: String?, departureDeviation: TimeTableState.JourneyCardInfo.DepartureDeviation?, )</ID>
-    <ID>CyclomaticComplexMethod:SearchStopScreen.kt$@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class, ExperimentalTime::class) @Composable fun SearchStopScreen( searchStopState: SearchStopState, modifier: Modifier = Modifier, searchQuery: String = "", goBack: () -&gt; Unit = {}, onStopSelect: (StopItem) -&gt; Unit = {}, onEvent: (SearchStopUiEvent) -&gt; Unit = {}, )</ID>
-    <ID>CyclomaticComplexMethod:ThemeSelectionRadioButton.kt$@Composable fun ThemeSelectionRadioButton( themeStyle: KrailThemeStyle, onClick: (KrailThemeStyle) -&gt; Unit, modifier: Modifier = Modifier, selected: Boolean = false, )</ID>
-    <ID>CyclomaticComplexMethod:TripResponseMapper.kt$@Suppress("ComplexCondition") private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg?</ID>
     <ID>FinalNewline:DiscoverScreen.kt$xyz.ksharma.krail.trip.planner.ui.discover.DiscoverScreen.kt</ID>
     <ID>FinalNewline:IntroContentPlanTrip.kt$xyz.ksharma.krail.trip.planner.ui.intro.IntroContentPlanTrip.kt</ID>
     <ID>FinalNewline:ParkRideCard.kt$xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard.kt</ID>

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -1,9 +1,8 @@
-@file:Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
+@file:Suppress("LongMethod", "LongParameterList")
 
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.StartOffset
@@ -16,7 +15,6 @@ import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
-import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -58,18 +56,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_close
 import kotlinx.collections.immutable.ImmutableList
-import krail.feature.trip_planner.ui.generated.resources.Res
-import krail.feature.trip_planner.ui.generated.resources.ic_settings
 import org.jetbrains.compose.resources.painterResource
-import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import xyz.ksharma.krail.core.adaptiveui.DualPaneScaffold
@@ -79,26 +71,15 @@ import xyz.ksharma.krail.feature.track.TrackedJourney
 import xyz.ksharma.krail.feature.track.ui.components.TrackingCard
 import xyz.ksharma.krail.info.tile.state.InfoTileData
 import xyz.ksharma.krail.info.tiles.ui.InfoTile
-import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalTextStyle
-import xyz.ksharma.krail.taj.components.Button
-import xyz.ksharma.krail.taj.components.ButtonDefaults
-import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeColor
-import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
-import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
-import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
-import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
-import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
-import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.fromStopDisplay
-import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.toStopDisplay
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import app.krail.taj.resources.Res as TajRes
 
@@ -189,36 +170,14 @@ fun SavedTripsScreen(
                         Text(text = "KRAIL", color = themeColor())
                     },
                     actions = {
-                        if (editing) {
-                            Button(
-                                onClick = { editing = false },
-                                colors = ButtonDefaults.monochromeButtonColors(),
-                                dimensions = ButtonDefaults.chipButtonSize(),
-                                modifier = Modifier.padding(horizontal = dim.spacingM),
-                            ) {
-                                Text(text = "Done")
-                            }
-                        } else {
-                            if (savedTripsState.isDiscoverAvailable) {
-                                RoundIconButton(
-                                    showBadge = savedTripsState.displayDiscoverBadge,
-                                    onClick = onDiscoverButtonClick,
-                                ) {
-                                    CityCodeText("SYD")
-                                }
-                            }
-
-                            RoundIconButton(
-                                onClick = onSettingsButtonClick,
-                            ) {
-                                Image(
-                                    painter = painterResource(Res.drawable.ic_settings),
-                                    contentDescription = "Settings",
-                                    colorFilter = ColorFilter.tint(LocalContentColor.current),
-                                    modifier = Modifier.size(dim.spacingXXXL),
-                                )
-                            }
-                        }
+                        SavedTripsTitleBarActions(
+                            editing = editing,
+                            isDiscoverAvailable = savedTripsState.isDiscoverAvailable,
+                            displayDiscoverBadge = savedTripsState.displayDiscoverBadge,
+                            onDoneClick = { editing = false },
+                            onDiscoverButtonClick = onDiscoverButtonClick,
+                            onSettingsButtonClick = onSettingsButtonClick,
+                        )
                     },
                 )
 
@@ -228,67 +187,20 @@ fun SavedTripsScreen(
                     state = lazyListState,
                     contentPadding = PaddingValues(bottom = LAZY_COLUMN_BOTTOM_PADDING.dp),
                 ) {
-                    when {
-                        savedTripsState.isSavedTripsLoading -> Unit
-
-                        savedTripsState.savedTrips.isEmpty() -> {
-                            savedTripsState.infoTiles?.let { infoTiles ->
-                                infoTiles(
-                                    infoTiles = infoTiles,
-                                    onCtaClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                    },
-                                    onDismissClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
-                                    },
-                                    onTileExpand = {
-                                        onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
-                                    },
-                                )
-                            }
-
-                            item(key = "empty_state") {
-                                ErrorMessage(
-                                    emoji = "🌟",
-                                    title = "Let's Go! Sydney",
-                                    message = emptyStateTip,
-                                    modifier = Modifier
-                                        .padding(horizontal = dim.pageHorizontalPadding)
-                                        .animateItem(),
-                                )
-                            }
-                        }
-
-                        savedTripsState.savedTrips.isNotEmpty() -> {
-                            savedTripsState.infoTiles?.let { infoTiles ->
-                                infoTiles(
-                                    infoTiles = infoTiles,
-                                    onCtaClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData))
-                                    },
-                                    onDismissClick = { tileData ->
-                                        onEvent(SavedTripUiEvent.DismissInfoTile(tileData))
-                                    },
-                                    onTileExpand = {
-                                        onEvent(SavedTripUiEvent.InfoTileExpand(it.key))
-                                    },
-                                )
-                            }
-
-                            savedTripsContent(
-                                savedTripsState = savedTripsState,
-                                trackedJourney = trackedJourney,
-                                onEvent = onEvent,
-                                onSavedTripCardClick = onSavedTripCardClick,
-                                onTrackingCardClick = onTrackingCardClick,
-                                onStopTracking = onStopTracking,
-                                expandedMap = expandedMap,
-                                editing = editing,
-                                reorderState = reorderState,
-                                onEnterEditing = { editing = true },
-                            )
-                        }
-                    }
+                    savedTripsListBody(
+                        savedTripsState = savedTripsState,
+                        trackedJourney = trackedJourney,
+                        emptyStateTip = emptyStateTip,
+                        pageHorizontalPadding = dim.pageHorizontalPadding,
+                        onEvent = onEvent,
+                        onSavedTripCardClick = onSavedTripCardClick,
+                        onTrackingCardClick = onTrackingCardClick,
+                        onStopTracking = onStopTracking,
+                        expandedMap = expandedMap,
+                        editing = editing,
+                        reorderState = reorderState,
+                        onEnterEditing = { editing = true },
+                    )
                 }
             }
 
@@ -301,42 +213,30 @@ fun SavedTripsScreen(
             // expanded search row. The pill's "alive" pulse lives inside CollapsedPill
             // itself — keeping the row-level reveal calm avoids stacking two bouncy
             // animations (parent scale + child pulse) on top of each other.
-            AnimatedVisibility(
+            SavedTripsBottomSearchRow(
                 visible = !savedTripsState.isSavedTripsLoading && !editing,
-                enter = slideInVertically(
-                    initialOffsetY = { it },
-                    animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing),
-                ) + fadeIn(animationSpec = tween(durationMillis = 200)),
+                fromStopItem = savedTripsState.fromStop,
+                toStopItem = savedTripsState.toStop,
+                isExpanded = effectiveIsExpanded,
+                isFromHighlighted = isFromHighlighted,
+                showPill = showPill,
+                onExpandRequest = {
+                    isSearchExpanded = true
+                    isFromHighlighted = false
+                },
+                onCollapseRequest = {
+                    isSearchExpanded = false
+                    isFromHighlighted = false
+                },
+                fromButtonClick = {
+                    isFromHighlighted = false
+                    fromButtonClick()
+                },
+                toButtonClick = toButtonClick,
+                onReverseButtonClick = { onEvent(SavedTripUiEvent.ReverseStopClick) },
+                onSearchButtonClick = { onSearchButtonClick() },
                 modifier = Modifier.align(Alignment.BottomCenter),
-            ) {
-                SearchStopRow(
-                    fromStopItem = savedTripsState.fromStop,
-                    toStopItem = savedTripsState.toStop,
-                    isExpanded = effectiveIsExpanded,
-                    isFromHighlighted = isFromHighlighted,
-                    onExpandRequest = {
-                        isSearchExpanded = true
-                        isFromHighlighted = false
-                    },
-                    onCollapseRequest = if (showPill) {
-                        {
-                            isSearchExpanded = false
-                            isFromHighlighted = false
-                        }
-                    } else {
-                        null
-                    },
-                    fromButtonClick = {
-                        isFromHighlighted = false
-                        fromButtonClick()
-                    },
-                    toButtonClick = toButtonClick,
-                    onReverseButtonClick = {
-                        onEvent(SavedTripUiEvent.ReverseStopClick)
-                    },
-                    onSearchButtonClick = { onSearchButtonClick() },
-                )
-            }
+            )
         }
         log(
             "[MAP_STOP_SEL] SavedTripsScreen dualPane=$dualPane " +
@@ -356,7 +256,7 @@ fun SavedTripsScreen(
     }
 }
 
-private fun LazyListScope.infoTiles(
+internal fun LazyListScope.infoTiles(
     infoTiles: ImmutableList<InfoTileData>,
     onCtaClick: (InfoTileData) -> Unit,
     onDismissClick: (InfoTileData) -> Unit,
@@ -389,7 +289,7 @@ private fun LazyListScope.infoTiles(
     }
 }
 
-private fun LazyListScope.savedTripsContent(
+internal fun LazyListScope.savedTripsContent(
     savedTripsState: SavedTripsState,
     trackedJourney: TrackedJourney?,
     onEvent: (SavedTripUiEvent) -> Unit,
@@ -470,99 +370,26 @@ private fun LazyListScope.savedTripsContent(
         items = savedTripsState.savedTrips,
         key = { trip -> trip.tripId },
     ) { trip ->
-        val dim = KrailTheme.dimensions
-        val haptic = LocalHapticFeedback.current
-
-        ReorderableItem(reorderState, key = trip.tripId) { isDragging ->
-            val rotation = rememberWiggleRotation(
-                active = editing && !isDragging,
-                seed = trip.tripId.hashCode(),
-            )
-
-            Column(modifier = Modifier.padding(top = if (editing) dim.spacingS else dim.spacingNone)) {
-                Box(
-                    modifier = Modifier
-                        .graphicsLayer { rotationZ = rotation }
-                        .padding(horizontal = dim.pageHorizontalPadding),
-                ) {
-                    SavedTripCard(
-                        fromDisplay = trip.fromStopDisplay(savedTripsState.stopLabels),
-                        toDisplay = trip.toStopDisplay(savedTripsState.stopLabels),
-                        onCardClick = {
-                            if (!editing) {
-                                onSavedTripCardClick(
-                                    StopItem(stopId = trip.fromStopId, stopName = trip.fromStopName),
-                                    StopItem(stopId = trip.toStopId, stopName = trip.toStopName),
-                                )
-                            }
-                        },
-                        editing = editing,
-                        onLongClick = if (!editing) {
-                            {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                onEnterEditing()
-                            }
-                        } else {
-                            null
-                        },
-                        modifier = Modifier.longPressDraggableHandle(
-                            enabled = editing,
-                            onDragStarted = {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                            },
-                        ),
-                    )
-
-                    if (editing) {
-                        TripDeleteOverlay(
-                            onClick = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
-                            modifier = Modifier.align(Alignment.TopEnd),
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(dim.spacingXL))
-            }
-        }
+        SavedTripItem(
+            trip = trip,
+            stopLabels = savedTripsState.stopLabels,
+            editing = editing,
+            reorderState = reorderState,
+            onSavedTripCardClick = onSavedTripCardClick,
+            onEnterEditing = onEnterEditing,
+            onDelete = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
+        )
     }
 
-    if (savedTripsState.parkRideUiState.isNotEmpty()) {
-        stickyHeader(key = "park_ride_title") {
-            SavedTripsTitle {
-                Text(text = "Park & Ride")
-            }
-        }
-
-        items(
-            items = savedTripsState.parkRideUiState,
-            key = { parkRide -> parkRide.stopId },
-        ) { parkRide ->
-            val dim = KrailTheme.dimensions
-            val isExpanded = expandedMap[parkRide.stopId] ?: false
-
-            ParkRideCard(
-                isExpanded = isExpanded,
-                modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding),
-                onClick = {
-                    val newExpanded = !isExpanded
-                    expandedMap[parkRide.stopId] = newExpanded
-                    onEvent(
-                        SavedTripUiEvent.ParkRideCardClick(
-                            parkRideState = parkRide,
-                            isExpanded = newExpanded,
-                        ),
-                    )
-                },
-                parkRideUiState = parkRide,
-            )
-
-            Spacer(modifier = Modifier.height(dim.spacingXL))
-        }
-    }
+    parkRideSection(
+        savedTripsState = savedTripsState,
+        expandedMap = expandedMap,
+        onEvent = onEvent,
+    )
 }
 
 @Composable
-private fun TripDeleteOverlay(
+internal fun TripDeleteOverlay(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -586,7 +413,7 @@ private fun TripDeleteOverlay(
 }
 
 @Composable
-private fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
+internal fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
     val transition = rememberInfiniteTransition(label = "trip-wiggle")
     val seedAbs = kotlin.math.abs(seed)
     val angle by transition.animateFloat(
@@ -610,7 +437,7 @@ private fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
 }
 
 @Composable
-private fun SavedTripsTitle(
+internal fun SavedTripsTitle(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -1,0 +1,308 @@
+@file:Suppress("LongMethod", "LongParameterList")
+
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.Dp
+import kotlinx.collections.immutable.ImmutableList
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_settings
+import org.jetbrains.compose.resources.painterResource
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.ReorderableLazyListState
+import xyz.ksharma.krail.feature.track.TrackedJourney
+import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.components.Button
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.RoundIconButton
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
+import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
+import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
+import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
+import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.fromStopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.toStopDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+
+/**
+ * Full LazyColumn body for [SavedTripsScreen] — picks the empty / populated branch and renders the
+ * matching content. Pure extraction of the original `when` block; behaviour is identical.
+ */
+internal fun LazyListScope.savedTripsListBody(
+    savedTripsState: SavedTripsState,
+    trackedJourney: TrackedJourney?,
+    emptyStateTip: String,
+    pageHorizontalPadding: Dp,
+    onEvent: (SavedTripUiEvent) -> Unit,
+    onSavedTripCardClick: (StopItem?, StopItem?) -> Unit,
+    onTrackingCardClick: () -> Unit,
+    onStopTracking: () -> Unit,
+    expandedMap: SnapshotStateMap<String, Boolean>,
+    editing: Boolean,
+    reorderState: ReorderableLazyListState,
+    onEnterEditing: () -> Unit,
+) {
+    when {
+        savedTripsState.isSavedTripsLoading -> Unit
+
+        savedTripsState.savedTrips.isEmpty() -> {
+            savedTripsInfoTiles(savedTripsState, onEvent)
+            item(key = "empty_state") {
+                ErrorMessage(
+                    emoji = "🌟",
+                    title = "Let's Go! Sydney",
+                    message = emptyStateTip,
+                    modifier = Modifier
+                        .padding(horizontal = pageHorizontalPadding)
+                        .animateItem(),
+                )
+            }
+        }
+
+        savedTripsState.savedTrips.isNotEmpty() -> {
+            savedTripsInfoTiles(savedTripsState, onEvent)
+            savedTripsContent(
+                savedTripsState = savedTripsState,
+                trackedJourney = trackedJourney,
+                onEvent = onEvent,
+                onSavedTripCardClick = onSavedTripCardClick,
+                onTrackingCardClick = onTrackingCardClick,
+                onStopTracking = onStopTracking,
+                expandedMap = expandedMap,
+                editing = editing,
+                reorderState = reorderState,
+                onEnterEditing = onEnterEditing,
+            )
+        }
+    }
+}
+
+private fun LazyListScope.savedTripsInfoTiles(
+    savedTripsState: SavedTripsState,
+    onEvent: (SavedTripUiEvent) -> Unit,
+) {
+    savedTripsState.infoTiles?.let { infoTiles ->
+        infoTiles(
+            infoTiles = infoTiles,
+            onCtaClick = { tileData -> onEvent(SavedTripUiEvent.InfoTileCtaClick(tileData)) },
+            onDismissClick = { tileData -> onEvent(SavedTripUiEvent.DismissInfoTile(tileData)) },
+            onTileExpand = { onEvent(SavedTripUiEvent.InfoTileExpand(it.key)) },
+        )
+    }
+}
+
+internal fun LazyListScope.parkRideSection(
+    savedTripsState: SavedTripsState,
+    expandedMap: SnapshotStateMap<String, Boolean>,
+    onEvent: (SavedTripUiEvent) -> Unit,
+) {
+    if (savedTripsState.parkRideUiState.isEmpty()) return
+
+    stickyHeader(key = "park_ride_title") {
+        SavedTripsTitle {
+            Text(text = "Park & Ride")
+        }
+    }
+
+    items(
+        items = savedTripsState.parkRideUiState,
+        key = { parkRide -> parkRide.stopId },
+    ) { parkRide ->
+        val dim = KrailTheme.dimensions
+        val isExpanded = expandedMap[parkRide.stopId] ?: false
+
+        ParkRideCard(
+            isExpanded = isExpanded,
+            modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding),
+            onClick = {
+                val newExpanded = !isExpanded
+                expandedMap[parkRide.stopId] = newExpanded
+                onEvent(
+                    SavedTripUiEvent.ParkRideCardClick(
+                        parkRideState = parkRide,
+                        isExpanded = newExpanded,
+                    ),
+                )
+            },
+            parkRideUiState = parkRide,
+        )
+
+        Spacer(modifier = Modifier.height(dim.spacingXL))
+    }
+}
+
+@Composable
+internal fun LazyItemScope.SavedTripItem(
+    trip: Trip,
+    stopLabels: ImmutableList<StopLabel>,
+    editing: Boolean,
+    reorderState: ReorderableLazyListState,
+    onSavedTripCardClick: (StopItem?, StopItem?) -> Unit,
+    onEnterEditing: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    val dim = KrailTheme.dimensions
+    val haptic = LocalHapticFeedback.current
+
+    ReorderableItem(reorderState, key = trip.tripId) { isDragging ->
+        val rotation = rememberWiggleRotation(
+            active = editing && !isDragging,
+            seed = trip.tripId.hashCode(),
+        )
+
+        Column(modifier = Modifier.padding(top = if (editing) dim.spacingS else dim.spacingNone)) {
+            Box(
+                modifier = Modifier
+                    .graphicsLayer { rotationZ = rotation }
+                    .padding(horizontal = dim.pageHorizontalPadding),
+            ) {
+                SavedTripCard(
+                    fromDisplay = trip.fromStopDisplay(stopLabels),
+                    toDisplay = trip.toStopDisplay(stopLabels),
+                    onCardClick = {
+                        if (!editing) {
+                            onSavedTripCardClick(
+                                StopItem(stopId = trip.fromStopId, stopName = trip.fromStopName),
+                                StopItem(stopId = trip.toStopId, stopName = trip.toStopName),
+                            )
+                        }
+                    },
+                    editing = editing,
+                    onLongClick = if (!editing) {
+                        {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            onEnterEditing()
+                        }
+                    } else {
+                        null
+                    },
+                    modifier = Modifier.longPressDraggableHandle(
+                        enabled = editing,
+                        onDragStarted = {
+                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        },
+                    ),
+                )
+
+                if (editing) {
+                    TripDeleteOverlay(
+                        onClick = onDelete,
+                        modifier = Modifier.align(Alignment.TopEnd),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(dim.spacingXL))
+        }
+    }
+}
+
+@Composable
+internal fun SavedTripsTitleBarActions(
+    editing: Boolean,
+    isDiscoverAvailable: Boolean,
+    displayDiscoverBadge: Boolean,
+    onDoneClick: () -> Unit,
+    onDiscoverButtonClick: () -> Unit,
+    onSettingsButtonClick: () -> Unit,
+) {
+    val dim = KrailTheme.dimensions
+    if (editing) {
+        Button(
+            onClick = onDoneClick,
+            colors = ButtonDefaults.monochromeButtonColors(),
+            dimensions = ButtonDefaults.chipButtonSize(),
+            modifier = Modifier.padding(horizontal = dim.spacingM),
+        ) {
+            Text(text = "Done")
+        }
+    } else {
+        if (isDiscoverAvailable) {
+            RoundIconButton(
+                showBadge = displayDiscoverBadge,
+                onClick = onDiscoverButtonClick,
+            ) {
+                CityCodeText("SYD")
+            }
+        }
+
+        RoundIconButton(
+            onClick = onSettingsButtonClick,
+        ) {
+            Image(
+                painter = painterResource(Res.drawable.ic_settings),
+                contentDescription = "Settings",
+                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                modifier = Modifier.size(dim.spacingXXXL),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun BoxScope.SavedTripsBottomSearchRow(
+    visible: Boolean,
+    fromStopItem: StopItem?,
+    toStopItem: StopItem?,
+    isExpanded: Boolean,
+    isFromHighlighted: Boolean,
+    showPill: Boolean,
+    onExpandRequest: () -> Unit,
+    onCollapseRequest: () -> Unit,
+    fromButtonClick: () -> Unit,
+    toButtonClick: () -> Unit,
+    onReverseButtonClick: () -> Unit,
+    onSearchButtonClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = slideInVertically(
+            initialOffsetY = { it },
+            animationSpec = tween(durationMillis = 350, easing = FastOutSlowInEasing),
+        ) + fadeIn(animationSpec = tween(durationMillis = 200)),
+        modifier = modifier,
+    ) {
+        SearchStopRow(
+            fromStopItem = fromStopItem,
+            toStopItem = toStopItem,
+            isExpanded = isExpanded,
+            isFromHighlighted = isFromHighlighted,
+            onExpandRequest = onExpandRequest,
+            onCollapseRequest = if (showPill) onCollapseRequest else null,
+            fromButtonClick = fromButtonClick,
+            toButtonClick = toButtonClick,
+            onReverseButtonClick = onReverseButtonClick,
+            onSearchButtonClick = onSearchButtonClick,
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopLabelDialogs.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopLabelDialogs.kt
@@ -1,0 +1,174 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import androidx.compose.runtime.Composable
+import kotlinx.collections.immutable.ImmutableList
+import xyz.ksharma.krail.trip.planner.ui.components.AddLabelBottomSheet
+import xyz.ksharma.krail.trip.planner.ui.components.LabelConflictSheet
+import xyz.ksharma.krail.trip.planner.ui.components.SaveStopAsLabelSheet
+import xyz.ksharma.krail.trip.planner.ui.components.labelNamesMatch
+import xyz.ksharma.krail.trip.planner.ui.components.normaliseLabelName
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+// The label-management modals that hang off SearchStopScreen, split into one composable per
+// sheet so each flow reads on its own. Each is self-guarding (renders nothing unless its state
+// is active), so the screen calls all three unconditionally. State is hoisted in the caller;
+// these read it and report changes back through the on*Change callbacks. They live in this file
+// (not SearchStopScreen.kt) so their branching does not count toward the screen's complexity.
+
+/** "Create label" sheet. Shown while [show] is true. */
+@Composable
+internal fun SearchStopAddLabelDialog(
+    show: Boolean,
+    stopLabels: ImmutableList<StopLabel>,
+    pendingStopForNewLabel: StopItem?,
+    onEvent: (SearchStopUiEvent) -> Unit,
+    onShowAddLabelSheetChange: (Boolean) -> Unit,
+    onStopBeingSavedChange: (StopItem?) -> Unit,
+    onPendingStopForNewLabelChange: (StopItem?) -> Unit,
+    onAssigningLabelChange: (StopLabel?) -> Unit,
+) {
+    if (!show) return
+    AddLabelBottomSheet(
+        stopName = null,
+        existingLabels = stopLabels,
+        onDismiss = {
+            onShowAddLabelSheetChange(false)
+            // If the user backed out without saving, hand the stop back to the
+            // save-sheet flow so they're not stranded.
+            onStopBeingSavedChange(pendingStopForNewLabel)
+            onPendingStopForNewLabelChange(null)
+        },
+        onSave = { emoji, name ->
+            onShowAddLabelSheetChange(false)
+            val cleaned = normaliseLabelName(name)
+            if (cleaned.isNotBlank() &&
+                stopLabels.none { labelNamesMatch(it.label, cleaned) }
+            ) {
+                onEvent(SearchStopUiEvent.CreateLabel(name = cleaned, emoji = emoji))
+                val pending = pendingStopForNewLabel
+                onPendingStopForNewLabelChange(null)
+                if (pending != null) {
+                    // Came from "+ New label" inside SaveStopAsLabelSheet —
+                    // auto-attach the stop to the freshly created label so the
+                    // user's original intent ("save this stop as a new label")
+                    // completes in one go.
+                    onEvent(SearchStopUiEvent.AssignLabelStop(cleaned, pending))
+                } else {
+                    // Came from the standalone "+ Add" pill — drop into assigning
+                    // mode so the user knows what to do next.
+                    onAssigningLabelChange(StopLabel(emoji = emoji, label = cleaned))
+                }
+            } else {
+                // Save was blocked (blank or duplicate). Restore the save-sheet
+                // flow so the user can pick a different option.
+                onStopBeingSavedChange(pendingStopForNewLabel)
+                onPendingStopForNewLabelChange(null)
+            }
+        },
+    )
+}
+
+/** "Save stop as label" sheet. Shown while [stopBeingSaved] is non-null. */
+@Composable
+internal fun SearchStopSaveLabelDialog(
+    stopBeingSaved: StopItem?,
+    stopLabels: ImmutableList<StopLabel>,
+    onEvent: (SearchStopUiEvent) -> Unit,
+    onShowAddLabelSheetChange: (Boolean) -> Unit,
+    onStopBeingSavedChange: (StopItem?) -> Unit,
+    onPendingConflictChange: (LabelConflict?) -> Unit,
+    onPendingStopForNewLabelChange: (StopItem?) -> Unit,
+) {
+    val stop = stopBeingSaved ?: return
+    SaveStopAsLabelSheet(
+        stopName = stop.stopName,
+        labels = stopLabels,
+        onLabelClick = { label ->
+            val stopOnAnotherLabel = stopLabels.firstOrNull { other ->
+                other.stopId == stop.stopId && other.label != label.label
+            }
+            val labelHasDifferentStop = label.takeIf {
+                it.isSet && it.stopId != stop.stopId
+            }
+            when {
+                stopOnAnotherLabel != null -> {
+                    onPendingConflictChange(
+                        LabelConflict.StopAlreadyOnAnotherLabel(
+                            target = label,
+                            stop = stop,
+                            existingLabel = stopOnAnotherLabel,
+                        ),
+                    )
+                    onStopBeingSavedChange(null)
+                }
+                labelHasDifferentStop != null -> {
+                    onPendingConflictChange(
+                        LabelConflict.LabelHasDifferentStop(
+                            target = label,
+                            stop = stop,
+                            existingStopName = labelHasDifferentStop.stopName.orEmpty(),
+                        ),
+                    )
+                    onStopBeingSavedChange(null)
+                }
+                else -> {
+                    onEvent(SearchStopUiEvent.AssignLabelStop(label.label, stop))
+                    onStopBeingSavedChange(null)
+                }
+            }
+        },
+        onCreateNewLabel = {
+            // Carry the stop into the AddLabel flow so that creating the label
+            // can auto-assign it on save, instead of dropping the user back at
+            // step one.
+            onPendingStopForNewLabelChange(stop)
+            onStopBeingSavedChange(null)
+            onShowAddLabelSheetChange(true)
+        },
+        onDismiss = { onStopBeingSavedChange(null) },
+    )
+}
+
+/** 1:1 conflict-resolution sheet. Shown while [pendingConflict] is non-null. */
+@Composable
+internal fun SearchStopConflictDialog(
+    pendingConflict: LabelConflict?,
+    onEvent: (SearchStopUiEvent) -> Unit,
+    onStopBeingSavedChange: (StopItem?) -> Unit,
+    onPendingConflictChange: (LabelConflict?) -> Unit,
+) {
+    val conflict = pendingConflict ?: return
+    // Cancelling a conflict warning hands the stop back to SaveStopAsLabelSheet so
+    // the user can pick a different label instead of being stranded on the screen.
+    val onConflictCancel = {
+        onStopBeingSavedChange(conflict.stop)
+        onPendingConflictChange(null)
+    }
+    when (conflict) {
+        is LabelConflict.StopAlreadyOnAnotherLabel -> LabelConflictSheet(
+            title = "Already saved",
+            message = "${conflict.stop.stopName} is currently saved as " +
+                "${conflict.existingLabel.label}. Move it to ${conflict.target.label}?",
+            confirmLabel = "Move",
+            onConfirm = {
+                onEvent(SearchStopUiEvent.ClearLabelStop(conflict.existingLabel.label))
+                onEvent(SearchStopUiEvent.AssignLabelStop(conflict.target.label, conflict.stop))
+                onPendingConflictChange(null)
+            },
+            onCancel = onConflictCancel,
+        )
+        is LabelConflict.LabelHasDifferentStop -> LabelConflictSheet(
+            title = "Already in use",
+            message = "${conflict.target.label} is currently saved as " +
+                "${conflict.existingStopName}. Replace with ${conflict.stop.stopName}?",
+            confirmLabel = "Replace",
+            onConfirm = {
+                onEvent(SearchStopUiEvent.AssignLabelStop(conflict.target.label, conflict.stop))
+                onPendingConflictChange(null)
+            },
+            onCancel = onConflictCancel,
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopLabelShortcuts.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopLabelShortcuts.kt
@@ -1,0 +1,161 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalHapticFeedback
+import kotlinx.coroutines.withTimeoutOrNull
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.ReorderableLazyListState
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.SetLabelPill
+import xyz.ksharma.krail.trip.planner.ui.components.UnsetLabelPill
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+@Suppress("LongParameterList")
+@Composable
+internal fun LazyItemScope.LabelShortcutPill(
+    label: StopLabel,
+    isAssigning: Boolean,
+    editing: Boolean,
+    reorderState: ReorderableLazyListState,
+    onSetLabelClick: (StopItem) -> Unit,
+    onUnsetLabelClick: (StopLabel) -> Unit,
+    onEnterEditing: () -> Unit,
+    onDeleteLabel: (StopLabel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+    val haptic = LocalHapticFeedback.current
+    ReorderableItem(reorderState, key = label.label, modifier = modifier) { isDragging ->
+        val rotation = rememberWiggleRotation(
+            active = editing && !isDragging,
+            seed = label.label.hashCode(),
+        )
+        // Scale up the pill when it's the assigning target — same visual
+        // language as the departure-board chips. We don't tint the pill
+        // here because the screen background is already themeColor and a
+        // colour change would blend the pill in.
+        val targetScale = when {
+            isDragging -> PILL_DRAG_SCALE
+            isAssigning -> PILL_ASSIGNING_SCALE
+            else -> PILL_RESTING_SCALE
+        }
+        val scale by animateFloatAsState(
+            targetValue = targetScale,
+            label = "pill-scale",
+        )
+        Box(
+            modifier = Modifier.graphicsLayer {
+                rotationZ = rotation
+                scaleX = scale
+                scaleY = scale
+            },
+        ) {
+            // clip BEFORE the gesture detector so the ripple is contained inside
+            // the rounded shape. longPressDraggableHandle (active only while
+            // editing) handles long-press + drag for reordering. The custom
+            // awaitEachGesture below distinguishes tap (release inside long-press
+            // timeout) from long-press (timeout reached) without competing with
+            // the drag handle for events the way combinedClickable did.
+            val pillModifier = Modifier
+                .clip(RoundedCornerShape(dim.radiusFull))
+                .longPressDraggableHandle(
+                    enabled = editing,
+                    onDragStarted = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                )
+                .labelPillTapGestures(
+                    label = label,
+                    editing = editing,
+                    haptic = haptic,
+                    onSetLabelClick = onSetLabelClick,
+                    onUnsetLabelClick = onUnsetLabelClick,
+                    onEnterEditing = onEnterEditing,
+                )
+
+            if (label.isSet) {
+                SetLabelPill(label = label, modifier = pillModifier)
+            } else {
+                UnsetLabelPill(
+                    label = label,
+                    isAssigning = isAssigning,
+                    modifier = pillModifier,
+                )
+            }
+
+            if (editing && !label.isProtected) {
+                DeleteOverlay(
+                    onClick = { onDeleteLabel(label) },
+                    modifier = Modifier.align(Alignment.TopEnd),
+                )
+            }
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+private fun Modifier.labelPillTapGestures(
+    label: StopLabel,
+    editing: Boolean,
+    haptic: HapticFeedback,
+    onSetLabelClick: (StopItem) -> Unit,
+    onUnsetLabelClick: (StopLabel) -> Unit,
+    onEnterEditing: () -> Unit,
+): Modifier = pointerInput(label.label, editing) {
+    awaitEachGesture {
+        awaitFirstDown(requireUnconsumed = false)
+        val tappedQuickly = withTimeoutOrNull(
+            viewConfiguration.longPressTimeoutMillis,
+        ) {
+            waitForUpOrCancellation() != null
+        }
+        when (tappedQuickly) {
+            true -> {
+                // Released within the long-press window → tap.
+                // In edit mode, taps are suppressed entirely so an
+                // accidental brush against a pill mid-reorder can't
+                // navigate away or enter assigning mode. Only drag
+                // and the ✕ delete chip work while editing.
+                if (!editing) {
+                    if (label.isSet) {
+                        label.toStopItem()?.let(onSetLabelClick)
+                    } else {
+                        onUnsetLabelClick(label)
+                    }
+                }
+            }
+            null -> {
+                // Long-press timeout reached without release.
+                if (!editing) {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onEnterEditing()
+                }
+                // Wait for release; null return means another
+                // detector (the drag handle) took over.
+                waitForUpOrCancellation()
+            }
+            false -> {
+                // Cancellation inside timeout (e.g. drag detector
+                // consumed the events) — let the drag handle run.
+            }
+        }
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -11,16 +11,12 @@ import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.StartOffset
 import androidx.compose.animation.core.StartOffsetType
 import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -60,12 +56,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import app.krail.taj.resources.ic_close
@@ -80,10 +72,8 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.withTimeoutOrNull
 import krail.feature.trip_planner.ui.generated.resources.ic_map
 import org.jetbrains.compose.resources.painterResource
-import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import xyz.ksharma.aagya.permission.PermissionStatus
 import xyz.ksharma.krail.core.adaptiveui.AdaptiveScreenContent
@@ -104,15 +94,10 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeColor
-import xyz.ksharma.krail.trip.planner.ui.components.AddLabelBottomSheet
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
-import xyz.ksharma.krail.trip.planner.ui.components.LabelConflictSheet
-import xyz.ksharma.krail.trip.planner.ui.components.SaveStopAsLabelSheet
-import xyz.ksharma.krail.trip.planner.ui.components.SetLabelPill
 import xyz.ksharma.krail.trip.planner.ui.components.StopSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.TripSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.TripSearchListItemState
-import xyz.ksharma.krail.trip.planner.ui.components.UnsetLabelPill
 import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionPane
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.SearchStopMap
@@ -127,11 +112,6 @@ import app.krail.taj.resources.Res as TajRes
 import krail.feature.trip_planner.ui.generated.resources.Res as TripPlannerRes
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
-@Suppress("LongMethod", "CyclomaticComplexMethod")
-// Length and branching are dominated by orchestration state for the screen
-// (assigning mode, edit mode, three save-flow sheets, pending conflict, plus their
-// saver wiring + LaunchedEffect chains). Pulling them apart hurts readability —
-// every state piece is plumbed back into the same single AdaptiveScreenContent.
 @Composable
 fun SearchStopScreen(
     searchStopState: SearchStopState,
@@ -314,133 +294,36 @@ fun SearchStopScreen(
         },
     )
 
-    if (showAddLabelSheet) {
-        AddLabelBottomSheet(
-            stopName = null,
-            existingLabels = searchStopState.stopLabels,
-            onDismiss = {
-                showAddLabelSheet = false
-                // If the user backed out without saving, hand the stop back to the
-                // save-sheet flow so they're not stranded.
-                stopBeingSaved = pendingStopForNewLabel
-                pendingStopForNewLabel = null
-            },
-            onSave = { emoji, name ->
-                showAddLabelSheet = false
-                val cleaned = xyz.ksharma.krail.trip.planner.ui.components
-                    .normaliseLabelName(name)
-                if (cleaned.isNotBlank() &&
-                    searchStopState.stopLabels.none {
-                        xyz.ksharma.krail.trip.planner.ui.components
-                            .labelNamesMatch(it.label, cleaned)
-                    }
-                ) {
-                    onEvent(SearchStopUiEvent.CreateLabel(name = cleaned, emoji = emoji))
-                    val pending = pendingStopForNewLabel
-                    pendingStopForNewLabel = null
-                    if (pending != null) {
-                        // Came from "+ New label" inside SaveStopAsLabelSheet —
-                        // auto-attach the stop to the freshly created label so the
-                        // user's original intent ("save this stop as a new label")
-                        // completes in one go.
-                        onEvent(SearchStopUiEvent.AssignLabelStop(cleaned, pending))
-                    } else {
-                        // Came from the standalone "+ Add" pill — drop into assigning
-                        // mode so the user knows what to do next.
-                        assigningLabel = StopLabel(emoji = emoji, label = cleaned)
-                    }
-                } else {
-                    // Save was blocked (blank or duplicate). Restore the save-sheet
-                    // flow so the user can pick a different option.
-                    stopBeingSaved = pendingStopForNewLabel
-                    pendingStopForNewLabel = null
-                }
-            },
-        )
-    }
+    SearchStopAddLabelDialog(
+        show = showAddLabelSheet,
+        stopLabels = searchStopState.stopLabels,
+        pendingStopForNewLabel = pendingStopForNewLabel,
+        onEvent = onEvent,
+        onShowAddLabelSheetChange = { showAddLabelSheet = it },
+        onStopBeingSavedChange = { stopBeingSaved = it },
+        onPendingStopForNewLabelChange = { pendingStopForNewLabel = it },
+        onAssigningLabelChange = { assigningLabel = it },
+    )
 
-    stopBeingSaved?.let { stop ->
-        SaveStopAsLabelSheet(
-            stopName = stop.stopName,
-            labels = searchStopState.stopLabels,
-            onLabelClick = { label ->
-                val stopOnAnotherLabel = searchStopState.stopLabels.firstOrNull { other ->
-                    other.stopId == stop.stopId && other.label != label.label
-                }
-                val labelHasDifferentStop = label.takeIf {
-                    it.isSet && it.stopId != stop.stopId
-                }
-                when {
-                    stopOnAnotherLabel != null -> {
-                        pendingConflict = LabelConflict.StopAlreadyOnAnotherLabel(
-                            target = label,
-                            stop = stop,
-                            existingLabel = stopOnAnotherLabel,
-                        )
-                        stopBeingSaved = null
-                    }
-                    labelHasDifferentStop != null -> {
-                        pendingConflict = LabelConflict.LabelHasDifferentStop(
-                            target = label,
-                            stop = stop,
-                            existingStopName = labelHasDifferentStop.stopName.orEmpty(),
-                        )
-                        stopBeingSaved = null
-                    }
-                    else -> {
-                        onEvent(SearchStopUiEvent.AssignLabelStop(label.label, stop))
-                        stopBeingSaved = null
-                    }
-                }
-            },
-            onCreateNewLabel = {
-                // Carry the stop into the AddLabel flow so that creating the label
-                // can auto-assign it on save, instead of dropping the user back at
-                // step one.
-                pendingStopForNewLabel = stop
-                stopBeingSaved = null
-                showAddLabelSheet = true
-            },
-            onDismiss = { stopBeingSaved = null },
-        )
-    }
+    SearchStopSaveLabelDialog(
+        stopBeingSaved = stopBeingSaved,
+        stopLabels = searchStopState.stopLabels,
+        onEvent = onEvent,
+        onShowAddLabelSheetChange = { showAddLabelSheet = it },
+        onStopBeingSavedChange = { stopBeingSaved = it },
+        onPendingConflictChange = { pendingConflict = it },
+        onPendingStopForNewLabelChange = { pendingStopForNewLabel = it },
+    )
 
-    pendingConflict?.let { conflict ->
-        // Cancelling a conflict warning hands the stop back to SaveStopAsLabelSheet so
-        // the user can pick a different label instead of being stranded on the screen.
-        val onConflictCancel = {
-            stopBeingSaved = conflict.stop
-            pendingConflict = null
-        }
-        when (conflict) {
-            is LabelConflict.StopAlreadyOnAnotherLabel -> LabelConflictSheet(
-                title = "Already saved",
-                message = "${conflict.stop.stopName} is currently saved as " +
-                    "${conflict.existingLabel.label}. Move it to ${conflict.target.label}?",
-                confirmLabel = "Move",
-                onConfirm = {
-                    onEvent(SearchStopUiEvent.ClearLabelStop(conflict.existingLabel.label))
-                    onEvent(SearchStopUiEvent.AssignLabelStop(conflict.target.label, conflict.stop))
-                    pendingConflict = null
-                },
-                onCancel = onConflictCancel,
-            )
-            is LabelConflict.LabelHasDifferentStop -> LabelConflictSheet(
-                title = "Already in use",
-                message = "${conflict.target.label} is currently saved as " +
-                    "${conflict.existingStopName}. Replace with ${conflict.stop.stopName}?",
-                confirmLabel = "Replace",
-                onConfirm = {
-                    onEvent(SearchStopUiEvent.AssignLabelStop(conflict.target.label, conflict.stop))
-                    pendingConflict = null
-                },
-                onCancel = onConflictCancel,
-            )
-        }
-    }
+    SearchStopConflictDialog(
+        pendingConflict = pendingConflict,
+        onEvent = onEvent,
+        onStopBeingSavedChange = { stopBeingSaved = it },
+        onPendingConflictChange = { pendingConflict = it },
+    )
 }
 
-private sealed interface LabelConflict {
+internal sealed interface LabelConflict {
     val target: StopLabel
     val stop: StopItem
 
@@ -1318,12 +1201,7 @@ private fun LazyListScope.emptyStateStopsList(
 }
 
 @OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
-@Suppress("LongMethod", "LongParameterList", "CyclomaticComplexMethod")
-// All callbacks below are forwarded from SearchStopScreen, and the body is one
-// LazyRow whose items each carry a fair amount of gesture wiring (longPressDraggable
-// + custom awaitEachGesture for tap/long-press/drag distinction + DeleteOverlay).
-// Extracting either further fragments the row's gesture state across composables,
-// which previously led to subtle bugs (see the rotation/SaveAsLabelStar fix).
+@Suppress("LongParameterList")
 @Composable
 private fun LabelShortcutsRow(
     labels: ImmutableList<StopLabel>,
@@ -1339,7 +1217,6 @@ private fun LabelShortcutsRow(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-    val haptic = LocalHapticFeedback.current
     val lazyListState = rememberLazyListState()
     val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->
         val key = from.key as? String ?: return@rememberReorderableLazyListState
@@ -1363,105 +1240,16 @@ private fun LabelShortcutsRow(
         horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
         items(items = labels, key = { it.label }) { label ->
-            val isAssigning = assigningLabel?.label == label.label
-            ReorderableItem(reorderState, key = label.label) { isDragging ->
-                val rotation = rememberWiggleRotation(
-                    active = editing && !isDragging,
-                    seed = label.label.hashCode(),
-                )
-                // Scale up the pill when it's the assigning target — same visual
-                // language as the departure-board chips. We don't tint the pill
-                // here because the screen background is already themeColor and a
-                // colour change would blend the pill in.
-                val targetScale = when {
-                    isDragging -> PILL_DRAG_SCALE
-                    isAssigning -> PILL_ASSIGNING_SCALE
-                    else -> PILL_RESTING_SCALE
-                }
-                val scale by animateFloatAsState(
-                    targetValue = targetScale,
-                    label = "pill-scale",
-                )
-                Box(
-                    modifier = Modifier.graphicsLayer {
-                        rotationZ = rotation
-                        scaleX = scale
-                        scaleY = scale
-                    },
-                ) {
-                    // clip BEFORE the gesture detector so the ripple is contained inside
-                    // the rounded shape. longPressDraggableHandle (active only while
-                    // editing) handles long-press + drag for reordering. The custom
-                    // awaitEachGesture below distinguishes tap (release inside long-press
-                    // timeout) from long-press (timeout reached) without competing with
-                    // the drag handle for events the way combinedClickable did.
-                    val pillModifier = Modifier
-                        .clip(RoundedCornerShape(dim.radiusFull))
-                        .longPressDraggableHandle(
-                            enabled = editing,
-                            onDragStarted = {
-                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                            },
-                        )
-                        .pointerInput(label.label, editing) {
-                            awaitEachGesture {
-                                awaitFirstDown(requireUnconsumed = false)
-                                val tappedQuickly = withTimeoutOrNull(
-                                    viewConfiguration.longPressTimeoutMillis,
-                                ) {
-                                    waitForUpOrCancellation() != null
-                                }
-                                when (tappedQuickly) {
-                                    true -> {
-                                        // Released within the long-press window → tap.
-                                        // In edit mode, taps are suppressed entirely so an
-                                        // accidental brush against a pill mid-reorder can't
-                                        // navigate away or enter assigning mode. Only drag
-                                        // and the ✕ delete chip work while editing.
-                                        if (!editing) {
-                                            if (label.isSet) {
-                                                label.toStopItem()?.let(onSetLabelClick)
-                                            } else {
-                                                onUnsetLabelClick(label)
-                                            }
-                                        }
-                                    }
-                                    null -> {
-                                        // Long-press timeout reached without release.
-                                        if (!editing) {
-                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                            onEnterEditing()
-                                        }
-                                        // Wait for release; null return means another
-                                        // detector (the drag handle) took over.
-                                        waitForUpOrCancellation()
-                                    }
-                                    false -> {
-                                        // Cancellation inside timeout (e.g. drag detector
-                                        // consumed the events) — let the drag handle run.
-                                    }
-                                }
-                            }
-                        }
-
-                    if (label.isSet) {
-                        SetLabelPill(label = label, modifier = pillModifier)
-                    } else {
-                        UnsetLabelPill(
-                            label = label,
-                            isAssigning = isAssigning,
-                            modifier = pillModifier,
-                        )
-                    }
-
-                    if (editing && !label.isProtected) {
-                        DeleteOverlay(
-                            onClick = { onDeleteLabel(label) },
-                            modifier = Modifier.align(Alignment.TopEnd),
-                        )
-                    }
-                }
-            }
+            LabelShortcutPill(
+                label = label,
+                isAssigning = assigningLabel?.label == label.label,
+                editing = editing,
+                reorderState = reorderState,
+                onSetLabelClick = onSetLabelClick,
+                onUnsetLabelClick = onUnsetLabelClick,
+                onEnterEditing = onEnterEditing,
+                onDeleteLabel = onDeleteLabel,
+            )
         }
         // Trailing slot: "+ Add" while idle, "Done" while editing. Putting Done at
         // the END (not the front) keeps the reorder UX smooth — front-anchored Done
@@ -1494,7 +1282,7 @@ private fun LabelShortcutsRow(
 }
 
 @Composable
-private fun DeleteOverlay(
+internal fun DeleteOverlay(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -1521,7 +1309,7 @@ private fun DeleteOverlay(
 }
 
 @Composable
-private fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
+internal fun rememberWiggleRotation(active: Boolean, seed: Int): Float {
     val transition = rememberInfiniteTransition(label = "wiggle")
     val seedAbs = kotlin.math.abs(seed)
     val angle by transition.animateFloat(
@@ -1625,9 +1413,9 @@ private fun MapAutoInitEffect(
 
 // Pill scale factors used by LabelShortcutsRow's graphicsLayer transform — extracted
 // here so the call site reads as intent, not magic numbers.
-private const val PILL_RESTING_SCALE = 1f
-private const val PILL_DRAG_SCALE = 1.05f
-private const val PILL_ASSIGNING_SCALE = 1.10f
+internal const val PILL_RESTING_SCALE = 1f
+internal const val PILL_DRAG_SCALE = 1.05f
+internal const val PILL_ASSIGNING_SCALE = 1.10f
 
 // Wiggle animation in edit mode. Per-pill randomisation prevents the row from
 // looking mechanically synchronised — every pill has its own duration bucket and

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/themeselection/ThemeSelectionRadioButton.kt
@@ -26,9 +26,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.platform.LocalDensity
@@ -114,35 +116,12 @@ fun ThemeSelectionRadioButton(
             .scalingKlickable { onClick(themeStyle) },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier = Modifier
-                .size(COLOR_SWATCH_OUTER_SIZE)
-                .then(
-                    if (selected) {
-                        Modifier.drawBehind {
-                            val color = themeStyle.hexColorCode.hexToComposeColor()
-                            withTransform({
-                                scale(pulseScale, pulseScale, pivot = center)
-                            }) {
-                                drawCircle(
-                                    color = color.copy(alpha = pulseAlpha),
-                                    radius = size.minDimension / 2,
-                                )
-                            }
-                        }
-                    } else {
-                        Modifier
-                    },
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(dim.iconL)
-                    .clip(CircleShape)
-                    .background(color = themeStyle.hexColorCode.hexToComposeColor()),
-            )
-        }
+        ThemeColorSwatch(
+            themeStyle = themeStyle,
+            selected = selected,
+            pulseScale = pulseScale,
+            pulseAlpha = pulseAlpha,
+        )
 
         Box(
             modifier = Modifier
@@ -155,54 +134,11 @@ fun ThemeSelectionRadioButton(
                         .width(textWidth)
                         .padding(horizontal = dim.spacingL),
                 ) {
-                    val layout = textLayoutResult!!
-                    val lineCount = layout.lineCount
-                    val strokeWidth = WAVE_STROKE_WIDTH.toPx()
-                    val amplitude = WAVE_AMPLITUDE.toPx()
-                    val waveLength = WAVE_LENGTH.toPx()
-                    var remaining = currentPathLength
-
-                    for (line in 0 until lineCount) {
-                        val left = layout.getLineLeft(line)
-                        val right = layout.getLineRight(line)
-                        val lineWidth = right - left
-                        if (remaining <= 0f) break
-                        val highlightEnd = left + remaining.coerceAtMost(lineWidth)
-                        val top = layout.getLineTop(line)
-                        val bottom = layout.getLineBottom(line)
-                        val centerY = (top + bottom) / 2f
-
-                        val path = Path()
-                        var x = left
-                        var up = true
-                        path.moveTo(x, centerY)
-                        while (x < highlightEnd) {
-                            val nextX = (x + waveLength).coerceAtMost(highlightEnd)
-                            val controlX1 = x + waveLength / 3
-                            val controlX2 = x + 2 * waveLength / 3
-                            val endY = if (up) centerY - amplitude else centerY + amplitude
-                            path.cubicTo(
-                                controlX1,
-                                centerY,
-                                controlX2,
-                                endY,
-                                nextX,
-                                endY,
-                            )
-                            x = nextX
-                            up = !up
-                        }
-                        drawPath(
-                            path = path,
-                            color = highlightColor,
-                            style = Stroke(
-                                width = strokeWidth,
-                                cap = StrokeCap.Round,
-                                join = StrokeJoin.Round,
-                            ),
-                        )
-                        remaining -= lineWidth
-                    }
+                    drawWaveHighlight(
+                        layout = textLayoutResult!!,
+                        currentPathLength = currentPathLength,
+                        highlightColor = highlightColor,
+                    )
                 }
             }
 
@@ -218,6 +154,109 @@ fun ThemeSelectionRadioButton(
             )
         }
     }
+}
+
+@Composable
+private fun ThemeColorSwatch(
+    themeStyle: KrailThemeStyle,
+    selected: Boolean,
+    pulseScale: Float,
+    pulseAlpha: Float,
+) {
+    val dim = KrailTheme.dimensions
+    Box(
+        modifier = Modifier
+            .size(COLOR_SWATCH_OUTER_SIZE)
+            .then(
+                if (selected) {
+                    Modifier.drawBehind {
+                        val color = themeStyle.hexColorCode.hexToComposeColor()
+                        withTransform({
+                            scale(pulseScale, pulseScale, pivot = center)
+                        }) {
+                            drawCircle(
+                                color = color.copy(alpha = pulseAlpha),
+                                radius = size.minDimension / 2,
+                            )
+                        }
+                    }
+                } else {
+                    Modifier
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(dim.iconL)
+                .clip(CircleShape)
+                .background(color = themeStyle.hexColorCode.hexToComposeColor()),
+        )
+    }
+}
+
+private fun DrawScope.drawWaveHighlight(
+    layout: TextLayoutResult,
+    currentPathLength: Float,
+    highlightColor: Color,
+) {
+    val strokeWidth = WAVE_STROKE_WIDTH.toPx()
+    val amplitude = WAVE_AMPLITUDE.toPx()
+    val waveLength = WAVE_LENGTH.toPx()
+    var remaining = currentPathLength
+
+    for (line in 0 until layout.lineCount) {
+        val left = layout.getLineLeft(line)
+        val lineWidth = layout.getLineRight(line) - left
+        if (remaining <= 0f) break
+        val highlightEnd = left + remaining.coerceAtMost(lineWidth)
+        val centerY = (layout.getLineTop(line) + layout.getLineBottom(line)) / 2f
+
+        drawPath(
+            path = buildWavePath(
+                left = left,
+                highlightEnd = highlightEnd,
+                centerY = centerY,
+                amplitude = amplitude,
+                waveLength = waveLength,
+            ),
+            color = highlightColor,
+            style = Stroke(
+                width = strokeWidth,
+                cap = StrokeCap.Round,
+                join = StrokeJoin.Round,
+            ),
+        )
+        remaining -= lineWidth
+    }
+}
+
+private fun buildWavePath(
+    left: Float,
+    highlightEnd: Float,
+    centerY: Float,
+    amplitude: Float,
+    waveLength: Float,
+): Path {
+    val path = Path()
+    var x = left
+    var up = true
+    path.moveTo(x, centerY)
+    while (x < highlightEnd) {
+        val nextX = (x + waveLength).coerceAtMost(highlightEnd)
+        val endY = if (up) centerY - amplitude else centerY + amplitude
+        path.cubicTo(
+            x + waveLength / 3,
+            centerY,
+            x + 2 * waveLength / 3,
+            endY,
+            nextX,
+            endY,
+        )
+        x = nextX
+        up = !up
+    }
+    return path
 }
 
 @Preview


### PR DESCRIPTION
Remove all CyclomaticComplexMethod suppressions by extracting SearchStopScreen
dialogs/shortcuts, SavedTripsScreen sections, and ThemeSelectionRadioButton logic
into focused files. Updates the detekt baseline and CLAUDE.md zero-tolerance note.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>