### PR TITLE
fix(trip-planner): correct NSW API mode exclusion params

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,14 @@ Always use the project's custom preview annotations — never bare `@Preview`.
 
 Both are defined in `xyz.ksharma.krail.taj.preview`. They expand to multiple device/theme combinations automatically. Using `@Preview` directly produces a single-config preview and misses dark mode, font scale, etc.
 
+## Background polling — WhileSubscribed lifecycle rule
+
+See `docs/POLLING_LIFECYCLE.md` for full rules and patterns.
+
+**TL;DR:** Use `repeatOnLifecycle(STARTED)` inside `LaunchedEffect` to activate
+side-effect flows — never plain `LaunchedEffect { launch { flow.collect {} } }`.
+Always collect `uiState` with `collectAsStateWithLifecycle()`.
+
 ## Per-feature UX rule docs
 
 Some features have a markdown file capturing their UX invariants and outstanding test
@@ -211,3 +219,5 @@ that contradicts the doc should also update the doc in the same change.
   edit mode, conflict warnings, contextual banner, state persistence).
 - `docs/TABLET_FOLDABLE_UX.md` — adaptive layout rules for tablets, foldables, and phone
   landscape (per-screen dual-pane behaviour, compact-height adaptations, breakpoint contract).
+- `docs/POLLING_LIFECYCLE.md` — WhileSubscribed polling rules: `repeatOnLifecycle(STARTED)`
+  pattern, why plain `LaunchedEffect` breaks background gating, all polling flows listed.

--- a/docs/POLLING_LIFECYCLE.md
+++ b/docs/POLLING_LIFECYCLE.md
@@ -1,0 +1,56 @@
+# Polling & WhileSubscribed Lifecycle Rules
+
+All polling flows use `SharingStarted.WhileSubscribed(threshold)` so they stop when no UI
+is collecting them. This only works if the UI collects with lifecycle awareness.
+
+## Rule: use `repeatOnLifecycle(STARTED)` to activate side-effect flows
+
+`LaunchedEffect` is Composition-scoped — it keeps subscribers alive through background and
+lock-screen, defeating `WhileSubscribed` and causing continuous API calls when the user is
+not looking at the screen.
+
+**Correct pattern:**
+
+```kotlin
+val lifecycleOwner = LocalLifecycleOwner.current
+LaunchedEffect(viewModel, lifecycleOwner) {
+    lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        launch { viewModel.pollingFlow.collect {} }
+    }
+}
+```
+
+`repeatOnLifecycle(STARTED)` cancels inner coroutines when the Activity goes to background
+(STOPPED), dropping subscriber count to 0 so `WhileSubscribed` halts the poll loop. It
+restarts automatically on foreground.
+
+**Wrong — keeps polling through lock-screen:**
+
+```kotlin
+// ❌ LaunchedEffect is Composition-scoped, not Activity-lifecycle-scoped
+LaunchedEffect(viewModel) {
+    launch { viewModel.pollingFlow.collect {} }
+}
+```
+
+## Rule: collect `uiState` with `collectAsStateWithLifecycle()`
+
+`collectAsState()` is not lifecycle-aware. Always use `collectAsStateWithLifecycle()` for
+any `StateFlow` that a `WhileSubscribed` poll depends on.
+
+## How it fits together
+
+```
+UI subscribes via collectAsStateWithLifecycle() or repeatOnLifecycle(STARTED)
+  → Activity goes to background → subscriber count drops to 0
+  → WhileSubscribed(threshold) fires after threshold ms
+  → onStart coroutine (while-true poll loop) is cancelled
+  → no more API calls
+```
+
+Polling flows in this codebase that use this pattern:
+- `TimeTableViewModel.autoRefreshTimeTable` — 30s trip refresh
+- `TimeTableViewModel.isLoading` — triggers `fetchTrip()` on screen entry
+- `TimeTableViewModel.isActive` — 10s time-text refresh
+- `TrackTripViewModel.uiState` — GTFS-RT live tracking poll
+- `DeparturesViewModel` — departure board poll (gated on `_uiState.subscriptionCount`)

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -114,31 +114,44 @@ internal class RealTripPlanningService(
         val excludeProductClassSet: Set<Int>,
     )
 
+    /**
+     * Appends mode-exclusion params to the trip request.
+     *
+     * NSW API rules (verified against official docs):
+     * - `excludedMeans=checkbox` MUST NOT be sent when the set is empty. Sending it with no
+     *   accompanying `exclMOT_*` params causes the API to return only default/fallback modes
+     *   (typically bus), silently dropping trains and other modes.
+     * - Each `exclMOT_<N>` param name uses an underscore before the number (`exclMOT_5`, not
+     *   `exclMOT5`). The API silently ignores params with the wrong name — no error returned.
+     * - Each `exclMOT_<N>` value must be `"1"` (boolean flag). The mode number itself (e.g. `"5"`)
+     *   is not a valid value and is silently ignored by the API.
+     */
     private fun addExcludedTransportModes(
         excludeProductClassSet: Set<Int>,
         parameters: ParametersBuilder,
     ) {
         log("Exclude transport mode - $excludeProductClassSet")
+        if (excludeProductClassSet.isEmpty()) return
         parameters.append(TripRequestParams.excludedMeans, "checkbox")
 
         if (excludeProductClassSet.contains(1)) {
             parameters.append(TripRequestParams.exclMOT1, "1")
         }
         if (excludeProductClassSet.contains(2)) {
-            parameters.append(TripRequestParams.exclMOT2, "2")
+            parameters.append(TripRequestParams.exclMOT2, "1")
         }
         if (excludeProductClassSet.contains(4)) {
-            parameters.append(TripRequestParams.exclMOT4, "4")
+            parameters.append(TripRequestParams.exclMOT4, "1")
         }
         if (excludeProductClassSet.contains(5) || excludeProductClassSet.contains(11)) {
-            parameters.append(TripRequestParams.exclMOT5, "5")
-            parameters.append(TripRequestParams.exclMOT11, "11")
+            parameters.append(TripRequestParams.exclMOT5, "1")
+            parameters.append(TripRequestParams.exclMOT11, "1")
         }
         if (excludeProductClassSet.contains(7)) {
-            parameters.append(TripRequestParams.exclMOT7, "7")
+            parameters.append(TripRequestParams.exclMOT7, "1")
         }
         if (excludeProductClassSet.contains(9)) {
-            parameters.append(TripRequestParams.exclMOT9, "9")
+            parameters.append(TripRequestParams.exclMOT9, "1")
         }
     }
 

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -114,44 +114,13 @@ internal class RealTripPlanningService(
         val excludeProductClassSet: Set<Int>,
     )
 
-    /**
-     * Appends mode-exclusion params to the trip request.
-     *
-     * NSW API rules (verified against official docs):
-     * - `excludedMeans=checkbox` MUST NOT be sent when the set is empty. Sending it with no
-     *   accompanying `exclMOT_*` params causes the API to return only default/fallback modes
-     *   (typically bus), silently dropping trains and other modes.
-     * - Each `exclMOT_<N>` param name uses an underscore before the number (`exclMOT_5`, not
-     *   `exclMOT5`). The API silently ignores params with the wrong name — no error returned.
-     * - Each `exclMOT_<N>` value must be `"1"` (boolean flag). The mode number itself (e.g. `"5"`)
-     *   is not a valid value and is silently ignored by the API.
-     */
     private fun addExcludedTransportModes(
         excludeProductClassSet: Set<Int>,
         parameters: ParametersBuilder,
     ) {
         log("Exclude transport mode - $excludeProductClassSet")
-        if (excludeProductClassSet.isEmpty()) return
-        parameters.append(TripRequestParams.excludedMeans, "checkbox")
-
-        if (excludeProductClassSet.contains(1)) {
-            parameters.append(TripRequestParams.exclMOT1, "1")
-        }
-        if (excludeProductClassSet.contains(2)) {
-            parameters.append(TripRequestParams.exclMOT2, "1")
-        }
-        if (excludeProductClassSet.contains(4)) {
-            parameters.append(TripRequestParams.exclMOT4, "1")
-        }
-        if (excludeProductClassSet.contains(5) || excludeProductClassSet.contains(11)) {
-            parameters.append(TripRequestParams.exclMOT5, "1")
-            parameters.append(TripRequestParams.exclMOT11, "1")
-        }
-        if (excludeProductClassSet.contains(7)) {
-            parameters.append(TripRequestParams.exclMOT7, "1")
-        }
-        if (excludeProductClassSet.contains(9)) {
-            parameters.append(TripRequestParams.exclMOT9, "1")
+        buildExclusionParams(excludeProductClassSet).forEach { (key, value) ->
+            parameters.append(key, value)
         }
     }
 
@@ -177,6 +146,45 @@ internal class RealTripPlanningService(
                 parameters.append(StopFinderRequestParams.tfNSWSF, "true")
             }
         }.body()
+    }
+}
+
+private const val PRODUCT_CLASS_TRAIN = 1
+private const val PRODUCT_CLASS_METRO = 2
+private const val PRODUCT_CLASS_LIGHT_RAIL = 4
+private const val PRODUCT_CLASS_BUS = 5
+private const val PRODUCT_CLASS_COACH = 7
+private const val PRODUCT_CLASS_FERRY = 9
+private const val PRODUCT_CLASS_SCHOOL_BUS = 11
+
+/**
+ * Builds the NSW API query params required to exclude specific transport modes.
+ *
+ * NSW API rules (verified against official docs):
+ * - `excludedMeans=checkbox` MUST NOT be sent when the set is empty. Sending it with no
+ *   accompanying `exclMOT_*` params causes the API to return only default/fallback modes
+ *   (typically bus), silently dropping trains and other modes.
+ * - Each `exclMOT_<N>` param name uses an underscore before the number (`exclMOT_5`, not
+ *   `exclMOT5`). The API silently ignores params with the wrong name — no error returned.
+ * - Each `exclMOT_<N>` value must be `"1"` (boolean flag). The mode number itself (e.g. `"5"`)
+ *   is not a valid value and is silently ignored by the API.
+ * - Bus and school bus share a single exclusion toggle — excluding either excludes both.
+ */
+internal fun buildExclusionParams(excludeProductClassSet: Set<Int>): Map<String, String> {
+    if (excludeProductClassSet.isEmpty()) return emptyMap()
+    val excludeBus = excludeProductClassSet.contains(PRODUCT_CLASS_BUS) ||
+        excludeProductClassSet.contains(PRODUCT_CLASS_SCHOOL_BUS)
+    return buildMap {
+        put(TripRequestParams.excludedMeans, "checkbox")
+        if (excludeProductClassSet.contains(PRODUCT_CLASS_TRAIN)) put(TripRequestParams.exclMOT1, "1")
+        if (excludeProductClassSet.contains(PRODUCT_CLASS_METRO)) put(TripRequestParams.exclMOT2, "1")
+        if (excludeProductClassSet.contains(PRODUCT_CLASS_LIGHT_RAIL)) put(TripRequestParams.exclMOT4, "1")
+        if (excludeBus) {
+            put(TripRequestParams.exclMOT5, "1")
+            put(TripRequestParams.exclMOT11, "1")
+        }
+        if (excludeProductClassSet.contains(PRODUCT_CLASS_COACH)) put(TripRequestParams.exclMOT7, "1")
+        if (excludeProductClassSet.contains(PRODUCT_CLASS_FERRY)) put(TripRequestParams.exclMOT9, "1")
     }
 }
 

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/trip/TripRequestParams.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/trip/TripRequestParams.kt
@@ -120,7 +120,7 @@ internal object TripRequestParams {
      * select one of the following: 1 = train, 2 = metro, 4 = light rail, 5 = bus, 7 = coach,
      * 9 = ferry, 11 = school bus.
      * `checkbox` allows you to exclude more than one means of transport when used in conjunction
-     * with the exclMOT<ID> parameters.
+     * with the exclMOT_<ID> parameters.
      *
      * Available values : checkbox, 1, 2, 4, 5, 7, 9, 11
      */
@@ -133,7 +133,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT1 = "exclMOT1" // Optional, to exclude trains
+    const val exclMOT1 = "exclMOT_1" // Optional, to exclude trains
 
     /**
      * Excludes metro services from the trip plan. Must be used in conjunction with
@@ -141,7 +141,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT2 = "exclMOT2" // Optional, to exclude metro
+    const val exclMOT2 = "exclMOT_2" // Optional, to exclude metro
 
     /**
      * Excludes light rail services from the trip plan. Must be used in conjunction with
@@ -149,7 +149,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT4 = "exclMOT4" // Optional, to exclude light rail
+    const val exclMOT4 = "exclMOT_4" // Optional, to exclude light rail
 
     /**
      * Excludes bus services from the trip plan. Must be used in conjunction with
@@ -157,7 +157,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT5 = "exclMOT5" // Optional, to exclude bus
+    const val exclMOT5 = "exclMOT_5" // Optional, to exclude bus
 
     /**
      * Excludes coach services from the trip plan. Must be used in conjunction with
@@ -165,7 +165,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT7: String = "exclMOT7" // Optional, to exclude coach
+    const val exclMOT7: String = "exclMOT_7" // Optional, to exclude coach
 
     /**
      * Excludes ferry services from the trip plan. Must be used in conjunction with
@@ -173,7 +173,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT9 = "exclMOT9" // Optional, to exclude ferry
+    const val exclMOT9 = "exclMOT_9" // Optional, to exclude ferry
 
     /**
      * Excludes school bus services from the trip plan. Must be used in conjunction with
@@ -181,7 +181,7 @@ internal object TripRequestParams {
      *
      * Available values : 1
      */
-    const val exclMOT11 = "exclMOT11"
+    const val exclMOT11 = "exclMOT_11" // Optional, to exclude school bus
 
     /**
      * Including this parameter enables a number of options that result in this API call

--- a/feature/trip-planner/network/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/ExclusionParamsTest.kt
+++ b/feature/trip-planner/network/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/ExclusionParamsTest.kt
@@ -1,0 +1,97 @@
+package xyz.ksharma.krail.trip.planner.network.api.service
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExclusionParamsTest {
+
+    @Test
+    fun `Given empty set Then returns empty map`() {
+        val params = buildExclusionParams(emptySet())
+        assertTrue(params.isEmpty())
+    }
+
+    @Test
+    fun `Given empty set Then excludedMeans is not included`() {
+        val params = buildExclusionParams(emptySet())
+        assertFalse(params.containsKey("excludedMeans"))
+    }
+
+    @Test
+    fun `Given non-empty set Then includes excludedMeans=checkbox`() {
+        val params = buildExclusionParams(setOf(5))
+        assertEquals("checkbox", params["excludedMeans"])
+    }
+
+    @Test
+    fun `Given bus excluded Then exclMOT_5 and exclMOT_11 both set to 1`() {
+        val params = buildExclusionParams(setOf(5))
+        assertEquals("1", params["exclMOT_5"])
+        assertEquals("1", params["exclMOT_11"])
+    }
+
+    @Test
+    fun `Given school bus excluded Then exclMOT_5 and exclMOT_11 both set to 1`() {
+        val params = buildExclusionParams(setOf(11))
+        assertEquals("1", params["exclMOT_5"])
+        assertEquals("1", params["exclMOT_11"])
+    }
+
+    @Test
+    fun `Given train excluded Then exclMOT_1 set to 1`() {
+        val params = buildExclusionParams(setOf(1))
+        assertEquals("1", params["exclMOT_1"])
+    }
+
+    @Test
+    fun `Given metro excluded Then exclMOT_2 set to 1`() {
+        val params = buildExclusionParams(setOf(2))
+        assertEquals("1", params["exclMOT_2"])
+    }
+
+    @Test
+    fun `Given light rail excluded Then exclMOT_4 set to 1`() {
+        val params = buildExclusionParams(setOf(4))
+        assertEquals("1", params["exclMOT_4"])
+    }
+
+    @Test
+    fun `Given coach excluded Then exclMOT_7 set to 1`() {
+        val params = buildExclusionParams(setOf(7))
+        assertEquals("1", params["exclMOT_7"])
+    }
+
+    @Test
+    fun `Given ferry excluded Then exclMOT_9 set to 1`() {
+        val params = buildExclusionParams(setOf(9))
+        assertEquals("1", params["exclMOT_9"])
+    }
+
+    @Test
+    fun `Given multiple modes excluded Then all corresponding params present`() {
+        val params = buildExclusionParams(setOf(1, 5, 9))
+        assertEquals("checkbox", params["excludedMeans"])
+        assertEquals("1", params["exclMOT_1"])
+        assertEquals("1", params["exclMOT_5"])
+        assertEquals("1", params["exclMOT_11"])
+        assertEquals("1", params["exclMOT_9"])
+        assertFalse(params.containsKey("exclMOT_2"))
+        assertFalse(params.containsKey("exclMOT_4"))
+        assertFalse(params.containsKey("exclMOT_7"))
+    }
+
+    @Test
+    fun `Given bus excluded Then param value is 1 not mode number`() {
+        val params = buildExclusionParams(setOf(5))
+        assertEquals("1", params["exclMOT_5"], "Value must be '1' not '5' — NSW API treats it as a boolean flag")
+    }
+
+    @Test
+    fun `Given train excluded Then param name uses underscore`() {
+        val params = buildExclusionParams(setOf(1))
+        assertTrue(params.containsKey("exclMOT_1"), "Param must be 'exclMOT_1' with underscore, not 'exclMOT1'")
+        assertFalse(params.containsKey("exclMOT1"), "Param 'exclMOT1' without underscore must not be present")
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -16,7 +16,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import kotlinx.collections.immutable.persistentSetOf
@@ -66,12 +69,18 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
         val timeTableState by viewModel.uiState.collectAsStateWithLifecycle()
         val expandedJourneyId by viewModel.expandedJourneyId.collectAsStateWithLifecycle()
 
-        // Collect these flows to trigger their onStart side-effects (polling, lifecycle
-        // gating) without exposing the values as unused local variables.
-        LaunchedEffect(viewModel) {
-            launch { viewModel.isLoading.collect {} }
-            launch { viewModel.isActive.collect {} }
-            launch { viewModel.autoRefreshTimeTable.collect {} }
+        // Collect these flows to trigger their WhileSubscribed side-effects (polling, time
+        // text refresh). Must use repeatOnLifecycle(STARTED) so collection stops when the
+        // Activity goes to background — a plain LaunchedEffect is Composition-scoped and
+        // would keep subscribers alive through lock-screen/background, preventing
+        // WhileSubscribed from ever seeing 0 collectors and halting the poll loop.
+        val lifecycleOwner = LocalLifecycleOwner.current
+        LaunchedEffect(viewModel, lifecycleOwner) {
+            lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                launch { viewModel.isLoading.collect {} }
+                launch { viewModel.isActive.collect {} }
+                launch { viewModel.autoRefreshTimeTable.collect {} }
+            }
         }
 
         // Modal visibility state


### PR DESCRIPTION
fix(trip-planner): correct NSW API mode exclusion params

Three bugs prevented mode filtering from working:
- `exclMOT5` → `exclMOT_5` (underscore required; API silently ignores wrong name)
- exclMOT_* values → "1" (boolean flag; mode number is not a valid value)
- `excludedMeans=checkbox` skipped when exclusion set is empty (sending it
  alone with no exclMOT_* params caused API to return bus-only results)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

fix(timetable): stop background API polling when screen is not visible

LaunchedEffect is Composition-scoped — it kept subscribers alive on
autoRefreshTimeTable/isLoading/isActive even after the app went to
background or the screen was locked. WhileSubscribed never saw 0
collectors so the 30s poll loop ran indefinitely in the background.

Wrap the side-effect collectors in repeatOnLifecycle(STARTED) so
Android lifecycle cancels the inner coroutines on background, dropping
subscriber count to 0 and letting WhileSubscribed halt the poll.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

docs(claude): add WhileSubscribed lifecycle polling rule

Document the repeatOnLifecycle(STARTED) pattern required for
activating WhileSubscribed polling flows from Compose UI. Plain
LaunchedEffect is Composition-scoped and defeats WhileSubscribed,
causing background API calls through lock-screen.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>