### PR TITLE
fix(search-stop): remove IME padding from floating top bar in single-pane

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -638,6 +638,12 @@ private fun SearchStopScreenSinglePane(
                 }
                 onTextChange(value)
             },
+            // The top bar floats at the TOP of the screen; the keyboard is at the BOTTOM.
+            // They never overlap, so IME padding on the bar is wrong: it inflates topBarHeightDp
+            // by the keyboard height, which pushes SearchStopListContent down by the same amount
+            // even though the root Box's imePadding() already shrinks the layout area.
+            // The root Box handles keyboard avoidance for all children.
+            applyImePadding = false,
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.TopStart)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
@@ -88,12 +88,12 @@ fun SearchTopBar(
         modifier = modifier
             .fillMaxWidth()
             .statusBarsPadding()
-            // Single-pane: the top bar floats in a Box over the content, so ime padding keeps it
-            // clear of the keyboard. Dual-pane: the top bar is the FIRST child of the left Column,
-            // so ime padding inflates its height by the keyboard height and shoves the list content
-            // down (severe on iOS landscape where the keyboard is ~50% of the height). The keyboard
-            // is at the bottom and the top bar at the top — they never overlap — so dual-pane opts
-            // out via applyImePadding = false.
+            // The top bar is at the TOP of the screen; the keyboard is at the BOTTOM — they never
+            // overlap. IME padding on this Row inflates the bar's measured height by the keyboard
+            // height, which then double-counts it in the content's top-padding offset. Both
+            // single-pane (floating Box) and dual-pane (Column first child) must pass
+            // applyImePadding = false; keyboard avoidance is the caller's responsibility via
+            // imePadding() on the root container.
             .then(if (applyImePadding) Modifier.windowInsetsPadding(WindowInsets.ime) else Modifier)
             .padding(horizontal = dim.spacingXL, vertical = dim.spacingL)
             .background(


### PR DESCRIPTION
SearchTopBar in single-pane was using applyImePadding=true (the default).
This adds windowInsetsPadding(ime) as BOTTOM padding to the bar's Row,
inflating topBarHeightDp by the keyboard height. SearchStopListContent's
padding(top = topBarHeightDp) then included the keyboard height even though
the root Box's imePadding() already excluded that area — double-counting.
Visible as a large gap between the search bar and results on iOS portrait
(where ime.bottom ≈ 336dp); landscape and Android are unaffected because
the keyboard either doesn't report a non-zero ime inset or the gap is less
noticeable.

The top bar is at the TOP of the screen; the keyboard is at the BOTTOM —
they never overlap, so IME padding on the bar serves no purpose. Both
single-pane and dual-pane now pass applyImePadding=false. Root container's
imePadding() handles keyboard avoidance for all children.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>