### PR TITLE
refactor: reuse TransportMode.productClass in place of private PRODUCT_CLASS constants

### DIFF
--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
@@ -34,6 +34,10 @@ sealed class TransportMode(
     @Serializable object Coach : TransportMode("#742282", "Coach", 7, 6, 5)
 
     companion object {
+        // School Bus is not a selectable mode in the app UI but shares the Bus exclusion toggle
+        // in the NSW trip-planning API. Not a sealed subclass to keep `all` accurate.
+        const val SCHOOL_BUS_PRODUCT_CLASS = 11
+
         val all: List<TransportMode> by lazy { listOf(Train, Metro, Bus, LightRail, Ferry, Coach) }
 
         private val byProductClass: Map<Int, TransportMode> by lazy { all.associateBy { it.productClass } }

--- a/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
+++ b/feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/business/DepartureMonitorMapper.kt
@@ -137,8 +137,11 @@ private fun DepartureMonitorResponse.Location.resolvePlatformText(productClass: 
         // ── Bus (5), School Bus (11) ─────────────────────────────────────────────
         // Extract "Stand X" from compound platformName:
         //   "Central Station, Eddy Ave, Stand A" → "Stand A"
-        // Note: School Bus (11) is not yet a TransportMode subclass — kept as literal.
-        TransportMode.Bus.productClass, 11 -> (pName ?: disassembledName)?.let { extractPlatformText(it) }
+        TransportMode.Bus.productClass, TransportMode.SCHOOL_BUS_PRODUCT_CLASS -> (pName ?: disassembledName)?.let {
+            extractPlatformText(
+                it,
+            )
+        }
 
         // ── Ferry (9) ────────────────────────────────────────────────────────────
         // Wharf name is the stop name itself; raw code ("F1") is the useful label.

--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
                 implementation(projects.core.di)
                 implementation(projects.core.log)
                 implementation(projects.core.network)
+                implementation(projects.core.transport)
                 implementation(projects.io.bffApi)
 
                 implementation(libs.kotlinx.serialization.json)

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/service/RealTripPlanningService.kt
@@ -16,6 +16,7 @@ import xyz.ksharma.krail.core.network.NSW_TRANSPORT_BASE_URL
 import xyz.ksharma.krail.core.network.NetworkUpstream
 import xyz.ksharma.krail.core.network.logNetworkCall
 import xyz.ksharma.krail.core.network.toNetworkUpstream
+import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.trip.planner.network.api.mapper.journeyListToTripResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.StopFinderResponse
 import xyz.ksharma.krail.trip.planner.network.api.model.StopType
@@ -149,14 +150,6 @@ internal class RealTripPlanningService(
     }
 }
 
-private const val PRODUCT_CLASS_TRAIN = 1
-private const val PRODUCT_CLASS_METRO = 2
-private const val PRODUCT_CLASS_LIGHT_RAIL = 4
-private const val PRODUCT_CLASS_BUS = 5
-private const val PRODUCT_CLASS_COACH = 7
-private const val PRODUCT_CLASS_FERRY = 9
-private const val PRODUCT_CLASS_SCHOOL_BUS = 11
-
 /**
  * Builds the NSW API query params required to exclude specific transport modes.
  *
@@ -172,19 +165,19 @@ private const val PRODUCT_CLASS_SCHOOL_BUS = 11
  */
 internal fun buildExclusionParams(excludeProductClassSet: Set<Int>): Map<String, String> {
     if (excludeProductClassSet.isEmpty()) return emptyMap()
-    val excludeBus = excludeProductClassSet.contains(PRODUCT_CLASS_BUS) ||
-        excludeProductClassSet.contains(PRODUCT_CLASS_SCHOOL_BUS)
+    val excludeBus = excludeProductClassSet.contains(TransportMode.Bus.productClass) ||
+        excludeProductClassSet.contains(TransportMode.SCHOOL_BUS_PRODUCT_CLASS)
     return buildMap {
         put(TripRequestParams.excludedMeans, "checkbox")
-        if (excludeProductClassSet.contains(PRODUCT_CLASS_TRAIN)) put(TripRequestParams.exclMOT1, "1")
-        if (excludeProductClassSet.contains(PRODUCT_CLASS_METRO)) put(TripRequestParams.exclMOT2, "1")
-        if (excludeProductClassSet.contains(PRODUCT_CLASS_LIGHT_RAIL)) put(TripRequestParams.exclMOT4, "1")
+        if (excludeProductClassSet.contains(TransportMode.Train.productClass)) put(TripRequestParams.exclMOT1, "1")
+        if (excludeProductClassSet.contains(TransportMode.Metro.productClass)) put(TripRequestParams.exclMOT2, "1")
+        if (excludeProductClassSet.contains(TransportMode.LightRail.productClass)) put(TripRequestParams.exclMOT4, "1")
         if (excludeBus) {
             put(TripRequestParams.exclMOT5, "1")
             put(TripRequestParams.exclMOT11, "1")
         }
-        if (excludeProductClassSet.contains(PRODUCT_CLASS_COACH)) put(TripRequestParams.exclMOT7, "1")
-        if (excludeProductClassSet.contains(PRODUCT_CLASS_FERRY)) put(TripRequestParams.exclMOT9, "1")
+        if (excludeProductClassSet.contains(TransportMode.Coach.productClass)) put(TripRequestParams.exclMOT7, "1")
+        if (excludeProductClassSet.contains(TransportMode.Ferry.productClass)) put(TripRequestParams.exclMOT9, "1")
     }
 }
 


### PR DESCRIPTION
RealTripPlanningService redefined 7 product-class ints as private file-level
constants instead of reading them from the canonical TransportMode sealed class
in :core:transport. This PR removes the duplicates:

- Add `projects.core.transport` dependency to :feature:trip-planner:network
- Replace the 7 private constants with TransportMode.X.productClass references
- Add TransportMode.SCHOOL_BUS_PRODUCT_CLASS = 11 companion const (School Bus
  has no sealed subclass — it is not a user-selectable filter mode — but the
  API needs its product-class int for the exclusion toggle)
- Update DepartureMonitorMapper's literal `11` to use the new companion const

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>