### PR TITLE
fix(journey): fix school bus display across map, header, and track UI

### DIFF
--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfig.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfig.kt
@@ -12,8 +12,15 @@ import xyz.ksharma.krail.core.transport.TransportModeSortOrder
  */
 object NswTransportConfig : TransportConfig {
 
+    // School Bus (class 11) is not a TransportMode subclass — it shares Bus UI and API behaviour.
+    // Mapping it here means all callers get TransportMode.Bus automatically; no per-callsite guard needed.
+    // Add future product-class aliases here if another class maps to an existing mode.
     override fun modeFromProductClass(productClass: Int): TransportMode? =
-        TransportMode.fromProductClass(productClass)
+        if (productClass == TransportMode.SCHOOL_BUS_PRODUCT_CLASS) {
+            TransportMode.Bus
+        } else {
+            TransportMode.fromProductClass(productClass)
+        }
 
     override fun colorFor(mode: TransportMode): String = mode.colorCode
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -162,6 +162,10 @@ data class TimeTableState(
 
                 /** Stable timetable identifier (transportation.id only). Used for trip tracking deep links. */
                 val transportationId: String? = null,
+
+                /** True when the leg's product class is 11 (School Bus). Rendered as a bus leg
+                 *  with a "School service" tag so users know the service is not public. */
+                val isSchoolBus: Boolean = false,
             ) : Leg()
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -115,6 +115,12 @@ fun JourneyCard(
         )
     }
 
+    val hasSchoolBus by remember(legList) {
+        mutableStateOf(
+            legList.filterIsInstance<TimeTableState.JourneyCardInfo.Leg.TransportLeg>()
+                .any { it.isSchoolBus },
+        )
+    }
     val coroutineScope = rememberCoroutineScope()
     val graphicsLayer = rememberGraphicsLayer()
     val cardBackground =
@@ -150,6 +156,7 @@ fun JourneyCard(
             transportModeLineList = transportModeLineList,
             platformText = platformText,
             timeToDeparture = timeToDeparture,
+            isSchoolBus = hasSchoolBus,
         )
 
         // Always visible content
@@ -178,9 +185,7 @@ fun JourneyCard(
 
         // Expandable content - only leg details
         when (cardState) {
-            JourneyCardState.DEFAULT -> {
-                // No additional content in default state
-            }
+            JourneyCardState.DEFAULT -> Unit
 
             JourneyCardState.EXPANDED -> ExpandedJourneyCardContent(
                 legList = legList,
@@ -345,6 +350,7 @@ fun ExpandedJourneyCardContent(
                             transportModeLine = leg.transportModeLine,
                             stops = leg.stops,
                             displayAllStops = displayAllStops,
+                            isSchoolBus = leg.isSchoolBus,
                             modifier = Modifier.padding(
                                 top = if (index > 0) {
                                     getPaddingValue(
@@ -400,9 +406,9 @@ private fun ResponsiveJourneyInfoRow(
     isPast: Boolean = false,
 ) {
     val dim = KrailTheme.dimensions
-    Row(
+    FlowRow(
         horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
     ) {
         Text(
             text = destinationTime,
@@ -756,6 +762,43 @@ private fun Preview_JourneyCard_Expanded_NoAlerts() {
 @ScreenshotTest
 @PreviewComponent
 @Composable
+private fun Preview_Expanded_SchoolBusLeg() {
+    PreviewTheme(themeStyle = DEFAULT_THEME_STYLE) {
+        JourneyCard(
+            timeToDeparture = "in 5 mins",
+            originTime = "8:05am",
+            destinationTime = "8:45am",
+            totalTravelTime = "40 mins",
+            platformNumber = null,
+            platformText = null,
+            transportModeLineList = persistentListOf(
+                TransportModeLine(transportMode = TransportMode.Bus, lineName = "8550"),
+            ),
+            legList = persistentListOf(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
+                    stops = PREVIEW_STOPS,
+                    displayText = "towards Parramatta via Great Western Hwy",
+                    transportModeLine = TransportModeLine(
+                        transportMode = TransportMode.Bus,
+                        lineName = "8550",
+                    ),
+                    totalDuration = "30 mins",
+                    tripId = "8550",
+                    isSchoolBus = true,
+                ),
+            ),
+            cardState = JourneyCardState.EXPANDED,
+            totalWalkTime = null,
+            totalUniqueServiceAlerts = 0,
+            onClick = {},
+            departureDeviation = TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime,
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
 private fun Preview_Default_WithWalkTime() {
     PreviewTheme(themeStyle = DEFAULT_THEME_STYLE) {
         JourneyCard(
@@ -1002,6 +1045,80 @@ private fun JourneyCardCollapsedOnTimePreview() {
             cardState = JourneyCardState.DEFAULT,
             totalWalkTime = null,
             totalUniqueServiceAlerts = 0,
+            onClick = {},
+            departureDeviation = TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime,
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun Preview_Default_SchoolBus() {
+    PreviewTheme(themeStyle = DEFAULT_THEME_STYLE) {
+        JourneyCard(
+            timeToDeparture = "in 6 mins",
+            originTime = "8:05am",
+            destinationTime = "8:50am",
+            totalTravelTime = "45 mins",
+            platformNumber = null,
+            platformText = null,
+            transportModeLineList = persistentListOf(
+                TransportModeLine(transportMode = TransportMode.Bus, lineName = "8550"),
+            ),
+            legList = persistentListOf(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
+                    stops = PREVIEW_STOPS,
+                    displayText = "towards Parramatta via Great Western Hwy",
+                    transportModeLine = TransportModeLine(
+                        transportMode = TransportMode.Bus,
+                        lineName = "8550",
+                    ),
+                    totalDuration = "30 mins",
+                    tripId = "8550",
+                    isSchoolBus = true,
+                ),
+            ),
+            cardState = JourneyCardState.DEFAULT,
+            totalWalkTime = null,
+            totalUniqueServiceAlerts = 0,
+            onClick = {},
+            departureDeviation = TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime,
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun Preview_Default_SchoolBus_WithAlerts() {
+    PreviewTheme(themeStyle = DEFAULT_THEME_STYLE) {
+        JourneyCard(
+            timeToDeparture = "in 6 mins",
+            originTime = "8:05am",
+            destinationTime = "8:55am",
+            totalTravelTime = "50 mins",
+            platformNumber = null,
+            platformText = null,
+            transportModeLineList = persistentListOf(
+                TransportModeLine(transportMode = TransportMode.Bus, lineName = "8550"),
+            ),
+            legList = persistentListOf(
+                TimeTableState.JourneyCardInfo.Leg.TransportLeg(
+                    stops = PREVIEW_STOPS,
+                    displayText = "towards Parramatta via Great Western Hwy",
+                    transportModeLine = TransportModeLine(
+                        transportMode = TransportMode.Bus,
+                        lineName = "8550",
+                    ),
+                    totalDuration = "30 mins",
+                    tripId = "8550",
+                    isSchoolBus = true,
+                ),
+            ),
+            cardState = JourneyCardState.DEFAULT,
+            totalWalkTime = null,
+            totalUniqueServiceAlerts = 2,
             onClick = {},
             departureDeviation = TimeTableState.JourneyCardInfo.DepartureDeviation.OnTime,
         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCardHeader.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCardHeader.kt
@@ -10,11 +10,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.core.snapshot.ScreenshotTest
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.components.SeparatorIcon
+import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
@@ -39,6 +41,7 @@ internal fun JourneyCardHeader(
     platformText: String?,
     timeToDeparture: String,
     modifier: Modifier = Modifier,
+    isSchoolBus: Boolean = false,
 ) {
     val isPast by remember(timeToDeparture) {
         mutableStateOf(timeToDeparture.contains(other = "ago", ignoreCase = true))
@@ -64,6 +67,7 @@ internal fun JourneyCardHeader(
                 TransportModesRow(
                     transportModeLineList = transportModeLineList,
                     showBadge = { it.transportMode is TransportMode.Bus },
+                    isSchoolBus = isSchoolBus,
                 )
             }
         }
@@ -74,6 +78,7 @@ internal fun JourneyCardHeader(
             TransportModesRow(
                 transportModeLineList = transportModeLineList,
                 showBadge = { it.transportMode is TransportMode.Bus },
+                isSchoolBus = isSchoolBus,
                 modifier = Modifier.padding(top = dim.journeyCardLegSpacing),
             )
         }
@@ -93,6 +98,7 @@ internal fun TransportModesRow(
     transportModeLineList: ImmutableList<TransportModeLine>,
     showBadge: (TransportModeLine) -> Boolean,
     modifier: Modifier = Modifier,
+    isSchoolBus: Boolean = false,
 ) {
     val dim = KrailTheme.dimensions
     FlowRow(
@@ -115,6 +121,13 @@ internal fun TransportModesRow(
             if (index != transportModeLineList.lastIndex) {
                 SeparatorIcon(modifier = Modifier.align(Alignment.CenterVertically))
             }
+        }
+        if (isSchoolBus) {
+            Text(
+                text = "School Bus",
+                style = KrailTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                color = KrailTheme.colors.onSurface,
+            )
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -60,6 +60,7 @@ fun LegView(
     stops: ImmutableList<TimeTableState.JourneyCardInfo.Stop>,
     modifier: Modifier = Modifier,
     displayAllStops: Boolean = false,
+    isSchoolBus: Boolean = false,
     onClick: () -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
@@ -137,6 +138,7 @@ fun LegView(
                         StopsRow(
                             stops = "$stopsCount stops",
                             line = transportModeLine,
+                            isSchoolBus = isSchoolBus,
                             onClick = {
                                 onClick()
                             },
@@ -216,23 +218,23 @@ private fun RouteSummary(
     modifier: Modifier = Modifier,
 ) {
     val dim = KrailTheme.dimensions
-    Row(
-        modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        TransportModeBadge(
-            backgroundColor = badgeColor,
-            badgeText = badgeText,
-            modifier = Modifier.padding(end = KrailTheme.dimensions.spacingML),
-        )
-
-        routeText?.let {
-            Text(
-                text = routeText,
-                style = KrailTheme.typography.labelLarge.copy(fontWeight = FontWeight.Normal), // token todo
-                modifier = Modifier
-                    .align(Alignment.CenterVertically),
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TransportModeBadge(
+                backgroundColor = badgeColor,
+                badgeText = badgeText,
+                modifier = Modifier.padding(end = dim.spacingML),
             )
+
+            routeText?.let {
+                Text(
+                    text = routeText,
+                    style = KrailTheme.typography.labelLarge.copy(fontWeight = FontWeight.Normal),
+                    modifier = Modifier.align(Alignment.CenterVertically),
+                )
+            }
         }
     }
 }
@@ -314,6 +316,7 @@ private fun StopsRow(
     stops: String,
     line: TransportModeLine,
     modifier: Modifier = Modifier,
+    isSchoolBus: Boolean = false,
     onClick: () -> Unit,
 ) {
     val dim = KrailTheme.dimensions
@@ -342,6 +345,14 @@ private fun StopsRow(
             transportMode = line.transportMode,
             modifier = Modifier.align(Alignment.CenterVertically),
         )
+
+        if (isSchoolBus) {
+            Text(
+                text = "School Bus",
+                style = KrailTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+                color = KrailTheme.colors.onSurface,
+            )
+        }
     }
 }
 
@@ -484,6 +495,35 @@ private fun PreviewLegViewLightRail() {
                 TimeTableState.JourneyCardInfo.Stop(
                     time = "01:00 am",
                     name = "DEF Station, Platform 3",
+                    isWheelchairAccessible = false,
+                ),
+            ).toImmutableList(),
+            modifier = Modifier.background(KrailTheme.colors.surface),
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewLegViewSchoolBus() {
+    PreviewTheme {
+        LegView(
+            routeText = "towards Parramatta via Great Western Hwy",
+            transportModeLine = TransportModeLine(
+                transportMode = TransportMode.Bus,
+                lineName = "8550",
+            ),
+            isSchoolBus = true,
+            stops = listOf(
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "8:05 am",
+                    name = "Penrith Station, Stop A",
+                    isWheelchairAccessible = false,
+                ),
+                TimeTableState.JourneyCardInfo.Stop(
+                    time = "8:35 am",
+                    name = "Parramatta Station, Stop B",
                     isWheelchairAccessible = false,
                 ),
             ).toImmutableList(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.timetable.business
 import kotlinx.collections.immutable.toImmutableList
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toFormattedDurationTimeString
 import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
@@ -32,7 +33,9 @@ internal fun TripResponse.Leg.toWalkingLegUiModel(): TimeTableState.JourneyCardI
 @OptIn(ExperimentalTime::class)
 @Suppress("ComplexCondition")
 internal fun TripResponse.Leg.toTransportLegUiModel(): TimeTableState.JourneyCardInfo.Leg? {
-    val transportMode = transportation?.product?.productClass?.toInt()
+    val rawProductClass = transportation?.product?.productClass?.toInt()
+    val isSchoolBus = rawProductClass == TransportMode.SCHOOL_BUS_PRODUCT_CLASS
+    val transportMode = rawProductClass
         ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
     val lineName = transportation?.disassembledName
     val displayText = NswTransportConfig.resolveServiceDisplayText(
@@ -71,5 +74,6 @@ internal fun TripResponse.Leg.toTransportLegUiModel(): TimeTableState.JourneyCar
         },
         tripId = transportation?.id + transportation?.properties?.realtimeTripId,
         transportationId = transportation?.id,
+        isSchoolBus = isSchoolBus,
     )
 }


### PR DESCRIPTION
## Summary

`NswTransportConfig.modeFromProductClass(11)` returns `null` for school bus legs, causing silent drops in multiple mappers. This PR fixes all three remaining callsites:

- **Map polyline color** (`JourneyMapMapper`): school bus route rendered as gray walking-path color instead of bus blue
- **Journey card header** (`TripResponseMapper.getTransportModeLines`): school bus `TransportModeLine` never created → second bus icon missing from collapsed/expanded header
- **Live track UI** (`feature/track/ui TripResponseMapper`): school bus legs dropped entirely from tracked journey leg list

All three now fall back to `TransportMode.Bus` for product class 11, matching the fix already in `TripResponseLegMapper` (shipped in #1665).

## Test plan

- [ ] Plan a journey that includes a school bus leg (product class 11)
- [ ] Confirm second bus icon appears in journey card header alongside regular bus
- [ ] Confirm school bus route polyline on map renders in bus blue (`#00B5EF`), not gray
- [ ] Confirm school bus leg appears in live track UI when tracking such a journey

🤖 Generated with [Claude Code](https://claude.com/claude-code)