### PR TITLE
feat(release): add cut-release script and /cut-release Claude command

### DIFF
--- a/.claude/commands/cut-release.md
+++ b/.claude/commands/cut-release.md
@@ -1,0 +1,46 @@
+# Cut Release
+
+Trigger a KRAIL release branch cut via local CLI → GitHub Actions. No manual GH UI steps needed.
+
+**Trigger phrases:** "cut a release", "start next version rollout", "ship 1.x", "release time", `/cut-release`
+
+## Steps — run these without asking unless something is ambiguous
+
+1. Read current version:
+   ```bash
+   grep -oP '(?<=versionName = ")[^"]+' androidApp/build.gradle.kts
+   ```
+
+2. Check the prod branch doesn't already exist:
+   ```bash
+   git ls-remote --heads origin "prod/{version}"
+   ```
+   If it exists, stop and tell the user.
+
+3. Run the release script — this triggers the GH Actions workflow from local CLI:
+   ```bash
+   ./scripts/cut-release.sh
+   ```
+   The script reads the current version, prints what it will do, and asks for a single `y/N` confirmation before firing `gh workflow run`. Answer `y`.
+
+   To specify the next version explicitly (e.g. skip to 1.25.0):
+   ```bash
+   ./scripts/cut-release.sh 1.25.0
+   ```
+
+4. After the script exits successfully, tell the user:
+   - `prod/{version}` is being created — GH Actions fires automatically
+   - "2. Deploy RC" auto-triggers on that push → builds signed AAB, tags `v{version}-RC1`, distributes to GP Internal + TestFlight + Firebase Friends, creates a draft GitHub Release
+   - Watch: `https://github.com/ksharma-xyz/KRAIL/actions`
+
+## What happens in CI (no action needed from user)
+
+| Stage | What |
+|---|---|
+| `release-1-cut.yml` | Creates `prod/{version}` from main; opens bump-main PR |
+| `release-2-deploy-rc.yml` | Fires on push to `prod/*`; quality gate → build AAB → RC tag → distribute |
+| Draft release | Auto-created on GitHub, stays draft until user publishes |
+
+## Keeping this skill in sync with CI
+
+The source of truth is `.github/workflows/release-1-cut.yml`. If inputs, branch naming, or flow change there, update this skill and `scripts/cut-release.sh` in the same PR.

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# cut-release.sh — trigger the "1. Cut Release Branch" GitHub Actions workflow.
+#
+# Usage:
+#   ./scripts/cut-release.sh                    # auto-increment minor on main
+#   ./scripts/cut-release.sh 1.25.0             # specify explicit next version for main
+#   ./scripts/cut-release.sh --base feat/foo    # cut from a branch other than main
+#
+# What happens after you run this:
+#   1. GH Actions creates prod/{current-version} from <base-branch>
+#   2. A PR to bump main to <next-version> is opened and auto-merged
+#   3. Pushing prod/{version} auto-triggers "2. Deploy RC" → RC1 tag + GP Internal + TestFlight
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+BASE_BRANCH="main"
+NEXT_VERSION=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE_BRANCH="$2"; shift 2 ;;
+    --base=*)
+      BASE_BRANCH="${1#--base=}"; shift ;;
+    -*)
+      echo "Unknown flag: $1" >&2; exit 1 ;;
+    *)
+      NEXT_VERSION="$1"; shift ;;
+  esac
+done
+
+# Read current version from the base branch (local checkout must be up-to-date)
+CURRENT_VERSION=$(grep -oP '(?<=versionName = ")[^"]+' "$ROOT/androidApp/build.gradle.kts")
+if [[ -z "$CURRENT_VERSION" ]]; then
+  echo "error: could not read versionName from androidApp/build.gradle.kts" >&2
+  exit 1
+fi
+
+# Compute next version if not supplied
+if [[ -z "$NEXT_VERSION" ]]; then
+  MAJOR=$(echo "$CURRENT_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$CURRENT_VERSION" | cut -d. -f2)
+  NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0"
+fi
+
+echo ""
+echo "  Release branch : prod/${CURRENT_VERSION}  (from ${BASE_BRANCH})"
+echo "  Next on main   : ${NEXT_VERSION}"
+echo ""
+read -r -p "Proceed? [y/N] " CONFIRM
+[[ "$CONFIRM" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+
+# Build gh workflow run args — only pass next-version if we have one
+EXTRA_FIELDS=()
+if [[ -n "$NEXT_VERSION" ]]; then
+  EXTRA_FIELDS+=(--field "next-version=${NEXT_VERSION}")
+fi
+
+gh workflow run release-1-cut.yml \
+  --ref "$BASE_BRANCH" \
+  --field "base-branch=${BASE_BRANCH}" \
+  "${EXTRA_FIELDS[@]}"
+
+echo ""
+echo "Workflow triggered. Track progress at:"
+echo "  https://github.com/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/workflows/release-1-cut.yml"


### PR DESCRIPTION
## Summary
- `scripts/cut-release.sh` — triggers `release-1-cut.yml` GH Actions workflow from local CLI via `gh workflow run`; reads current `versionName`, shows what it will do, asks `y/N`, fires the workflow
- `.claude/commands/cut-release.md` — `/cut-release` slash command (also triggers on phrases like "start next version rollout"); fully autonomous, no back-and-forth

## Usage
```bash
./scripts/cut-release.sh           # auto-increment minor
./scripts/cut-release.sh 1.25.0   # explicit next version
```
Or just tell Claude: "start next version rollout"

## Test plan
- [ ] `./scripts/cut-release.sh --help` (or run dry — confirm it reads versionName correctly)
- [ ] Verify `/cut-release` appears in Claude Code slash command list
- [ ] Trigger a real release cut and confirm GH Actions workflow fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)