### PR TITLE
fix(ci): use github.token for version bump PR in release-1-cut

### DIFF
--- a/.github/workflows/release-1-cut.yml
+++ b/.github/workflows/release-1-cut.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Commit and open version bump PR into main
         env:
-          GH_TOKEN: ${{ secrets.PAT_KRAIL_GITHUB }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           git add androidApp/build.gradle.kts iosApp/Configuration/Config.xcconfig
           if git diff --staged --quiet; then


### PR DESCRIPTION
## Problem
`PAT_KRAIL_GITHUB` lacks `createPullRequest` GraphQL permission, so the version bump PR step fails with:
> Resource not accessible by personal access token (createPullRequest)

## Fix
The job already declares `pull-requests: write`, so `github.token` has the right to open PRs. Only the checkout/push steps need the PAT. Switch `GH_TOKEN` in the bump PR step to `github.token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)