### PR TITLE
feat(track): live tracking via KRAIL-BFF snapshot endpoint (A1)

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -47,4 +47,15 @@ enum class FlagKeys(val key: String) {
      * value.
      */
     ENABLE_PROTO_BFF("enable_proto_bff"),
+
+    /**
+     * Per-feature kill switch for the BFF live-tracking path
+     * (`POST /api/v1/track/snapshot`). Only consulted when the endpoint
+     * already resolves to the BFF (see [ENABLE_PROTO_BFF] + the arming
+     * gate): `true`/unset → tracking polls the BFF snapshot endpoint;
+     * `false` → tracking falls back to direct GTFS-RT polling even while
+     * the rest of the app uses the BFF. Defaults to enabled so debug
+     * `BFF_LOCAL` testing needs no RC change.
+     */
+    BFF_USE_FOR_TRACK("bff_use_for_track"),
 }

--- a/feature/track/network/build.gradle.kts
+++ b/feature/track/network/build.gradle.kts
@@ -24,8 +24,10 @@ kotlin {
                 implementation(projects.core.dateTime)
                 implementation(projects.core.log)
                 implementation(projects.core.network)
+                implementation(projects.core.remoteConfig)
                 implementation(projects.core.transport)
                 implementation(projects.feature.track.state)
+                implementation(projects.io.bffApi)
                 implementation(projects.io.gtfs)
 
                 implementation(libs.ktor.client.core)

--- a/feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/BffGtfsRealtimeRepository.kt
+++ b/feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/BffGtfsRealtimeRepository.kt
@@ -1,0 +1,162 @@
+package xyz.ksharma.krail.feature.track.network
+
+import app.krail.bff.proto.TrackRequest
+import app.krail.bff.proto.TrackResponse
+import app.krail.bff.proto.VehicleLive
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.accept
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.number
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.utcToLocalDateTimeAEST
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.log.logError
+import xyz.ksharma.krail.core.network.BffEndpointResolver
+import xyz.ksharma.krail.core.network.NetworkUpstream
+import xyz.ksharma.krail.core.network.logNetworkCall
+import xyz.ksharma.krail.core.network.toNetworkUpstream
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
+import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
+import xyz.ksharma.krail.feature.track.LegTrackingInfo
+import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
+import xyz.ksharma.krail.feature.track.LiveVehiclePosition
+import xyz.ksharma.krail.feature.track.VehicleStatus
+
+/**
+ * BFF-backed [GtfsRealtimeRepository]: one `POST /api/v1/track/snapshot`
+ * replaces the per-feed GTFS-RT fetch + client-side matching — the BFF
+ * polls NSW once for all users and returns a render-ready [TrackResponse]
+ * (contract: track.proto, krail-api-proto v0.4.0).
+ *
+ * Routing: used only when [BffEndpointResolver] resolves to the BFF AND the
+ * [FlagKeys.BFF_USE_FOR_TRACK] kill switch is not off. Any BFF failure
+ * falls back to [direct] (NSW GTFS-RT polling) for that poll — tracking
+ * never breaks because the BFF is unreachable.
+ */
+internal class BffGtfsRealtimeRepository(
+    private val httpClient: HttpClient,
+    private val resolver: BffEndpointResolver,
+    private val flag: Flag,
+    private val direct: GtfsRealtimeRepository,
+    private val ioDispatcher: CoroutineDispatcher,
+) : GtfsRealtimeRepository {
+
+    override suspend fun pollLiveTracking(
+        legs: List<LegTrackingInfo>,
+        originUtcDateTime: String,
+    ): LiveTrackingOverlay {
+        val baseUrl = resolver.resolveBaseUrl()
+        val useBff = baseUrl.toNetworkUpstream() == NetworkUpstream.BFF &&
+            flag.getFlagValue(FlagKeys.BFF_USE_FOR_TRACK.key).asBoolean(fallback = true)
+        if (!useBff) {
+            return direct.pollLiveTracking(legs, originUtcDateTime)
+        }
+        return runCatching { snapshotOverlay(baseUrl, legs, originUtcDateTime) }
+            .getOrElse { error ->
+                logError("[BFFTRACK] snapshot failed, falling back to direct GTFS-RT", error)
+                direct.pollLiveTracking(legs, originUtcDateTime)
+            }
+    }
+
+    override fun clearCache() = direct.clearCache()
+
+    private suspend fun snapshotOverlay(
+        baseUrl: String,
+        legs: List<LegTrackingInfo>,
+        originUtcDateTime: String,
+    ): LiveTrackingOverlay = withContext(ioDispatcher) {
+        val request = TrackRequest(
+            legs = legs.mapNotNull { leg -> leg.toTrackLeg(originUtcDateTime) },
+        )
+        if (request.legs.isEmpty()) {
+            log("[BFFTRACK] no legs with a realtimeTripId — nothing to track via BFF")
+            return@withContext LiveTrackingOverlay(emptyMap(), emptyMap(), lastModified = null)
+        }
+
+        logNetworkCall(
+            target = NetworkUpstream.BFF,
+            method = "POST",
+            path = "/api/v1/track/snapshot",
+        )
+        val bytes: ByteArray = httpClient.post("$baseUrl/api/v1/track/snapshot") {
+            contentType(ContentType("application", "x-protobuf"))
+            accept(ContentType("application", "x-protobuf"))
+            setBody(TrackRequest.ADAPTER.encode(request))
+        }.body()
+
+        val response = TrackResponse.ADAPTER.decode(bytes)
+        log(
+            "[BFFTRACK] snapshot — ${response.legs.size} legs, statuses=" +
+                response.legs.joinToString { it.status.name },
+        )
+        response.toOverlay()
+    }
+
+    private fun LegTrackingInfo.toTrackLeg(originUtcDateTime: String): TrackRequest.TrackLeg? {
+        val tripId = realtimeTripId?.takeIf { it.isNotBlank() } ?: return null
+        val departureUtc = plannedDepartureUtc.ifBlank { originUtcDateTime }
+        return TrackRequest.TrackLeg(
+            leg_ref = legIndex.toString(),
+            realtime_trip_id = tripId,
+            product_class = transportMode.productClass,
+            origin_stop_id = originStopId,
+            destination_stop_id = destinationStopId,
+            service_date = departureUtc.toServiceDate(),
+            planned_departure_utc = departureUtc,
+        )
+    }
+}
+
+/**
+ * Maps the BFF snapshot onto the overlay shape the track screen already
+ * renders. Legs keep their request order; `leg_ref` round-trips the
+ * original `legIndex`.
+ */
+internal fun TrackResponse.toOverlay(): LiveTrackingOverlay {
+    val positions = buildMap {
+        legs.forEach { leg ->
+            val legIndex = leg.leg_ref.toIntOrNull() ?: return@forEach
+            val vehicle = leg.vehicle ?: return@forEach
+            put(legIndex, vehicle.toLivePosition())
+        }
+    }
+    val delays = buildMap {
+        legs.forEach { leg ->
+            if (!leg.has_delay) return@forEach
+            leg.stops.forEach { stop -> put(stop.stop_id, leg.delay_seconds) }
+        }
+    }
+    return LiveTrackingOverlay(
+        vehiclePositions = positions,
+        stopDelays = delays,
+        lastModified = fetched_at_epoch_sec.takeIf { it > 0 }?.toString(),
+    )
+}
+
+private fun VehicleLive.toLivePosition(): LiveVehiclePosition = LiveVehiclePosition(
+    latitude = latitude,
+    longitude = longitude,
+    bearing = if (has_bearing) bearing_degrees else 0f,
+    status = when (stop_relation) {
+        VehicleLive.StopRelation.INCOMING_AT -> VehicleStatus.INCOMING_AT
+        VehicleLive.StopRelation.STOPPED_AT -> VehicleStatus.STOPPED_AT
+        else -> VehicleStatus.IN_TRANSIT_TO
+    },
+    lastUpdatedEpochSec = measured_at_epoch_sec,
+)
+
+/** ISO-8601 UTC → YYYYMMDD Sydney service date (the BFF expiry key). */
+internal fun String.toServiceDate(): String = runCatching {
+    utcToLocalDateTimeAEST().let { dt ->
+        dt.year.toString() +
+            dt.month.number.toString().padStart(2, '0') +
+            dt.dayOfMonth.toString().padStart(2, '0')
+    }
+}.getOrDefault(substringBefore("T").replace("-", ""))

--- a/feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/di/TrackNetworkModule.kt
+++ b/feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/di/TrackNetworkModule.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.feature.track.network.di
 import kotlinx.coroutines.Dispatchers
 import org.koin.dsl.module
 import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
+import xyz.ksharma.krail.feature.track.network.BffGtfsRealtimeRepository
 import xyz.ksharma.krail.feature.track.network.GtfsRealtimeService
 import xyz.ksharma.krail.feature.track.network.RealGtfsRealtimeRepository
 import xyz.ksharma.krail.feature.track.network.RealGtfsRealtimeService
@@ -15,7 +16,16 @@ val trackNetworkModule = module {
             resolver = get(),
         )
     }
+    // The BFF snapshot path wraps the direct GTFS-RT path: each poll routes
+    // via BffEndpointResolver + the bff_use_for_track kill switch, and any
+    // BFF failure falls back to direct polling for that poll.
     single<GtfsRealtimeRepository> {
-        RealGtfsRealtimeRepository(service = get(), ioDispatcher = Dispatchers.Default)
+        BffGtfsRealtimeRepository(
+            httpClient = gtfsRealtimeHttpClient(get()),
+            resolver = get(),
+            flag = get(),
+            direct = RealGtfsRealtimeRepository(service = get(), ioDispatcher = Dispatchers.Default),
+            ioDispatcher = Dispatchers.Default,
+        )
     }
 }

--- a/feature/track/network/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/network/BffTrackOverlayMapperTest.kt
+++ b/feature/track/network/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/network/BffTrackOverlayMapperTest.kt
@@ -1,0 +1,110 @@
+package xyz.ksharma.krail.feature.track.network
+
+import app.krail.bff.proto.LegTracking
+import app.krail.bff.proto.StopProgress
+import app.krail.bff.proto.TrackResponse
+import app.krail.bff.proto.VehicleLive
+import xyz.ksharma.krail.feature.track.VehicleStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BffTrackOverlayMapperTest {
+
+    private fun vehicle(
+        lat: Double = -33.87,
+        lon: Double = 151.21,
+        bearing: Float? = 42f,
+        relation: VehicleLive.StopRelation = VehicleLive.StopRelation.IN_TRANSIT_TO,
+    ) = VehicleLive(
+        latitude = lat,
+        longitude = lon,
+        bearing_degrees = bearing ?: 0f,
+        has_bearing = bearing != null,
+        measured_at_epoch_sec = 1_700_000_000L,
+        stop_relation = relation,
+    )
+
+    @Test
+    fun `maps vehicles back onto their legIndex via leg_ref`() {
+        val response = TrackResponse(
+            fetched_at_epoch_sec = 1_700_000_123L,
+            legs = listOf(
+                LegTracking(leg_ref = "0", status = LegTracking.Status.TRACKING, vehicle = vehicle()),
+                LegTracking(leg_ref = "2", status = LegTracking.Status.NOT_STARTED),
+            ),
+        )
+        val overlay = response.toOverlay()
+
+        assertEquals(setOf(0), overlay.vehiclePositions.keys, "leg without vehicle contributes nothing")
+        val pos = overlay.vehiclePositions.getValue(0)
+        assertEquals(-33.87, pos.latitude)
+        assertEquals(42f, pos.bearing)
+        assertEquals(VehicleStatus.IN_TRANSIT_TO, pos.status)
+        assertEquals(1_700_000_000L, pos.lastUpdatedEpochSec)
+        assertEquals("1700000123", overlay.lastModified)
+    }
+
+    @Test
+    fun `missing bearing maps to zero, stop relations map across`() {
+        val response = TrackResponse(
+            legs = listOf(
+                LegTracking(
+                    leg_ref = "0",
+                    status = LegTracking.Status.TRACKING,
+                    vehicle = vehicle(bearing = null, relation = VehicleLive.StopRelation.STOPPED_AT),
+                ),
+            ),
+        )
+        val pos = response.toOverlay().vehiclePositions.getValue(0)
+        assertEquals(0f, pos.bearing)
+        assertEquals(VehicleStatus.STOPPED_AT, pos.status)
+    }
+
+    @Test
+    fun `leg delay fans out to every stop id only when has_delay is set`() {
+        val response = TrackResponse(
+            legs = listOf(
+                LegTracking(
+                    leg_ref = "0",
+                    status = LegTracking.Status.TRACKING,
+                    delay_seconds = 120,
+                    has_delay = true,
+                    stops = listOf(
+                        StopProgress(stop_id = "S1", state = StopProgress.State.DEPARTED),
+                        StopProgress(stop_id = "S2", state = StopProgress.State.UPCOMING),
+                    ),
+                ),
+                LegTracking(
+                    leg_ref = "1",
+                    status = LegTracking.Status.TRACKING,
+                    delay_seconds = 0,
+                    has_delay = false,
+                    stops = listOf(StopProgress(stop_id = "S3", state = StopProgress.State.UPCOMING)),
+                ),
+            ),
+        )
+        val delays = response.toOverlay().stopDelays
+        assertEquals(mapOf("S1" to 120, "S2" to 120), delays, "no-delay leg contributes nothing")
+    }
+
+    @Test
+    fun `non-numeric leg_ref is skipped, empty response maps to empty overlay`() {
+        val overlay = TrackResponse(
+            legs = listOf(
+                LegTracking(leg_ref = "weird", status = LegTracking.Status.TRACKING, vehicle = vehicle()),
+            ),
+        ).toOverlay()
+        assertTrue(overlay.vehiclePositions.isEmpty())
+        assertNull(overlay.lastModified)
+    }
+
+    @Test
+    fun `service date converts UTC to the Sydney calendar day`() {
+        // 18:05Z on the 11th is 04:05 AEST on the 12th.
+        assertEquals("20260612", "2026-06-11T18:05:30Z".toServiceDate())
+        // Garbage input falls back to the raw date portion.
+        assertEquals("20260611", "2026-06-11Tgarbage".toServiceDate())
+    }
+}

--- a/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/GtfsRealtimeRepository.kt
+++ b/feature/track/state/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/GtfsRealtimeRepository.kt
@@ -37,4 +37,13 @@ data class LegTrackingInfo(
     val lineName: String,
     /** GTFS-RT RealtimeTripId from the TfNSW API. Enables exact trip_id matching. */
     val realtimeTripId: String?,
+    /**
+     * Boarding / alighting stop ids and the leg's planned departure
+     * (ISO-8601 UTC). Used by the BFF tracking path (`TrackRequest.TrackLeg`)
+     * to slice the trip to the user's journey segment and detect expiry.
+     * Defaults keep the legacy GTFS-RT direct path source-compatible.
+     */
+    val originStopId: String = "",
+    val destinationStopId: String = "",
+    val plannedDepartureUtc: String = "",
 )

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
@@ -412,6 +412,9 @@ internal class TripPoller(
                 transportMode = leg.transportMode,
                 lineName = leg.lineName,
                 realtimeTripId = leg.realtimeTripId,
+                originStopId = leg.stops.firstOrNull()?.stopId.orEmpty(),
+                destinationStopId = leg.stops.lastOrNull()?.stopId.orEmpty(),
+                plannedDepartureUtc = leg.stops.firstOrNull()?.scheduledUtcTime.orEmpty(),
             )
         }
         if (legInfos.isEmpty()) {

--- a/io/gtfs/src/commonMain/proto/gtfs-realtime.proto
+++ b/io/gtfs/src/commonMain/proto/gtfs-realtime.proto
@@ -151,7 +151,9 @@ message EntitySelector {
 message TripDescriptor {
   optional string trip_id = 1;
   optional string route_id = 5;
-  optional string direction_id = 6;
+  // uint32 per the GTFS-Realtime spec. Was wrongly declared `string`,
+  // which breaks Wire decoding on feeds that populate it (metro does).
+  optional uint32 direction_id = 6;
   optional string start_time = 2;
   optional string start_date = 3;
   optional ScheduleRelationship schedule_relationship = 4;


### PR DESCRIPTION
## What

Live tracking can now poll the KRAIL-BFF instead of fetching + decoding NSW GTFS-RT feeds on-device. Two commits:

1. **fix(gtfs):** `TripDescriptor.direction_id` was vendored as `string`; spec says `uint32`. Metro feeds populate it → Wire decode breaks on the direct path. Type-only change (no Kotlin reads it). Also bumps krail-api-proto to **v0.4.0**, which adds `track.proto` — `:io:bff-api` Wire codegen picks it up automatically.
2. **feat(track):** `BffGtfsRealtimeRepository` wraps the existing repository. Per poll: `BffEndpointResolver` (NSW vs BFF) → new `bff_use_for_track` RC kill switch (default on) → one `POST /api/v1/track/snapshot` (protobuf) mapped onto the existing `LiveTrackingOverlay`. **Any BFF failure falls back to direct GTFS-RT for that poll** — tracking never breaks because the BFF is down. No UI changes.

`LegTrackingInfo` gains origin/destination stop ids + planned leg departure (defaulted; legacy path source-compatible) so the BFF can slice the run to the user's journey segment and detect expiry.

## How to test

1. Start the BFF locally: `cd KRAIL-BFF && ./scripts/dev.sh up` (listens on :8080; emulator reaches it via the existing `krail.bffBaseUrl=http://10.0.2.2:8080` in local.properties)
2. Debug build → Debug Config → Network source = **BFF_LOCAL**
3. Track a live trip. Logcat: `[BFFTRACK] snapshot — N legs, statuses=TRACKING…` and `logNetworkCall POST /api/v1/track/snapshot`
4. Kill the BFF mid-track → next poll logs the fallback and the map keeps working via direct GTFS-RT
5. Flip Network source back to NSW_DIRECT → `[BFFTRACK]` lines disappear

## Safety

- Release builds unaffected: `BFF_ROLLOUT_ARMED = false` still pins FOLLOW_RC to NSW direct.
- `bff_use_for_track` is the tracking-specific kill switch for later cohort rollout.
- Tests: new mapper tests (`BffTrackOverlayMapperTest`) + all existing track module tests green; detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)