### PR TITLE
fix(discover): fix expired test date and deprecated adaptive API

### DIFF
--- a/discover/network/real/src/commonTest/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManagerTest.kt
+++ b/discover/network/real/src/commonTest/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManagerTest.kt
@@ -188,7 +188,7 @@ class RealDiscoverSydneyManagerTest {
                 "title": "Complex Card",
                 "description": "Test description with special chars: @#$%",
                 "startDate": "2026-05-22",
-                "endDate": "2026-06-13",
+                "endDate": "2099-12-31",
                 "disclaimer": "Test disclaimer",
                 "imageList": ["https://example.com/img1.jpg", "https://example.com/img2.jpg"],
                 "buttons": [
@@ -214,7 +214,7 @@ class RealDiscoverSydneyManagerTest {
         val returnedCard = result[0]
         assertEquals("Complex Card", returnedCard.title)
         assertEquals("2026-05-22", returnedCard.startDate)
-        assertEquals("2026-06-13", returnedCard.endDate)
+        assertEquals("2099-12-31", returnedCard.endDate)
         assertEquals("Test disclaimer", returnedCard.disclaimer)
         assertEquals(2, returnedCard.imageList.size)
         assertNotNull(returnedCard.buttons)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -34,7 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
-import xyz.ksharma.krail.core.adaptiveui.AdaptiveBreakpoints
+import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
 import xyz.ksharma.krail.core.appinfo.LocalAppInfo
 import xyz.ksharma.krail.core.snapshot.ScreenshotTest
 import xyz.ksharma.krail.discover.state.Button
@@ -65,8 +64,7 @@ fun DiscoverScreen(
     resetAllSeenCards: () -> Unit,
     onChipSelected: (DiscoverCardType) -> Unit,
 ) {
-    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-    val isCompactWidth = windowSizeClass.minWidthDp < AdaptiveBreakpoints.COMPACT_WIDTH
+    val isCompactWidth = rememberAdaptiveLayoutInfo().isCompactWidth
     if (isCompactWidth) {
         DiscoverScreenCompact(
             modifier = modifier,


### PR DESCRIPTION
## What

Two unrelated fixes discovered when CI for #1680 failed.

### 1. Expired test date — `RealDiscoverSydneyManagerTest`

`testFetchDiscoverData_withComplexCard_parsesCorrectly` had `endDate: "2026-06-13"` hardcoded. After June 13 the card is filtered by `filterActiveCards()` as a past event, so `result.size` is 0 instead of 1.

Fixed by updating both the JSON fixture and the matching `assertEquals` to `"2099-12-31"`.

### 2. Deprecated `currentWindowAdaptiveInfo()` — `DiscoverScreen.kt`

`DiscoverScreen` called the deprecated `currentWindowAdaptiveInfo()` (the overload with `supportLargeAndXLargeWidth`) directly to derive `isCompactWidth`. The project already has `rememberAdaptiveLayoutInfo()` in `core/adaptive-ui` which wraps the V2 API and exposes `isCompactWidth` as a property.

Replaced the direct deprecated call with `rememberAdaptiveLayoutInfo().isCompactWidth`.

## Test plan

- [ ] `./gradlew :discover:network:real:testAndroidHostTest` — green
- [ ] `./gradlew :feature:trip-planner:ui:testAndroidHostTest` — green
- [ ] `./gradlew :discover:network:real:detekt :feature:trip-planner:ui:detekt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)