### PR TITLE
build(proto): consume api-proto from GitHub Packages; remove submodule

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -15,10 +15,6 @@ jobs:
       actions: write  # required to write back ANDROID_VERSION_CODE repo variable
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Wire codegen for :io:bff-api reads protos from the krail-api-proto submodule.
-          # Without this, CI checkout would skip the submodule and the build would fail.
-          submodules: true
 
       - name: Setup environment variables
         run: |
@@ -97,6 +93,7 @@ jobs:
       - name: Build ${{ inputs.variant }}
         env:
           ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           if [[ "${{ inputs.variant }}" == "debug" ]]; then

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -11,10 +11,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-        with:
-          # Wire codegen for :io:bff-api reads protos from the krail-api-proto submodule.
-          # Without this, CI checkout would skip the submodule and the build would fail.
-          submodules: true
 
       # -----------------------------------------------------------
       # Debug: Xcode Version Listing
@@ -74,6 +70,8 @@ jobs:
       # Build SPM & Final iOS App
       # -----------------------------------------------------------
       - name: Pre-build SPM for MapLibre (Gradle)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew :feature:trip-planner:ui:SwiftPackageConfigAppleSpmMaplibreCompileSwiftPackageIosSimulatorArm64 --no-daemon --stacktrace
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,10 +19,6 @@ jobs:
       passed: ${{ steps.detekt.outcome == 'success' }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Wire codegen for :io:bff-api reads protos from the krail-api-proto submodule.
-          # Without this, CI checkout would skip the submodule and the build would fail.
-          submodules: true
 
       - name: Setup environment variables
         run: |
@@ -62,6 +58,7 @@ jobs:
           IOS_NSW_TRANSPORT_API_KEY: ${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}
           CI: true
           GITHUB_ACTIONS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew detekt -PciQuality=true
 
       # Run all KMP host tests (Compose UI tests via Robolectric live in
@@ -75,6 +72,7 @@ jobs:
           IOS_NSW_TRANSPORT_API_KEY: ${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}
           CI: true
           GITHUB_ACTIONS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew testAndroidHostTest --continue -PciQuality=true
 
       - name: Upload Detekt reports

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           CI: true
           GITHUB_ACTIONS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           ./gradlew
           verifyTestWiring verifyTestingModuleUsage verifyNoAdHocBoundaryFakes

--- a/.github/workflows/distribute-testflight.yml
+++ b/.github/workflows/distribute-testflight.yml
@@ -33,10 +33,6 @@ jobs:
       FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Wire codegen for :io:bff-api reads protos from the krail-api-proto submodule.
-          # Without this, CI checkout would skip the submodule and the build would fail.
-          submodules: true
 
       # Select Xcode before anything else runs.
       # xcversion is not used — relies on the sunsetted xcode-install gem
@@ -76,6 +72,8 @@ jobs:
       # Without this, fastlane's build_app (archive) fails to resolve the framework.
       # Uses IosArm64 (real device target) unlike build-ios.yml which uses IosSimulatorArm64.
       - name: Pre-build SPM for MapLibre (Gradle - device)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./gradlew :feature:trip-planner:ui:SwiftPackageConfigAppleSpmMaplibreCompileSwiftPackageIosArm64 --no-daemon --stacktrace
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "krail-api-proto"]
-	path = krail-api-proto
-	url = https://github.com/ksharma-xyz/KRAIL-API-PROTO.git

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ reorderable = "2.5.1"
 # KRAIL-extracted libraries (published as separate KMP libs)
 aagya = "0.1.1"
 dhruva = "0.1.1"
+krail-api-proto = "0.4.2"
 
 [libraries]
 # KRAIL-extracted libraries
@@ -58,6 +59,7 @@ aagya-state = { module = "io.github.ksharma-xyz:aagya-state", version.ref = "aag
 aagya-data = { module = "io.github.ksharma-xyz:aagya-data", version.ref = "aagya" }
 dhruva-state = { module = "io.github.ksharma-xyz:dhruva-state", version.ref = "dhruva" }
 dhruva-data = { module = "io.github.ksharma-xyz:dhruva-data", version.ref = "dhruva" }
+krail-api-proto = { module = "xyz.ksharma.krail:api-proto", version.ref = "krail-api-proto" }
 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 buildkonfig-gradle-plugin = { module = "com.codingfeline.buildkonfig:buildkonfig-gradle-plugin", version.ref = "buildkonfigGradlePlugin" }

--- a/io/bff-api/build.gradle.kts
+++ b/io/bff-api/build.gradle.kts
@@ -41,23 +41,20 @@ kotlin {
     }
 }
 
-// The .proto contract is shared with KRAIL-BFF via a public submodule
-// pinned to a SemVer git tag (currently v0.1.0). Wire codegen reads from
-// the submodule path; we never copy generated Kotlin into the repo.
-//
-// Submodule: https://github.com/ksharma-xyz/KRAIL-API-PROTO
-// Layout:
-//   krail-api-proto/proto/api/   contains app.krail.bff.proto (JourneyList, JourneyCardInfo, ...)
-//   krail-api-proto/proto/data/  contains app.krail.bff.proto.data (StopsDataset, RoutesDataset)
+// Proto sources JAR from GitHub Packages — published by KRAIL-API-PROTO on each tag.
+// Version in gradle/libs.versions.toml (krail-api-proto). Renovate opens bump PRs.
+// Must be populated BEFORE wire{} reads krailProto.singleFile (Kotlin DSL eval order).
+val krailProto: Configuration by configurations.creating { isTransitive = false }
+dependencies {
+    krailProto(libs.krailApiProto) { artifact { classifier = "proto" } }
+}
+
 wire {
     kotlin {
         javaInterop = true
         out = "$projectDir/build/generated/source/wire"
     }
-    protoPath {
-        srcDir("$rootDir/krail-api-proto/proto")
-    }
     sourcePath {
-        srcDir("$rootDir/krail-api-proto/proto")
+        srcJar(krailProto.singleFile.absolutePath)
     }
 }

--- a/io/bff-api/build.gradle.kts
+++ b/io/bff-api/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
     applyDefaultHierarchyTemplate()
 
-    android {
+    androidLibrary {
         namespace = "xyz.ksharma.krail.io.bffapi"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK

--- a/io/bff-api/build.gradle.kts
+++ b/io/bff-api/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 kotlin {
     applyDefaultHierarchyTemplate()
 
-    androidLibrary {
+    android {
         namespace = "xyz.ksharma.krail.io.bffapi"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
@@ -46,7 +46,7 @@ kotlin {
 // Must be populated BEFORE wire{} reads krailProto.singleFile (Kotlin DSL eval order).
 val krailProto: Configuration by configurations.creating { isTransitive = false }
 dependencies {
-    krailProto(libs.krailApiProto) { artifact { classifier = "proto" } }
+    krailProto(libs.krail.api.proto) { artifact { classifier = "proto" } }
 }
 
 wire {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 pluginManagement {
@@ -20,6 +22,11 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+// Read local.properties for dev credentials (git-ignored, never committed).
+val localProps = Properties().apply {
+    rootProject.projectDir.resolve("local.properties").takeIf { it.exists() }?.inputStream()?.use(::load)
+}
+
 dependencyResolutionManagement {
     repositories {
         google {
@@ -30,6 +37,19 @@ dependencyResolutionManagement {
             }
         }
         mavenCentral()
+        // KRAIL-API-PROTO proto sources JAR — published on each proto release tag.
+        // CI: GITHUB_TOKEN env var is set automatically (has read:packages scope).
+        // Local dev: add gpr.token=<github-pat-with-read:packages> to local.properties.
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/ksharma-xyz/KRAIL-API-PROTO")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                    ?: localProps.getProperty("gpr.user") ?: "token"
+                password = System.getenv("GITHUB_TOKEN")
+                    ?: localProps.getProperty("gpr.token") ?: ""
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `krail-api-proto` git submodule with a versioned Maven artifact from GitHub Packages (`xyz.ksharma.krail:api-proto:0.4.2:proto@jar`)
- Wire 6.2.0 in `:io:bff-api` now reads proto files via `srcJar()` from the downloaded JAR — no checkout needed
- Version tracked in `gradle/libs.versions.toml` (`krail-api-proto = "0.4.2"`) — Renovate will open bump PRs automatically on new tags
- Deletes `proto-bump.yml` (replaced by Renovate)
- All CI workflows: removes `submodules: true`, passes `GITHUB_TOKEN` to Gradle build steps for GitHub Packages auth

## Test plan

- [ ] CI Android build passes (no submodule, resolves proto JAR from GitHub Packages)
- [ ] CI iOS build passes (Gradle SPM step resolves proto JAR)
- [ ] Code Quality / Detekt passes
- [ ] Verify `libs.versions.toml` bump triggers Renovate PR on next KRAIL-API-PROTO release

🤖 Generated with [Claude Code](https://claude.com/claude-code)