### PR TITLE
feat(transport): per-surface mode availability; hide School Bus from map stop filter

### DIFF
--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/ModeSelectionSurface.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/ModeSelectionSurface.kt
@@ -1,0 +1,17 @@
+package xyz.ksharma.krail.core.transport
+
+/**
+ * A surface that lets the user pick transport modes.
+ *
+ * Each mode declares which surfaces it belongs to via the city config (see
+ * [xyz.ksharma.krail.core.transport.nsw.NswTransportConfig.modesFor]). This keeps
+ * "which modes show where" a single, exhaustive policy decision rather than scattered
+ * `.filter` hacks at each call site.
+ */
+enum class ModeSelectionSurface {
+    /** Map "Show stops for" filter — which nearby stop types appear on the map. */
+    NEARBY_STOPS,
+
+    /** Timetable trip-planner mode picker — real modes passed to the trip API. */
+    TRIP_PLANNER,
+}

--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportConfig.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportConfig.kt
@@ -24,6 +24,15 @@ interface TransportConfig {
     /** All modes supported by this city, sorted by [order]. */
     fun sortedModes(order: TransportModeSortOrder = TransportModeSortOrder.PRIORITY): List<TransportMode>
 
+    /** Modes available on [surface], sorted by [order]. */
+    fun modesFor(
+        surface: ModeSelectionSurface,
+        order: TransportModeSortOrder = TransportModeSortOrder.PRIORITY,
+    ): List<TransportMode>
+
+    /** API product-class codes available on [surface]. */
+    fun productClassesFor(surface: ModeSelectionSurface): Set<Int>
+
     /** All API product-class codes supported by this city. */
     fun allProductClasses(): Set<Int>
 

--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/ModeSurfaceEligibility.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/ModeSurfaceEligibility.kt
@@ -1,0 +1,24 @@
+package xyz.ksharma.krail.core.transport.nsw
+
+import xyz.ksharma.krail.core.transport.ModeSelectionSurface
+import xyz.ksharma.krail.core.transport.TransportMode
+
+/**
+ * Per-surface eligibility policy for NSW transport modes.
+ *
+ * Exhaustive `when` (no `else`) by design: adding a new [TransportMode] subobject breaks
+ * compilation here until its surface policy is declared. This keeps "which modes show where"
+ * a single, deliberate decision instead of scattered `.filter` hacks at each call site.
+ */
+internal fun TransportMode.isAvailableOn(surface: ModeSelectionSurface): Boolean =
+    when (this) {
+        // School Bus is a real mode for trip planning, but never a stop type you pick on the map.
+        TransportMode.SchoolBus -> surface == ModeSelectionSurface.TRIP_PLANNER
+        TransportMode.Train,
+        TransportMode.Metro,
+        TransportMode.Bus,
+        TransportMode.LightRail,
+        TransportMode.Ferry,
+        TransportMode.Coach,
+        -> true
+    }

--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfig.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfig.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.core.transport.nsw
 
+import xyz.ksharma.krail.core.transport.ModeSelectionSurface
 import xyz.ksharma.krail.core.transport.TransportConfig
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.TransportModeSortOrder
@@ -27,6 +28,14 @@ object NswTransportConfig : TransportConfig {
             TransportModeSortOrder.PRIORITY -> TransportMode.all.sortedBy { it.priority }
             TransportModeSortOrder.PRODUCT_CLASS -> TransportMode.all.sortedBy { it.productClass }
         }
+
+    override fun modesFor(
+        surface: ModeSelectionSurface,
+        order: TransportModeSortOrder,
+    ): List<TransportMode> = sortedModes(order).filter { it.isAvailableOn(surface) }
+
+    override fun productClassesFor(surface: ModeSelectionSurface): Set<Int> =
+        TransportMode.all.filter { it.isAvailableOn(surface) }.map { it.productClass }.toSet()
 
     override fun allProductClasses(): Set<Int> =
         TransportMode.all.map { it.productClass }.toSet()

--- a/core/transport/src/commonTest/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfigTest.kt
+++ b/core/transport/src/commonTest/kotlin/xyz/ksharma/krail/core/transport/nsw/NswTransportConfigTest.kt
@@ -1,8 +1,12 @@
 package xyz.ksharma.krail.core.transport.nsw
 
+import xyz.ksharma.krail.core.transport.ModeSelectionSurface
+import xyz.ksharma.krail.core.transport.TransportMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class NswTransportConfigTest {
 
@@ -126,6 +130,49 @@ class NswTransportConfigTest {
             description = null,
         )
         assertEquals("Liverpool", result)
+    }
+
+    // region: per-surface mode availability
+
+    @Test
+    fun `Given NEARBY_STOPS surface When resolving product classes Then School Bus is excluded`() {
+        val result = NswTransportConfig.productClassesFor(ModeSelectionSurface.NEARBY_STOPS)
+
+        assertFalse(result.contains(TransportMode.SchoolBus.productClass))
+        assertTrue(
+            result.containsAll(
+                listOf(
+                    TransportMode.Train.productClass,
+                    TransportMode.Metro.productClass,
+                    TransportMode.Bus.productClass,
+                    TransportMode.LightRail.productClass,
+                    TransportMode.Ferry.productClass,
+                    TransportMode.Coach.productClass,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `Given TRIP_PLANNER surface When resolving product classes Then all modes including School Bus are present`() {
+        val result = NswTransportConfig.productClassesFor(ModeSelectionSurface.TRIP_PLANNER)
+
+        assertEquals(NswTransportConfig.allProductClasses(), result)
+        assertTrue(result.contains(TransportMode.SchoolBus.productClass))
+    }
+
+    @Test
+    fun `Given NEARBY_STOPS surface When resolving modes Then School Bus is not in the list`() {
+        val result = NswTransportConfig.modesFor(ModeSelectionSurface.NEARBY_STOPS)
+
+        assertFalse(result.contains(TransportMode.SchoolBus))
+    }
+
+    @Test
+    fun `Given TRIP_PLANNER surface When resolving modes Then School Bus is in the list`() {
+        val result = NswTransportConfig.modesFor(ModeSelectionSurface.TRIP_PLANNER)
+
+        assertTrue(result.contains(TransportMode.SchoolBus))
     }
 }
 

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/MapUiState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/MapUiState.kt
@@ -10,6 +10,7 @@ import xyz.ksharma.krail.core.maps.state.RouteFeature
 import xyz.ksharma.krail.core.maps.state.SearchRadius
 import xyz.ksharma.krail.core.maps.state.SelectedStopUi
 import xyz.ksharma.krail.core.maps.state.StopFeature
+import xyz.ksharma.krail.core.transport.ModeSelectionSurface
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 
@@ -44,7 +45,8 @@ data class MapDisplay(
     val stops: ImmutableList<StopFeature> = persistentListOf(),
     val selectedStop: SelectedStopUi? = null,
     val nearbyStops: ImmutableList<NearbyStopFeature> = persistentListOf(),
-    val selectedTransportModes: ImmutableSet<Int> = NswTransportConfig.allProductClasses().toImmutableSet(),
+    val selectedTransportModes: ImmutableSet<Int> =
+        NswTransportConfig.productClassesFor(ModeSelectionSurface.NEARBY_STOPS).toImmutableSet(),
     val mapCenter: LatLng = LatLng(
         NearbyStopsConfig.DEFAULT_CENTER_LAT,
         NearbyStopsConfig.DEFAULT_CENTER_LON,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toPersistentSet
 import xyz.ksharma.krail.core.maps.state.SearchRadius
+import xyz.ksharma.krail.core.transport.ModeSelectionSurface
 import xyz.ksharma.krail.core.transport.TransportMode
-import xyz.ksharma.krail.core.transport.TransportModeSortOrder
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.ButtonDefaults
@@ -298,7 +298,7 @@ private fun TransportModeFilterRow(
     modifier: Modifier = Modifier,
 ) {
     val allModes = remember {
-        NswTransportConfig.sortedModes(TransportModeSortOrder.PRIORITY)
+        NswTransportConfig.modesFor(ModeSelectionSurface.NEARBY_STOPS)
     }
     val dim = KrailTheme.dimensions
 
@@ -361,7 +361,9 @@ private fun PreviewMapOptionsBottomSheet() {
     PreviewTheme {
         MapOptionsBottomSheet(
             searchRadiusKm = SearchRadius.DEFAULT.km,
-            selectedTransportModes = NswTransportConfig.allProductClasses().toPersistentSet(),
+            selectedTransportModes = NswTransportConfig
+                .productClassesFor(ModeSelectionSurface.NEARBY_STOPS)
+                .toPersistentSet(),
             showDistanceScale = false,
             showCompass = true,
             onDismiss = {},

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -64,8 +64,8 @@ import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.transport.ModeSelectionSurface
 import xyz.ksharma.krail.core.transport.TransportMode
-import xyz.ksharma.krail.core.transport.TransportModeSortOrder
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
 import xyz.ksharma.krail.departures.ui.DeparturesViewModel
@@ -298,7 +298,7 @@ fun TimeTableScreen(
                             .animateItem(),
                     ) {
                         items(
-                            items = NswTransportConfig.sortedModes(TransportModeSortOrder.PRIORITY),
+                            items = NswTransportConfig.modesFor(ModeSelectionSurface.TRIP_PLANNER),
                             key = { item -> NswTransportConfig.productClassFor(item) },
                         ) {
                             TransportModeChip(


### PR DESCRIPTION
School Bus (productClass 11) was shown on every surface that lists transport
modes, because all surfaces read the single TransportMode.all list. It is wrong
for map stop selection (you don't pick a stop 'to ride a school bus') but correct
for the timetable trip-planner picker, where selected modes drive the trip API's
exclMOT_11 exclusion param.

Introduce ModeSelectionSurface (NEARBY_STOPS, TRIP_PLANNER) and resolve mode lists
per surface via NswTransportConfig.modesFor()/productClassesFor(). Eligibility is an
exhaustive when() over the sealed TransportMode in ModeSurfaceEligibility.kt: adding
a new mode (or surface) fails to compile until its policy is declared, so no surface
can silently leak a mode.

- Map nearby-stops seed (MapUiState) and chip row (MapOptionsBottomSheet) now use
  NEARBY_STOPS, dropping School Bus from both the rendered stops and the filter chips.
- Timetable mode row uses TRIP_PLANNER, keeping all 7 modes (behaviour unchanged).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>