### PR TITLE
fix(trip-planner): collapse same-route legs split by a quick walk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,3 +221,7 @@ that contradicts the doc should also update the doc in the same change.
   landscape (per-screen dual-pane behaviour, compact-height adaptations, breakpoint contract).
 - `docs/POLLING_LIFECYCLE.md` — WhileSubscribed polling rules: `repeatOnLifecycle(STARTED)`
   pattern, why plain `LaunchedEffect` breaks background gating, all polling flows listed.
+- `docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md` — why `TripResponseMapper.kt`'s
+  `collapseSameRouteQuickWalks()` merges same-route-number legs split by a trivial walk;
+  read before changing leg-merge/split logic in `TripResponseMapper.kt` or
+  `TripResponseLegMapper.kt`.

--- a/docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md
+++ b/docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md
@@ -1,0 +1,235 @@
+# Investigation: "715 / walk / 715 / T1" shown as 3 legs instead of 1 bus
+
+## User report
+
+Trip from stop `214758` (Seven Hills Rd opp Monaro St) to Redfern Station shows:
+
+```
+715 bus -> walk -> 715 bus -> T1 train
+```
+
+instead of the expected `1 bus (715) -> 1 train (T1)`. Google Maps and the Opal Travel app
+both show the same real-world trip as a single 715 bus leg.
+
+## Raw NSW TripPlanner API response
+
+Full response saved at the time of investigation: `/Users/ksharma/notes/home-redfern-investigate.json`
+(9 journey options returned for this origin/destination/time).
+
+The journey matching the user's report is journey index 1 in that response (near-identical
+patterns also appear at index 3 and 6, for later departures):
+
+| Leg | Route | tripCode | RealtimeTripId | Transportation description |
+|---|---|---|---|---|
+| 0 | 715 | **77** | 2647807 | "Seven Hills to Rouse Hill Station via Norwest & Kellyville" (outbound) |
+| 1 | walk | — | — | `position: IDEST`, 31 m / 60 s, crosses Seven Hills Rd |
+| 2 | 715 | **15** | 2648028 | "Rouse Hill Station to Seven Hills via Kellyville & Norwest" (inbound) |
+| 3 | T1 | — | — | Seven Hills Station → Central/Redfern |
+
+Leg 0's origin/destination stops (`214758` → `214759`) and leg 2's origin/destination stops
+(`2147213` → Seven Hills Station) are both on Seven Hills Rd near Solander Rd, on opposite
+sides of the road — the walk leg is literally "cross the street."
+
+## What the KRAIL codebase does today
+
+`TripResponseMapper.kt` (`feature/trip-planner/ui`) maps every raw API `Leg` 1:1 into a UI
+`Leg` (`getLegsList()` → `mapNotNull { it.toUiModel() }`). There is **no logic anywhere** that
+compares adjacent legs' route number, stop IDs, or trip IDs to decide whether to merge them.
+So KRAIL is rendering exactly what the NSW API sent — 4 legs, faithfully.
+
+## Is it really "the same bus"?
+
+This is the crux of the user's complaint, and the honest answer is: **NSW's API data alone
+doesn't prove or disprove it, and it doesn't matter for the fix.**
+
+- `tripCode` (77 vs 15) and `RealtimeTripId` (2647807 vs 2648028) differ — these are two
+  distinct GTFS trips in NSW's schedule data.
+- The transportation `description` fields are opposite directions ("to Rouse Hill" vs "to
+  Seven Hills") — i.e. NSW's own model has the passenger travelling one stop the *wrong*
+  way, walking across the road, then boarding a bus travelling *back* the way they came.
+- The NSW TripPlanner API response does **not** expose a GTFS `block_id` (the field that
+  would prove "same physical vehicle, continuing as a new trip after a scheduled reversal").
+  Only `tripCode`, `AVMSTripID`, `RealtimeTripId`, `gtfsTripId` are present — none of which
+  encode vehicle/block continuity.
+- It is plausible this is genuinely the same physical bus reaching a short local reversal
+  point near Solander Rd and continuing on its return working — NSW buses commonly do this.
+  It is equally plausible it's two different scheduled trips that happen to overlap in time
+  at this stop pair. **The API data available to KRAIL cannot distinguish these cases.**
+
+Google Maps and Opal Travel almost certainly aren't proving vehicle continuity either — they
+are very likely applying a **display-layer heuristic** (same route number + trivial walk +
+short time gap ⇒ show as one bus), not a data-verified "same vehicle" fact. This is the gap:
+KRAIL has no such heuristic; those products do.
+
+## Why this journey option exists at all
+
+Journey index 0 in the same response is a strictly better option: direct 715 (no backtrack)
+to Norwest Station → M1 Metro → Central, departing ~4 minutes later than journey 1's first
+leg and **arriving at the exact same time** (`00:35:06`). NSW's engine returns both options
+without deduplicating/deprioritizing the worse one. That's a secondary, separate issue from
+the display problem below.
+
+## Recommendation: add a display-layer merge heuristic
+
+Don't try to prove "same vehicle" — match what Google Maps/Opal visibly do: merge two
+transit legs of the **same route number** separated by a **trivially short walk** into one
+displayed leg, regardless of whether the underlying trip IDs match.
+
+### Proposed heuristic (candidate for `TripResponseMapper.kt`)
+
+Add a pre-processing pass over `journey.legs` **before** `getLegsList()` runs, that collapses
+a 3-leg window `[TransportLeg A, WalkLeg, TransportLeg B]` into a single displayed
+`TransportLeg` when **all** of the following hold:
+
+1. `A.transportation.number == B.transportation.number` (same route number, e.g. "715") —
+   this is the strongest and simplest signal, and it's what a passenger visually sees at the
+   stop (same route number bus pulls up).
+2. The walk leg's `footPathInfo.position == "IDEST"` (whole leg is walking, not a
+   partial-leg annotation) — confirms it's a genuine standalone walk, not noise.
+3. The walk leg is short: e.g. `duration <= 120` seconds (2 min) — tune against real
+   fixtures; NSW's own "trivial interchange" cases (`Leg.interchange` field, `type: 100`)
+   suggest ~1-2 min is the right order of magnitude for "not a real walking leg."
+4. Do **not** require direction/description to match — direction is exactly the case that
+   differs in this report, and the merge should still apply since that's what users expect
+   to see collapsed.
+
+When merged, render:
+- `origin` = leg A's origin, `destination` = leg B's destination
+- `departureTime`/`arrivalTime` spanning the whole window (so travel time / totalWalkTime
+  stays accurate underneath)
+- Optionally, a small annotation on the card (e.g. "change side of street") reusing the
+  existing `WalkInterchange`/`WalkPosition` model in `TimeTableState.kt`, rather than
+  inventing a new UI element — this already exists for the "short interchange, not a
+  standalone walk" case and is conceptually the same thing.
+
+### What NOT to do
+
+- Don't try to detect "same vehicle" via `tripCode`/`RealtimeTripId` equality — in this real
+  case they legitimately differ, so that check would never fire and wouldn't fix the
+  complaint.
+- Don't merge legs of *different* route numbers (e.g. 715 → 718) even if the walk is short —
+  that's a genuine route change a user should see.
+- Don't touch the underlying raw `TripResponse.Journey` data used for map visualization
+  (`rawDataMap` in `buildJourneyListWithRawData`) — only the UI `Leg` list passed to the
+  journey card should be affected, so the map view / detailed stop-by-stop view can still
+  show the real walk if the user drills in.
+
+### Where to implement
+
+- New function e.g. `List<TripResponse.Leg>.collapseSameRouteQuickWalks()` in
+  `TripResponseMapper.kt`, called from `buildJourneyListWithRawData()` right after
+  `journey.getFilteredValidLegs()` (line ~43) and before `legs.getLegsList()` (line ~49).
+- Needs test coverage in `TripResponseMapperTest.kt` — at minimum: (a) the exact case from
+  this investigation (715/walk/715/T1 → collapses to 715/T1), (b) a same-route-number but
+  *long* walk that should NOT collapse, (c) a different-route-number pair that should NOT
+  collapse, (d) confirm total travel time / totalWalkTime stay correct across the merge.
+
+## Implementation (this branch)
+
+The merge heuristic above has been implemented on `feature/merge-same-route-quick-walk`,
+**not yet reviewed or pushed**.
+
+- `TripResponseMapper.kt`: `getFilteredValidLegs()` now runs `legs?.collapseSameRouteQuickWalks()`
+  before the existing `filter { it.transportation != null }`.
+- `collapseSameRouteQuickWalks()`: slides a 3-leg window over the raw leg list and, when
+  `canCollapseAcross()` matches, replaces `[A, walk, B]` with a single synthetic
+  `TripResponse.Leg` via `collapseAcrossQuickWalk()`.
+- `canCollapseAcross()` matches when: the middle leg `isWalkingLeg()`, its
+  `footPathInfo[0].position == "IDEST"` (genuine standalone walk, not a before/after
+  annotation), its `duration <= QUICK_WALK_MAX_SECONDS` (120s), and
+  `A.transportation.number == B.transportation.number` (same route number). Trip ID /
+  direction are deliberately not compared, per "What NOT to do" above.
+- `collapseAcrossQuickWalk()`: keeps leg A's `origin`/`transportation` (route number, mode,
+  displayText, tripId all come from A), takes leg B's `destination`, concatenates
+  `stopSequence` from both (dropping the walk's own 2 stops), combines `infos` (service
+  alerts), and sets `duration = null` so `resolveDurationSeconds()` recomputes the real
+  door-to-door time from A's origin timestamp to B's destination timestamp (rather than
+  summing durations, which would double count or miss the walk gap).
+- Only affects the `legs` variable feeding `getLegsList()`/`getTransportModeLines()`/
+  `getTotalStops()`/`totalWalkingDuration` in `buildJourneyListWithRawData()`. The raw
+  `rawDataMap` used for map visualization is untouched (map still gets the true 4-leg
+  journey from `journey.legs`), and `getFirstPublicTransportLeg()`/`getLastPublicTransportLeg()`
+  (used for origin/arrival time) also read `journey.legs` directly, so they're unaffected too.
+
+### Fixtures and tests added
+
+- `feature/trip-planner/network/src/commonTest/assets/trip_seven_hills_redfern_715_backtrack.json` —
+  the real captured API response for this investigation (journey index 1, the one that
+  reproduces the bug), with only `coords`/`pathDescriptions` arrays stripped (they're
+  irrelevant to leg mapping and add ~8000 lines of lat/lng noise). Committed for provenance —
+  unlike `OranParkToSevenHillsFixture`'s KDoc, which references a
+  `trip_oranpark_sevenhills.json` asset that was never actually committed (checked: it doesn't
+  exist in the repo). Don't repeat that — if you trim a fixture from a real response, commit
+  the full-fidelity source alongside it.
+- `Redfern715BacktrackFixture.kt` (`.../fixtures/`) — the same journey, trimmed further to
+  essential fields only (times, IDs, route numbers, `tripCode`/`RealtimeTripId`, `footPathInfo`,
+  `interchange`), matching the values in the asset above exactly (T1's 19 intermediate stations
+  trimmed to origin+destination; every other leg's `stopSequence` is verbatim). Its KDoc
+  explains the full backtrack scenario inline so a reader doesn't need this doc open to
+  understand the test.
+- Three new tests in `TripResponseMapperTest.kt`, under `//region collapseSameRouteQuickWalks`:
+  1. `buildJourneyList collapses same-route legs separated by a quick walk` — decodes
+     `Redfern715BacktrackFixture.JSON` (real data, not hand-built). Asserts 2 legs (not 4),
+     merged leg's `transportModeLine.lineName == "715"`, `totalDuration == "6 mins"` (the real
+     door-to-door window, `00:03:00` → `00:09:42` estimated — not leg A's own 60s), combined
+     `stops.size == 10` (2 + 8 real stops), and `totalWalkTime == null`.
+  2. `... does not collapse ... when the walk exceeds the quick-walk threshold` — **synthetic**
+     (the real capture doesn't contain this variant): a 150s walk (over the 120s cutoff) stays
+     as 4 separate legs, and `totalWalkTime` is still populated.
+  3. `... does not collapse legs on different route numbers ...` — **synthetic**: 715 → 718
+     stays 4 legs even with a trivial walk between them.
+
+  Tests 2 and 3 use two synthetic-fixture builders (`buildRouteLeg`, `buildQuickWalkLeg`) kept
+  in the test file itself, clearly labelled as synthetic in their own KDoc, since they pin
+  heuristic boundaries the real capture doesn't happen to exercise.
+
+**Bug found and fixed while wiring up the real fixture**: the test class's `json` parser was
+missing `isLenient = true`, despite its comment claiming to "mirror how Ktor deserialises
+API responses in production" — production (`core/network/HttpClient.kt`,
+`core/remote-config/JsonConfig.kt`) does set it. Real NSW payloads send some `String?` fields
+(e.g. `Transportation.properties.tripCode`) as unquoted JSON numbers, which strict decoding
+rejects. This never surfaced before because `OranParkToSevenHillsFixture` doesn't include
+`tripCode`. Fixed by adding `isLenient = true` with a comment explaining why — this benefits
+every future real-JSON fixture test in this file, not just this one.
+
+All tests pass, plus the full existing `TripResponseMapperTest` suite (verified via
+`./gradlew :feature:trip-planner:ui:testAndroidHostTest`) and
+`./gradlew :feature:trip-planner:ui:detekt` / `:feature:trip-planner:network:detekt` (clean
+after fixing two findings in the mapper: a doc comment misplaced over a private property, and
+`canCollapseAcross` exceeding the max-return-count rule — rewritten as a single boolean
+expression).
+
+### How this is meant to scale (kept discoverable on purpose)
+
+- `collapseSameRouteQuickWalks()`'s KDoc in `TripResponseMapper.kt` points back to this file
+  and to the test region, and explicitly says "read the 'What NOT to do' section before
+  changing this" — so the reasoning travels with the code, not just in a doc that can go stale
+  unnoticed.
+- This doc is now listed in `CLAUDE.md`'s "Per-feature UX rule docs" section, the same
+  mechanism already used for `SEARCH_STOP_UX.md` / `TABLET_FOLDABLE_UX.md` /
+  `POLLING_LIFECYCLE.md` — anyone (human or Claude) working on `TripResponseMapper.kt` or
+  `TripResponseLegMapper.kt` is directed here before making changes.
+- The regression test decodes a real captured response rather than a hand-built object tree,
+  so it also catches NSW API shape drift (renamed/retyped fields), not just logic regressions
+  in the collapse heuristic itself.
+
+### Not done in this branch (left for follow-up)
+
+- No "change side of street" annotation on the merged card — the doc above suggested reusing
+  `WalkInterchange`/`WalkPosition`, but that's a UI-layer change (`TripResponseLegMapper.kt` /
+  `JourneyCard.kt`) beyond the mapper fix and needs its own review.
+- The window-scan is single-pass and won't chain a second consecutive quick-walk merge
+  (e.g. 715/walk/715/walk/715) in one call — no evidence this occurs in practice, not
+  handled to avoid speculative complexity.
+- The secondary "journey de-duplication" recommendation below is not implemented.
+
+## Secondary recommendation: journey de-duplication
+
+Independent of the display merge above: NSW returns near-duplicate/dominated journeys (see
+"why this journey option exists at all"). A journey-quality filter that deprioritizes options
+with a same-route backtrack-and-walk pattern when a strictly-dominant alternative exists in
+the same response (same or later departure, same or earlier arrival, fewer real interchanges)
+would prevent this journey from surfacing prominently at all, on top of fixing its display.
+Lower priority than the merge heuristic above, since it changes journey *ranking*, not just
+per-journey rendering, and needs its own product discussion (which journey wins when times
+aren't identical, how many alternates to suppress, etc).

--- a/feature/trip-planner/network/src/commonTest/assets/trip_seven_hills_redfern_715_backtrack.json
+++ b/feature/trip-planner/network/src/commonTest/assets/trip_seven_hills_redfern_715_backtrack.json
@@ -1,0 +1,2626 @@
+{
+  "version": "10.6.21.17",
+  "journeys": [
+    {
+      "rating": 0,
+      "isAdditional": false,
+      "interchanges": 2,
+      "legs": [
+        {
+          "duration": 60,
+          "isRealtimeControlled": true,
+          "realtimeStatus": [
+            "MONITORED"
+          ],
+          "origin": {
+            "isGlobalId": true,
+            "id": "214758",
+            "name": "Seven Hills Rd opp Monaro St, Seven Hills",
+            "disassembledName": "Seven Hills Rd opp Monaro St",
+            "type": "platform",
+            "coord": [
+              -33.762677,
+              150.950347
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "G214758",
+              "name": "Seven Hills Rd opp Monaro St, Seven Hills",
+              "disassembledName": "Seven Hills Rd opp Monaro St",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308035:1",
+                "name": "Seven Hills",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10118709"
+              },
+              "coord": [
+                -33.762677,
+                150.950347
+              ],
+              "niveau": 0
+            },
+            "departureTimeBaseTimetable": "2026-07-03T00:03:00Z",
+            "departureTimePlanned": "2026-07-03T00:03:00Z",
+            "departureTimeEstimated": "2026-07-03T00:03:00Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "stoppingPointPlanned": "Seven Hills Rd opp Monaro St",
+              "areaGid": "G214758",
+              "area": "0",
+              "platform": "X1",
+              "platformName": "Seven Hills Rd opp Monaro St",
+              "plannedPlatformName": "Seven Hills Rd opp Monaro St"
+            },
+            "modes": [
+              5,
+              11
+            ]
+          },
+          "destination": {
+            "isGlobalId": true,
+            "id": "214759",
+            "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+            "disassembledName": "Seven Hills Rd after Solander Rd",
+            "type": "platform",
+            "coord": [
+              -33.761156,
+              150.952262
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "G214759",
+              "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+              "disassembledName": "Seven Hills Rd after Solander Rd",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308018:1",
+                "name": "Kings Langley",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10118774"
+              },
+              "coord": [
+                -33.761156,
+                150.952262
+              ],
+              "niveau": 0
+            },
+            "arrivalTimeBaseTimetable": "2026-07-03T00:04:00Z",
+            "arrivalTimePlanned": "2026-07-03T00:04:00Z",
+            "arrivalTimeEstimated": "2026-07-03T00:04:00Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "stoppingPointPlanned": "Seven Hills Rd after Solander Rd",
+              "areaGid": "G214759",
+              "area": "0",
+              "platform": "X1",
+              "platformName": "Seven Hills Rd after Solander Rd",
+              "plannedPlatformName": "Seven Hills Rd after Solander Rd"
+            },
+            "modes": [
+              5,
+              11
+            ]
+          },
+          "transportation": {
+            "id": "nsw:14715: :H:sj2",
+            "name": "Sydney Buses Network 715",
+            "disassembledName": "715",
+            "number": "715",
+            "description": "Seven Hills to Rouse Hill Station via Norwest & Kellyville",
+            "product": {
+              "id": 5,
+              "class": 5,
+              "name": "Sydney Buses Network",
+              "iconId": 5
+            },
+            "operator": {
+              "id": "2504",
+              "name": "CDC NSW R4"
+            },
+            "destination": {
+              "id": "10101501",
+              "name": "Rouse Hill Station",
+              "type": "stop"
+            },
+            "properties": {
+              "isTTB": true,
+              "tripCode": 77,
+              "timetablePeriod": "NSW JP",
+              "lineDisplay": "LINE",
+              "globalId": "3002",
+              "AVMSTripID": "2647807",
+              "RealtimeTripId": "2647807",
+              "gtfsTripId": "3002.nsw-14-715.1.TA.81.sj2"
+            },
+            "iconId": 5
+          },
+          "stopSequence": [
+            {
+              "isGlobalId": true,
+              "id": "214758",
+              "name": "Seven Hills Rd opp Monaro St, Seven Hills",
+              "disassembledName": "Seven Hills Rd opp Monaro St",
+              "type": "platform",
+              "coord": [
+                -33.762677,
+                150.950347
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G214758",
+                "name": "Seven Hills Rd opp Monaro St, Seven Hills",
+                "disassembledName": "Seven Hills Rd opp Monaro St",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118709"
+                },
+                "coord": [
+                  -33.762677,
+                  150.950347
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Rd opp Monaro St",
+                "areaGid": "G214758",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Seven Hills Rd opp Monaro St",
+                "plannedPlatformName": "Seven Hills Rd opp Monaro St"
+              },
+              "departureTimePlanned": "2026-07-03T00:03:00Z",
+              "departureTimeEstimated": "2026-07-03T00:03:00Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "214759",
+              "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+              "disassembledName": "Seven Hills Rd after Solander Rd",
+              "type": "platform",
+              "coord": [
+                -33.761156,
+                150.952262
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G214759",
+                "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+                "disassembledName": "Seven Hills Rd after Solander Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308018:1",
+                  "name": "Kings Langley",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118774"
+                },
+                "coord": [
+                  -33.761156,
+                  150.952262
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Rd after Solander Rd",
+                "areaGid": "G214759",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Seven Hills Rd after Solander Rd",
+                "plannedPlatformName": "Seven Hills Rd after Solander Rd"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:04:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:04:00Z",
+              "modes": [
+                5,
+                11
+              ]
+            }
+          ],
+          "infos": [],
+          "properties": {
+            "vehicleAccess": [
+              {
+                "height": 0,
+                "halfWidth": 0,
+                "doorWidth": 2000,
+                "attributes": 1073741824,
+                "areaToStay": 0,
+                "areaToMove": 0,
+                "equipments": [
+                  {
+                    "vehicleEquipment": {
+                      "equipmentType": 1,
+                      "length": 0,
+                      "width": 0,
+                      "lengthAtPl": 0,
+                      "widthAtPl": 0,
+                      "maxWeight": 0
+                    }
+                  }
+                ]
+              }
+            ],
+            "PlanLowFloorVehicle": "1",
+            "PlanWheelChairAccess": "1"
+          }
+        },
+        {
+          "duration": 60,
+          "origin": {
+            "isGlobalId": true,
+            "id": "214759",
+            "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+            "disassembledName": "Seven Hills Rd after Solander Rd",
+            "type": "platform",
+            "coord": [
+              -33.761156,
+              150.952262
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "G214759",
+              "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+              "disassembledName": "Seven Hills Rd after Solander Rd",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308018:1",
+                "name": "Kings Langley",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10118774"
+              },
+              "coord": [
+                -33.761156,
+                150.952262
+              ],
+              "niveau": 0
+            },
+            "departureTimeBaseTimetable": "2026-07-03T00:08:00Z",
+            "departureTimePlanned": "2026-07-03T00:08:00Z",
+            "departureTimeEstimated": "2026-07-03T00:04:48Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "stoppingPointPlanned": "Seven Hills Rd after Solander Rd",
+              "areaGid": "G214759",
+              "area": "0",
+              "platform": "X1",
+              "platformName": "Seven Hills Rd after Solander Rd",
+              "plannedPlatformName": "Seven Hills Rd after Solander Rd"
+            },
+            "modes": [
+              5,
+              11
+            ]
+          },
+          "destination": {
+            "isGlobalId": true,
+            "id": "2147213",
+            "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+            "disassembledName": "Seven Hills Rd before Solander Rd",
+            "type": "platform",
+            "coord": [
+              -33.761221,
+              150.952492
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "G2147213",
+              "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+              "disassembledName": "Seven Hills Rd before Solander Rd",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308035:1",
+                "name": "Seven Hills",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10118708"
+              },
+              "coord": [
+                -33.761221,
+                150.952492
+              ],
+              "niveau": 0
+            },
+            "arrivalTimeBaseTimetable": "2026-07-03T00:09:00Z",
+            "arrivalTimePlanned": "2026-07-03T00:09:00Z",
+            "arrivalTimeEstimated": "2026-07-03T00:05:48Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "stoppingPointPlanned": "Seven Hills Rd before Solander Rd",
+              "areaGid": "G2147213",
+              "area": "0",
+              "platform": "X1",
+              "platformName": "Seven Hills Rd before Solander Rd",
+              "plannedPlatformName": "Seven Hills Rd before Solander Rd"
+            },
+            "modes": [
+              5,
+              11
+            ]
+          },
+          "transportation": {
+            "product": {
+              "class": 99,
+              "name": "footpath",
+              "iconId": 99
+            },
+            "properties": {
+              "tripCode": 0,
+              "lineDisplay": "LINE"
+            }
+          },
+          "stopSequence": [
+            {
+              "isGlobalId": true,
+              "id": "214759",
+              "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+              "disassembledName": "Seven Hills Rd after Solander Rd",
+              "type": "platform",
+              "coord": [
+                -33.761156,
+                150.952262
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G214759",
+                "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+                "disassembledName": "Seven Hills Rd after Solander Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308018:1",
+                  "name": "Kings Langley",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118774"
+                },
+                "coord": [
+                  -33.761156,
+                  150.952262
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "areaGid": "G214759",
+                "area": "0",
+                "platform": "X1"
+              },
+              "departureTimePlanned": "2026-07-03T00:08:00Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147213",
+              "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+              "disassembledName": "Seven Hills Rd before Solander Rd",
+              "type": "platform",
+              "coord": [
+                -33.761221,
+                150.952492
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147213",
+                "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+                "disassembledName": "Seven Hills Rd before Solander Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118708"
+                },
+                "coord": [
+                  -33.761221,
+                  150.952492
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "areaGid": "G2147213",
+                "area": "0",
+                "platform": "X1"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:09:00Z",
+              "modes": [
+                5,
+                11
+              ]
+            }
+          ],
+          "footPathInfo": [
+            {
+              "position": "IDEST",
+              "duration": 60,
+              "footPathElem": [
+                {
+                  "description": "",
+                  "type": "LEVEL",
+                  "levelFrom": 0,
+                  "levelTo": 0,
+                  "level": "LEVEL",
+                  "origin": {
+                    "location": {
+                      "id": "G214759",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Rd after Solander Rd",
+                      "coord": [
+                        -33.761156,
+                        150.952262
+                      ],
+                      "properties": {
+                        "area": "0",
+                        "georef": "503750110:129:GDAV:100",
+                        "areaGid": "",
+                        "areaType": 97
+                      }
+                    },
+                    "area": "0",
+                    "georef": "503750110:129:GDAV:100"
+                  },
+                  "destination": {
+                    "location": {
+                      "id": "G2147213",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Rd before Solander Rd",
+                      "coord": [
+                        -33.761221,
+                        150.952492
+                      ],
+                      "properties": {
+                        "area": "0",
+                        "georef": "1003836595:157:GDAV:100",
+                        "areaGid": "",
+                        "areaType": 33
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "duration": 4,
+                    "distance": 31,
+                    "narrowestWidth": -1,
+                    "elevLength": 0,
+                    "elevWidth": 0,
+                    "elevDoorWidth": 0,
+                    "rampLength": 0,
+                    "rampWidth": 0,
+                    "rampInclination": 0,
+                    "numberSteps": 0,
+                    "maxStepHeight": 0
+                  },
+                  "openingHours": []
+                }
+              ]
+            }
+          ],
+          "infos": []
+        },
+        {
+          "duration": 234,
+          "isRealtimeControlled": true,
+          "realtimeStatus": [
+            "MONITORED"
+          ],
+          "origin": {
+            "isGlobalId": true,
+            "id": "2147213",
+            "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+            "disassembledName": "Seven Hills Rd before Solander Rd",
+            "type": "platform",
+            "coord": [
+              -33.761221,
+              150.952492
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "G2147213",
+              "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+              "disassembledName": "Seven Hills Rd before Solander Rd",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308035:1",
+                "name": "Seven Hills",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10118708"
+              },
+              "coord": [
+                -33.761221,
+                150.952492
+              ],
+              "niveau": 0
+            },
+            "departureTimeBaseTimetable": "2026-07-03T00:09:00Z",
+            "departureTimePlanned": "2026-07-03T00:09:00Z",
+            "departureTimeEstimated": "2026-07-03T00:05:48Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "stoppingPointPlanned": "Seven Hills Rd before Solander Rd",
+              "occupancy": "MANY_SEATS",
+              "areaGid": "G2147213",
+              "area": "0",
+              "platform": "X1",
+              "platformName": "Seven Hills Rd before Solander Rd",
+              "plannedPlatformName": "Seven Hills Rd before Solander Rd"
+            },
+            "modes": [
+              5,
+              11
+            ]
+          },
+          "destination": {
+            "isGlobalId": true,
+            "id": "214732",
+            "name": "Seven Hills Station, Stand A, Seven Hills",
+            "disassembledName": "Seven Hills Station, Stand A",
+            "type": "platform",
+            "coord": [
+              -33.773761,
+              150.936268
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "214710",
+              "name": "Seven Hills Station, Stand A, Seven Hills",
+              "disassembledName": "Seven Hills Station, Stand A",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308035:1",
+                "name": "Seven Hills",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10101234"
+              },
+              "coord": [
+                -33.774351,
+                150.936123
+              ],
+              "niveau": 0
+            },
+            "arrivalTimeBaseTimetable": "2026-07-03T00:15:00Z",
+            "arrivalTimePlanned": "2026-07-03T00:15:00Z",
+            "arrivalTimeEstimated": "2026-07-03T00:09:42Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "stoppingPointPlanned": "Seven Hills Station, Stand A",
+              "occupancy": "MANY_SEATS",
+              "area": "11",
+              "platform": "A",
+              "platformName": "Seven Hills Station, Stand A",
+              "plannedPlatformName": "Seven Hills Station, Stand A",
+              "accessArray": [
+                {
+                  "stoppointAccess": {
+                    "equipment": 0,
+                    "maxWeight": 0,
+                    "distanceTrack": 0,
+                    "lengthAvail": 0,
+                    "widthAvail": 0,
+                    "attributes": 0,
+                    "stepFromStreet": 0
+                  }
+                }
+              ]
+            },
+            "modes": [
+              1,
+              5,
+              11
+            ]
+          },
+          "transportation": {
+            "id": "nsw:14715: :R:sj2",
+            "name": "Sydney Buses Network 715",
+            "disassembledName": "715",
+            "number": "715",
+            "description": "Rouse Hill Station to Seven Hills via Kellyville & Norwest",
+            "product": {
+              "id": 5,
+              "class": 5,
+              "name": "Sydney Buses Network",
+              "iconId": 5
+            },
+            "operator": {
+              "id": "2504",
+              "name": "CDC NSW R4"
+            },
+            "destination": {
+              "id": "10101234",
+              "name": "Seven Hills Station",
+              "type": "stop"
+            },
+            "properties": {
+              "isTTB": true,
+              "tripCode": 15,
+              "timetablePeriod": "NSW JP",
+              "lineDisplay": "LINE",
+              "globalId": "3002",
+              "AVMSTripID": "2648028",
+              "RealtimeTripId": "2648028",
+              "gtfsTripId": "3002.nsw-14-715.1.TA.49.sj2"
+            },
+            "iconId": 5
+          },
+          "stopSequence": [
+            {
+              "isGlobalId": true,
+              "id": "2147213",
+              "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+              "disassembledName": "Seven Hills Rd before Solander Rd",
+              "type": "platform",
+              "coord": [
+                -33.761221,
+                150.952492
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147213",
+                "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+                "disassembledName": "Seven Hills Rd before Solander Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118708"
+                },
+                "coord": [
+                  -33.761221,
+                  150.952492
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Rd before Solander Rd",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147213",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Seven Hills Rd before Solander Rd",
+                "plannedPlatformName": "Seven Hills Rd before Solander Rd"
+              },
+              "departureTimePlanned": "2026-07-03T00:09:00Z",
+              "departureTimeEstimated": "2026-07-03T00:05:48Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147214",
+              "name": "Seven Hills Rd at Monaro St, Seven Hills",
+              "disassembledName": "Seven Hills Rd at Monaro St",
+              "type": "platform",
+              "coord": [
+                -33.762781,
+                150.950492
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147214",
+                "name": "Seven Hills Rd at Monaro St, Seven Hills",
+                "disassembledName": "Seven Hills Rd at Monaro St",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10124398"
+                },
+                "coord": [
+                  -33.76279,
+                  150.950471
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Rd at Monaro St",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147214",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Seven Hills Rd at Monaro St",
+                "plannedPlatformName": "Seven Hills Rd at Monaro St"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:09:00Z",
+              "departureTimePlanned": "2026-07-03T00:09:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:06:00Z",
+              "departureTimeEstimated": "2026-07-03T00:06:06Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147215",
+              "name": "Seven Hills Rd after Nattai St, Seven Hills",
+              "disassembledName": "Seven Hills Rd after Nattai St",
+              "type": "platform",
+              "coord": [
+                -33.764459,
+                150.948724
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147215",
+                "name": "Seven Hills Rd after Nattai St, Seven Hills",
+                "disassembledName": "Seven Hills Rd after Nattai St",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118710"
+                },
+                "coord": [
+                  -33.764459,
+                  150.948724
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Rd after Nattai St",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147215",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Seven Hills Rd after Nattai St",
+                "plannedPlatformName": "Seven Hills Rd after Nattai St"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:10:00Z",
+              "departureTimePlanned": "2026-07-03T00:10:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:06:12Z",
+              "departureTimeEstimated": "2026-07-03T00:06:24Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147216",
+              "name": "Seven Hills Rd opp Marnpar Rd, Seven Hills",
+              "disassembledName": "Seven Hills Rd opp Marnpar Rd",
+              "type": "platform",
+              "coord": [
+                -33.766457,
+                150.94627
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147216",
+                "name": "Seven Hills Rd opp Marnpar Rd, Seven Hills",
+                "disassembledName": "Seven Hills Rd opp Marnpar Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10124028"
+                },
+                "coord": [
+                  -33.766458,
+                  150.946259
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Rd opp Marnpar Rd",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147216",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Seven Hills Rd opp Marnpar Rd",
+                "plannedPlatformName": "Seven Hills Rd opp Marnpar Rd"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:11:00Z",
+              "departureTimePlanned": "2026-07-03T00:11:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:06:36Z",
+              "departureTimeEstimated": "2026-07-03T00:06:36Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147241",
+              "name": "Prospect Hwy after Station Rd, Seven Hills",
+              "disassembledName": "Prospect Hwy after Station Rd",
+              "type": "platform",
+              "coord": [
+                -33.769387,
+                150.942013
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147241",
+                "name": "Prospect Hwy after Station Rd, Seven Hills",
+                "disassembledName": "Prospect Hwy after Station Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118732"
+                },
+                "coord": [
+                  -33.769387,
+                  150.942013
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Prospect Hwy after Station Rd",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147241",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Prospect Hwy after Station Rd",
+                "plannedPlatformName": "Prospect Hwy after Station Rd"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:13:00Z",
+              "departureTimePlanned": "2026-07-03T00:13:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:08:36Z",
+              "departureTimeEstimated": "2026-07-03T00:08:42Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147242",
+              "name": "Prospect Hwy opp Lucas Rd, Seven Hills",
+              "disassembledName": "Prospect Hwy opp Lucas Rd",
+              "type": "platform",
+              "coord": [
+                -33.770724,
+                150.939949
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147242",
+                "name": "Prospect Hwy opp Lucas Rd, Seven Hills",
+                "disassembledName": "Prospect Hwy opp Lucas Rd",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10132311"
+                },
+                "coord": [
+                  -33.770724,
+                  150.939949
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Prospect Hwy opp Lucas Rd",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147242",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Prospect Hwy opp Lucas Rd",
+                "plannedPlatformName": "Prospect Hwy opp Lucas Rd"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:13:00Z",
+              "departureTimePlanned": "2026-07-03T00:13:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:08:54Z",
+              "departureTimeEstimated": "2026-07-03T00:09:00Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2147243",
+              "name": "Prospect Hwy opp Hope St, Seven Hills",
+              "disassembledName": "Prospect Hwy opp Hope St",
+              "type": "platform",
+              "coord": [
+                -33.771566,
+                150.938131
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "G2147243",
+                "name": "Prospect Hwy opp Hope St, Seven Hills",
+                "disassembledName": "Prospect Hwy opp Hope St",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10118734"
+                },
+                "coord": [
+                  -33.771574,
+                  150.938143
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Prospect Hwy opp Hope St",
+                "occupancy": "MANY_SEATS",
+                "areaGid": "G2147243",
+                "area": "0",
+                "platform": "X1",
+                "platformName": "Prospect Hwy opp Hope St",
+                "plannedPlatformName": "Prospect Hwy opp Hope St"
+              },
+              "arrivalTimePlanned": "2026-07-03T00:14:00Z",
+              "departureTimePlanned": "2026-07-03T00:14:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:09:12Z",
+              "departureTimeEstimated": "2026-07-03T00:09:12Z",
+              "modes": [
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "214732",
+              "name": "Seven Hills Station, Stand A, Seven Hills",
+              "disassembledName": "Seven Hills Station, Stand A",
+              "type": "platform",
+              "coord": [
+                -33.773761,
+                150.936268
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214710",
+                "name": "Seven Hills Station, Stand A, Seven Hills",
+                "disassembledName": "Seven Hills Station, Stand A",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101234"
+                },
+                "coord": [
+                  -33.774351,
+                  150.936123
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Seven Hills Station, Stand A",
+                "occupancy": "MANY_SEATS",
+                "area": "11",
+                "platform": "A",
+                "platformName": "Seven Hills Station, Stand A",
+                "plannedPlatformName": "Seven Hills Station, Stand A",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "distanceTrack": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0,
+                      "stepFromStreet": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:15:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:09:42Z",
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            }
+          ],
+          "footPathInfo": [
+            {
+              "position": "AFTER",
+              "duration": 240,
+              "footPathElem": [
+                {
+                  "description": "",
+                  "type": "LEVEL",
+                  "levelFrom": 0,
+                  "levelTo": 0,
+                  "level": "LEVEL",
+                  "origin": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.773761,
+                        150.936268
+                      ],
+                      "properties": {
+                        "area": "11",
+                        "georef": "503757050:6:GDAV:100",
+                        "areaGid": "",
+                        "areaType": 65
+                      }
+                    },
+                    "area": "11",
+                    "georef": "503757050:6:GDAV:100"
+                  },
+                  "destination": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774078,
+                        150.935927
+                      ],
+                      "properties": {
+                        "area": "28",
+                        "georef": "505390600:0:GDAV:100",
+                        "areaGid": "",
+                        "areaType": 32
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "duration": 15,
+                    "distance": 0,
+                    "narrowestWidth": -1,
+                    "elevLength": 0,
+                    "elevWidth": 0,
+                    "elevDoorWidth": 0,
+                    "rampLength": 0,
+                    "rampWidth": 0,
+                    "rampInclination": 0,
+                    "numberSteps": 0,
+                    "maxStepHeight": 0
+                  },
+                  "openingHours": []
+                },
+                {
+                  "description": "",
+                  "type": "RAMP",
+                  "levelFrom": 0,
+                  "levelTo": 1,
+                  "level": "UP",
+                  "origin": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774078,
+                        150.935927
+                      ],
+                      "properties": {
+                        "area": "28",
+                        "georef": "505390600:0:GDAV:100",
+                        "areaGid": "",
+                        "areaType": 32
+                      }
+                    },
+                    "area": "28",
+                    "georef": "505390600:0:GDAV:100"
+                  },
+                  "destination": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774134,
+                        150.936156
+                      ],
+                      "properties": {
+                        "area": "27",
+                        "georef": "0:0::100",
+                        "areaGid": "",
+                        "areaType": 4096
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "duration": 8,
+                    "distance": 0,
+                    "narrowestWidth": -1,
+                    "elevLength": 0,
+                    "elevWidth": 0,
+                    "elevDoorWidth": 0,
+                    "rampLength": 0,
+                    "rampWidth": 0,
+                    "rampInclination": 0,
+                    "numberSteps": 0,
+                    "maxStepHeight": 0
+                  },
+                  "openingHours": []
+                },
+                {
+                  "description": "",
+                  "type": "LEVEL",
+                  "levelFrom": 1,
+                  "levelTo": 1,
+                  "level": "LEVEL",
+                  "origin": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774134,
+                        150.936156
+                      ],
+                      "properties": {
+                        "area": "27",
+                        "georef": "0:0::100",
+                        "areaGid": "",
+                        "areaType": 4096
+                      }
+                    },
+                    "area": "27",
+                    "georef": "0:0::100"
+                  },
+                  "destination": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774269,
+                        150.93614
+                      ],
+                      "properties": {
+                        "area": "26",
+                        "georef": "0:0::100",
+                        "areaGid": "",
+                        "areaType": 4096
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "duration": 3,
+                    "distance": 0,
+                    "narrowestWidth": -1,
+                    "elevLength": 0,
+                    "elevWidth": 0,
+                    "elevDoorWidth": 0,
+                    "rampLength": 0,
+                    "rampWidth": 0,
+                    "rampInclination": 0,
+                    "numberSteps": 0,
+                    "maxStepHeight": 0
+                  },
+                  "openingHours": []
+                },
+                {
+                  "description": "",
+                  "type": "STAIRS",
+                  "levelFrom": 1,
+                  "levelTo": 0,
+                  "level": "DOWN",
+                  "origin": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774269,
+                        150.93614
+                      ],
+                      "properties": {
+                        "area": "26",
+                        "georef": "0:0::100",
+                        "areaGid": "",
+                        "areaType": 4096
+                      }
+                    },
+                    "area": "26",
+                    "georef": "0:0::100"
+                  },
+                  "destination": {
+                    "location": {
+                      "id": "214710",
+                      "isGlobalId": true,
+                      "type": "stop",
+                      "name": "Seven Hills Station",
+                      "coord": [
+                        -33.774284,
+                        150.935968
+                      ],
+                      "properties": {
+                        "area": "1",
+                        "georef": "1002097582:2:GDAV:100",
+                        "areaGid": "",
+                        "areaType": 81
+                      }
+                    }
+                  },
+                  "attributes": {
+                    "duration": 5,
+                    "distance": 0,
+                    "narrowestWidth": -1,
+                    "elevLength": 0,
+                    "elevWidth": 0,
+                    "elevDoorWidth": 0,
+                    "rampLength": 0,
+                    "rampWidth": 0,
+                    "rampInclination": 0,
+                    "numberSteps": 0,
+                    "maxStepHeight": 0
+                  },
+                  "openingHours": []
+                }
+              ]
+            }
+          ],
+          "footPathInfoRedundant": true,
+          "infos": [],
+          "interchange": {
+            "desc": "Fussweg",
+            "type": 100
+          },
+          "properties": {
+            "vehicleAccess": [
+              {
+                "height": 0,
+                "halfWidth": 0,
+                "doorWidth": 2000,
+                "attributes": 1342177280,
+                "areaToStay": 0,
+                "areaToMove": 0,
+                "equipments": [
+                  {
+                    "vehicleEquipment": {
+                      "equipmentType": 1,
+                      "length": 0,
+                      "width": 0,
+                      "lengthAtPl": 0,
+                      "widthAtPl": 0,
+                      "maxWeight": 0
+                    }
+                  }
+                ]
+              }
+            ],
+            "AVMLowFloorVeh": "1",
+            "PlanLowFloorVehicle": "1",
+            "PlanWheelChairAccess": "1"
+          }
+        },
+        {
+          "duration": 2130,
+          "isRealtimeControlled": true,
+          "realtimeStatus": [
+            "MONITORED"
+          ],
+          "origin": {
+            "isGlobalId": true,
+            "id": "2147422",
+            "name": "Seven Hills Station, Platform 2, Seven Hills",
+            "disassembledName": "Seven Hills Station, Platform 2",
+            "type": "platform",
+            "coord": [
+              -33.774284,
+              150.935968
+            ],
+            "niveau": 0,
+            "parent": {
+              "isGlobalId": true,
+              "id": "214710",
+              "name": "Seven Hills Station, Platform 2, Seven Hills",
+              "disassembledName": "Seven Hills Station, Platform 2",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95308035:1",
+                "name": "Seven Hills",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10101234"
+              },
+              "coord": [
+                -33.774351,
+                150.936123
+              ],
+              "niveau": 0
+            },
+            "departureTimeBaseTimetable": "2026-07-03T00:18:30Z",
+            "departureTimePlanned": "2026-07-03T00:18:30Z",
+            "departureTimeEstimated": "2026-07-03T00:18:30Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "0",
+              "NumberOfCars": "8",
+              "TravelInCarsFrom": "1",
+              "TravelInCarsTo": "8",
+              "TravelInCarsMessage": "any",
+              "stoppingPointPlanned": "Platform 2",
+              "occupancy": "MANY_SEATS",
+              "area": "1",
+              "platform": "SVH2",
+              "platformName": "Platform 2",
+              "plannedPlatformName": "Platform 2",
+              "accessArray": [
+                {
+                  "stoppointAccess": {
+                    "height": 780,
+                    "equipment": 0,
+                    "maxWeight": 0,
+                    "lengthAvail": 0,
+                    "widthAvail": 0,
+                    "attributes": 0,
+                    "stepFromStreet": 0
+                  }
+                }
+              ]
+            },
+            "modes": [
+              1,
+              5,
+              11
+            ]
+          },
+          "destination": {
+            "isGlobalId": true,
+            "id": "2000336",
+            "name": "Central Station, Platform 16, Sydney",
+            "disassembledName": "Central Station, Platform 16",
+            "type": "platform",
+            "coord": [
+              -33.883967,
+              151.206838
+            ],
+            "niveau": 1,
+            "parent": {
+              "isGlobalId": true,
+              "id": "200060",
+              "name": "Central Station, Platform 16, Sydney",
+              "disassembledName": "Central Station, Platform 16",
+              "type": "stop",
+              "parent": {
+                "id": "placeID:95301001:1",
+                "name": "Sydney",
+                "type": "locality"
+              },
+              "properties": {
+                "stopId": "10101100"
+              },
+              "coord": [
+                -33.884024,
+                151.206203
+              ],
+              "niveau": 0
+            },
+            "arrivalTimeBaseTimetable": "2026-07-03T00:54:00Z",
+            "arrivalTimePlanned": "2026-07-03T00:54:00Z",
+            "arrivalTimeEstimated": "2026-07-03T00:54:00Z",
+            "properties": {
+              "WheelchairAccess": "true",
+              "AREA_NIVEAU_DIVA": "1",
+              "stoppingPointPlanned": "Platform 16",
+              "occupancy": "FEW_SEATS",
+              "area": "9",
+              "platform": "CE16",
+              "platformName": "Platform 16",
+              "plannedPlatformName": "Platform 16",
+              "callType": [
+                "NOBOARDING"
+              ],
+              "accessArray": [
+                {
+                  "stoppointAccess": {
+                    "height": 780,
+                    "equipment": 0,
+                    "maxWeight": 0,
+                    "distanceTrack": 0,
+                    "lengthAvail": 0,
+                    "widthAvail": 0,
+                    "attributes": 0,
+                    "stepFromStreet": 0
+                  }
+                }
+              ]
+            },
+            "modes": [
+              1,
+              2,
+              4,
+              5,
+              7,
+              11
+            ]
+          },
+          "transportation": {
+            "id": "nsw:020T1:W:R:sj2",
+            "name": "Sydney Trains Network T1 North Shore & Western Line",
+            "disassembledName": "T1",
+            "number": "T1 North Shore & Western Line",
+            "description": "Emu Plains or Richmond to City",
+            "product": {
+              "id": 1,
+              "class": 1,
+              "name": "Sydney Trains Network",
+              "iconId": 1
+            },
+            "operator": {
+              "id": "x0001",
+              "name": "Sydney Trains"
+            },
+            "destination": {
+              "id": "10101100",
+              "name": "Berowra via Gordon",
+              "type": "stop"
+            },
+            "properties": {
+              "isTTB": true,
+              "tripCode": 541,
+              "timetablePeriod": "NSW JP",
+              "lineDisplay": "LINE",
+              "globalId": "3001",
+              "AVMSTripID": "145F.424.146.64.A.8.90146738",
+              "RealtimeTripId": "145F.424.146.64.A.8.90146738",
+              "OperatorURL": "http://www.sydneytrains.info/",
+              "gtfsTripId": "3001.nsw-2-T1-W.1.TA.1840.sj2"
+            },
+            "iconId": 1
+          },
+          "stopSequence": [
+            {
+              "isGlobalId": true,
+              "id": "2147422",
+              "name": "Seven Hills Station, Platform 2, Seven Hills",
+              "disassembledName": "Seven Hills Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.774284,
+                150.935968
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214710",
+                "name": "Seven Hills Station, Platform 2, Seven Hills",
+                "disassembledName": "Seven Hills Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308035:1",
+                  "name": "Seven Hills",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101234"
+                },
+                "coord": [
+                  -33.774351,
+                  150.936123
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 2",
+                "occupancy": "MANY_SEATS",
+                "area": "1",
+                "platform": "SVH2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0,
+                      "stepFromStreet": 0
+                    }
+                  }
+                ]
+              },
+              "departureTimePlanned": "2026-07-03T00:18:30Z",
+              "departureTimeEstimated": "2026-07-03T00:18:30Z",
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2146112",
+              "name": "Toongabbie Station, Platform 2, Toongabbie",
+              "disassembledName": "Toongabbie Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.78725,
+                150.951466
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214610",
+                "name": "Toongabbie Station, Platform 2, Toongabbie",
+                "disassembledName": "Toongabbie Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95308040:1",
+                  "name": "Toongabbie",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101233"
+                },
+                "coord": [
+                  -33.787386,
+                  150.95144
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 2",
+                "area": "1",
+                "platform": "TGB2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2145642",
+              "name": "Pendle Hill Station, Platform 2, Pendle Hill",
+              "disassembledName": "Pendle Hill Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.801323,
+                150.956313
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214530",
+                "name": "Pendle Hill Station, Platform 2, Pendle Hill",
+                "disassembledName": "Pendle Hill Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346014:1",
+                  "name": "Pendle Hill",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101232"
+                },
+                "coord": [
+                  -33.801204,
+                  150.95608
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 2",
+                "area": "1",
+                "platform": "PDH2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2145652",
+              "name": "Wentworthville Station, Platform 2, Wentworthville",
+              "disassembledName": "Wentworthville Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.80709,
+                150.972543
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214520",
+                "name": "Wentworthville Station, Platform 2, Wentworthville",
+                "disassembledName": "Wentworthville Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346019:1",
+                  "name": "Wentworthville",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101231"
+                },
+                "coord": [
+                  -33.807069,
+                  150.97237
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 2",
+                "area": "1",
+                "platform": "WVL2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2145662",
+              "name": "Westmead Station, Platform 2, Westmead",
+              "disassembledName": "Westmead Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.808365,
+                150.987747
+              ],
+              "niveau": -1,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214510",
+                "name": "Westmead Station, Platform 2, Westmead",
+                "disassembledName": "Westmead Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346020:1",
+                  "name": "Westmead",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101230"
+                },
+                "coord": [
+                  -33.808478,
+                  150.987892
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "-1",
+                "stoppingPointPlanned": "Platform 2",
+                "occupancy": "MANY_SEATS",
+                "area": "1",
+                "platform": "WMD2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0,
+                      "stepFromStreet": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:24:00Z",
+              "departureTimePlanned": "2026-07-03T00:24:30Z",
+              "arrivalTimeEstimated": "2026-07-03T00:24:00Z",
+              "departureTimeEstimated": "2026-07-03T00:24:30Z",
+              "modes": [
+                1,
+                4,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2150411",
+              "name": "Parramatta Station, Platform 1, Parramatta",
+              "disassembledName": "Parramatta Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.817277,
+                151.005239
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "215020",
+                "name": "Parramatta Station, Platform 1, Parramatta",
+                "disassembledName": "Parramatta Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346013:1",
+                  "name": "Parramatta",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101229"
+                },
+                "coord": [
+                  -33.81749,
+                  151.005325
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "occupancy": "FEW_SEATS",
+                "area": "1",
+                "platform": "PTA1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0,
+                      "stepFromStreet": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:27:00Z",
+              "departureTimePlanned": "2026-07-03T00:28:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:27:00Z",
+              "departureTimeEstimated": "2026-07-03T00:28:00Z",
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2150401",
+              "name": "Harris Park Station, Platform 1, Harris Park",
+              "disassembledName": "Harris Park Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.823568,
+                151.007692
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "215010",
+                "name": "Harris Park Station, Platform 1, Harris Park",
+                "disassembledName": "Harris Park Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346008:1",
+                  "name": "Harris Park",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101228"
+                },
+                "coord": [
+                  -33.823353,
+                  151.00765
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "area": "1",
+                "platform": "HPK1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1"
+              },
+              "modes": [
+                1
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2142321",
+              "name": "Granville Station, Platform 1, Granville",
+              "disassembledName": "Granville Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.832818,
+                151.012239
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214240",
+                "name": "Granville Station, Platform 1, Granville",
+                "disassembledName": "Granville Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346007:1",
+                  "name": "Granville",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101227"
+                },
+                "coord": [
+                  -33.832758,
+                  151.011869
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "area": "1",
+                "platform": "GVL1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2142312",
+              "name": "Clyde Station, Platform 2, Granville",
+              "disassembledName": "Clyde Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.835929,
+                151.017135
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214230",
+                "name": "Clyde Station, Platform 2, Granville",
+                "disassembledName": "Clyde Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95346007:1",
+                  "name": "Granville",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101220"
+                },
+                "coord": [
+                  -33.835953,
+                  151.016942
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 2",
+                "area": "1",
+                "platform": "CLJ2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2"
+              },
+              "modes": [
+                1
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2144241",
+              "name": "Auburn Station, Platform 1, Auburn",
+              "disassembledName": "Auburn Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.849225,
+                151.032964
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214410",
+                "name": "Auburn Station, Platform 1, Auburn",
+                "disassembledName": "Auburn Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95304001:1",
+                  "name": "Auburn",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101219"
+                },
+                "coord": [
+                  -33.84943,
+                  151.033017
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "area": "1",
+                "platform": "AUB1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2141311",
+              "name": "Lidcombe Station, Platform 1, Lidcombe",
+              "disassembledName": "Lidcombe Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.863606,
+                151.045036
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214110",
+                "name": "Lidcombe Station, Platform 1, Lidcombe",
+                "disassembledName": "Lidcombe Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95304004:1",
+                  "name": "Lidcombe",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101218"
+                },
+                "coord": [
+                  -33.863756,
+                  151.04513
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "occupancy": "FEW_SEATS",
+                "area": "1",
+                "platform": "LCE1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "distanceTrack": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:34:00Z",
+              "departureTimePlanned": "2026-07-03T00:34:30Z",
+              "arrivalTimeEstimated": "2026-07-03T00:34:00Z",
+              "departureTimeEstimated": "2026-07-03T00:34:30Z",
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "214061",
+              "name": "Flemington Station, Platform 1, Homebush West",
+              "disassembledName": "Flemington Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.864775,
+                151.069967
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214020",
+                "name": "Flemington Station, Platform 1, Homebush West",
+                "disassembledName": "Flemington Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95356002:1",
+                  "name": "Homebush West",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101217"
+                },
+                "coord": [
+                  -33.864912,
+                  151.070178
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "area": "1",
+                "platform": "FLM1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1"
+              },
+              "modes": [
+                1,
+                5
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "214072",
+              "name": "Homebush Station, Platform 2, Homebush",
+              "disassembledName": "Homebush Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.866646,
+                151.086376
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "214010",
+                "name": "Homebush Station, Platform 2, Homebush",
+                "disassembledName": "Homebush Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95356001:1",
+                  "name": "Homebush",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101216"
+                },
+                "coord": [
+                  -33.866688,
+                  151.086195
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 2",
+                "area": "1",
+                "platform": "HOM2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2135234",
+              "name": "Strathfield Station, Platform 4, Strathfield",
+              "disassembledName": "Strathfield Station, Platform 4",
+              "type": "platform",
+              "coord": [
+                -33.871464,
+                151.094027
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "213510",
+                "name": "Strathfield Station, Platform 4, Strathfield",
+                "disassembledName": "Strathfield Station, Platform 4",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95356003:1",
+                  "name": "Strathfield",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101206"
+                },
+                "coord": [
+                  -33.871672,
+                  151.094286
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 4",
+                "occupancy": "FEW_SEATS",
+                "area": "2",
+                "platform": "STR4",
+                "platformName": "Platform 4",
+                "plannedPlatformName": "Platform 4",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0,
+                      "stepFromStreet": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:40:00Z",
+              "departureTimePlanned": "2026-07-03T00:41:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:40:00Z",
+              "departureTimeEstimated": "2026-07-03T00:41:00Z",
+              "modes": [
+                1,
+                5,
+                7,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "213493",
+              "name": "Burwood Station, Platform 3, Burwood",
+              "disassembledName": "Burwood Station, Platform 3",
+              "type": "platform",
+              "coord": [
+                -33.877125,
+                151.104226
+              ],
+              "niveau": 1,
+              "parent": {
+                "isGlobalId": true,
+                "id": "213410",
+                "name": "Burwood Station, Platform 3, Burwood",
+                "disassembledName": "Burwood Station, Platform 3",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95311001:1",
+                  "name": "Burwood",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101207"
+                },
+                "coord": [
+                  -33.877102,
+                  151.103857
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "1",
+                "stoppingPointPlanned": "Platform 3",
+                "area": "2",
+                "platform": "BWD3",
+                "platformName": "Platform 3",
+                "plannedPlatformName": "Platform 3"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "213282",
+              "name": "Croydon Station, Platform 2, Croydon",
+              "disassembledName": "Croydon Station, Platform 2",
+              "type": "platform",
+              "coord": [
+                -33.88311,
+                151.115489
+              ],
+              "niveau": -1,
+              "parent": {
+                "isGlobalId": true,
+                "id": "213210",
+                "name": "Croydon Station, Platform 2, Croydon",
+                "disassembledName": "Croydon Station, Platform 2",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95311003:1",
+                  "name": "Croydon",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101208"
+                },
+                "coord": [
+                  -33.883075,
+                  151.115206
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "-1",
+                "AREA_NIVEAU_GIS": "-1.00",
+                "stoppingPointPlanned": "Platform 2",
+                "area": "1",
+                "platform": "CYD2",
+                "platformName": "Platform 2",
+                "plannedPlatformName": "Platform 2"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2131121",
+              "name": "Ashfield Station, Platform 1, Ashfield",
+              "disassembledName": "Ashfield Station, Platform 1",
+              "type": "platform",
+              "coord": [
+                -33.887438,
+                151.125626
+              ],
+              "niveau": 0,
+              "parent": {
+                "isGlobalId": true,
+                "id": "213110",
+                "name": "Ashfield Station, Platform 1, Ashfield",
+                "disassembledName": "Ashfield Station, Platform 1",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95303001:1",
+                  "name": "Ashfield",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101209"
+                },
+                "coord": [
+                  -33.887638,
+                  151.125851
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "AREA_NIVEAU_DIVA": "0",
+                "stoppingPointPlanned": "Platform 1",
+                "area": "1",
+                "platform": "ASH1",
+                "platformName": "Platform 1",
+                "plannedPlatformName": "Platform 1"
+              },
+              "modes": [
+                1,
+                5,
+                11
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2015133",
+              "name": "Redfern Station, Platform 3, Eveleigh",
+              "disassembledName": "Redfern Station, Platform 3",
+              "type": "platform",
+              "coord": [
+                -33.891999,
+                151.198276
+              ],
+              "niveau": -1,
+              "parent": {
+                "isGlobalId": true,
+                "id": "201510",
+                "name": "Redfern Station, Platform 3, Eveleigh",
+                "disassembledName": "Redfern Station, Platform 3",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95301014:1",
+                  "name": "Eveleigh",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101421"
+                },
+                "coord": [
+                  -33.892048,
+                  151.198419
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "-1",
+                "AREA_NIVEAU_GIS": "-1.00",
+                "stoppingPointPlanned": "Platform 3",
+                "occupancy": "FEW_SEATS",
+                "area": "2",
+                "platform": "RD03",
+                "platformName": "Platform 3",
+                "plannedPlatformName": "Platform 3",
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "distanceTrack": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:51:42Z",
+              "departureTimePlanned": "2026-07-03T00:52:12Z",
+              "arrivalTimeEstimated": "2026-07-03T00:51:42Z",
+              "departureTimeEstimated": "2026-07-03T00:52:12Z",
+              "modes": [
+                1,
+                5
+              ]
+            },
+            {
+              "isGlobalId": true,
+              "id": "2000336",
+              "name": "Central Station, Platform 16, Sydney",
+              "disassembledName": "Central Station, Platform 16",
+              "type": "platform",
+              "coord": [
+                -33.883967,
+                151.206838
+              ],
+              "niveau": 1,
+              "parent": {
+                "isGlobalId": true,
+                "id": "200060",
+                "name": "Central Station, Platform 16, Sydney",
+                "disassembledName": "Central Station, Platform 16",
+                "type": "stop",
+                "parent": {
+                  "id": "placeID:95301001:1",
+                  "name": "Sydney",
+                  "type": "locality"
+                },
+                "properties": {
+                  "stopId": "10101100"
+                },
+                "coord": [
+                  -33.884024,
+                  151.206203
+                ],
+                "niveau": 0
+              },
+              "properties": {
+                "WheelchairAccess": "true",
+                "AREA_NIVEAU_DIVA": "1",
+                "stoppingPointPlanned": "Platform 16",
+                "occupancy": "FEW_SEATS",
+                "area": "9",
+                "platform": "CE16",
+                "platformName": "Platform 16",
+                "plannedPlatformName": "Platform 16",
+                "callType": [
+                  "NOBOARDING"
+                ],
+                "accessArray": [
+                  {
+                    "stoppointAccess": {
+                      "height": 780,
+                      "equipment": 0,
+                      "maxWeight": 0,
+                      "distanceTrack": 0,
+                      "lengthAvail": 0,
+                      "widthAvail": 0,
+                      "attributes": 0,
+                      "stepFromStreet": 0
+                    }
+                  }
+                ]
+              },
+              "arrivalTimePlanned": "2026-07-03T00:54:00Z",
+              "arrivalTimeEstimated": "2026-07-03T00:54:00Z",
+              "modes": [
+                1,
+                2,
+                4,
+                5,
+                7,
+                11
+              ]
+            }
+          ],
+          "infos": [],
+          "coupledTripsInfo": [
+            {
+              "positionInTrain": "-1",
+              "usableForLeg": true,
+              "infoOnCarLevel": true,
+              "transportation": {
+                "id": "nsw:020T1:W:R:sj2",
+                "name": "Sydney Trains Network T1 North Shore & Western Line",
+                "disassembledName": "T1",
+                "number": "T1 North Shore & Western Line",
+                "product": {
+                  "id": 1,
+                  "class": 1,
+                  "name": "Sydney Trains Network",
+                  "iconId": 1
+                },
+                "destination": {
+                  "name": "Berowra via Gordon",
+                  "type": "stop"
+                },
+                "properties": {
+                  "lineDisplay": "LINE",
+                  "globalId": "3001"
+                }
+              },
+              "properties": {
+                "tripId": "541"
+              }
+            }
+          ],
+          "properties": {
+            "vehicleAccess": [
+              {
+                "height": 0,
+                "halfWidth": 0,
+                "doorWidth": 0,
+                "attributes": 1073741824,
+                "areaToStay": 0,
+                "areaToMove": 0,
+                "equipments": [
+                  {
+                    "vehicleEquipment": {
+                      "equipmentType": 1,
+                      "length": 0,
+                      "width": 0,
+                      "lengthAtPl": 0,
+                      "widthAtPl": 0,
+                      "maxWeight": 0
+                    }
+                  }
+                ]
+              }
+            ],
+            "PlanLowFloorVehicle": "1",
+            "PlanWheelChairAccess": "1"
+          }
+        }
+      ],
+      "fare": {
+        "tickets": []
+      },
+      "daysOfService": {
+        "rvb": "00000004000000000000000000000000"
+      }
+    }
+  ]
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -113,7 +113,74 @@ private fun TripResponse.Leg?.getDepartureTime() =
 private fun TripResponse.Leg?.getArrivalTime() =
     this?.destination?.arrivalTimeEstimated ?: this?.destination?.arrivalTimePlanned
 
-private fun TripResponse.Journey.getFilteredValidLegs() = legs?.filter { it.transportation != null }
+private fun TripResponse.Journey.getFilteredValidLegs() =
+    legs?.collapseSameRouteQuickWalks()?.filter { it.transportation != null }
+
+private const val QUICK_WALK_MAX_SECONDS = 120L
+private const val COLLAPSE_WINDOW_SIZE = 3
+
+/**
+ * The NSW API sometimes represents a route continuing on a different scheduled trip (e.g. a
+ * bus that reverses at a nearby stop and continues under a new trip ID) as three separate legs:
+ * a transport leg, a trivial standalone walk (crossing the road), then another transport leg on
+ * the *same route number*. Google Maps and Opal both display this as a single bus leg, so we
+ * collapse the same pattern here rather than surfacing a confusing 3-leg detour to the user.
+ *
+ * Deliberately does not check trip/vehicle IDs for equality - those legitimately differ in this
+ * scenario (different scheduled trip, sometimes opposite-direction description), which is
+ * exactly the case this heuristic needs to handle. Route number + a trivial walk is the same
+ * signal a passenger sees in person: the bus that pulls up is signed with the same number.
+ *
+ * Full investigation, the real API response that motivated this, and what was deliberately
+ * left out of scope: `docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md`. Regression tests
+ * (including one against a real captured response) live in `TripResponseMapperTest.kt` under
+ * `//region collapseSameRouteQuickWalks`. If you're changing this function, read that doc
+ * first - the "What NOT to do" section explains why trip-ID/direction checks were rejected.
+ */
+private fun List<TripResponse.Leg>.collapseSameRouteQuickWalks(): List<TripResponse.Leg> {
+    if (size < COLLAPSE_WINDOW_SIZE) return this
+    val result = mutableListOf<TripResponse.Leg>()
+    var index = 0
+    while (index < size) {
+        val current = this[index]
+        val walk = getOrNull(index + 1)
+        val next = getOrNull(index + 2)
+        if (current.canCollapseAcross(walk, next)) {
+            result += current.collapseAcrossQuickWalk(requireNotNull(next))
+            index += COLLAPSE_WINDOW_SIZE
+        } else {
+            result += current
+            index += 1
+        }
+    }
+    return result
+}
+
+private fun TripResponse.Leg.canCollapseAcross(walk: TripResponse.Leg?, next: TripResponse.Leg?): Boolean {
+    val walkPosition = walk?.footPathInfo?.firstOrNull()?.position
+    val walkDuration = walk?.duration
+    val thisRouteNumber = transportation?.number
+    return walk != null &&
+        next != null &&
+        walk.isWalkingLeg() &&
+        walkPosition == TimeTableState.JourneyCardInfo.WalkPosition.IDEST.position &&
+        walkDuration != null &&
+        walkDuration <= QUICK_WALK_MAX_SECONDS &&
+        thisRouteNumber != null &&
+        thisRouteNumber == next.transportation?.number
+}
+
+private fun TripResponse.Leg.collapseAcrossQuickWalk(next: TripResponse.Leg): TripResponse.Leg = copy(
+    destination = next.destination,
+    stopSequence = stopSequence.orEmpty() + next.stopSequence.orEmpty(),
+    // Force recalculation from the (now-merged) origin/destination timestamps via
+    // resolveDurationSeconds() instead of summing the two legs' durations, so the real
+    // door-to-door time - including the walk gap - stays accurate.
+    duration = null,
+    infos = (infos.orEmpty() + next.infos.orEmpty()).ifEmpty { null },
+    footPathInfo = null,
+    interchange = next.interchange,
+)
 
 private fun List<TripResponse.Leg>.getTotalStops() = sumOf { leg -> leg.stopSequence?.size ?: 0 }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.Json
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures.OranParkToSevenHillsFixture
+import xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures.Redfern715BacktrackFixture
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -19,8 +20,15 @@ import kotlin.test.assertNull
  */
 class TripResponseMapperTest {
 
-    // Lenient JSON parser — mirrors how Ktor deserialises API responses in production
-    private val json = Json { ignoreUnknownKeys = true }
+    // Mirrors the Json config Ktor actually uses in production (core/network/HttpClient.kt,
+    // core/remote-config/JsonConfig.kt) - isLenient is required because NSW sends some
+    // String-typed fields (e.g. Transportation.properties.tripCode) as unquoted JSON numbers.
+    // Without it, a real captured response (see Redfern715BacktrackFixture) fails to parse
+    // here even though the app decodes it fine, which would be a false test failure.
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
 
     //region resolveDurationSeconds
 
@@ -511,6 +519,170 @@ class TripResponseMapperTest {
 
     //endregion
 
+    //region collapseSameRouteQuickWalks (715 / walk / 715 backtrack)
+    //
+    // Full background: docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md
+    //
+    // User complaint: a trip shows as "715 bus / walk / 715 bus / T1 train" (3 transit legs)
+    // instead of "715 bus / T1 train", while Google Maps and Opal both show it as the latter.
+    // Root cause, confirmed from a real captured API response: NSW splits a 715 that reverses
+    // direction one stop from the origin into two separate scheduled trips (different tripCode,
+    // opposite-direction description) connected by a genuine but trivial (60s) road-crossing
+    // walk. [collapseSameRouteQuickWalks] in TripResponseMapper.kt collapses that pattern back
+    // into one displayed leg, matching what other apps show, without claiming to prove it's the
+    // same physical vehicle (it deliberately does NOT compare tripCode/RealtimeTripId/direction —
+    // those legitimately differ here, which is exactly the case being handled).
+    //
+    // The first test below decodes the real captured JSON (Redfern715BacktrackFixture) so it
+    // also catches API shape drift, not just mapper logic regressions. The other two tests pin
+    // the heuristic's boundaries (walk too long / route number differs) with synthetic data,
+    // since the real capture doesn't happen to contain those variants.
+
+    /**
+     * Regression test for the "715 / walk / 715 / T1" complaint, using the real API response
+     * that reproduces it (see [Redfern715BacktrackFixture] for full provenance/background).
+     * Decoding real JSON rather than hand-building a [TripResponse.Leg] tree also means this
+     * test breaks if NSW's field shape changes in a way the mapper doesn't handle, not just if
+     * the collapse logic itself regresses.
+     */
+    @Test
+    fun `buildJourneyList collapses same-route legs separated by a quick walk`() {
+        // Arrange: real captured response — leg0 715 tripCode 77 (outbound) -> 60s IDEST walk
+        // across the road -> leg2 715 tripCode 15 (inbound) -> leg3 T1.
+        val response = json.decodeFromString<TripResponse>(Redfern715BacktrackFixture.JSON)
+
+        // Act
+        val journey = response.buildJourneyList()?.firstOrNull()
+        val legs = journey?.legs
+
+        // Assert
+        assertEquals(2, legs?.size, "The two 715 legs and the quick walk must collapse into one leg")
+        val mergedLeg = legs?.getOrNull(0) as? TimeTableState.JourneyCardInfo.Leg.TransportLeg
+        assertEquals("715", mergedLeg?.transportModeLine?.lineName)
+        assertEquals(
+            "6 mins",
+            mergedLeg?.totalDuration,
+            "Merged duration must span the real door-to-door window (00:03:00 -> 00:09:42 " +
+                "estimated), not just the first leg's own 60s ride",
+        )
+        assertEquals(
+            10,
+            mergedLeg?.stops?.size,
+            "Stops from both real 715 legs (2 + 8) must be combined",
+        )
+        assertEquals(
+            null,
+            journey?.totalWalkTime,
+            "The collapsed quick walk must not be counted as walking time",
+        )
+    }
+
+    /**
+     * Synthetic edge case (not present in the real capture): pins the 120s quick-walk cutoff.
+     * A longer walk is a real interchange a user needs to know about — e.g. enough time to
+     * actually leave the stop precinct — and must never silently disappear into a merged leg.
+     */
+    @Test
+    fun `buildJourneyList does not collapse same-route legs when the walk exceeds the quick-walk threshold`() {
+        val response = TripResponse(
+            journeys = listOf(
+                TripResponse.Journey(
+                    legs = listOf(
+                        buildRouteLeg(
+                            routeNumber = "715",
+                            realtimeTripId = "trip-outbound-77",
+                            depTime = "2026-04-18T22:00:00Z",
+                            arrTime = "2026-04-18T22:01:00Z",
+                        ),
+                        buildQuickWalkLeg(
+                            depTime = "2026-04-18T22:01:00Z",
+                            arrTime = "2026-04-18T22:03:30Z",
+                            durationSeconds = 150L, // exceeds the 120s quick-walk threshold
+                        ),
+                        buildRouteLeg(
+                            routeNumber = "715",
+                            realtimeTripId = "trip-inbound-15",
+                            depTime = "2026-04-18T22:03:30Z",
+                            arrTime = "2026-04-18T22:06:00Z",
+                        ),
+                        buildRouteLeg(
+                            routeNumber = "T1",
+                            realtimeTripId = "trip-t1",
+                            depTime = "2026-04-18T22:10:00Z",
+                            arrTime = "2026-04-18T22:40:00Z",
+                            productClass = 1L,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(
+            4,
+            journey?.legs?.size,
+            "A walk longer than the quick-walk threshold is a real interchange and must stay separate",
+        )
+        assertEquals(
+            true,
+            journey?.totalWalkTime != null,
+            "A real (non-collapsed) walking leg must still be counted as walking time",
+        )
+    }
+
+    /**
+     * Synthetic edge case (not present in the real capture): pins that route number is the
+     * *only* merge signal, not a coincidence of this fixture. A genuine route change (e.g.
+     * transferring from a 715 to a 718) must always render as two legs even if the connecting
+     * walk happens to be trivially short.
+     */
+    @Test
+    fun `buildJourneyList does not collapse legs on different route numbers even with a quick walk`() {
+        val response = TripResponse(
+            journeys = listOf(
+                TripResponse.Journey(
+                    legs = listOf(
+                        buildRouteLeg(
+                            routeNumber = "715",
+                            realtimeTripId = "trip-715",
+                            depTime = "2026-04-18T22:00:00Z",
+                            arrTime = "2026-04-18T22:01:00Z",
+                        ),
+                        buildQuickWalkLeg(
+                            depTime = "2026-04-18T22:01:00Z",
+                            arrTime = "2026-04-18T22:02:00Z",
+                            durationSeconds = 60L,
+                        ),
+                        buildRouteLeg(
+                            routeNumber = "718", // different route number - must not collapse
+                            realtimeTripId = "trip-718",
+                            depTime = "2026-04-18T22:02:00Z",
+                            arrTime = "2026-04-18T22:05:00Z",
+                        ),
+                        buildRouteLeg(
+                            routeNumber = "T1",
+                            realtimeTripId = "trip-t1",
+                            depTime = "2026-04-18T22:10:00Z",
+                            arrTime = "2026-04-18T22:40:00Z",
+                            productClass = 1L,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(
+            4,
+            journey?.legs?.size,
+            "A route change (715 -> 718) is a real interchange and must never be collapsed",
+        )
+    }
+
+    //endregion
+
     //region helpers
 
     /**
@@ -599,4 +771,84 @@ class TripResponseMapperTest {
     )
 
     // endregion
+
+    //region collapseSameRouteQuickWalks helpers
+
+    /**
+     * Builds a [TripResponse.Leg] for a transport leg identified by [routeNumber], with two
+     * stops spanning [depTime] to [arrTime]. Mirrors the shape a same-numbered bus leg has in
+     * the real NSW response (see `home-redfern-investigate.json`, journey index 1).
+     */
+    private fun buildRouteLeg(
+        routeNumber: String,
+        realtimeTripId: String,
+        depTime: String,
+        arrTime: String,
+        productClass: Long = 5L,
+    ) = TripResponse.Leg(
+        origin = TripResponse.StopSequence(
+            name = "$routeNumber origin",
+            departureTimePlanned = depTime,
+            departureTimeEstimated = depTime,
+        ),
+        destination = TripResponse.StopSequence(
+            name = "$routeNumber destination",
+            arrivalTimePlanned = arrTime,
+            arrivalTimeEstimated = arrTime,
+        ),
+        stopSequence = listOf(
+            TripResponse.StopSequence(
+                name = "$routeNumber origin",
+                departureTimePlanned = depTime,
+                departureTimeEstimated = depTime,
+            ),
+            TripResponse.StopSequence(
+                name = "$routeNumber destination",
+                arrivalTimePlanned = arrTime,
+                arrivalTimeEstimated = arrTime,
+            ),
+        ),
+        transportation = TripResponse.Transportation(
+            id = "nsw:$routeNumber:$realtimeTripId",
+            number = routeNumber,
+            disassembledName = routeNumber,
+            description = "$routeNumber towards somewhere",
+            destination = TripResponse.OperatorClass(name = "Terminus"),
+            product = TripResponse.Product(productClass = productClass, name = "Sydney Buses Network"),
+            properties = TripResponse.TransportationProperties(realtimeTripId = realtimeTripId),
+        ),
+    )
+
+    /**
+     * Builds a standalone walking [TripResponse.Leg] (`productClass = 99`, `position = IDEST`)
+     * of [durationSeconds] — the shape of the "cross the road" leg between two same-numbered
+     * bus trips in the real NSW response.
+     */
+    private fun buildQuickWalkLeg(
+        depTime: String,
+        arrTime: String,
+        durationSeconds: Long,
+    ) = TripResponse.Leg(
+        duration = durationSeconds,
+        origin = TripResponse.StopSequence(
+            departureTimePlanned = depTime,
+            departureTimeEstimated = depTime,
+        ),
+        destination = TripResponse.StopSequence(
+            arrivalTimePlanned = arrTime,
+            arrivalTimeEstimated = arrTime,
+        ),
+        stopSequence = listOf(
+            TripResponse.StopSequence(departureTimePlanned = depTime, departureTimeEstimated = depTime),
+            TripResponse.StopSequence(arrivalTimePlanned = arrTime, arrivalTimeEstimated = arrTime),
+        ),
+        transportation = TripResponse.Transportation(
+            product = TripResponse.Product(productClass = 99L, name = "footpath"),
+        ),
+        footPathInfo = listOf(
+            TripResponse.FootPathInfo(duration = durationSeconds, position = "IDEST"),
+        ),
+    )
+
+    //endregion
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/fixtures/OranParkToSevenHillsFixture.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/fixtures/OranParkToSevenHillsFixture.kt
@@ -3,8 +3,10 @@ package xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures
 /**
  * Fixture for a real NSW Transport API trip response: Oran Park → Seven Hills.
  *
- * Source: real API response captured 2026-04-18 (see `/feature/trip-planner/network/src/commonTest/assets/trip_oranpark_sevenhills.json`
- * for the full response).
+ * Source: real API response captured 2026-04-18. The full untrimmed response was not committed
+ * to the repo (checked 2026-07-03 while investigating `Redfern715BacktrackFixture` — no
+ * `trip_oranpark_sevenhills.json` exists under `network/src/commonTest/assets/`); only the
+ * trimmed JSON below survives. If you need to re-trim this fixture, re-capture from the API.
  *
  * This fixture captures the **null-duration bug** observed in production logs:
  * the first bus leg (Bus 858, 2 stops, ~1 min) sometimes returns `"duration": null`

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/fixtures/Redfern715BacktrackFixture.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/fixtures/Redfern715BacktrackFixture.kt
@@ -1,0 +1,259 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business.fixtures
+
+/**
+ * Fixture for a real NSW Transport API trip response: Seven Hills Rd opp Monaro St (214758)
+ * → Redfern/Central, captured 2026-07-03.
+ *
+ * Source: real API response, journey index 1 of the response captured for this query. Full
+ * capture (coords/pathDescriptions stripped, everything else verbatim) committed at
+ * `feature/trip-planner/network/src/commonTest/assets/trip_seven_hills_redfern_715_backtrack.json`.
+ * This fixture trims it further to just the essential fields (as [OranParkToSevenHillsFixture]
+ * does) and keeps only the 4-leg journey that reproduces the bug — the other 8 journeys in the
+ * real response are single-interchange 715→M1 options and aren't needed to test this mapping.
+ *
+ * Background: see `docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md` for the full writeup.
+ * In short — NSW represents a 715 bus that reverses direction one stop from the origin (to
+ * board a different scheduled trip, `tripCode` 77 → 15, opposite-direction `description`) as:
+ *
+ *   Leg 0: 715 (outbound, tripCode 77)   Seven Hills Rd opp Monaro St → after Solander Rd
+ *   Leg 1: walk (IDEST, 60s)             after Solander Rd → before Solander Rd (cross the road)
+ *   Leg 2: 715 (inbound, tripCode 15)    before Solander Rd → Seven Hills Station
+ *   Leg 3: T1                             Seven Hills Station → Central
+ *
+ * Google Maps and Opal both show this as a single 715 leg + T1, not two 715 legs split by a
+ * walk. [collapseSameRouteQuickWalks] (in `TripResponseMapper.kt`) is what makes KRAIL do the
+ * same. This fixture is the regression test for that specific behaviour: if a future change to
+ * the collapse heuristic (or an unrelated refactor of [TripResponse.Leg] mapping) breaks it,
+ * this is the test that should catch it — decoding real API JSON also catches shape drift
+ * (renamed/removed fields) that a hand-built Kotlin object tree cannot.
+ */
+internal object Redfern715BacktrackFixture {
+
+    /**
+     * Minimal TripResponse JSON for the single journey that reproduces the "715 / walk / 715 /
+     * T1" complaint. Times, stop IDs, trip codes and route numbers are kept exactly as captured
+     * from the real API. `stopSequence` for the T1 leg is trimmed to origin + destination only
+     * (the real leg has 19 intermediate stations, irrelevant to this test); every other leg's
+     * `stopSequence` is verbatim.
+     */
+    val JSON = """
+        {
+          "version": "10.6.21.17",
+          "journeys": [
+            {
+              "rating": 0,
+              "isAdditional": false,
+              "interchanges": 1,
+              "legs": [
+                {
+                  "duration": 60,
+                  "origin": {
+                    "id": "214758",
+                    "name": "Seven Hills Rd opp Monaro St, Seven Hills",
+                    "disassembledName": "Seven Hills Rd opp Monaro St",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-07-03T00:03:00Z",
+                    "departureTimeEstimated": "2026-07-03T00:03:00Z"
+                  },
+                  "destination": {
+                    "id": "214759",
+                    "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+                    "disassembledName": "Seven Hills Rd after Solander Rd",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-07-03T00:04:00Z",
+                    "arrivalTimeEstimated": "2026-07-03T00:04:00Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:14715: :H:sj2",
+                    "name": "Sydney Buses Network 715",
+                    "disassembledName": "715",
+                    "number": "715",
+                    "description": "Seven Hills to Rouse Hill Station via Norwest & Kellyville",
+                    "product": { "id": 5, "class": 5, "name": "Sydney Buses Network", "iconId": 5 },
+                    "destination": { "id": "10101501", "name": "Rouse Hill Station", "type": "stop" },
+                    "properties": { "tripCode": 77, "RealtimeTripId": "2647807" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "214758",
+                      "name": "Seven Hills Rd opp Monaro St, Seven Hills",
+                      "disassembledName": "Seven Hills Rd opp Monaro St",
+                      "departureTimePlanned": "2026-07-03T00:03:00Z",
+                      "departureTimeEstimated": "2026-07-03T00:03:00Z"
+                    },
+                    {
+                      "id": "214759",
+                      "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+                      "disassembledName": "Seven Hills Rd after Solander Rd",
+                      "arrivalTimePlanned": "2026-07-03T00:04:00Z",
+                      "arrivalTimeEstimated": "2026-07-03T00:04:00Z"
+                    }
+                  ]
+                },
+                {
+                  "duration": 60,
+                  "origin": {
+                    "id": "214759",
+                    "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+                    "disassembledName": "Seven Hills Rd after Solander Rd",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-07-03T00:08:00Z",
+                    "departureTimeEstimated": "2026-07-03T00:04:48Z"
+                  },
+                  "destination": {
+                    "id": "2147213",
+                    "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+                    "disassembledName": "Seven Hills Rd before Solander Rd",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-07-03T00:09:00Z",
+                    "arrivalTimeEstimated": "2026-07-03T00:05:48Z"
+                  },
+                  "transportation": {
+                    "product": { "class": 99, "name": "footpath", "iconId": 99 },
+                    "properties": { "tripCode": 0 }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "214759",
+                      "name": "Seven Hills Rd after Solander Rd, Kings Langley",
+                      "departureTimePlanned": "2026-07-03T00:08:00Z"
+                    },
+                    {
+                      "id": "2147213",
+                      "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:09:00Z"
+                    }
+                  ],
+                  "footPathInfo": [
+                    { "position": "IDEST", "duration": 60 }
+                  ]
+                },
+                {
+                  "duration": 234,
+                  "origin": {
+                    "id": "2147213",
+                    "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+                    "disassembledName": "Seven Hills Rd before Solander Rd",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-07-03T00:09:00Z",
+                    "departureTimeEstimated": "2026-07-03T00:05:48Z"
+                  },
+                  "destination": {
+                    "id": "214732",
+                    "name": "Seven Hills Station, Stand A, Seven Hills",
+                    "disassembledName": "Seven Hills Station, Stand A",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-07-03T00:15:00Z",
+                    "arrivalTimeEstimated": "2026-07-03T00:09:42Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:14715: :R:sj2",
+                    "name": "Sydney Buses Network 715",
+                    "disassembledName": "715",
+                    "number": "715",
+                    "description": "Rouse Hill Station to Seven Hills via Kellyville & Norwest",
+                    "product": { "id": 5, "class": 5, "name": "Sydney Buses Network", "iconId": 5 },
+                    "destination": { "id": "10101234", "name": "Seven Hills Station", "type": "stop" },
+                    "properties": { "tripCode": 15, "RealtimeTripId": "2648028" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "2147213",
+                      "name": "Seven Hills Rd before Solander Rd, Seven Hills",
+                      "departureTimePlanned": "2026-07-03T00:09:00Z",
+                      "departureTimeEstimated": "2026-07-03T00:05:48Z"
+                    },
+                    {
+                      "id": "2147214",
+                      "name": "Seven Hills Rd at Monaro St, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:09:00Z",
+                      "departureTimePlanned": "2026-07-03T00:09:00Z"
+                    },
+                    {
+                      "id": "2147215",
+                      "name": "Seven Hills Rd after Nattai St, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:10:00Z",
+                      "departureTimePlanned": "2026-07-03T00:10:00Z"
+                    },
+                    {
+                      "id": "2147216",
+                      "name": "Seven Hills Rd opp Marnpar Rd, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:11:00Z",
+                      "departureTimePlanned": "2026-07-03T00:11:00Z"
+                    },
+                    {
+                      "id": "2147241",
+                      "name": "Prospect Hwy after Station Rd, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:13:00Z",
+                      "departureTimePlanned": "2026-07-03T00:13:00Z"
+                    },
+                    {
+                      "id": "2147242",
+                      "name": "Prospect Hwy opp Lucas Rd, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:13:00Z",
+                      "departureTimePlanned": "2026-07-03T00:13:00Z"
+                    },
+                    {
+                      "id": "2147243",
+                      "name": "Prospect Hwy opp Hope St, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:14:00Z",
+                      "departureTimePlanned": "2026-07-03T00:14:00Z"
+                    },
+                    {
+                      "id": "214732",
+                      "name": "Seven Hills Station, Stand A, Seven Hills",
+                      "arrivalTimePlanned": "2026-07-03T00:15:00Z"
+                    }
+                  ],
+                  "footPathInfoRedundant": true,
+                  "interchange": { "desc": "Fussweg", "type": 100 }
+                },
+                {
+                  "duration": 2130,
+                  "origin": {
+                    "id": "2147422",
+                    "name": "Seven Hills Station, Platform 2, Seven Hills",
+                    "disassembledName": "Seven Hills Station, Platform 2",
+                    "type": "platform",
+                    "departureTimePlanned": "2026-07-03T00:18:30Z",
+                    "departureTimeEstimated": "2026-07-03T00:18:30Z"
+                  },
+                  "destination": {
+                    "id": "2000336",
+                    "name": "Central Station, Platform 16, Sydney",
+                    "disassembledName": "Central Station, Platform 16",
+                    "type": "platform",
+                    "arrivalTimePlanned": "2026-07-03T00:54:00Z",
+                    "arrivalTimeEstimated": "2026-07-03T00:54:00Z"
+                  },
+                  "transportation": {
+                    "id": "nsw:020T1:W:R:sj2",
+                    "name": "Sydney Trains Network T1 North Shore & Western Line",
+                    "disassembledName": "T1",
+                    "number": "T1 North Shore & Western Line",
+                    "description": "Emu Plains or Richmond to City",
+                    "product": { "id": 1, "class": 1, "name": "Sydney Trains Network", "iconId": 1 },
+                    "destination": { "id": "10101100", "name": "Berowra via Gordon", "type": "stop" },
+                    "properties": { "tripCode": 541, "RealtimeTripId": "145F.424.146.64.A.8.90146738" }
+                  },
+                  "stopSequence": [
+                    {
+                      "id": "2147422",
+                      "name": "Seven Hills Station, Platform 2, Seven Hills",
+                      "departureTimePlanned": "2026-07-03T00:18:30Z",
+                      "departureTimeEstimated": "2026-07-03T00:18:30Z"
+                    },
+                    {
+                      "id": "2000336",
+                      "name": "Central Station, Platform 16, Sydney",
+                      "arrivalTimePlanned": "2026-07-03T00:54:00Z",
+                      "arrivalTimeEstimated": "2026-07-03T00:54:00Z"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+    """.trimIndent()
+}


### PR DESCRIPTION
NSW sometimes represents a bus continuing on a different scheduled
trip (e.g. reversing at a nearby stop) as 3 legs - transport, a
trivial standalone walk, transport again on the same route number -
even though Google Maps and Opal both show it as a single bus leg.
KRAIL was rendering all 3+ legs verbatim.

Collapses [TransportLeg A, walk, TransportLeg B] into one leg when
the walk is a genuine standalone crossing (IDEST) under 2 minutes
and both transport legs share a route number - deliberately not
comparing trip/vehicle IDs, since those legitimately differ in the
real-world case this fixes (different tripCode, opposite-direction
description). Only affects the UI leg list; raw map data and
origin/arrival time resolution are untouched.

Regression test decodes a real captured API response (trimmed of
coords/pathDescriptions only) rather than a hand-built object tree,
so it also catches NSW API shape drift, not just logic regressions.
Two further tests pin the heuristic's boundaries (walk too long,
different route number) with synthetic data, clearly labelled as
such since the real capture doesn't contain those variants.

Also fixes the test suite's json parser, which claimed to mirror
production's Ktor config but was missing isLenient = true (which
production actually sets) - real NSW payloads send some String
fields as unquoted numbers, invisible until a fixture happened to
include one.

Full investigation, reasoning, and what was deliberately left out of
scope: docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md, linked
from collapseSameRouteQuickWalks()'s KDoc and from CLAUDE.md's
"Per-feature UX rule docs" section so the reasoning stays
discoverable for whoever next touches this code.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYdoRHMBgy9sBbfh7Xj1UB