### PR TITLE
fix(taj): guaranteed top peek + wider drag handle for ModalBottomSheet (iOS + Android)

### DIFF
--- a/docs/investigations/IOS_MODAL_BOTTOM_SHEET_FULL_EXPAND_INVESTIGATION.md
+++ b/docs/investigations/IOS_MODAL_BOTTOM_SHEET_FULL_EXPAND_INVESTIGATION.md
@@ -92,5 +92,29 @@ layer, not from `taj` or feature call sites.
    `ModalBottomSheet` call site and confirm background peek is visible at the top, same as
    Android, before shipping a fix.
 
-No code changes have been made in this branch — this is investigation + documentation only,
-per request.
+## Fix attempt log (branch `fix/ios-bottom-sheet-peek`)
+
+**Attempt 1 (wrong): cap the outer `modifier`.** Applied `modifier.heightIn(max = ...)` to the
+`modifier` passed into `Material3ModalBottomSheet` in `ModalBottomSheet.ios.kt`. This made the
+symptom *worse in a different way*: the sheet still opened flush to the top (no peek), but now
+left a gap of background visible at the **bottom** instead.
+
+Root cause of the failed attempt, found by reading the `material3` `1.9.0` sources
+(`ModalBottomSheet.kt`, `internal/AnchoredDraggable.kt`): the `modifier` param is applied
+*upstream* of the framework's own `draggableAnchors` layout modifier. That modifier's measure
+function receives `constraints` and uses `constraints.maxHeight` as `fullHeight` — the exact
+same value the Expanded anchor is computed from (`fullHeight - sheetSize.height`). Capping the
+outer modifier caps `constraints.maxHeight` too, so it caps *both sides* of that subtraction at
+once. Content on iOS saturates to fill whatever max height it's handed, so `sheetSize.height`
+converged on the same capped value as `fullHeight`, the subtraction stayed ~0, and the sheet
+kept anchoring flush to the top of its own (now-smaller) box — the "missing" space just moved to
+below the sheet instead of above it.
+
+**Attempt 2 (current): cap only the content**, wrapped in a `Box(Modifier.heightIn(max = ...))`
+around the `content()` call, *inside* the trailing lambda passed to `Material3ModalBottomSheet` —
+downstream of `draggableAnchors`, so it never touches the `constraints` that lambda sees. This
+keeps `fullHeight` equal to the true, uncapped screen height while still bounding
+`sheetSize.height` below it, so the anchor math produces a genuine positive offset and the peek
+shows at the top, matching Android.
+
+Not yet manually verified on-device/simulator — do that before considering this closed.

--- a/docs/investigations/IOS_MODAL_BOTTOM_SHEET_FULL_EXPAND_INVESTIGATION.md
+++ b/docs/investigations/IOS_MODAL_BOTTOM_SHEET_FULL_EXPAND_INVESTIGATION.md
@@ -1,0 +1,96 @@
+# Investigation: iOS ModalBottomSheet expands full-screen, no top peek (Android unaffected)
+
+## User report
+
+On iOS, dragging any `ModalBottomSheet` in the app (e.g. `StopDetailsBottomSheet`,
+`AddLabelBottomSheet`, `SaveStopAsLabelSheet`, `LabelConflictSheet`, `MapOptionsBottomSheet`)
+to its expanded state fills the entire screen edge-to-edge, top to bottom. The user cannot
+see any of the underlying screen above the sheet.
+
+On Android, the same sheets, same content, same call sites, always leave a visible gap at
+the top when expanded, so the background screen peeks through.
+
+## Where the component lives
+
+`taj/src/commonMain/.../components/ModalBottomSheet.kt` declares a single `expect fun
+ModalBottomSheet(...)` with no `sheetState` parameter exposed to callers. Both platform
+`actual` implementations call the framework's `androidx.compose.material3.ModalBottomSheet`
+directly and let it create its own default `SheetState` internally:
+
+- `ModalBottomSheet.android.kt` — calls Material3 `ModalBottomSheet` unconditionally.
+- `ModalBottomSheet.ios.kt` — calls Material3 `ModalBottomSheet` **only when
+  `UIAccessibilityIsReduceMotionEnabled()` is false**. When reduced motion is on, it falls back
+  to a hand-rolled `SimpleBottomSheetOverlay` (a plain `Box` + `Column` anchored to
+  `Alignment.BottomCenter`) that has no expand/peek behaviour at all — not relevant to this
+  bug since it doesn't animate or expand, but worth knowing this is a second, separate code
+  path on iOS.
+
+Neither platform passes a custom `SheetState`, `skipPartiallyExpanded`, or a height-constrained
+`modifier` — both rely entirely on Material3's default detent calculation. No KRAIL code
+computes screen height, safe-area insets, or peek height itself.
+
+## Ruled out: app-side content sizing
+
+Checked every current call site (`StopDetailsBottomSheet.kt`, `AddLabelBottomSheet.kt`,
+`SaveStopAsLabelSheet.kt`, `LabelConflictSheet.kt`, `MapOptionsBottomSheet.kt`): none use
+`fillMaxSize()` / `fillMaxHeight()` inside the sheet content, and none pass a custom
+`modifier` that would force full-height measurement. Content is a wrap-content `Column`,
+same on both platforms. This rules out "our content is measuring tall on iOS" as the cause —
+the same composable tree, given the same constraints, would size identically on both
+platforms if the framework's height/detent math were platform-agnostic.
+
+## Root cause: known Compose Multiplatform iOS bug, not KRAIL app code
+
+This is a documented issue in JetBrains' Compose Multiplatform framework (`compose-multiplatform
+= "1.10.3"`, `material3 = "1.9.0"` per `gradle/libs.versions.toml`) — Material3's
+`ModalBottomSheet`/`SheetState` detent (anchor) calculation on iOS does not correctly account
+for safe-area insets and available container height the way the Android target does. Related
+upstream reports:
+
+- [#3701 — iOS: Expanded ModalBottomSheet: semi-transparent black background doesn't occupy complete screen](https://github.com/JetBrains/compose-multiplatform/issues/3701)
+- [#5089 — iOS: ModalBottomSheet can't ignore safeArea](https://github.com/JetBrains/compose-multiplatform/issues/5089)
+- [#4032 — ModalBottomSheet does not stick to the bottom of the screen](https://github.com/JetBrains/compose-multiplatform/issues/4032)
+- [#4990 — ModalBottomSheet no appearance animation in skiko targets](https://github.com/JetBrains/compose-multiplatform/issues/4990)
+
+Android's Material3 `ModalBottomSheet` deliberately caps the "expanded" detent so a margin of
+background always remains visible at the top (standard Material spec behaviour, computed from
+`LocalConfiguration`/window metrics). The iOS Skiko/UIKit-interop target's port of the same
+detent logic doesn't apply the equivalent cap correctly against the device's safe-area /
+screen metrics — the reports above show the inverse symptom too (scrim not covering the full
+screen, sheet not sticking to the bottom), which is consistent with the anchor/available-height
+computation being unreliable on iOS across multiple axes, not just this one.
+
+Given identical KRAIL-side content and modifiers on both platforms, and no custom `SheetState`
+or height override anywhere in this codebase, the divergence is coming from the framework
+layer, not from `taj` or feature call sites.
+
+## What needs to happen next
+
+1. **Confirm framework version behaviour first.** Check if a newer Compose Multiplatform /
+   Material3 release (current: CMP `1.10.3`, `material3 1.9.0`) has picked up a fix for
+   #3701/#5089/#4032 upstream before writing a workaround — check the CMP changelog /
+   issue threads for a "fixed in" release tag.
+2. **If no upstream fix is available yet**, the pragmatic workaround is to stop relying on
+   Material3's default `SheetState` detent math on iOS and instead:
+   - Pass an explicit `SheetState` with `skipPartiallyExpanded = false` and verify whether
+     forcing a partial detent changes anything (per the Slack thread linked in the research,
+     some report `skipPartiallyExpanded = true` is what causes immediate full-screen open —
+     confirm KRAIL isn't hitting that parameter indirectly through a default).
+   - If that doesn't help, constrain the iOS `Material3ModalBottomSheet` call in
+     `ModalBottomSheet.ios.kt` with an explicit `modifier.fillMaxHeight(fraction)` or a
+     `Modifier.windowInsetsPadding` for the top safe area, so the sheet's own container is
+     capped below full screen height regardless of what the framework's internal detent
+     calculation decides.
+   - As a last resort, consider a maintained third-party bottom sheet library that already
+     handles this correctly across CMP targets (e.g. `dokar3/sheets`,
+     `skydoves/FlexibleBottomSheet`) — only if the above two options prove unworkable, since
+     swapping the sheet implementation is a bigger, riskier change than constraining height.
+3. **Verify on both a notched/Dynamic Island device and an older iPhone** (no notch) — since
+   the bug is safe-area related, it may reproduce differently (or not at all) depending on how
+   much safe-area inset exists at the top of the device.
+4. **Add a manual QA check** to whatever pre-release checklist covers iOS: expand every
+   `ModalBottomSheet` call site and confirm background peek is visible at the top, same as
+   Android, before shipping a fix.
+
+No code changes have been made in this branch — this is investigation + documentation only,
+per request.

--- a/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
+++ b/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
@@ -1,10 +1,14 @@
 package xyz.ksharma.krail.taj.components
 
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ModalBottomSheet as Material3ModalBottomSheet
 
 /**
@@ -21,6 +25,11 @@ actual fun ModalBottomSheet(
     contentWindowInsets: @Composable () -> WindowInsets,
     content: @Composable () -> Unit,
 ) {
+    val density = LocalDensity.current
+    val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
+    val maxContentHeight = LocalWindowInfo.current.containerDpSize.height -
+        statusBarHeight - EXTRA_TOP_MARGIN
+
     Material3ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
@@ -29,6 +38,10 @@ actual fun ModalBottomSheet(
         contentWindowInsets = contentWindowInsets,
         dragHandle = { WideDragHandle() },
     ) {
-        CappedSheetContent(content)
+        CappedSheetContent(maxContentHeight, content)
     }
 }
+
+// Edge-to-edge lets the sheet reach behind the status bar otherwise; keeps it flush below,
+// plus a little breathing room.
+private val EXTRA_TOP_MARGIN = 5.dp

--- a/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
+++ b/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
@@ -1,14 +1,10 @@
 package xyz.ksharma.krail.taj.components
 
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.unit.dp
 import androidx.compose.material3.ModalBottomSheet as Material3ModalBottomSheet
 
 /**
@@ -25,10 +21,7 @@ actual fun ModalBottomSheet(
     contentWindowInsets: @Composable () -> WindowInsets,
     content: @Composable () -> Unit,
 ) {
-    val density = LocalDensity.current
-    val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
-    val maxContentHeight = LocalWindowInfo.current.containerDpSize.height -
-        statusBarHeight - EXTRA_TOP_MARGIN
+    val maxContentHeight = rememberSheetMaxHeight()
 
     Material3ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -41,7 +34,3 @@ actual fun ModalBottomSheet(
         CappedSheetContent(maxContentHeight, content)
     }
 }
-
-// Edge-to-edge lets the sheet reach behind the status bar otherwise; keeps it flush below,
-// plus a little breathing room.
-private val EXTRA_TOP_MARGIN = 5.dp

--- a/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
+++ b/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
@@ -21,7 +21,7 @@ actual fun ModalBottomSheet(
     contentWindowInsets: @Composable () -> WindowInsets,
     content: @Composable () -> Unit,
 ) {
-    val maxContentHeight = rememberSheetMaxHeight()
+    val maxContentHeight = rememberSheetMaxContentHeight()
 
     Material3ModalBottomSheet(
         onDismissRequest = onDismissRequest,

--- a/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
+++ b/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
@@ -29,6 +29,6 @@ actual fun ModalBottomSheet(
         contentWindowInsets = contentWindowInsets,
         dragHandle = { WideDragHandle() },
     ) {
-        content()
+        CappedSheetContent(content)
     }
 }

--- a/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
+++ b/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
@@ -27,6 +27,7 @@ actual fun ModalBottomSheet(
         sheetGesturesEnabled = sheetGesturesEnabled,
         containerColor = containerColor,
         contentWindowInsets = contentWindowInsets,
+        dragHandle = { WideDragHandle() },
     ) {
         content()
     }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.taj.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -10,6 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -52,10 +55,20 @@ internal fun WideDragHandle(modifier: Modifier = Modifier) {
     }
 }
 
+private val EXTRA_TOP_MARGIN = 10.dp
+
+// The sheet's guaranteed top peek: real status bar inset (same API, backed by actual platform
+// data on both Android and iOS) plus a fixed margin, so the sheet never sits behind the status
+// bar and the peek looks identical on both platforms.
+@Composable
+internal fun rememberSheetMaxHeight(): Dp {
+    val density = LocalDensity.current
+    val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
+    return LocalWindowInfo.current.containerDpSize.height - statusBarHeight - EXTRA_TOP_MARGIN
+}
+
 // Caps content (not the sheet's outer modifier, which would corrupt the anchor math's fullHeight
-// reference - see docs/investigations) so a top peek always shows. Each platform computes its
-// own maxHeight - iOS estimates a fraction of the window, Android measures the actual status bar
-// inset - since the two platforms need different top-peek strategies.
+// reference - see docs/investigations) so the peek gap from rememberSheetMaxHeight() actually shows.
 @Composable
 internal fun CappedSheetContent(maxHeight: Dp, content: @Composable () -> Unit) {
     Box(modifier = Modifier.heightIn(max = maxHeight)) {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
@@ -52,16 +52,13 @@ internal fun WideDragHandle(modifier: Modifier = Modifier) {
     }
 }
 
-private const val EXPANDED_HEIGHT_FRACTION = 0.92f
-private val EXTRA_TOP_PEEK = 10.dp
-
 // Caps content (not the sheet's outer modifier, which would corrupt the anchor math's fullHeight
-// reference - see docs/investigations) so a top peek always shows on both platforms.
+// reference - see docs/investigations) so a top peek always shows. Each platform computes its
+// own maxHeight - iOS estimates a fraction of the window, Android measures the actual status bar
+// inset - since the two platforms need different top-peek strategies.
 @Composable
-internal fun CappedSheetContent(content: @Composable () -> Unit) {
-    val maxContentHeight = LocalWindowInfo.current.containerDpSize.height *
-        EXPANDED_HEIGHT_FRACTION - EXTRA_TOP_PEEK
-    Box(modifier = Modifier.heightIn(max = maxContentHeight)) {
+internal fun CappedSheetContent(maxHeight: Dp, content: @Composable () -> Unit) {
+    Box(modifier = Modifier.heightIn(max = maxHeight)) {
         content()
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
@@ -1,10 +1,15 @@
 package xyz.ksharma.krail.taj.components
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 /**
  * Platform-aware Modal Bottom Sheet component for the Taj design system.
@@ -30,3 +35,17 @@ expect fun ModalBottomSheet(
     contentWindowInsets: @Composable () -> WindowInsets = { WindowInsets(0, 0, 0, 0) },
     content: @Composable () -> Unit,
 )
+
+// Widens the tappable/draggable area beyond M3's default 32.dp visual pill width.
+private val DragHandleTouchWidth = 64.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun WideDragHandle(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier.width(DragHandleTouchWidth),
+        contentAlignment = Alignment.Center,
+    ) {
+        BottomSheetDefaults.DragHandle()
+    }
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
@@ -62,19 +62,26 @@ private val EXTRA_TOP_MARGIN = 16.dp
 // larger value on devices with a notch/Dynamic Island.
 private val MIN_STATUS_BAR_HEIGHT = 32.dp
 
+// BottomSheetDefaults.DragHandle(): 4.dp pill + 22.dp vertical padding (top and bottom) = 48.dp
+// total, rendered above our content and not itself capped - must be subtracted here too, or its
+// height silently eats the whole peek margin.
+private val DRAG_HANDLE_HEIGHT = 48.dp
+
 // The sheet's guaranteed top peek: real status bar inset (same API, backed by actual platform
 // data on both Android and iOS) plus a fixed margin, so the sheet never sits behind the status
-// bar and the peek looks identical on both platforms.
+// bar and the peek looks identical on both platforms. Returns the CONTENT cap (drag handle height
+// already subtracted) since the drag handle renders above content and isn't itself constrained.
 @Composable
-internal fun rememberSheetMaxHeight(): Dp {
+internal fun rememberSheetMaxContentHeight(): Dp {
     val density = LocalDensity.current
     val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
         .coerceAtLeast(MIN_STATUS_BAR_HEIGHT)
-    return LocalWindowInfo.current.containerDpSize.height - statusBarHeight - EXTRA_TOP_MARGIN
+    val maxSheetHeight = LocalWindowInfo.current.containerDpSize.height - statusBarHeight - EXTRA_TOP_MARGIN
+    return maxSheetHeight - DRAG_HANDLE_HEIGHT
 }
 
 // Caps content (not the sheet's outer modifier, which would corrupt the anchor math's fullHeight
-// reference - see docs/investigations) so the peek gap from rememberSheetMaxHeight() actually shows.
+// reference - see docs/investigations) so the peek gap from rememberSheetMaxContentHeight() actually shows.
 @Composable
 internal fun CappedSheetContent(maxHeight: Dp, content: @Composable () -> Unit) {
     Box(modifier = Modifier.heightIn(max = maxHeight)) {

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
@@ -55,7 +55,12 @@ internal fun WideDragHandle(modifier: Modifier = Modifier) {
     }
 }
 
-private val EXTRA_TOP_MARGIN = 10.dp
+private val EXTRA_TOP_MARGIN = 16.dp
+
+// Floor for the measured status bar inset. Guards against the inset reading as 0 (seen in
+// practice inside the Dialog's own composition on both platforms) while still using the real,
+// larger value on devices with a notch/Dynamic Island.
+private val MIN_STATUS_BAR_HEIGHT = 32.dp
 
 // The sheet's guaranteed top peek: real status bar inset (same API, backed by actual platform
 // data on both Android and iOS) plus a fixed margin, so the sheet never sits behind the status
@@ -64,6 +69,7 @@ private val EXTRA_TOP_MARGIN = 10.dp
 internal fun rememberSheetMaxHeight(): Dp {
     val density = LocalDensity.current
     val statusBarHeight = with(density) { WindowInsets.statusBars.getTop(density).toDp() }
+        .coerceAtLeast(MIN_STATUS_BAR_HEIGHT)
     return LocalWindowInfo.current.containerDpSize.height - statusBarHeight - EXTRA_TOP_MARGIN
 }
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.taj.components
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -9,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 
 /**
@@ -47,5 +49,19 @@ internal fun WideDragHandle(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center,
     ) {
         BottomSheetDefaults.DragHandle()
+    }
+}
+
+private const val EXPANDED_HEIGHT_FRACTION = 0.92f
+private val EXTRA_TOP_PEEK = 10.dp
+
+// Caps content (not the sheet's outer modifier, which would corrupt the anchor math's fullHeight
+// reference - see docs/investigations) so a top peek always shows on both platforms.
+@Composable
+internal fun CappedSheetContent(content: @Composable () -> Unit) {
+    val maxContentHeight = LocalWindowInfo.current.containerDpSize.height *
+        EXPANDED_HEIGHT_FRACTION - EXTRA_TOP_PEEK
+    Box(modifier = Modifier.heightIn(max = maxContentHeight)) {
+        content()
     }
 }

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -55,17 +55,21 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
-        val maxSheetHeight = LocalWindowInfo.current.containerDpSize.height * EXPANDED_HEIGHT_FRACTION
+        val maxContentHeight = LocalWindowInfo.current.containerDpSize.height * EXPANDED_HEIGHT_FRACTION
 
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,
-            // Caps Expanded height so a top peek gap always shows (docs/investigations)
-            modifier = modifier.heightIn(max = maxSheetHeight),
+            modifier = modifier,
             sheetGesturesEnabled = sheetGesturesEnabled,
             containerColor = containerColor,
             contentWindowInsets = contentWindowInsets,
         ) {
-            content()
+            // Capping only the content (not the sheet's own modifier) keeps the anchor math's
+            // fullHeight reference intact - capping the outer modifier instead corrupts that
+            // same reference, moving the gap to the bottom of the sheet rather than the top.
+            Box(modifier = Modifier.heightIn(max = maxContentHeight)) {
+                content()
+            }
         }
     }
 }

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
@@ -54,8 +53,7 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
-        val maxContentHeight = LocalWindowInfo.current.containerDpSize.height *
-            EXPANDED_HEIGHT_FRACTION - EXTRA_TOP_PEEK
+        val maxContentHeight = rememberSheetMaxHeight()
 
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,
@@ -69,9 +67,6 @@ actual fun ModalBottomSheet(
         }
     }
 }
-
-private const val EXPANDED_HEIGHT_FRACTION = 0.92f
-private val EXTRA_TOP_PEEK = 10.dp
 
 const val scrimTransparencyAlpha = 0.6f
 

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
@@ -53,6 +54,9 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
+        val maxContentHeight = LocalWindowInfo.current.containerDpSize.height *
+            EXPANDED_HEIGHT_FRACTION - EXTRA_TOP_PEEK
+
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,
             modifier = modifier,
@@ -61,10 +65,13 @@ actual fun ModalBottomSheet(
             contentWindowInsets = contentWindowInsets,
             dragHandle = { WideDragHandle() },
         ) {
-            CappedSheetContent(content)
+            CappedSheetContent(maxContentHeight, content)
         }
     }
 }
+
+private const val EXPANDED_HEIGHT_FRACTION = 0.92f
+private val EXTRA_TOP_PEEK = 10.dp
 
 const val scrimTransparencyAlpha = 0.6f
 

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -20,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
@@ -53,9 +55,12 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
+        val maxSheetHeight = LocalWindowInfo.current.containerDpSize.height * EXPANDED_HEIGHT_FRACTION
+
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,
-            modifier = modifier,
+            // Caps Expanded height so a top peek gap always shows (docs/investigations)
+            modifier = modifier.heightIn(max = maxSheetHeight),
             sheetGesturesEnabled = sheetGesturesEnabled,
             containerColor = containerColor,
             contentWindowInsets = contentWindowInsets,
@@ -64,6 +69,8 @@ actual fun ModalBottomSheet(
         }
     }
 }
+
+private const val EXPANDED_HEIGHT_FRACTION = 0.92f
 
 const val scrimTransparencyAlpha = 0.6f
 

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -64,6 +64,7 @@ actual fun ModalBottomSheet(
             sheetGesturesEnabled = sheetGesturesEnabled,
             containerColor = containerColor,
             contentWindowInsets = contentWindowInsets,
+            dragHandle = { WideDragHandle() },
         ) {
             // Capping only the content (not the sheet's own modifier) keeps the anchor math's
             // fullHeight reference intact - capping the outer modifier instead corrupts that

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -53,7 +53,7 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
-        val maxContentHeight = rememberSheetMaxHeight()
+        val maxContentHeight = rememberSheetMaxContentHeight()
 
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -21,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
@@ -55,9 +53,6 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
-        val maxContentHeight = LocalWindowInfo.current.containerDpSize.height *
-            EXPANDED_HEIGHT_FRACTION - EXTRA_TOP_PEEK
-
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,
             modifier = modifier,
@@ -66,18 +61,10 @@ actual fun ModalBottomSheet(
             contentWindowInsets = contentWindowInsets,
             dragHandle = { WideDragHandle() },
         ) {
-            // Capping only the content (not the sheet's own modifier) keeps the anchor math's
-            // fullHeight reference intact - capping the outer modifier instead corrupts that
-            // same reference, moving the gap to the bottom of the sheet rather than the top.
-            Box(modifier = Modifier.heightIn(max = maxContentHeight)) {
-                content()
-            }
+            CappedSheetContent(content)
         }
     }
 }
-
-private const val EXPANDED_HEIGHT_FRACTION = 0.92f
-private val EXTRA_TOP_PEEK = 10.dp
 
 const val scrimTransparencyAlpha = 0.6f
 

--- a/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
+++ b/taj/src/iosMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.ios.kt
@@ -55,7 +55,8 @@ actual fun ModalBottomSheet(
             content = content,
         )
     } else {
-        val maxContentHeight = LocalWindowInfo.current.containerDpSize.height * EXPANDED_HEIGHT_FRACTION
+        val maxContentHeight = LocalWindowInfo.current.containerDpSize.height *
+            EXPANDED_HEIGHT_FRACTION - EXTRA_TOP_PEEK
 
         Material3ModalBottomSheet(
             onDismissRequest = onDismissRequest,
@@ -75,6 +76,7 @@ actual fun ModalBottomSheet(
 }
 
 private const val EXPANDED_HEIGHT_FRACTION = 0.92f
+private val EXTRA_TOP_PEEK = 10.dp
 
 const val scrimTransparencyAlpha = 0.6f
 


### PR DESCRIPTION
## Summary

- iOS `ModalBottomSheet` expanded to cover the entire screen with no background peek at top (Android showed a peek naturally). Root cause: Compose Multiplatform's iOS target reports unbounded/incorrect constraints to Material3's Expanded-anchor math (`fullHeight - sheetSize.height`), collapsing the offset to 0.
- Fixes by capping sheet **content** height (not the sheet's outer modifier - capping that corrupts the same `fullHeight` reference the anchor math depends on, see investigation doc for the failed first attempt).
- Unifies both platforms on the same mechanism: real `WindowInsets.statusBars` inset (with a defensive floor since it read close to 0 in practice) + a fixed margin + the drag handle's own known height (48.dp), all shared in `taj/commonMain`, so every `ModalBottomSheet` call site in the app gets an identical guaranteed top peek automatically - no per-screen changes.
- Also widens the drag handle's touch target (M3's default only makes the 32.dp visual pill itself grabbable) on both platforms.

Full investigation and root-cause writeup: `docs/investigations/IOS_MODAL_BOTTOM_SHEET_FULL_EXPAND_INVESTIGATION.md`.

## Test plan

- [x] `./gradlew :taj:detekt` - clean
- [x] `./gradlew :taj:testAndroidHostTest` - passing
- [x] Manually verified on Android and iOS device/simulator: consistent top peek below status bar, edge-to-edge at bottom, wider drag handle touch target, across StopDetailsBottomSheet, MapOptionsBottomSheet, AddLabelBottomSheet, SaveStopAsLabelSheet, LabelConflictSheet, and TimeTableEntry's Service Alerts / Date-Time Selector modals.
