### PR TITLE
docs: add v1.24.0 release notes

### DIFF
--- a/docs/release-notes/v1.24.0.md
+++ b/docs/release-notes/v1.24.0.md
@@ -1,0 +1,23 @@
+# KRAIL v1.24.0 — Release Notes
+
+## Android — Google Play Store
+
+v1.24.0
+
+Fixed: Some bus trips showed a fake extra leg + walk when the bus just reversed direction. Now it's one clean leg.
+
+Fixed: Bottom sheets (stop details, map options, alerts) now peek properly at the top, and the drag handle's easier to grab.
+
+Let's KRAIL.
+
+---
+
+## iOS — App Store
+
+v1.24.0
+
+1. Journey Fix: Some bus trips showed a false extra leg and walk when the bus simply reversed direction. Now it renders as one clean leg.
+
+2. Bottom Sheet Fix: Stop details, map options, and alert sheets now show a proper peek at the top, with an easier-to-grab drag handle.
+
+Let's KRAIL.


### PR DESCRIPTION
Android + iOS store copy for the ModalBottomSheet peek/drag-handle
fix and the same-route quick-walk leg collapse fix.