### PR TITLE
feat(timetable): header stop tap opens leg-scoped edit search

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -5,6 +5,7 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 private const val PROP_STOP_ID = "stopId"
+private const val PROP_ACTION = "action"
 private const val PROP_SOURCE = "source"
 private const val PROP_EXPAND = "expand"
 private const val PROP_STOP_NAME = "stopName"
@@ -244,7 +245,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         name = "stop_label_removed",
         properties = mapOf(
             PROP_LABEL_NAME to labelName,
-            "action" to action.value,
+            PROP_ACTION to action.value,
             "hadStop" to hadStop,
         ),
     ) {
@@ -447,7 +448,8 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     /**
      * Fired when the user taps the origin or destination label in the timetable
-     * sticky header — the gesture that opens the stop-details bottom sheet.
+     * sticky header — the gesture that opens stop search scoped to that leg
+     * ("Change origin" / "Change destination").
      *
      * The single most useful field is [isOrigin]: it answers
      * "are users more curious about where they're leaving from, or where they're
@@ -465,6 +467,10 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      *                       a single dashboard query can join on the trip pair
      *                       without re-deriving it from [stopId]).
      * @param tripToStopId   Destination of the trip the click happened inside.
+     * @param action        What the tap did. Historical events (pre stop-edit)
+     *                      carry no `action`; new events send
+     *                      [ACTION_EDIT_SEARCH] so the dashboard can split
+     *                      behaviour before/after the change.
      */
     data class TimeTableStopHeaderClickEvent(
         val stopId: String,
@@ -472,6 +478,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val isOrigin: Boolean,
         val tripFromStopId: String,
         val tripToStopId: String,
+        val action: String,
     ) : AnalyticsEvent(
         name = "timetable_stop_header_click",
         properties = mapOf(
@@ -480,6 +487,30 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             "isOrigin" to isOrigin,
             PROP_FROM_STOP_ID to tripFromStopId,
             PROP_TO_STOP_ID to tripToStopId,
+            PROP_ACTION to action,
+        ),
+    ) {
+        companion object {
+            /** Tap opened stop search pre-scoped to the tapped leg. */
+            const val ACTION_EDIT_SEARCH = "edit_search"
+        }
+    }
+
+    /**
+     * Fired when the user taps the departures icon next to a stop name in the
+     * timetable header. Opens the departure-board sheet that used to be bound
+     * to the stop-name tap itself (see [TimeTableStopHeaderClickEvent]).
+     */
+    data class TimeTableDeparturesIconClickEvent(
+        val stopId: String,
+        val stopName: String,
+        val isOrigin: Boolean,
+    ) : AnalyticsEvent(
+        name = "timetable_departures_icon_click",
+        properties = mapOf(
+            PROP_STOP_ID to stopId,
+            PROP_STOP_NAME to stopName,
+            "isOrigin" to isOrigin,
         ),
     )
 
@@ -1074,7 +1105,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         name = "dep_board_status",
         properties = mapOf(
             PROP_STOP_ID to stopId,
-            "action" to action.value,
+            PROP_ACTION to action.value,
             PROP_SOURCE to source.value,
         ),
     ) {

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -50,13 +50,38 @@ sealed interface TimeTableUiEvent {
 
     /**
      * Fired when the user taps the origin or destination label in the timetable
-     * sticky header (the gesture that opens the stop-details bottom sheet).
+     * sticky header (the gesture that opens stop search scoped to that leg).
      *
-     * Analytics-only — the sheet itself is opened by local Compose state in
-     * `TimeTableScreen`. Routing this through the VM keeps analytics calls in
-     * one place and makes the path testable with `FakeAnalytics`.
+     * Analytics-only — navigation to search is wired at the entry level.
+     * Routing this through the VM keeps analytics calls in one place and makes
+     * the path testable with `FakeAnalytics`.
      */
     data class OriginDestinationStopHeaderClicked(
+        val stopId: String,
+        val stopName: String,
+        val isOrigin: Boolean,
+    ) : TimeTableUiEvent
+
+    /**
+     * Fired when the user taps the departures icon next to a stop name in the
+     * timetable header (the gesture that opens the stop-details bottom sheet).
+     *
+     * Analytics-only — the sheet itself is opened by local Compose state in
+     * `TimeTableScreen`.
+     */
+    data class DeparturesIconClicked(
+        val stopId: String,
+        val stopName: String,
+        val isOrigin: Boolean,
+    ) : TimeTableUiEvent
+
+    /**
+     * Fired when the user picked a replacement stop from the leg-scoped search
+     * opened via [OriginDestinationStopHeaderClicked]. Reloads the timetable in
+     * place with the changed leg (no back-stack rebuild), reusing the
+     * reverse-trip reload mechanics.
+     */
+    data class TripStopChanged(
         val stopId: String,
         val stopName: String,
         val isOrigin: Boolean,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/OriginDestination.kt
@@ -26,9 +26,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_clock
 import krail.feature.trip_planner.ui.generated.resources.ic_location_on
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.core.snapshot.ScreenshotTest
@@ -55,6 +58,8 @@ internal fun OriginDestination(
     modifier: Modifier = Modifier,
     onOriginClick: ((StopDisplay) -> Unit)? = null,
     onDestinationClick: ((StopDisplay) -> Unit)? = null,
+    onOriginDeparturesClick: ((StopDisplay) -> Unit)? = null,
+    onDestinationDeparturesClick: ((StopDisplay) -> Unit)? = null,
 ) {
     val dim = KrailTheme.dimensions
     val cardShape = CardShape
@@ -70,6 +75,7 @@ internal fun OriginDestination(
             isOrigin = true,
             timeLineColor = timeLineColor,
             onClick = onOriginClick,
+            onDeparturesClick = onOriginDeparturesClick,
         )
         Divider(
             modifier = Modifier.padding(
@@ -82,6 +88,7 @@ internal fun OriginDestination(
             isOrigin = false,
             timeLineColor = timeLineColor,
             onClick = onDestinationClick,
+            onDeparturesClick = onDestinationDeparturesClick,
         )
     }
 }
@@ -93,6 +100,7 @@ private fun StopRow(
     timeLineColor: Color,
     onClick: ((StopDisplay) -> Unit)?,
     modifier: Modifier = Modifier,
+    onDeparturesClick: ((StopDisplay) -> Unit)? = null,
 ) {
     val dim = KrailTheme.dimensions
     val clickModifier = onClick?.let { handler ->
@@ -154,6 +162,7 @@ private fun StopRow(
             },
             contentAlignment = Alignment.CenterStart,
             label = if (isOrigin) "originStopName" else "destinationStopName",
+            modifier = Modifier.weight(1f),
         ) { targetDisplay ->
             targetDisplay.label?.let { label ->
                 FlowRow(
@@ -173,6 +182,28 @@ private fun StopRow(
                 Text(
                     text = targetDisplay.name,
                     style = KrailTheme.typography.titleMedium,
+                )
+            }
+        }
+
+        onDeparturesClick?.let { handler ->
+            // Explicit affordance for the departure-board sheet, which used to
+            // open on stop-name tap (that tap now edits the stop instead).
+            Box(
+                modifier = Modifier
+                    .size(dim.iconL)
+                    .clip(CircleShape)
+                    .klickable { handler(display) }
+                    .semantics(mergeDescendants = true) {
+                        contentDescription = "Departures from ${display.name}"
+                    },
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    painter = painterResource(Res.drawable.ic_clock),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                    modifier = Modifier.size(dim.iconS),
                 )
             }
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
@@ -11,7 +11,11 @@ import androidx.navigation3.runtime.NavKey
 @Suppress("ComplexInterface", "TooManyFunctions")
 interface TripPlannerNavigator {
 
-    fun navigateToSearchStop(fieldType: SearchStopFieldType, labelKey: String? = null)
+    fun navigateToSearchStop(
+        fieldType: SearchStopFieldType,
+        labelKey: String? = null,
+        editTripLeg: Boolean = false,
+    )
     fun navigateToTimeTable(fromStopId: String, fromStopName: String, toStopId: String, toStopName: String)
     fun navigateToJourneyMap(journeyId: String)
     fun navigateToSettings()
@@ -39,4 +43,16 @@ data class StopSelectedResult(
     val stopId: String,
     val stopName: String,
     val labelKey: String? = null,
+)
+
+/**
+ * Result when the user picked a replacement stop from the leg-scoped search
+ * opened via the timetable header (`SearchStopRoute.editTripLeg`). Delivered
+ * on its own ResultEventBus channel so it never races SavedTrips' listener
+ * for [StopSelectedResult].
+ */
+data class TimetableStopChangedResult(
+    val isOrigin: Boolean,
+    val stopId: String,
+    val stopName: String,
 )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
@@ -20,8 +20,18 @@ internal class TripPlannerNavigatorImpl(
     private val baseNavigator: NavigatorBase,
 ) : TripPlannerNavigator {
 
-    override fun navigateToSearchStop(fieldType: SearchStopFieldType, labelKey: String?) {
-        baseNavigator.goTo(SearchStopRoute(fieldType = fieldType, labelKey = labelKey))
+    override fun navigateToSearchStop(
+        fieldType: SearchStopFieldType,
+        labelKey: String?,
+        editTripLeg: Boolean,
+    ) {
+        baseNavigator.goTo(
+            SearchStopRoute(
+                fieldType = fieldType,
+                labelKey = labelKey,
+                editTripLeg = editTripLeg,
+            ),
+        )
     }
 
     override fun navigateToTimeTable(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
@@ -16,11 +16,17 @@ data object SavedTripsRoute : TripPlannerRoute
 
 /**
  * Detail route: Search for a stop
+ *
+ * @param editTripLeg When true, the search was opened from the timetable header
+ * to replace one leg of the current trip ("Change origin" / "Change destination").
+ * The selected stop is delivered as a `TimetableStopChangedResult` so the
+ * timetable reloads in place instead of updating the SavedTrips fields.
  */
 @Serializable
 data class SearchStopRoute(
     val fieldType: SearchStopFieldType,
     val labelKey: String? = null,
+    val editTripLeg: Boolean = false,
 ) : TripPlannerRoute
 
 @Serializable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SearchStopEntry.kt
@@ -9,8 +9,10 @@ import androidx.navigation3.runtime.NavKey
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.navigation.LocalResultEventBusObj
 import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
+import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
+import xyz.ksharma.krail.trip.planner.ui.navigation.TimetableStopChangedResult
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopScreen
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
@@ -55,16 +57,30 @@ internal fun EntryProviderScope<NavKey>.SearchStopEntry(
         SearchStopScreen(
             searchStopState = searchStopState,
             fieldType = key.fieldType,
+            editTripLeg = key.editTripLeg,
             onStopSelect = { stopItem ->
-                // Send result using captured bus reference
-                val result = StopSelectedResult(
-                    fieldType = key.fieldType,
-                    stopId = stopItem.stopId,
-                    stopName = stopItem.stopName,
-                    labelKey = key.labelKey,
-                )
-
-                resultEventBus.sendResult(result = result)
+                if (key.editTripLeg) {
+                    // Leg-scoped edit from the timetable header — deliver on a
+                    // dedicated channel so SavedTrips' StopSelectedResult
+                    // listener never consumes it.
+                    resultEventBus.sendResult(
+                        result = TimetableStopChangedResult(
+                            isOrigin = key.fieldType == SearchStopFieldType.FROM,
+                            stopId = stopItem.stopId,
+                            stopName = stopItem.stopName,
+                        ),
+                    )
+                } else {
+                    // Send result using captured bus reference
+                    resultEventBus.sendResult(
+                        result = StopSelectedResult(
+                            fieldType = key.fieldType,
+                            stopId = stopItem.stopId,
+                            stopName = stopItem.stopName,
+                            labelKey = key.labelKey,
+                        ),
+                    )
+                }
 
                 // Navigate back
                 tripPlannerNavigator.goBack()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -113,6 +113,16 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
             viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(dateTimeSelectionItem))
         }
 
+        // False only on the FIRST composition of a freshly pushed nav entry;
+        // rememberSaveable restores true across rotation, back-from-map and
+        // process death. Lets us tell fresh navigation (route key wins — force
+        // the VM back to the key's trip even if a surviving VM still holds an
+        // edited/reversed trip for the same key) apart from a restored
+        // composition (preserve the VM's current trip).
+        var hasInitializedTrip by rememberSaveable(key.fromStopId, key.toStopId) {
+            mutableStateOf(false)
+        }
+
         // Initialize trip when route changes
         LaunchedEffect(key.fromStopId, key.toStopId) {
             log("🗺️ TimeTableEntry - LaunchedEffect triggered, initializing trip")
@@ -121,7 +131,9 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                 fromStopName = key.fromStopName,
                 toStopId = key.toStopId,
                 toStopName = key.toStopName,
+                forceReload = !hasInitializedTrip,
             )
+            hasInitializedTrip = true
         }
 
         // Stop picked from the leg-scoped search opened via the timetable header

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -30,13 +30,16 @@ import kotlinx.coroutines.withContext
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.navigation.ResultEffect
 import xyz.ksharma.krail.taj.components.ModalBottomSheet
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.alerts.ServiceAlertScreen
 import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorScreen
 import xyz.ksharma.krail.trip.planner.ui.journeymap.JourneyMap
 import xyz.ksharma.krail.trip.planner.ui.journeymap.business.JourneyMapMapper.toJourneyMapState
+import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.TimetableStopChangedResult
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.dateTimeSelectionSaver
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.serviceAlertSaver
@@ -121,6 +124,19 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
             )
         }
 
+        // Stop picked from the leg-scoped search opened via the timetable header
+        // ("Change origin" / "Change destination"). Reloads the timetable in
+        // place — same mechanics as the Reverse button, no back-stack rebuild.
+        ResultEffect<TimetableStopChangedResult> { result ->
+            viewModel.onEvent(
+                TimeTableUiEvent.TripStopChanged(
+                    stopId = result.stopId,
+                    stopName = result.stopName,
+                    isOrigin = result.isOrigin,
+                ),
+            )
+        }
+
         // Adaptive layout — dual-pane on ≥ 600 dp width
         val adaptiveLayoutInfo = rememberAdaptiveLayoutInfo()
         val dualPane = adaptiveLayoutInfo.shouldShowDualPane
@@ -183,6 +199,16 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                     tripPlannerNavigator.navigateToJourneyMap(journeyId)
                 },
                 hideMapButton = hideMapBtn,
+                onEditStopClick = { isOrigin ->
+                    tripPlannerNavigator.navigateToSearchStop(
+                        fieldType = if (isOrigin) {
+                            SearchStopFieldType.FROM
+                        } else {
+                            SearchStopFieldType.TO
+                        },
+                        editTripLeg = true,
+                    )
+                },
                 modifier = mod,
             )
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -123,14 +123,13 @@ fun SearchStopScreen(
     onEvent: (SearchStopUiEvent) -> Unit = {},
     dualPaneMapUiState: MapUiState? = null,
     onDualPaneMapEvent: (MapStopSelectionEvent) -> Unit = {},
+    // True when opened from the timetable header to replace one leg of the
+    // current trip — scopes the copy to "Change origin" / "Change destination".
+    editTripLeg: Boolean = false,
 ) {
     SideEffect { log("[SEARCH_STOP_SCREEN] recomposed") }
 
-    val placeholderText = when (fieldType) {
-        SearchStopFieldType.FROM -> "Choose starting point"
-        SearchStopFieldType.TO -> "Choose destination"
-        SearchStopFieldType.LABEL -> "Choose a stop"
-    }
+    val placeholderText = searchFieldPlaceholder(fieldType = fieldType, editTripLeg = editTripLeg)
 
     val themeColor by LocalThemeColor.current
     // rememberSaveable so text survives rotation and dark/light mode config changes.
@@ -345,6 +344,20 @@ internal sealed interface LabelConflict {
 // Saver<T?, Any> shape (rather than mapSaver which requires `Original : Any`) so we can
 // hold nullable MutableState backed by a Saver. Returning null from save tells the
 // framework "nothing to persist"; restore is only called when there IS something saved.
+
+/**
+ * Search-field placeholder. Doubles as the screen's scope label: when
+ * [editTripLeg] is true the search replaces one leg of the trip shown in the
+ * timetable, so the copy switches to "Change origin" / "Change destination".
+ */
+private fun searchFieldPlaceholder(
+    fieldType: SearchStopFieldType,
+    editTripLeg: Boolean,
+): String = when (fieldType) {
+    SearchStopFieldType.FROM -> if (editTripLeg) "Change origin" else "Choose starting point"
+    SearchStopFieldType.TO -> if (editTripLeg) "Change destination" else "Choose destination"
+    SearchStopFieldType.LABEL -> "Choose a stop"
+}
 
 private val StopLabelSaver: Saver<StopLabel?, Any> = Saver(
     save = { label ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -118,6 +118,7 @@ fun TimeTableScreen(
     // When true, the per-card "Maps" button is suppressed because a persistent map pane
     // is rendered alongside this screen (see docs/TABLET_FOLDABLE_UX.md §3).
     hideMapButton: Boolean = false,
+    onEditStopClick: (isOrigin: Boolean) -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
@@ -219,7 +220,6 @@ fun TimeTableScreen(
                         destination = trip.toStopDisplay(timeTableState.stopLabels),
                         timeLineColor = KrailTheme.colors.onSurface,
                         onOriginClick = { display ->
-                            selectedStop = display
                             onEvent(
                                 TimeTableUiEvent.OriginDestinationStopHeaderClicked(
                                     stopId = display.stopId,
@@ -227,11 +227,32 @@ fun TimeTableScreen(
                                     isOrigin = true,
                                 ),
                             )
+                            onEditStopClick(true)
                         },
                         onDestinationClick = { display ->
-                            selectedStop = display
                             onEvent(
                                 TimeTableUiEvent.OriginDestinationStopHeaderClicked(
+                                    stopId = display.stopId,
+                                    stopName = display.name,
+                                    isOrigin = false,
+                                ),
+                            )
+                            onEditStopClick(false)
+                        },
+                        onOriginDeparturesClick = { display ->
+                            selectedStop = display
+                            onEvent(
+                                TimeTableUiEvent.DeparturesIconClicked(
+                                    stopId = display.stopId,
+                                    stopName = display.name,
+                                    isOrigin = true,
+                                ),
+                            )
+                        },
+                        onDestinationDeparturesClick = { display ->
+                            selectedStop = display
+                            onEvent(
+                                TimeTableUiEvent.DeparturesIconClicked(
                                     stopId = display.stopId,
                                     stopName = display.name,
                                     isOrigin = false,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -213,10 +213,19 @@ class TimeTableViewModel(
         fromStopName: String,
         toStopId: String,
         toStopName: String,
+        forceReload: Boolean = false,
     ) {
         val currentRoute = Pair(fromStopId, toStopId)
-        // Check if this is the EXACT SAME route we just initialized
-        if (lastInitializedRouteFromTo == currentRoute) {
+        // Check if this is the EXACT SAME route we just initialized.
+        //
+        // forceReload distinguishes a FRESH navigation (new nav entry pushed —
+        // the route key is the source of truth, even when a surviving VM still
+        // holds an in-place edited/reversed trip for the same key) from a
+        // RESTORED composition (rotation / back-from-map — preserve whatever
+        // trip the VM currently holds). Without it, a VM that outlives its nav
+        // entry briefly shows the edited trip when the user re-opens the same
+        // saved trip from SavedTrips.
+        if (!forceReload && lastInitializedRouteFromTo == currentRoute) {
             log("🗺️ initializeTrip: SKIPPING - Same route already initialized, preserving state!")
             // Don't reinitialize - this is likely navigation back from map
             // State is already correct, no need to call onLoadTimeTable
@@ -977,6 +986,10 @@ class TimeTableViewModel(
      */
     private fun reloadWithNewTrip(newTrip: Trip) {
         tripInfo = newTrip
+        // Keep trip-identity tracking honest: a later LoadTimeTable /
+        // initializeTrip(forceReload) for the pre-edit pair must be treated as
+        // a DIFFERENT trip (clear + refetch), not "same trip, preserve state".
+        previousTripId = newTrip.tripId
         journeys.clear() // Clear cached trips — they belong to the old trip pair.
         resetPaginationCaches()
         sandook.clearAlerts() // Alerts cache is keyed to the old trip pair too.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -297,18 +297,35 @@ class TimeTableViewModel(
 
             TimeTableUiEvent.LoadPreviousTrips -> onLoadPreviousTrips()
 
-            is TimeTableUiEvent.OriginDestinationStopHeaderClicked -> {
-                analytics.track(
-                    AnalyticsEvent.TimeTableStopHeaderClickEvent(
-                        stopId = event.stopId,
-                        stopName = event.stopName,
-                        isOrigin = event.isOrigin,
-                        tripFromStopId = tripInfo?.fromStopId.orEmpty(),
-                        tripToStopId = tripInfo?.toStopId.orEmpty(),
-                    ),
-                )
-            }
+            is TimeTableUiEvent.OriginDestinationStopHeaderClicked -> trackStopHeaderClick(event)
+
+            is TimeTableUiEvent.DeparturesIconClicked -> trackDeparturesIconClick(event)
+
+            is TimeTableUiEvent.TripStopChanged -> onTripStopChanged(event)
         }
+    }
+
+    private fun trackStopHeaderClick(event: TimeTableUiEvent.OriginDestinationStopHeaderClicked) {
+        analytics.track(
+            AnalyticsEvent.TimeTableStopHeaderClickEvent(
+                stopId = event.stopId,
+                stopName = event.stopName,
+                isOrigin = event.isOrigin,
+                tripFromStopId = tripInfo?.fromStopId.orEmpty(),
+                tripToStopId = tripInfo?.toStopId.orEmpty(),
+                action = AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_EDIT_SEARCH,
+            ),
+        )
+    }
+
+    private fun trackDeparturesIconClick(event: TimeTableUiEvent.DeparturesIconClicked) {
+        analytics.track(
+            AnalyticsEvent.TimeTableDeparturesIconClickEvent(
+                stopId = event.stopId,
+                stopName = event.stopName,
+                isOrigin = event.isOrigin,
+            ),
+        )
     }
 
     private fun observeStopLabels() {
@@ -923,22 +940,51 @@ class TimeTableViewModel(
             toStopId = tripInfo!!.fromStopId,
             toStopName = tripInfo!!.fromStopName,
         )
-        tripInfo = reverseTrip
-        journeys.clear() // Clear cache trips when reverse trip is clicked.
-        resetPaginationCaches()
-        sandook.clearAlerts() // Clear alerts cache when reverse trip is clicked.
 
         analytics.track(
             AnalyticsEvent.ReverseTimeTableClickEvent(
-                fromStopId = tripInfo!!.fromStopId,
-                toStopId = tripInfo!!.toStopId,
+                fromStopId = reverseTrip.fromStopId,
+                toStopId = reverseTrip.toStopId,
             ),
         )
 
-        val savedTrip = sandook.selectTripById(tripId = reverseTrip.tripId)
+        reloadWithNewTrip(reverseTrip)
+    }
+
+    /**
+     * User picked a replacement origin/destination from the leg-scoped stop search
+     * opened via the timetable header. Rebuilds the trip with the changed leg and
+     * reloads in place — same cache-clearing mechanics as reverse trip.
+     */
+    private fun onTripStopChanged(event: TimeTableUiEvent.TripStopChanged) {
+        val currentTrip = tripInfo ?: return
+        log("Trip stop changed -- isOrigin: ${event.isOrigin}, stopId: ${event.stopId}")
+        val newTrip = if (event.isOrigin) {
+            currentTrip.copy(fromStopId = event.stopId, fromStopName = event.stopName)
+        } else {
+            currentTrip.copy(toStopId = event.stopId, toStopName = event.stopName)
+        }
+        if (newTrip == currentTrip) {
+            log("Trip stop changed -- same stop picked, nothing to reload")
+            return
+        }
+        reloadWithNewTrip(newTrip)
+    }
+
+    /**
+     * Swaps [tripInfo] for [newTrip], clears every journey cache built for the old
+     * trip and triggers a fresh fetch. Shared by reverse-trip and stop-edit paths.
+     */
+    private fun reloadWithNewTrip(newTrip: Trip) {
+        tripInfo = newTrip
+        journeys.clear() // Clear cached trips — they belong to the old trip pair.
+        resetPaginationCaches()
+        sandook.clearAlerts() // Alerts cache is keyed to the old trip pair too.
+
+        val savedTrip = sandook.selectTripById(tripId = newTrip.tripId)
         updateUiState {
             copy(
-                trip = reverseTrip,
+                trip = newTrip,
                 isTripSaved = savedTrip != null,
                 isLoading = true,
                 isError = false,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -1699,7 +1699,7 @@ class TimeTableViewModelTest {
     }
 
     // region OriginDestinationStopHeaderClicked — analytics for the gesture that
-    // opens the stop-details sheet. The trip context (tripFromStopId / tripToStopId)
+    // opens the leg-scoped stop search. The trip context (tripFromStopId / tripToStopId)
     // comes from the VM's `tripInfo` field, which is set by LoadTimeTable.
 
     @Test
@@ -1741,6 +1741,12 @@ class TimeTableViewModelTest {
                 // PlanTripClickEvent / LoadTimeTableClickEvent.
                 assertEquals("FROM_STOP_ID_1", event.tripFromStopId)
                 assertEquals("TO_STOP_ID_1", event.tripToStopId)
+                // Post-A3 the tap opens the leg-scoped edit search — action lets the
+                // dashboard split behaviour before/after the change.
+                assertEquals(
+                    AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_EDIT_SEARCH,
+                    event.action,
+                )
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -1781,6 +1787,192 @@ class TimeTableViewModelTest {
                 assertFalse(event.isOrigin)
                 assertEquals("FROM_STOP_ID_1", event.tripFromStopId)
                 assertEquals("TO_STOP_ID_1", event.tripToStopId)
+                assertEquals(
+                    AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_EDIT_SEARCH,
+                    event.action,
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion
+
+    // region DeparturesIconClicked — analytics for the explicit departures icon
+    // that now owns the stop-details sheet (moved off the stop-name tap).
+
+    @Test
+    fun `GIVEN trip loaded WHEN departures icon is clicked THEN departures icon click event is tracked`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+
+            viewModel.onEvent(
+                TimeTableUiEvent.DeparturesIconClicked(
+                    stopId = "FROM_STOP_ID_1",
+                    stopName = "STOP_NAME_1",
+                    isOrigin = true,
+                ),
+            )
+            advanceUntilIdle()
+
+            val tracked = analytics.getTrackedEvent("timetable_departures_icon_click")
+            assertNotNull(tracked)
+            val event = assertIs<AnalyticsEvent.TimeTableDeparturesIconClickEvent>(tracked)
+            assertEquals("FROM_STOP_ID_1", event.stopId)
+            assertEquals("STOP_NAME_1", event.stopName)
+            assertTrue(event.isOrigin)
+        }
+
+    // endregion
+
+    // region TripStopChanged — stop picked from the leg-scoped edit search reloads
+    // the timetable in place with the changed leg, keeping the other leg untouched.
+
+    @Test
+    fun `GIVEN trip loaded WHEN origin stop is changed THEN timetable reloads with new origin and destination untouched`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                advanceUntilIdle()
+
+                viewModel.onEvent(
+                    TimeTableUiEvent.TripStopChanged(
+                        stopId = "NEW_FROM_STOP_ID",
+                        stopName = "NEW_FROM_STOP_NAME",
+                        isOrigin = true,
+                    ),
+                )
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals("NEW_FROM_STOP_ID", state.trip?.fromStopId)
+                assertEquals("NEW_FROM_STOP_NAME", state.trip?.fromStopName)
+                assertEquals("TO_STOP_ID_1", state.trip?.toStopId)
+                assertEquals("STOP_NAME_2", state.trip?.toStopName)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN trip loaded WHEN destination stop is changed THEN timetable reloads with new destination and origin untouched`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                advanceUntilIdle()
+
+                viewModel.onEvent(
+                    TimeTableUiEvent.TripStopChanged(
+                        stopId = "NEW_TO_STOP_ID",
+                        stopName = "NEW_TO_STOP_NAME",
+                        isOrigin = false,
+                    ),
+                )
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals("FROM_STOP_ID_1", state.trip?.fromStopId)
+                assertEquals("STOP_NAME_1", state.trip?.fromStopName)
+                assertEquals("NEW_TO_STOP_ID", state.trip?.toStopId)
+                assertEquals("NEW_TO_STOP_NAME", state.trip?.toStopName)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN trip loaded WHEN same stop is picked as replacement THEN nothing reloads`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                advanceUntilIdle()
+                expectMostRecentItem()
+
+                viewModel.onEvent(
+                    TimeTableUiEvent.TripStopChanged(
+                        stopId = "FROM_STOP_ID_1",
+                        stopName = "STOP_NAME_1",
+                        isOrigin = true,
+                    ),
+                )
+                advanceUntilIdle()
+
+                // Same stop picked — handler bails before touching state, so no
+                // new UI state is emitted.
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN changed trip matches a saved trip WHEN stop is changed THEN isTripSaved reflects the new pair`() =
+        runTest {
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            val savedTrip = Trip(
+                fromStopId = "NEW_FROM_STOP_ID",
+                fromStopName = "NEW_FROM_STOP_NAME",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            sandook.insertOrReplaceTrip(
+                tripId = savedTrip.tripId,
+                fromStopId = savedTrip.fromStopId,
+                fromStopName = savedTrip.fromStopName,
+                toStopId = savedTrip.toStopId,
+                toStopName = savedTrip.toStopName,
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+                advanceUntilIdle()
+
+                viewModel.onEvent(
+                    TimeTableUiEvent.TripStopChanged(
+                        stopId = "NEW_FROM_STOP_ID",
+                        stopName = "NEW_FROM_STOP_NAME",
+                        isOrigin = true,
+                    ),
+                )
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals("NEW_FROM_STOP_ID", state.trip?.fromStopId)
+                assertTrue(state.isTripSaved)
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -1977,6 +1977,39 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN trip reversed WHEN LoadTimeTable fires again for the original pair THEN original pair reloads fresh`() =
+        runTest {
+            // Reverse shares reloadWithNewTrip with the stop edit — the same
+            // stale-VM bug applied: reopening the original saved trip after a
+            // reverse used to hit the "same trip, preserve state" branch.
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            viewModel.onEvent(TimeTableUiEvent.ReverseTripButtonClicked)
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            assertEquals("TO_STOP_ID_1", viewModel.uiState.value.trip?.fromStopId)
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            advanceUntilIdle()
+
+            viewModel.uiState.value.run {
+                assertEquals("FROM_STOP_ID_1", this.trip?.fromStopId)
+                assertEquals("TO_STOP_ID_1", this.trip?.toStopId)
+                assertTrue(isLoading)
+            }
+        }
+
+    @Test
     fun `GIVEN stop changed WHEN initializeTrip is forced for the same nav key THEN key pair wins`() =
         runTest {
             // Fresh navigation onto a surviving VM: the route key is the source

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -1933,6 +1933,123 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN stop changed WHEN LoadTimeTable fires again for the original pair THEN original pair reloads fresh`() =
+        runTest {
+            // Regression: an in-place stop edit must update the VM's trip-identity
+            // tracking. Re-opening the original saved trip (same nav key) used to
+            // hit the "same trip, preserve state" branch and show the edited pair.
+            val trip = Trip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            tripPlanningService.isSuccess = true
+
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            viewModel.onEvent(
+                TimeTableUiEvent.TripStopChanged(
+                    stopId = "NEW_FROM_STOP_ID",
+                    stopName = "NEW_FROM_STOP_NAME",
+                    isOrigin = true,
+                ),
+            )
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.journeyList.isNotEmpty())
+
+            // User goes back and taps the original saved trip again.
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
+            advanceUntilIdle()
+
+            viewModel.uiState.value.run {
+                assertEquals("FROM_STOP_ID_1", this.trip?.fromStopId)
+                assertEquals("TO_STOP_ID_1", this.trip?.toStopId)
+                // The old "same trip, preserve state" branch left isLoading false
+                // and never refetched. isLoading=true proves the original pair is
+                // being reloaded fresh (the screen shows the loading state, not
+                // the edited pair's journeys).
+                assertTrue(isLoading)
+            }
+        }
+
+    @Test
+    fun `GIVEN stop changed WHEN initializeTrip is forced for the same nav key THEN key pair wins`() =
+        runTest {
+            // Fresh navigation onto a surviving VM: the route key is the source
+            // of truth, even though the key equals lastInitializedRouteFromTo.
+            tripPlanningService.isSuccess = true
+            viewModel.initializeTrip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            advanceUntilIdle()
+
+            viewModel.onEvent(
+                TimeTableUiEvent.TripStopChanged(
+                    stopId = "NEW_TO_STOP_ID",
+                    stopName = "NEW_TO_STOP_NAME",
+                    isOrigin = false,
+                ),
+            )
+            advanceUntilIdle()
+            assertEquals("NEW_TO_STOP_ID", viewModel.uiState.value.trip?.toStopId)
+
+            viewModel.initializeTrip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+                forceReload = true,
+            )
+            advanceUntilIdle()
+
+            viewModel.uiState.value.run {
+                assertEquals("TO_STOP_ID_1", this.trip?.toStopId)
+                assertTrue(isLoading)
+            }
+        }
+
+    @Test
+    fun `GIVEN stop changed WHEN initializeTrip is not forced for the same nav key THEN edited trip is preserved`() =
+        runTest {
+            // Restored composition (rotation / back-from-map): the VM's current
+            // trip wins; the stale nav key must not clobber the edit.
+            tripPlanningService.isSuccess = true
+            viewModel.initializeTrip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            advanceUntilIdle()
+
+            viewModel.onEvent(
+                TimeTableUiEvent.TripStopChanged(
+                    stopId = "NEW_TO_STOP_ID",
+                    stopName = "NEW_TO_STOP_NAME",
+                    isOrigin = false,
+                ),
+            )
+            advanceUntilIdle()
+
+            viewModel.initializeTrip(
+                fromStopId = "FROM_STOP_ID_1",
+                fromStopName = "STOP_NAME_1",
+                toStopId = "TO_STOP_ID_1",
+                toStopName = "STOP_NAME_2",
+            )
+            advanceUntilIdle()
+
+            assertEquals("NEW_TO_STOP_ID", viewModel.uiState.value.trip?.toStopId)
+        }
+
+    @Test
     fun `GIVEN changed trip matches a saved trip WHEN stop is changed THEN isTripSaved reflects the new pair`() =
         runTest {
             val trip = Trip(


### PR DESCRIPTION
## Story A3 — Timetable header tap opens edit-stop search

Analytics showed 424 taps by 116 users (27% of actives) on the timetable header stop names expecting to change the stop; the tap only opened a departure-board sheet, and the most common follow-up was bailing out to search.

### What changed

- Tapping the origin or destination name in the timetable header now opens stop search pre-scoped to that leg ("Change origin" / "Change destination").
- Picking a stop reloads the timetable in place with the changed leg. The other leg is untouched and there is no back-stack rebuild (reuses the reverse-trip reload mechanics via a shared `reloadWithNewTrip`).
- The departure-board sheet is still available: each header row gains an explicit clock icon that opens it. The feature has users, so it moved rather than died.
- Reverse button unchanged.
- The result travels on a dedicated `TimetableStopChangedResult` bus channel so it can never race SavedTrips' `StopSelectedResult` listener.

### Analytics

- `timetable_stop_header_click` keeps firing with `isOrigin`, plus new param `action: "edit_search"` (pre-fix events carry no `action`, so the dashboard can split before/after).
- New event `timetable_departures_icon_click` (`stopId`, `stopName`, `isOrigin`).

### Tests

- Header-click analytics tests updated for the `action` param.
- New VM tests: departures-icon event, origin change keeps destination, destination change keeps origin, same-stop pick is a no-op, `isTripSaved` recomputed for the new pair.
- `testAndroidHostTest` 370 tests green, detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)