### PR TITLE
feat(timetable): one-tap save-trip prompt at the aha moment

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -355,24 +355,23 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         }
     }
 
-    /** User tapped Save on the "Save this trip?" prompt. */
-    data class SaveTripPromptAcceptedEvent(val variant: String) : AnalyticsEvent(
-        name = "save_trip_prompt_accepted",
-        properties = mapOf(PROP_VARIANT to variant),
-    )
-
     /**
-     * User dismissed the "Save this trip?" prompt.
+     * User acted on the "Save this trip?" prompt. One event for both outcomes
+     * (accept and dismiss) to stay within the Firebase 500-event budget.
      *
+     * @param accepted true when the user tapped Save, false when dismissed.
      * @param dismissCount Total dismissals for this origin-destination pair
      * including this one — the prompt stops appearing for the pair at 2.
+     * Always 0 when [accepted] is true.
      */
-    data class SaveTripPromptDismissedEvent(
+    data class SaveTripPromptActionEvent(
+        val accepted: Boolean,
         val variant: String,
-        val dismissCount: Int,
+        val dismissCount: Int = 0,
     ) : AnalyticsEvent(
-        name = "save_trip_prompt_dismissed",
+        name = "save_trip_prompt_action",
         properties = mapOf(
+            "accepted" to accepted,
             PROP_VARIANT to variant,
             "dismissCount" to dismissCount,
         ),

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -6,6 +6,7 @@ import kotlin.time.ExperimentalTime
 
 private const val PROP_STOP_ID = "stopId"
 private const val PROP_ACTION = "action"
+private const val PROP_VARIANT = "variant"
 private const val PROP_SOURCE = "source"
 private const val PROP_EXPAND = "expand"
 private const val PROP_STOP_NAME = "stopName"
@@ -315,9 +316,66 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
-    data class SaveTripClickEvent(val fromStopId: String, val toStopId: String) : AnalyticsEvent(
+    /**
+     * @param source Where the save was triggered from: [SOURCE_STAR] for the
+     * title-bar star button, [SOURCE_PROMPT] for the "Save this trip?" prompt.
+     * Historical events (pre-prompt) carry no `source` — treat null as star.
+     */
+    data class SaveTripClickEvent(
+        val fromStopId: String,
+        val toStopId: String,
+        val source: String = SOURCE_STAR,
+    ) : AnalyticsEvent(
         name = "save_trip_click",
-        properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+        properties = mapOf(
+            PROP_FROM_STOP_ID to fromStopId,
+            PROP_TO_STOP_ID to toStopId,
+            PROP_SOURCE to source,
+        ),
+    ) {
+        companion object {
+            const val SOURCE_STAR = "star"
+            const val SOURCE_PROMPT = "prompt"
+        }
+    }
+
+    /**
+     * "Save this trip?" prompt shown on the timetable after loading an unsaved
+     * origin-destination pair (the aha-moment save nudge).
+     *
+     * @param variant `plain` for the simple save prompt; `commute` for the
+     * Home/Work label-assigning variant.
+     */
+    data class SaveTripPromptShownEvent(val variant: String) : AnalyticsEvent(
+        name = "save_trip_prompt_shown",
+        properties = mapOf(PROP_VARIANT to variant),
+    ) {
+        companion object {
+            const val VARIANT_PLAIN = "plain"
+        }
+    }
+
+    /** User tapped Save on the "Save this trip?" prompt. */
+    data class SaveTripPromptAcceptedEvent(val variant: String) : AnalyticsEvent(
+        name = "save_trip_prompt_accepted",
+        properties = mapOf(PROP_VARIANT to variant),
+    )
+
+    /**
+     * User dismissed the "Save this trip?" prompt.
+     *
+     * @param dismissCount Total dismissals for this origin-destination pair
+     * including this one — the prompt stops appearing for the pair at 2.
+     */
+    data class SaveTripPromptDismissedEvent(
+        val variant: String,
+        val dismissCount: Int,
+    ) : AnalyticsEvent(
+        name = "save_trip_prompt_dismissed",
+        properties = mapOf(
+            PROP_VARIANT to variant,
+            "dismissCount" to dismissCount,
+        ),
     )
 
     data class PlanTripClickEvent(val fromStopId: String, val toStopId: String) : AnalyticsEvent(

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -51,6 +51,13 @@ data class TimeTableState(
      * the timetable header shows the user's nickname for a stop when set.
      */
     val stopLabels: ImmutableList<StopLabel> = persistentListOf(),
+    /**
+     * True when the one-tap "Save this trip?" prompt should render below the
+     * timetable header. Set after a successful load of an unsaved pair,
+     * subject to the frequency rules in TimeTableViewModel (once per app
+     * session, max 2 dismissals per pair, never for saved pairs).
+     */
+    val showSaveTripPrompt: Boolean = false,
 ) {
     @OptIn(ExperimentalTime::class)
     @Stable

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -86,4 +86,10 @@ sealed interface TimeTableUiEvent {
         val stopName: String,
         val isOrigin: Boolean,
     ) : TimeTableUiEvent
+
+    /** User tapped Save on the "Save this trip?" prompt. */
+    data object SaveTripPromptAccepted : TimeTableUiEvent
+
+    /** User dismissed the "Save this trip?" prompt. */
+    data object SaveTripPromptDismissed : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -87,6 +87,7 @@ val viewModelsModule = module {
             tripPlanningService = get(),
             rateLimiter = get(),
             sandook = get(),
+            preferences = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
             festivalManager = get(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
@@ -1,0 +1,126 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import app.krail.taj.resources.ic_close
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.taj.components.Button
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.CardShape
+import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.themeBackgroundColor
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
+import app.krail.taj.resources.Res as TajRes
+
+/**
+ * Save nudge for an unsaved pair (story A2). A list item below the header,
+ * so it never covers journey results.
+ */
+internal fun LazyListScope.saveTripPromptItem(
+    showSaveTripPrompt: Boolean,
+    onEvent: (TimeTableUiEvent) -> Unit,
+) {
+    if (!showSaveTripPrompt) return
+    item(key = "save-trip-prompt") {
+        SaveTripPromptCard(
+            onSaveClick = { onEvent(TimeTableUiEvent.SaveTripPromptAccepted) },
+            onDismissClick = { onEvent(TimeTableUiEvent.SaveTripPromptDismissed) },
+            modifier = Modifier
+                .fillParentMaxWidth()
+                .padding(horizontal = KrailTheme.dimensions.spacingL)
+                .padding(top = KrailTheme.dimensions.spacingL)
+                .animateItem(),
+        )
+    }
+}
+
+/**
+ * One-tap save nudge shown below the timetable header after loading an
+ * unsaved origin-destination pair (story A2). Rendered as a list item so it
+ * never covers journey results; frequency rules live in [TimeTableViewModel].
+ */
+@Composable
+internal fun SaveTripPromptCard(
+    onSaveClick: () -> Unit,
+    onDismissClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(CardShape)
+            .background(color = themeBackgroundColor(), shape = CardShape)
+            .padding(horizontal = dim.spacingL, vertical = dim.spacingM),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
+    ) {
+        Text(
+            text = "Save this trip?",
+            style = KrailTheme.typography.titleSmall,
+            color = KrailTheme.colors.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+
+        Button(
+            onClick = onSaveClick,
+            dimensions = ButtonDefaults.mediumButtonSize(),
+        ) {
+            Text(text = "Save")
+        }
+
+        Box(
+            modifier = Modifier
+                .size(dim.iconL)
+                .clip(CircleShape)
+                .klickable { onDismissClick() }
+                .semantics(mergeDescendants = true) {
+                    contentDescription = "Dismiss save trip prompt"
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                painter = painterResource(TajRes.drawable.ic_close),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                modifier = Modifier.size(dim.iconS),
+            )
+        }
+    }
+}
+
+// region Preview
+
+@PreviewComponent
+@Composable
+private fun PreviewSaveTripPromptCard() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        SaveTripPromptCard(
+            onSaveClick = {},
+            onDismissClick = {},
+        )
+    }
+}
+
+// endregion

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
@@ -1,40 +1,37 @@
 package xyz.ksharma.krail.trip.planner.ui.timetable
 
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import app.krail.taj.resources.ic_close
-import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.taj.components.Button
-import xyz.ksharma.krail.taj.components.ButtonDefaults
-import xyz.ksharma.krail.taj.components.Text
-import xyz.ksharma.krail.taj.modifier.CardShape
-import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.info.tile.state.InfoTileCta
+import xyz.ksharma.krail.info.tile.state.InfoTileData
+import xyz.ksharma.krail.info.tile.state.InfoTileState
+import xyz.ksharma.krail.info.tiles.ui.InfoTile
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
-import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
-import app.krail.taj.resources.Res as TajRes
+
+// Static content for the "Save this trip?" nudge (story A2). Rendered with the
+// shared InfoTile component so the prompt looks and behaves like every other
+// actionable tile in the app. Dismissal tracking is handled by
+// TimeTableViewModel, not InfoTileManager — the tile's key is never
+// registered with the remote info-tile pipeline.
+private val saveTripPromptTileData = InfoTileData(
+    key = "save_trip_prompt",
+    title = "Save this trip?",
+    description = "Your trip will be one tap away on the home screen.",
+    primaryCta = InfoTileCta(text = "Save"),
+    dismissCtaText = "Not now",
+    type = InfoTileData.InfoTileType.INFO,
+)
 
 /**
  * Save nudge for an unsaved pair (story A2). A list item below the header,
- * so it never covers journey results.
+ * so it never covers journey results. Frequency rules live in
+ * [TimeTableViewModel].
  */
 internal fun LazyListScope.saveTripPromptItem(
     showSaveTripPrompt: Boolean,
@@ -42,11 +39,14 @@ internal fun LazyListScope.saveTripPromptItem(
 ) {
     if (!showSaveTripPrompt) return
     item(key = "save-trip-prompt") {
-        SaveTripPromptCard(
-            onSaveClick = { onEvent(TimeTableUiEvent.SaveTripPromptAccepted) },
+        InfoTile(
+            infoTileData = saveTripPromptTileData,
+            initialState = InfoTileState.EXPANDED,
+            onCtaClick = { onEvent(TimeTableUiEvent.SaveTripPromptAccepted) },
             onDismissClick = { onEvent(TimeTableUiEvent.SaveTripPromptDismissed) },
             modifier = Modifier
-                .fillParentMaxWidth()
+                // Horizontal inset matches the OriginDestination header and the
+                // trip-actions row above, so all timetable cards share one edge.
                 .padding(horizontal = KrailTheme.dimensions.spacingL)
                 .padding(top = KrailTheme.dimensions.spacingL)
                 .animateItem(),
@@ -54,70 +54,16 @@ internal fun LazyListScope.saveTripPromptItem(
     }
 }
 
-/**
- * One-tap save nudge shown below the timetable header after loading an
- * unsaved origin-destination pair (story A2). Rendered as a list item so it
- * never covers journey results; frequency rules live in [TimeTableViewModel].
- */
-@Composable
-internal fun SaveTripPromptCard(
-    onSaveClick: () -> Unit,
-    onDismissClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val dim = KrailTheme.dimensions
-
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(CardShape)
-            .background(color = themeBackgroundColor(), shape = CardShape)
-            .padding(horizontal = dim.spacingL, vertical = dim.spacingM),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
-    ) {
-        Text(
-            text = "Save this trip?",
-            style = KrailTheme.typography.titleSmall,
-            color = KrailTheme.colors.onSurface,
-            modifier = Modifier.weight(1f),
-        )
-
-        Button(
-            onClick = onSaveClick,
-            dimensions = ButtonDefaults.mediumButtonSize(),
-        ) {
-            Text(text = "Save")
-        }
-
-        Box(
-            modifier = Modifier
-                .size(dim.iconL)
-                .clip(CircleShape)
-                .klickable { onDismissClick() }
-                .semantics(mergeDescendants = true) {
-                    contentDescription = "Dismiss save trip prompt"
-                },
-            contentAlignment = Alignment.Center,
-        ) {
-            Image(
-                painter = painterResource(TajRes.drawable.ic_close),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                modifier = Modifier.size(dim.iconS),
-            )
-        }
-    }
-}
-
 // region Preview
 
 @PreviewComponent
 @Composable
-private fun PreviewSaveTripPromptCard() {
+private fun PreviewSaveTripPromptTile() {
     PreviewTheme(themeStyle = KrailThemeStyle.Train) {
-        SaveTripPromptCard(
-            onSaveClick = {},
+        InfoTile(
+            infoTileData = saveTripPromptTileData,
+            initialState = InfoTileState.EXPANDED,
+            onCtaClick = {},
             onDismissClick = {},
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
@@ -36,13 +36,19 @@ private val saveTripPromptTileData = InfoTileData(
 internal fun LazyListScope.saveTripPromptItem(
     showSaveTripPrompt: Boolean,
     onEvent: (TimeTableUiEvent) -> Unit,
+    onSaveAccepted: () -> Unit = {},
 ) {
     if (!showSaveTripPrompt) return
     item(key = "save-trip-prompt") {
         InfoTile(
             infoTileData = saveTripPromptTileData,
             initialState = InfoTileState.EXPANDED,
-            onCtaClick = { onEvent(TimeTableUiEvent.SaveTripPromptAccepted) },
+            onCtaClick = {
+                onEvent(TimeTableUiEvent.SaveTripPromptAccepted)
+                // Kick off the title-bar star celebration so the user sees
+                // where the save control permanently lives.
+                onSaveAccepted()
+            },
             onDismissClick = { onEvent(TimeTableUiEvent.SaveTripPromptDismissed) },
             modifier = Modifier
                 // Horizontal inset matches the OriginDestination header and the

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
@@ -60,7 +60,10 @@ internal fun LazyListScope.saveTripPromptItem(
                 // Horizontal inset matches the OriginDestination header and the
                 // trip-actions row above, so all timetable cards share one edge.
                 .padding(horizontal = KrailTheme.dimensions.spacingL)
-                .padding(top = KrailTheme.dimensions.spacingL)
+                // OriginDestination to trip-actions gap is spacingM (card's own
+                // bottom padding) + spacingL (actions row top padding) = 20dp.
+                // Match it here so both gaps around the actions row are equal.
+                .padding(top = KrailTheme.dimensions.spacingL + KrailTheme.dimensions.spacingM)
                 .animateItem(),
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import xyz.ksharma.krail.info.tile.state.InfoTileCta
 import xyz.ksharma.krail.info.tile.state.InfoTileData
 import xyz.ksharma.krail.info.tile.state.InfoTileState
@@ -40,10 +42,14 @@ internal fun LazyListScope.saveTripPromptItem(
 ) {
     if (!showSaveTripPrompt) return
     item(key = "save-trip-prompt") {
+        val haptic = LocalHapticFeedback.current
         InfoTile(
             infoTileData = saveTripPromptTileData,
             initialState = InfoTileState.EXPANDED,
             onCtaClick = {
+                // First save deserves a physical tick alongside the star
+                // celebration so the moment lands.
+                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 onEvent(TimeTableUiEvent.SaveTripPromptAccepted)
                 // Kick off the title-bar star celebration so the user sees
                 // where the save control permanently lives.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripStarButton.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripStarButton.kt
@@ -1,0 +1,106 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_star
+import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
+import org.jetbrains.compose.resources.painterResource
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+/**
+ * The title-bar save star. When [celebrate] flips true (first save via the
+ * "Save this trip?" tile), the star spins a full turn, flashes gold and pops
+ * in size before settling back to its normal tint and size — connecting the
+ * tile's Save action to where the save control permanently lives. Motion
+ * mirrors the intro screen's save-trips star (360 degree spin, tween).
+ */
+@Composable
+internal fun SaveTripStarButton(
+    isTripSaved: Boolean,
+    celebrate: Boolean,
+    onCelebrateEnd: () -> Unit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val rotation = remember { Animatable(0f) }
+    val scale = remember { Animatable(1f) }
+    val goldFraction = remember { Animatable(0f) }
+
+    LaunchedEffect(celebrate) {
+        if (!celebrate) return@LaunchedEffect
+        val spin = launch {
+            rotation.animateTo(
+                targetValue = SPIN_DEGREES,
+                animationSpec = tween(durationMillis = SPIN_DURATION_MS, easing = FastOutSlowInEasing),
+            )
+            rotation.snapTo(0f)
+        }
+        val pop = launch {
+            scale.animateTo(
+                targetValue = POP_SCALE,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+            )
+            scale.animateTo(
+                targetValue = 1f,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+            )
+        }
+        val gold = launch {
+            goldFraction.animateTo(1f, animationSpec = tween(durationMillis = GOLD_IN_MS))
+            delay(GOLD_HOLD_MS)
+            goldFraction.animateTo(0f, animationSpec = tween(durationMillis = GOLD_OUT_MS))
+        }
+        joinAll(spin, pop, gold)
+        onCelebrateEnd()
+    }
+
+    val tint = lerp(KrailTheme.colors.onSurface, StarGold, goldFraction.value)
+
+    ActionButton(
+        onClick = onClick,
+        contentDescription = if (isTripSaved) "Remove Saved Trip" else "Save Trip",
+        modifier = modifier,
+    ) {
+        Image(
+            painter = if (isTripSaved) {
+                painterResource(Res.drawable.ic_star_filled)
+            } else {
+                painterResource(Res.drawable.ic_star)
+            },
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(tint),
+            modifier = Modifier
+                .size(KrailTheme.dimensions.iconM)
+                .graphicsLayer {
+                    rotationZ = rotation.value
+                    scaleX = scale.value
+                    scaleY = scale.value
+                },
+        )
+    }
+}
+
+private val StarGold = Color(color = 0xFFFFD700)
+private const val SPIN_DEGREES = 360f
+private const val SPIN_DURATION_MS = 700
+private const val POP_SCALE = 1.5f
+private const val GOLD_IN_MS = 250
+private const val GOLD_HOLD_MS = 250L
+private const val GOLD_OUT_MS = 300

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -58,8 +58,6 @@ import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_check
 import krail.feature.trip_planner.ui.generated.resources.ic_filter
 import krail.feature.trip_planner.ui.generated.resources.ic_reverse
-import krail.feature.trip_planner.ui.generated.resources.ic_star
-import krail.feature.trip_planner.ui.generated.resources.ic_star_filled
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DepartureBoardSource
@@ -132,6 +130,9 @@ fun TimeTableScreen(
     // Tracks which stop's details sheet is open. Tap on a stop in the
     // OriginDestination header sets this; the sheet is dismissed back to null.
     var selectedStop by remember { mutableStateOf<StopDisplay?>(null) }
+    // One-shot: true while the title-bar star plays its first-save celebration
+    // (triggered by the "Save this trip?" tile's Save button).
+    var celebrateSaveStar by remember { mutableStateOf(false) }
 
     Box(
         modifier = modifier.fillMaxSize().background(color = KrailTheme.colors.surface),
@@ -191,25 +192,12 @@ fun TimeTableScreen(
                                 modifier = Modifier.size(dim.iconM),
                             )
                         }
-                        ActionButton(
+                        SaveTripStarButton(
+                            isTripSaved = timeTableState.isTripSaved,
+                            celebrate = celebrateSaveStar,
+                            onCelebrateEnd = { celebrateSaveStar = false },
                             onClick = { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
-                            contentDescription = if (timeTableState.isTripSaved) {
-                                "Remove Saved Trip"
-                            } else {
-                                "Save Trip"
-                            },
-                        ) {
-                            Image(
-                                painter = if (timeTableState.isTripSaved) {
-                                    painterResource(Res.drawable.ic_star_filled)
-                                } else {
-                                    painterResource(Res.drawable.ic_star)
-                                },
-                                contentDescription = null,
-                                colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
-                                modifier = Modifier.size(dim.iconM),
-                            )
-                        }
+                        )
                     },
                 )
             }
@@ -373,6 +361,7 @@ fun TimeTableScreen(
             saveTripPromptItem(
                 showSaveTripPrompt = timeTableState.showSaveTripPrompt,
                 onEvent = onEvent,
+                onSaveAccepted = { celebrateSaveStar = true },
             )
 
             item(key = "spacer-top") {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -370,6 +370,11 @@ fun TimeTableScreen(
                 }
             }
 
+            saveTripPromptItem(
+                showSaveTripPrompt = timeTableState.showSaveTripPrompt,
+                onEvent = onEvent,
+            )
+
             item(key = "spacer-top") {
                 Spacer(modifier = Modifier.height(dim.spacingL))
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -642,18 +642,19 @@ class TimeTableViewModel(
     }
 
     /**
-     * Shows the one-tap "Save this trip?" prompt after a successful load of an
-     * unsaved pair. Frequency rules (story A2): at most once per app session,
-     * never for already-saved pairs, and stop after
+     * Shows the one-tap "Save this trip?" prompt after a successful load.
+     * Only users with ZERO saved trips ever see it — once any trip is saved
+     * the user has discovered the feature and the nudge is pointless.
+     * Frequency rules (story A2): at most once per app session, and stop after
      * [MAX_SAVE_TRIP_PROMPT_DISMISSALS] dismissals for the same pair.
      */
     private fun maybeShowSaveTripPrompt() {
         val trip = tripInfo ?: return
         val state = _uiState.value
-        val alreadyShownOrSaved =
-            savePromptShownInSession || state.showSaveTripPrompt || state.isTripSaved
-        val eligible = !alreadyShownOrSaved &&
+        val alreadyShown = savePromptShownInSession || state.showSaveTripPrompt
+        val eligible = !alreadyShown &&
             state.journeyList.isNotEmpty() &&
+            sandook.selectAllTrips().isEmpty() &&
             promptDismissCount(trip.tripId) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
         if (!eligible) return
         savePromptShownInSession = true

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -46,6 +46,7 @@ import xyz.ksharma.krail.core.share.ShareManager
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.feature.track.TripDeepLinkEncoder
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SelectServiceAlertsByJourneyId
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.ratelimit.RateLimiter
@@ -70,6 +71,7 @@ class TimeTableViewModel(
     private val tripPlanningService: TripPlanningService,
     private val rateLimiter: RateLimiter,
     private val sandook: Sandook,
+    private val preferences: SandookPreferences,
     private val analytics: Analytics,
     private val shareManager: ShareManager,
     private val ioDispatcher: CoroutineDispatcher,
@@ -311,6 +313,10 @@ class TimeTableViewModel(
             is TimeTableUiEvent.DeparturesIconClicked -> trackDeparturesIconClick(event)
 
             is TimeTableUiEvent.TripStopChanged -> onTripStopChanged(event)
+
+            TimeTableUiEvent.SaveTripPromptAccepted -> onSaveTripPromptAccepted()
+
+            TimeTableUiEvent.SaveTripPromptDismissed -> onSaveTripPromptDismissed()
         }
     }
 
@@ -631,6 +637,80 @@ class TimeTableViewModel(
                 paginationEnabled = PAGINATION_ENABLED,
             )
         }
+
+        maybeShowSaveTripPrompt()
+    }
+
+    /**
+     * Shows the one-tap "Save this trip?" prompt after a successful load of an
+     * unsaved pair. Frequency rules (story A2): at most once per app session,
+     * never for already-saved pairs, and stop after
+     * [MAX_SAVE_TRIP_PROMPT_DISMISSALS] dismissals for the same pair.
+     */
+    private fun maybeShowSaveTripPrompt() {
+        val trip = tripInfo ?: return
+        val state = _uiState.value
+        val alreadyShownOrSaved =
+            savePromptShownInSession || state.showSaveTripPrompt || state.isTripSaved
+        val eligible = !alreadyShownOrSaved &&
+            state.journeyList.isNotEmpty() &&
+            promptDismissCount(trip.tripId) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
+        if (!eligible) return
+        savePromptShownInSession = true
+        updateUiState { copy(showSaveTripPrompt = true) }
+        analytics.track(
+            AnalyticsEvent.SaveTripPromptShownEvent(
+                variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
+            ),
+        )
+    }
+
+    private fun promptDismissCount(tripId: String): Long =
+        preferences.getLong(SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + tripId) ?: 0L
+
+    private fun onSaveTripPromptAccepted() {
+        val trip = tripInfo ?: return
+        viewModelScope.launch(ioDispatcher) {
+            analytics.track(
+                AnalyticsEvent.SaveTripClickEvent(
+                    fromStopId = trip.fromStopId,
+                    toStopId = trip.toStopId,
+                    source = AnalyticsEvent.SaveTripClickEvent.SOURCE_PROMPT,
+                ),
+            )
+            analytics.track(
+                AnalyticsEvent.SaveTripPromptAcceptedEvent(
+                    variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
+                ),
+            )
+            sandook.insertOrReplaceTrip(
+                tripId = trip.tripId,
+                fromStopId = trip.fromStopId,
+                fromStopName = trip.fromStopName,
+                toStopId = trip.toStopId,
+                toStopName = trip.toStopName,
+            )
+            log("Saved Trip (Prompt): $trip")
+            updateUiState { copy(isTripSaved = true, showSaveTripPrompt = false) }
+        }
+    }
+
+    private fun onSaveTripPromptDismissed() {
+        val trip = tripInfo ?: return
+        updateUiState { copy(showSaveTripPrompt = false) }
+        viewModelScope.launch(ioDispatcher) {
+            val newCount = promptDismissCount(trip.tripId) + 1
+            preferences.setLong(
+                key = SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + trip.tripId,
+                value = newCount,
+            )
+            analytics.track(
+                AnalyticsEvent.SaveTripPromptDismissedEvent(
+                    variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
+                    dismissCount = newCount.toInt(),
+                ),
+            )
+        }
     }
 
     private suspend fun loadTrip(): Result<TripResponse> = withContext(ioDispatcher) {
@@ -844,7 +924,8 @@ class TimeTableViewModel(
                         toStopName = trip.toStopName,
                     )
                     log("Saved Trip (Pref): $trip")
-                    updateUiState { copy(isTripSaved = true) }
+                    // Saving via the star makes the prompt redundant — drop it.
+                    updateUiState { copy(isTripSaved = true, showSaveTripPrompt = false) }
                 }
             }
         }
@@ -922,6 +1003,8 @@ class TimeTableViewModel(
                     trip = trip,
                     isTripSaved = savedTrip != null,
                     isError = false,
+                    // Prompt eligibility is re-evaluated after the new pair loads.
+                    showSaveTripPrompt = false,
                 )
             }
 
@@ -1001,6 +1084,8 @@ class TimeTableViewModel(
                 isTripSaved = savedTrip != null,
                 isLoading = true,
                 isError = false,
+                // Prompt eligibility is re-evaluated after the new pair loads.
+                showSaveTripPrompt = false,
             )
         }
         rateLimiter.triggerEvent()
@@ -1197,6 +1282,19 @@ class TimeTableViewModel(
          * Replace with a remote flag lookup when ready.
          */
         const val PAGINATION_ENABLED = true
+
+        /** Dismissals per pair after which the "Save this trip?" prompt never returns. */
+        @VisibleForTesting
+        const val MAX_SAVE_TRIP_PROMPT_DISMISSALS = 2L
+
+        // "Save this trip?" prompt is shown at most once per app session
+        // (process lifetime), across all TimeTableViewModel instances.
+        private var savePromptShownInSession = false
+
+        @VisibleForTesting
+        fun resetSavePromptSessionFlagForTest() {
+            savePromptShownInSession = false
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -680,7 +680,8 @@ class TimeTableViewModel(
                 ),
             )
             analytics.track(
-                AnalyticsEvent.SaveTripPromptAcceptedEvent(
+                AnalyticsEvent.SaveTripPromptActionEvent(
+                    accepted = true,
                     variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
                 ),
             )
@@ -706,7 +707,8 @@ class TimeTableViewModel(
                 value = newCount,
             )
             analytics.track(
-                AnalyticsEvent.SaveTripPromptDismissedEvent(
+                AnalyticsEvent.SaveTripPromptActionEvent(
+                    accepted = false,
                     variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
                     dismissCount = newCount.toInt(),
                 ),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -637,33 +637,33 @@ class TimeTableViewModel(
                 paginationEnabled = PAGINATION_ENABLED,
             )
         }
-
-        maybeShowSaveTripPrompt()
     }
 
     /**
-     * Shows the one-tap "Save this trip?" prompt after a successful load.
-     * Only users with ZERO saved trips ever see it — once any trip is saved
-     * the user has discovered the feature and the nudge is pointless.
+     * Resolves whether the one-tap "Save this trip?" prompt should be visible
+     * for the trip being loaded. Returns the value for the load's own state
+     * update; also fires the shown event and burns the per-session allowance
+     * the first time it resolves true.
+     *
+     * Only users with ZERO saved trips ever see the prompt — once any trip is
+     * saved the user has discovered the feature and the nudge is pointless.
      * Frequency rules (story A2): at most once per app session, and stop after
      * [MAX_SAVE_TRIP_PROMPT_DISMISSALS] dismissals for the same pair.
      */
-    private fun maybeShowSaveTripPrompt() {
-        val trip = tripInfo ?: return
-        val state = _uiState.value
-        val alreadyShown = savePromptShownInSession || state.showSaveTripPrompt
-        val eligible = !alreadyShown &&
-            state.journeyList.isNotEmpty() &&
+    private fun resolveSavePromptOnLoad(tripId: String): Boolean {
+        // Already on screen (e.g. same-trip re-init) — keep it there.
+        if (_uiState.value.showSaveTripPrompt) return true
+        val eligible = !savePromptShownInSession &&
             sandook.selectAllTrips().isEmpty() &&
-            promptDismissCount(trip.tripId) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
-        if (!eligible) return
+            promptDismissCount(tripId) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
+        if (!eligible) return false
         savePromptShownInSession = true
-        updateUiState { copy(showSaveTripPrompt = true) }
         analytics.track(
             AnalyticsEvent.SaveTripPromptShownEvent(
                 variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
             ),
         )
+        return true
     }
 
     private fun promptDismissCount(tripId: String): Long =
@@ -989,6 +989,10 @@ class TimeTableViewModel(
 
         tripInfo = trip
         val savedTrip = sandook.selectTripById(tripId = trip.tripId)
+        // Resolved at load time so the prompt shows while journeys are still
+        // loading; results simply render below it when they arrive. Folded into
+        // the same state update as the load itself (single emission).
+        val showSavePrompt = resolveSavePromptOnLoad(currentTripId)
 
         if (!isSameTrip) {
             // Different trip - clear state and fetch new data
@@ -1004,8 +1008,7 @@ class TimeTableViewModel(
                     trip = trip,
                     isTripSaved = savedTrip != null,
                     isError = false,
-                    // Prompt eligibility is re-evaluated after the new pair loads.
-                    showSaveTripPrompt = false,
+                    showSaveTripPrompt = showSavePrompt,
                 )
             }
 
@@ -1017,6 +1020,7 @@ class TimeTableViewModel(
                 copy(
                     trip = trip,
                     isTripSaved = savedTrip != null,
+                    showSaveTripPrompt = showSavePrompt,
                 )
             }
         }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelCacheTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelCacheTest.kt
@@ -29,6 +29,7 @@ import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
 import xyz.ksharma.krail.core.testing.fakes.FakeFlag
 import xyz.ksharma.krail.core.testing.fakes.FakeRateLimiter
 import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
 import xyz.ksharma.krail.core.testing.fakes.FakeShareManager
 import xyz.ksharma.krail.core.testing.fakes.FakeTripPlanningService
 import xyz.ksharma.krail.core.testing.fakes.FakeTripResponseBuilder
@@ -74,10 +75,12 @@ class TimeTableViewModelCacheTest {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        TimeTableViewModel.resetSavePromptSessionFlagForTest()
         viewModel = TimeTableViewModel(
             tripPlanningService = tripPlanningService,
             rateLimiter = rateLimiter,
             sandook = FakeSandook(),
+            preferences = FakeSandookPreferences(),
             analytics = FakeAnalytics(),
             shareManager = FakeShareManager(),
             ioDispatcher = testDispatcher,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -17,6 +17,7 @@ import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
 import xyz.ksharma.krail.core.testing.fakes.FakeFlag
 import xyz.ksharma.krail.core.testing.fakes.FakeRateLimiter
 import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
 import xyz.ksharma.krail.core.testing.fakes.FakeShareManager
 import xyz.ksharma.krail.core.testing.fakes.FakeTripPlanningService
 import xyz.ksharma.krail.core.testing.fakes.FakeTripResponseBuilder
@@ -28,6 +29,7 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.formatTo12HourTime
 import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
 import xyz.ksharma.krail.trip.planner.network.api.service.DepArr
 import xyz.ksharma.krail.core.transport.TransportMode
@@ -61,6 +63,7 @@ import kotlin.time.ExperimentalTime
 class TimeTableViewModelTest {
 
     private val sandook: Sandook = FakeSandook()
+    private val fakePreferences = FakeSandookPreferences()
     private val fakeAnalytics: Analytics = FakeAnalytics()
     private val fakeShareManager = FakeShareManager()
     private val tripPlanningService = FakeTripPlanningService()
@@ -75,10 +78,12 @@ class TimeTableViewModelTest {
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        TimeTableViewModel.resetSavePromptSessionFlagForTest()
         viewModel = TimeTableViewModel(
             tripPlanningService = tripPlanningService,
             rateLimiter = rateLimiter,
             sandook = sandook,
+            preferences = fakePreferences,
             analytics = fakeAnalytics,
             shareManager = fakeShareManager,
             ioDispatcher = testDispatcher,
@@ -2126,6 +2131,150 @@ class TimeTableViewModelTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    // endregion
+
+    // region Save-trip prompt (story A2) — one-tap save nudge after loading an
+    // unsaved pair. Frequency rules: once per app session, never for saved
+    // pairs, gone forever after MAX_SAVE_TRIP_PROMPT_DISMISSALS dismissals.
+
+    private val promptTrip = Trip(
+        fromStopId = "FROM_STOP_ID_1",
+        fromStopName = "STOP_NAME_1",
+        toStopId = "TO_STOP_ID_1",
+        toStopName = "STOP_NAME_2",
+    )
+
+    private fun loadPromptTrip() {
+        tripPlanningService.isSuccess = true
+        viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(promptTrip))
+        viewModel.fetchTrip()
+    }
+
+    @Test
+    fun `GIVEN unsaved pair WHEN timetable loads THEN save prompt is shown and shown event fires once`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+            val tracked = analytics.getTrackedEvent("save_trip_prompt_shown")
+            assertNotNull(tracked)
+            val event = assertIs<AnalyticsEvent.SaveTripPromptShownEvent>(tracked)
+            assertEquals(AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN, event.variant)
+        }
+
+    @Test
+    fun `GIVEN already-saved pair WHEN timetable loads THEN no prompt is shown`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            sandook.insertOrReplaceTrip(
+                tripId = promptTrip.tripId,
+                fromStopId = promptTrip.fromStopId,
+                fromStopName = promptTrip.fromStopName,
+                toStopId = promptTrip.toStopId,
+                toStopName = promptTrip.toStopName,
+            )
+
+            loadPromptTrip()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            assertFalse(analytics.isEventTracked("save_trip_prompt_shown"))
+        }
+
+    @Test
+    fun `GIVEN prompt visible WHEN accepted THEN trip saved and accepted plus save click events fire`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptAccepted)
+            advanceUntilIdle()
+
+            viewModel.uiState.value.run {
+                assertTrue(isTripSaved)
+                assertFalse(showSaveTripPrompt)
+            }
+            assertNotNull(sandook.selectTripById(promptTrip.tripId))
+
+            val saveClick = analytics.getTrackedEvent("save_trip_click")
+            val saveClickEvent = assertIs<AnalyticsEvent.SaveTripClickEvent>(assertNotNull(saveClick))
+            assertEquals(AnalyticsEvent.SaveTripClickEvent.SOURCE_PROMPT, saveClickEvent.source)
+
+            val accepted = analytics.getTrackedEvent("save_trip_prompt_accepted")
+            val acceptedEvent = assertIs<AnalyticsEvent.SaveTripPromptAcceptedEvent>(assertNotNull(accepted))
+            assertEquals(AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN, acceptedEvent.variant)
+        }
+
+    @Test
+    fun `GIVEN prompt visible WHEN dismissed THEN prompt hides and dismissal is persisted with count`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDismissed)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            assertEquals(
+                1L,
+                fakePreferences.getLong(
+                    SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + promptTrip.tripId,
+                ),
+            )
+            val dismissed = analytics.getTrackedEvent("save_trip_prompt_dismissed")
+            val dismissedEvent =
+                assertIs<AnalyticsEvent.SaveTripPromptDismissedEvent>(assertNotNull(dismissed))
+            assertEquals(1, dismissedEvent.dismissCount)
+        }
+
+    @Test
+    fun `GIVEN pair dismissed twice before WHEN timetable loads in a new session THEN prompt never returns for that pair`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            fakePreferences.setLong(
+                SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + promptTrip.tripId,
+                TimeTableViewModel.MAX_SAVE_TRIP_PROMPT_DISMISSALS,
+            )
+
+            loadPromptTrip()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            assertFalse(analytics.isEventTracked("save_trip_prompt_shown"))
+        }
+
+    @Test
+    fun `GIVEN prompt already shown this session WHEN another unsaved pair loads THEN prompt is not shown again`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDismissed)
+            advanceUntilIdle()
+            analytics.clear()
+
+            // Change to a different unsaved pair and let it load.
+            viewModel.onEvent(
+                TimeTableUiEvent.TripStopChanged(
+                    stopId = "OTHER_STOP_ID",
+                    stopName = "OTHER_STOP_NAME",
+                    isOrigin = false,
+                ),
+            )
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            assertFalse(analytics.isEventTracked("save_trip_prompt_shown"))
         }
 
     // endregion

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -2156,7 +2156,17 @@ class TimeTableViewModelTest {
     fun `GIVEN unsaved pair WHEN timetable loads THEN save prompt is shown and shown event fires once`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics
-            loadPromptTrip()
+
+            // Prompt shows at load time, while journeys are still loading.
+            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(promptTrip))
+            viewModel.uiState.value.run {
+                assertTrue(showSaveTripPrompt)
+                assertTrue(isLoading)
+            }
+
+            // Journeys arriving must keep the prompt visible.
+            tripPlanningService.isSuccess = true
+            viewModel.fetchTrip()
             advanceUntilIdle()
 
             assertTrue(viewModel.uiState.value.showSaveTripPrompt)

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -2186,6 +2186,27 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN a different trip is already saved WHEN timetable loads THEN no prompt is shown`() =
+        runTest {
+            // The prompt only targets users with ZERO saved trips — once any
+            // trip is saved the user has discovered the save feature.
+            val analytics = fakeAnalytics as FakeAnalytics
+            sandook.insertOrReplaceTrip(
+                tripId = "OTHER_TRIP_ID",
+                fromStopId = "OTHER_FROM",
+                fromStopName = "Other From",
+                toStopId = "OTHER_TO",
+                toStopName = "Other To",
+            )
+
+            loadPromptTrip()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            assertFalse(analytics.isEventTracked("save_trip_prompt_shown"))
+        }
+
+    @Test
     fun `GIVEN prompt visible WHEN accepted THEN trip saved and accepted plus save click events fire`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -2237,9 +2237,10 @@ class TimeTableViewModelTest {
             val saveClickEvent = assertIs<AnalyticsEvent.SaveTripClickEvent>(assertNotNull(saveClick))
             assertEquals(AnalyticsEvent.SaveTripClickEvent.SOURCE_PROMPT, saveClickEvent.source)
 
-            val accepted = analytics.getTrackedEvent("save_trip_prompt_accepted")
-            val acceptedEvent = assertIs<AnalyticsEvent.SaveTripPromptAcceptedEvent>(assertNotNull(accepted))
-            assertEquals(AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN, acceptedEvent.variant)
+            val action = analytics.getTrackedEvent("save_trip_prompt_action")
+            val actionEvent = assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(assertNotNull(action))
+            assertTrue(actionEvent.accepted)
+            assertEquals(AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN, actionEvent.variant)
         }
 
     @Test
@@ -2260,9 +2261,10 @@ class TimeTableViewModelTest {
                     SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + promptTrip.tripId,
                 ),
             )
-            val dismissed = analytics.getTrackedEvent("save_trip_prompt_dismissed")
+            val dismissed = analytics.getTrackedEvent("save_trip_prompt_action")
             val dismissedEvent =
-                assertIs<AnalyticsEvent.SaveTripPromptDismissedEvent>(assertNotNull(dismissed))
+                assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(assertNotNull(dismissed))
+            assertFalse(dismissedEvent.accepted)
             assertEquals(1, dismissedEvent.dismissCount)
         }
 

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/SandookPreferences.kt
@@ -42,5 +42,12 @@ interface SandookPreferences {
         const val KEY_HAS_SEEN_MAP_OPTIONS_SHEET = "KEY_HAS_SEEN_MAP_OPTIONS_SHEET"
 
         const val KEY_HAS_SEEN_SAVED_TRIP_CARD_REORDER_TIP = "KEY_HAS_SEEN_SAVED_TRIP_CARD_REORDER_TIP"
+
+        /**
+         * Prefix for per-trip "Save this trip?" prompt dismissal counters.
+         * Full key is this prefix + tripId; value is the number of times the
+         * user dismissed the prompt for that origin-destination pair.
+         */
+        const val KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX = "KEY_SAVE_TRIP_PROMPT_DISMISSALS_"
     }
 }


### PR DESCRIPTION
## Story A2 — Save-trip prompt at the aha moment (plain variant)

Only 25.8% of new users save a trip in week 1, and the aha moment (first timetable load) passes with no save nudge. This adds the one-tap prompt.

Plain variant only: the "Save as commute? Home and Work" variant depends on story A1 (label assignment), which is not built yet.

### What changed

- Users with ZERO saved trips see a "Save this trip?" tile the moment a timetable loads — eligibility resolves synchronously inside the load's own state update, so the tile renders together with the loading state and journeys fill in below it (no layout shift).
- Rendered with the shared InfoTile component ("Save" primary CTA, "Not now" dismiss), matching every other actionable tile. Insets aligned with the OriginDestination header; top gap equals the header-to-actions gap (20dp).
- Tapping Save: haptic tick (same LongPress haptic as label pills), trip saved, and the title-bar star plays a one-shot celebration — 360 spin (intro-screen motion language), gold flash, bouncy size pop, settling back filled. Connects the tile action to the permanent save control.
- Frequency rules in `TimeTableViewModel`, dismissal counts in Sandook `KrailPref`:
  - only while the user has no saved trips at all — first save retires the nudge forever
  - at most once per app session
  - never again for a pair after 2 dismissals
- Star save, reverse, or trip switch clears the prompt; eligibility re-evaluates on the next load.

### Analytics

- New events: `save_trip_prompt_shown` (`variant: plain`) and `save_trip_prompt_action` (`accepted: true|false`, `variant`, `dismissCount` on dismissals). Accept and dismiss share one event to conserve the Firebase 500-event budget.
- `save_trip_click` gains `source: star | prompt` (historical events carry no source; treat null as star).

### Tests

VM tests: prompt visible while loading and stays after journeys arrive (+ shown event), no prompt when the pair is saved, no prompt when ANY other trip is saved, accept saves and fires both events with `source=prompt`, dismiss persists count and fires dismissed event, 2 prior dismissals suppress in a new session, once-per-session across pair changes.

`testAndroidHostTest` green, detekt clean. Manually verified on device (prompt timing, star celebration, haptic, spacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
