### PR TITLE
refactor(analytics): fold departures icon event + event design rules doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,40 @@
 Compose Multiplatform app targeting Android + iOS.
 Android is the primary testable target from the command line. iOS tests are not run.
 
+## Analytics events — design before you add
+
+Firebase Analytics hard-caps the app at **500 unique event names, forever** — GA never
+lets a name be reclaimed from history. Event definitions live in
+`core/analytics/.../AnalyticsEvent.kt`. Before adding an event, apply this checklist:
+
+**A new event NAME is justified only when ALL of these hold:**
+1. It captures a new user intent (not a new gesture/surface for an existing intent).
+2. It shares no surface AND no param set with an existing event.
+3. It would be charted standalone on a dashboard.
+
+**Otherwise extend an existing event with a param** — params are free (limit is 25 per
+event, nowhere near it):
+- Different gesture, same surface, same params: add an `action` value.
+  Example: departures icon fires `timetable_stop_header_click` with
+  `action = open_departures`, not a separate `timetable_departures_icon_click`.
+- Outcomes of one interaction (accept/dismiss, on/off, success/failure): ONE event
+  with a boolean or enum param. Example: `save_trip_prompt_action(accepted: Boolean)`,
+  not `_accepted` + `_dismissed`.
+- Same event across surfaces: `source` param (see `DepartureBoardSource`,
+  `SaveTripClickEvent.source`).
+
+Also check the sheet/screen you are instrumenting doesn't already fire an equivalent
+event (e.g. opening the departure board already fires `dep_board_screen_view` with
+`source` — a click event for the same open may be double counting).
+
+Folding beats splitting analytically too: a feature that moves between gestures keeps
+a single-event query timeline (`action IS NULL OR action = 'x'`) instead of forcing
+dashboards to UNION event names.
+
+Every new event or param must be registered in `docs/EVENT_REGISTRY.md` in the
+KRAIL-Analytics repo before the app PR merges (params, trigger description, owner
+story link).
+
 ## Test Commands
 
 | Scope | Command |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,39 +5,13 @@
 Compose Multiplatform app targeting Android + iOS.
 Android is the primary testable target from the command line. iOS tests are not run.
 
-## Analytics events — design before you add
+## Analytics events
 
-Firebase Analytics hard-caps the app at **500 unique event names, forever** — GA never
-lets a name be reclaimed from history. Event definitions live in
-`core/analytics/.../AnalyticsEvent.kt`. Before adding an event, apply this checklist:
-
-**A new event NAME is justified only when ALL of these hold:**
-1. It captures a new user intent (not a new gesture/surface for an existing intent).
-2. It shares no surface AND no param set with an existing event.
-3. It would be charted standalone on a dashboard.
-
-**Otherwise extend an existing event with a param** — params are free (limit is 25 per
-event, nowhere near it):
-- Different gesture, same surface, same params: add an `action` value.
-  Example: departures icon fires `timetable_stop_header_click` with
-  `action = open_departures`, not a separate `timetable_departures_icon_click`.
-- Outcomes of one interaction (accept/dismiss, on/off, success/failure): ONE event
-  with a boolean or enum param. Example: `save_trip_prompt_action(accepted: Boolean)`,
-  not `_accepted` + `_dismissed`.
-- Same event across surfaces: `source` param (see `DepartureBoardSource`,
-  `SaveTripClickEvent.source`).
-
-Also check the sheet/screen you are instrumenting doesn't already fire an equivalent
-event (e.g. opening the departure board already fires `dep_board_screen_view` with
-`source` — a click event for the same open may be double counting).
-
-Folding beats splitting analytically too: a feature that moves between gestures keeps
-a single-event query timeline (`action IS NULL OR action = 'x'`) instead of forcing
-dashboards to UNION event names.
-
-Every new event or param must be registered in `docs/EVENT_REGISTRY.md` in the
-KRAIL-Analytics repo before the app PR merges (params, trigger description, owner
-story link).
+Firebase caps the app at **500 unique event names, forever**. Before adding or
+changing anything in `AnalyticsEvent.kt`, read `docs/ANALYTICS_EVENTS.md` — it has the
+new-event-vs-param decision checklist, aggregation patterns (`action`/`source`/boolean
+params), the double-counting check, and the EVENT_REGISTRY.md registration gate.
+Never mint an event name without passing that checklist.
 
 ## Test Commands
 

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -504,9 +504,13 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         )
 
     /**
-     * Fired when the user taps the origin or destination label in the timetable
-     * sticky header — the gesture that opens stop search scoped to that leg
-     * ("Change origin" / "Change destination").
+     * Fired when the user taps either affordance on a stop row in the timetable
+     * sticky header: the stop name (opens leg-scoped stop search, "Change
+     * origin" / "Change destination") or the departures icon (opens the
+     * departure-board sheet). One event, split by [action] — same surface and
+     * identical params, so a second event name would only burn a slot of the
+     * Firebase 500-event budget and force dashboards to UNION two names to
+     * trace the departures sheet across the A3 change.
      *
      * The single most useful field is [isOrigin]: it answers
      * "are users more curious about where they're leaving from, or where they're
@@ -525,9 +529,9 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      *                       without re-deriving it from [stopId]).
      * @param tripToStopId   Destination of the trip the click happened inside.
      * @param action        What the tap did. Historical events (pre stop-edit)
-     *                      carry no `action`; new events send
-     *                      [ACTION_EDIT_SEARCH] so the dashboard can split
-     *                      behaviour before/after the change.
+     *                      carry no `action` and were departures-sheet opens,
+     *                      so the sheet's full usage timeline is
+     *                      `action IS NULL OR action = open_departures`.
      */
     data class TimeTableStopHeaderClickEvent(
         val stopId: String,
@@ -548,28 +552,13 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         ),
     ) {
         companion object {
-            /** Tap opened stop search pre-scoped to the tapped leg. */
+            /** Stop-name tap opened stop search pre-scoped to the tapped leg. */
             const val ACTION_EDIT_SEARCH = "edit_search"
+
+            /** Departures-icon tap opened the departure-board sheet. */
+            const val ACTION_OPEN_DEPARTURES = "open_departures"
         }
     }
-
-    /**
-     * Fired when the user taps the departures icon next to a stop name in the
-     * timetable header. Opens the departure-board sheet that used to be bound
-     * to the stop-name tap itself (see [TimeTableStopHeaderClickEvent]).
-     */
-    data class TimeTableDeparturesIconClickEvent(
-        val stopId: String,
-        val stopName: String,
-        val isOrigin: Boolean,
-    ) : AnalyticsEvent(
-        name = "timetable_departures_icon_click",
-        properties = mapOf(
-            PROP_STOP_ID to stopId,
-            PROP_STOP_NAME to stopName,
-            "isOrigin" to isOrigin,
-        ),
-    )
 
     /**
      * Fired when the user taps "Load more" at the bottom of the timetable list to

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -1,0 +1,56 @@
+# Analytics Events — Design Rules
+
+Read this before adding or modifying any event in
+`core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt`.
+
+## The budget
+
+Firebase Analytics hard-caps the app at **500 unique event names, forever**. GA never
+lets a name be reclaimed from history — a shipped event name is a permanently spent
+slot, even if the code stops sending it. Budget as of 2026-07-07: 57 events defined in
+code plus ~10 historical names, roughly 430 slots left. Update this count when adding
+or removing events.
+
+## Decision checklist: new event name vs param
+
+**A new event NAME is justified only when ALL of these hold:**
+
+1. It captures a new user intent — not a new gesture or surface for an existing intent.
+2. It shares no surface AND no param set with an existing event.
+3. It would be charted standalone on a dashboard.
+
+**Otherwise extend an existing event with a param.** Params are effectively free: the
+limit is 25 per event and nothing in the app is near it.
+
+| Situation | Pattern | Example |
+|---|---|---|
+| Different gesture, same surface, same params | `action` value on the existing event | Departures icon fires `timetable_stop_header_click` with `action = open_departures` — not a separate `timetable_departures_icon_click` |
+| Outcomes of one interaction (accept/dismiss, on/off, success/failure) | ONE event with a boolean or enum param | `save_trip_prompt_action(accepted: Boolean, dismissCount)` — not `_accepted` + `_dismissed` |
+| Same event fired from several surfaces | `source` param | `DepartureBoardSource` enum, `SaveTripClickEvent.source = star \| prompt` |
+| Feature state changes (error/retry/loading) | `{feature}_status(action)` | `dep_board_status(action: error \| retry)` — not one event per state |
+
+## Double-counting check
+
+Before instrumenting a tap that opens a screen or sheet, check whether the destination
+already fires an equivalent event. Example: opening the departure board fires
+`dep_board_screen_view(stopId, stopName, source)` from `DeparturesAnalytics.kt` — a
+click event for the same open would count the same action twice.
+
+## Why folding beats splitting (beyond slot-thrift)
+
+A feature that moves between gestures keeps a single-event query timeline:
+
+```sql
+WHERE event_name = 'timetable_stop_header_click'
+  AND (action IS NULL OR action = 'open_departures')
+```
+
+Separate names force every dashboard and derivation to UNION two event names to trace
+one feature across a change. Missing param on historical rows = "before the change",
+which gives before/after splits for free.
+
+## Registration gate
+
+Every new event or param must be registered in `docs/EVENT_REGISTRY.md` in the
+**KRAIL-Analytics** repo before the app PR merges: params, trigger description, and
+owner story link.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -321,24 +321,39 @@ class TimeTableViewModel(
     }
 
     private fun trackStopHeaderClick(event: TimeTableUiEvent.OriginDestinationStopHeaderClicked) {
-        analytics.track(
-            AnalyticsEvent.TimeTableStopHeaderClickEvent(
-                stopId = event.stopId,
-                stopName = event.stopName,
-                isOrigin = event.isOrigin,
-                tripFromStopId = tripInfo?.fromStopId.orEmpty(),
-                tripToStopId = tripInfo?.toStopId.orEmpty(),
-                action = AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_EDIT_SEARCH,
-            ),
+        trackStopHeaderClick(
+            stopId = event.stopId,
+            stopName = event.stopName,
+            isOrigin = event.isOrigin,
+            action = AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_EDIT_SEARCH,
         )
     }
 
     private fun trackDeparturesIconClick(event: TimeTableUiEvent.DeparturesIconClicked) {
+        // Same surface and params as the stop-name tap — folded into the same
+        // event as action=open_departures instead of a separate event name.
+        trackStopHeaderClick(
+            stopId = event.stopId,
+            stopName = event.stopName,
+            isOrigin = event.isOrigin,
+            action = AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_OPEN_DEPARTURES,
+        )
+    }
+
+    private fun trackStopHeaderClick(
+        stopId: String,
+        stopName: String,
+        isOrigin: Boolean,
+        action: String,
+    ) {
         analytics.track(
-            AnalyticsEvent.TimeTableDeparturesIconClickEvent(
-                stopId = event.stopId,
-                stopName = event.stopName,
-                isOrigin = event.isOrigin,
+            AnalyticsEvent.TimeTableStopHeaderClickEvent(
+                stopId = stopId,
+                stopName = stopName,
+                isOrigin = isOrigin,
+                tripFromStopId = tripInfo?.fromStopId.orEmpty(),
+                tripToStopId = tripInfo?.toStopId.orEmpty(),
+                action = action,
             ),
         )
     }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -1807,7 +1807,7 @@ class TimeTableViewModelTest {
     // that now owns the stop-details sheet (moved off the stop-name tap).
 
     @Test
-    fun `GIVEN trip loaded WHEN departures icon is clicked THEN departures icon click event is tracked`() =
+    fun `GIVEN trip loaded WHEN departures icon is clicked THEN header click event is tracked with open_departures action`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics
 
@@ -1820,12 +1820,18 @@ class TimeTableViewModelTest {
             )
             advanceUntilIdle()
 
-            val tracked = analytics.getTrackedEvent("timetable_departures_icon_click")
+            // Same event name as the stop-name tap — split by action so the
+            // departures sheet's usage timeline stays a single-event query.
+            val tracked = analytics.getTrackedEvent("timetable_stop_header_click")
             assertNotNull(tracked)
-            val event = assertIs<AnalyticsEvent.TimeTableDeparturesIconClickEvent>(tracked)
+            val event = assertIs<AnalyticsEvent.TimeTableStopHeaderClickEvent>(tracked)
             assertEquals("FROM_STOP_ID_1", event.stopId)
             assertEquals("STOP_NAME_1", event.stopName)
             assertTrue(event.isOrigin)
+            assertEquals(
+                AnalyticsEvent.TimeTableStopHeaderClickEvent.ACTION_OPEN_DEPARTURES,
+                event.action,
+            )
         }
 
     // endregion


### PR DESCRIPTION
## Fold departures-icon click into timetable_stop_header_click

Follow-up to #1693. `timetable_departures_icon_click` burned a Firebase 500-budget event slot for a tap on the same surface with identical params (`stopId`, `stopName`, `isOrigin`).

### What changed

- Event class deleted. The departures icon now fires `timetable_stop_header_click` with `action = "open_departures"` (stop-name tap keeps `action = "edit_search"`); both carry the trip-pair context params.
- Historical no-`action` events were departures-sheet opens, so the sheet's full usage timeline before and after A3 is a single-event query: `action IS NULL OR action = 'open_departures'`. The previous design forced a UNION across two event names.
- VM tracking consolidated into one `trackStopHeaderClick(stopId, stopName, isOrigin, action)` helper.

### Event design rules, made durable

- New `docs/ANALYTICS_EVENTS.md`: the 500-cap budget, the new-event-vs-param decision checklist (new name only for new intent + new surface/params + standalone charting), aggregation patterns (`action` / boolean outcome / `source` / `{feature}_status`), double-counting check, and the EVENT_REGISTRY.md registration gate.
- CLAUDE.md carries a short pointer with the trigger (read the doc before touching `AnalyticsEvent.kt`) — lazy-loaded like POLLING_LIFECYCLE.md, so it costs nothing in sessions that don't touch analytics.

### Tests

Departures-icon VM test asserts `timetable_stop_header_click` with `ACTION_OPEN_DEPARTURES`. `testAndroidHostTest` green, detekt clean.

Stacked on #1694 (shared TimeTableViewModel edits). Merge order: #1694 first, this retargets automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)