### PR TITLE
fix(searchstop): label name max length, Manage-button gating, chip height

### DIFF
--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenInteractionTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreenInteractionTest.kt
@@ -243,7 +243,7 @@ class SearchStopScreenInteractionTest {
         composeRule.setContent {
             PreviewTheme {
                 SearchStopScreen(
-                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    searchStopState = SearchStopFixtures.recentWithHomeSet(),
                     onEvent = {},
                 )
             }
@@ -251,8 +251,24 @@ class SearchStopScreenInteractionTest {
 
         // The trailing "Manage" button is the sole entry point to
         // ManageStopLabelsSheet (change/remove/delete/reorder). It must be present
-        // whenever the pill row renders.
+        // whenever the pill row renders (i.e. at least one label is set).
         composeRule.onNodeWithText("Manage").assertIsDisplayed()
+    }
+
+    @Test
+    fun manageButton_isHidden_whenNoLabelIsSetYet() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    // Fresh install: Home/Work seeded but unset. No pills to show, so
+                    // the trailing Manage button shouldn't float there alone either.
+                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Manage").assertDoesNotExist()
     }
 
     @Test
@@ -261,7 +277,7 @@ class SearchStopScreenInteractionTest {
         composeRule.setContent {
             PreviewTheme {
                 SearchStopScreen(
-                    searchStopState = SearchStopFixtures.recentWithDefaults(),
+                    searchStopState = SearchStopFixtures.recentWithHomeSet(),
                     onEvent = {},
                     onManageLabelsClick = { manageClicked = true },
                 )
@@ -289,7 +305,7 @@ class SearchStopScreenInteractionTest {
             PreviewTheme {
                 CompositionLocalProvider(LocalSoftwareKeyboardController provides spyKeyboardController) {
                     SearchStopScreen(
-                        searchStopState = SearchStopFixtures.recentWithDefaults(),
+                        searchStopState = SearchStopFixtures.recentWithHomeSet(),
                         onEvent = {},
                         onManageLabelsClick = { events += "manageClicked" },
                     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AssignNewLabelSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/AssignNewLabelSheet.kt
@@ -142,11 +142,8 @@ internal fun AssignNewLabelSheetContent(
             // Blocks emoji/punctuation at keystroke time rather than silently stripping
             // them later — keeps what the user sees in sync with the normalised name
             // that CreateLabel actually stores under.
-            filter = { input ->
-                input.filter { c ->
-                    c.isLetterOrDigit() || c.isWhitespace() || c == '-' || c == '_' || c == '\''
-                }
-            },
+            filter = ::filterLabelNameInput,
+            maxLength = LABEL_NAME_MAX_LENGTH,
             modifier = Modifier.fillMaxWidth(),
         )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LabelNameNormalizer.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LabelNameNormalizer.kt
@@ -1,9 +1,28 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
 /**
- * Strips emoji and exotic characters from a user-typed label name and collapses
- * whitespace. We use this both before saving and for case-insensitive dedupe so that
- * `🏠 Home`, `Home`, and `home ` all resolve to the same canonical name.
+ * Label names are short pill/chip text (e.g. "Home", "Gym") rendered inline next to
+ * transport-mode icons and in a horizontally-scrolling row — there's no wrap/ellipsis
+ * handling anywhere a label renders, so an unbounded name would break that layout.
+ * Enforced at the TextField (`maxLength`) in both AssignNewLabelSheet and
+ * ManageStopLabelRow's rename field. Matches the cap SearchTopBar already uses for
+ * its (longer-lived) search query field, halved since labels are meant to be short.
+ */
+internal const val LABEL_NAME_MAX_LENGTH = 20
+
+/**
+ * Strips emoji and exotic characters from a user-typed label name, collapses
+ * whitespace, and caps the result at [LABEL_NAME_MAX_LENGTH]. We use this both before
+ * saving and for case-insensitive dedupe so that `🏠 Home`, `Home`, and `home ` all
+ * resolve to the same canonical name.
+ *
+ * This is the actual DB-write path (`SearchStopViewModel`'s `CreateLabel`/
+ * `RenameLabel` handlers call it before persisting), so it's the real enforcement
+ * point for both the character set and the length cap — not just a UI nicety. The
+ * TextField-level `filter`/`maxLength` in AssignNewLabelSheet and
+ * ManageStopLabelRow's rename field exist so the user sees the constraint as they
+ * type, but this function is what a caller that skipped the UI (a test, a future
+ * entry point) still can't bypass.
  */
 internal fun normaliseLabelName(input: String): String {
     val cleaned = buildString(input.length) {
@@ -16,9 +35,18 @@ internal fun normaliseLabelName(input: String): String {
             }
         }
     }
-    return cleaned.trim().replace(Regex("\\s+"), " ")
+    return cleaned.trim().replace(Regex("\\s+"), " ").take(LABEL_NAME_MAX_LENGTH).trim()
 }
 
 /** Returns true if [a] and [b] resolve to the same canonical label name. */
 internal fun labelNamesMatch(a: String, b: String): Boolean =
     normaliseLabelName(a).equals(normaliseLabelName(b), ignoreCase = true)
+
+/**
+ * Keystroke-level allowlist mirroring [normaliseLabelName]'s character rules. Passed
+ * to the TextField `filter` param in both AssignNewLabelSheet and ManageStopLabelRow's
+ * rename field so disallowed characters (emoji, punctuation) never appear even
+ * transiently, instead of being silently stripped later.
+ */
+internal fun filterLabelNameInput(input: CharSequence): CharSequence =
+    input.filter { c -> c.isLetterOrDigit() || c.isWhitespace() || c == '-' || c == '_' || c == '\'' }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/managestoplabels/ManageStopLabelRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/managestoplabels/ManageStopLabelRow.kt
@@ -52,6 +52,8 @@ import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeBackgroundColor
 import xyz.ksharma.krail.trip.planner.ui.components.ConfirmLabelActionSheet
+import xyz.ksharma.krail.trip.planner.ui.components.LABEL_NAME_MAX_LENGTH
+import xyz.ksharma.krail.trip.planner.ui.components.filterLabelNameInput
 import xyz.ksharma.krail.trip.planner.ui.components.normaliseLabelName
 import xyz.ksharma.krail.trip.planner.ui.components.stopLabelColor
 import xyz.ksharma.krail.trip.planner.ui.components.stopLabelIcon
@@ -206,6 +208,33 @@ internal fun ManageStopLabelRow(
 
 private const val DRAG_SCALE = 1.02f
 
+/** Result of tapping "Save changes" in [ExpandedRenameContent]'s rename field. */
+internal sealed interface RenameSaveAction {
+    /** Blank or unchanged — nothing to save, just collapse the row. */
+    data object CollapseOnly : RenameSaveAction
+
+    /** Normalises to the same name as another existing label — block with a sheet. */
+    data class Duplicate(val cleanedName: String) : RenameSaveAction
+
+    /** A genuinely new, non-duplicate name — proceed with the rename. */
+    data class Save(val trimmedName: String) : RenameSaveAction
+}
+
+internal fun resolveRenameSaveAction(
+    typedName: String,
+    currentName: String,
+    existingLabelNames: List<String>,
+): RenameSaveAction {
+    val trimmed = typedName.trim()
+    if (trimmed.isBlank() || trimmed == currentName) return RenameSaveAction.CollapseOnly
+    val cleaned = normaliseLabelName(trimmed)
+    val duplicate = existingLabelNames.any {
+        !it.equals(currentName, ignoreCase = true) &&
+            normaliseLabelName(it).equals(cleaned, ignoreCase = true)
+    }
+    return if (duplicate) RenameSaveAction.Duplicate(cleaned) else RenameSaveAction.Save(trimmed)
+}
+
 @Composable
 private fun ExpandedRenameContent(
     currentName: String,
@@ -244,6 +273,11 @@ private fun ExpandedRenameContent(
             TextField(
                 placeholder = "e.g. Home, Gym, School…",
                 state = textFieldState,
+                // Same allowlist as AssignNewLabelSheet's create field — blocks
+                // emoji/punctuation at keystroke time instead of silently stripping
+                // them later, so raw and normalised never diverge here either.
+                filter = ::filterLabelNameInput,
+                maxLength = LABEL_NAME_MAX_LENGTH,
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
@@ -263,27 +297,31 @@ private fun ExpandedRenameContent(
             if (!isProtected) {
                 Button(
                     onClick = {
-                        val trimmed = textFieldState.text.toString().trim()
-                        if (trimmed.isBlank() || trimmed == currentName) {
-                            focusManager.clearFocus()
-                            onCollapse()
-                            return@Button
-                        }
-                        val cleaned = normaliseLabelName(trimmed)
-                        val duplicate = existingLabelNames.any {
-                            !it.equals(currentName, ignoreCase = true) &&
-                                normaliseLabelName(it).equals(cleaned, ignoreCase = true)
-                        }
-                        if (duplicate) {
-                            // Don't collapse — the ViewModel's own dedupe check is a
-                            // silent no-op, so collapsing here would close the row
-                            // while implying the rename succeeded when nothing was
-                            // saved.
-                            duplicateName = cleaned
-                        } else {
-                            focusManager.clearFocus()
-                            onRename(trimmed)
-                            onCollapse()
+                        when (
+                            val action = resolveRenameSaveAction(
+                                typedName = textFieldState.text.toString(),
+                                currentName = currentName,
+                                existingLabelNames = existingLabelNames,
+                            )
+                        ) {
+                            RenameSaveAction.CollapseOnly -> {
+                                focusManager.clearFocus()
+                                onCollapse()
+                            }
+
+                            is RenameSaveAction.Duplicate -> {
+                                // Don't collapse — the ViewModel's own dedupe check is
+                                // a silent no-op, so collapsing here would close the
+                                // row while implying the rename succeeded when
+                                // nothing was saved.
+                                duplicateName = action.cleanedName
+                            }
+
+                            is RenameSaveAction.Save -> {
+                                focusManager.clearFocus()
+                                onRename(action.trimmedName)
+                                onCollapse()
+                            }
                         }
                     },
                     colors = ButtonDefaults.monochromeButtonColors(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRules.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRules.kt
@@ -1,5 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.searchstop
 
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 
@@ -16,10 +17,16 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
  */
 
 /**
- * Whether the pill row (label shortcuts) should render.
+ * Whether the pill row (label shortcuts + trailing Manage button) should render.
  *
- * Hide it on a fresh-install / empty-search canvas where there are no stops below to
- * assign — an empty pill row with nothing to act on feels broken to the user.
+ * Two independent reasons to hide it:
+ * - Fresh-install / empty-search canvas with no stops below to assign — an empty pill
+ *   row with nothing to act on feels broken to the user.
+ * - No label is actually set yet. `LabelShortcutsRow` only ever renders `isSet`
+ *   labels as pills, and Home/Work are always seeded on install (unset), so
+ *   `stopLabels` itself is never empty — without this check the row would render as
+ *   a lone floating "Manage" button with no pills next to it, which reads as broken
+ *   (nothing on screen yet to manage).
  *
  * - In Recent mode: show iff the user has at least one recent stop.
  * - In Results mode: show iff the search returned at least one result. Loading,
@@ -28,10 +35,14 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 internal fun shouldShowPillRow(
     listState: ListState,
     recentStops: List<SearchStopState.StopResult>,
-): Boolean = when (listState) {
-    ListState.Recent -> recentStops.isNotEmpty()
-    is ListState.Results -> listState.results.isNotEmpty()
-    ListState.NoMatch, ListState.Error -> false
+    stopLabels: List<StopLabel>,
+): Boolean {
+    if (stopLabels.none { it.isSet }) return false
+    return when (listState) {
+        ListState.Recent -> recentStops.isNotEmpty()
+        is ListState.Results -> listState.results.isNotEmpty()
+        ListState.NoMatch, ListState.Error -> false
+    }
 }
 
 /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -612,8 +612,8 @@ private fun SearchStopListContent(
     modifier: Modifier = Modifier,
 ) {
     val isLoading = listState is ListState.Results && listState.isLoading
-    val showPillRow = remember(listState, searchStopState.recentStops) {
-        shouldShowPillRow(listState, searchStopState.recentStops)
+    val showPillRow = remember(listState, searchStopState.recentStops, searchStopState.stopLabels) {
+        shouldShowPillRow(listState, searchStopState.recentStops, searchStopState.stopLabels)
     }
     val showEmptyStateStops = remember(listState, searchStopState.recentStops) {
         shouldShowEmptyStateStops(listState, searchStopState.recentStops)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopLabelAssignRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopLabelAssignRow.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
@@ -88,7 +89,7 @@ internal fun StopLabelAssignRow(
                     // ripple looked clipped to just the text+icons content.
                     .padding(top = dim.spacingM),
             ) {
-                xyz.ksharma.krail.taj.components.Text(
+                Text(
                     text = stopName,
                     style = KrailTheme.typography.titleLarge.copy(fontWeight = FontWeight.Medium),
                     color = KrailTheme.colors.onSurface,
@@ -155,7 +156,7 @@ private fun NewLabelAssignChip(onClick: () -> Unit) {
             .klickable(onClick = onClick)
             .padding(horizontal = dim.chipHorizontalPadding, vertical = dim.chipVerticalPadding),
     ) {
-        xyz.ksharma.krail.taj.components.Text(
+        Text(
             text = "+ New label",
             style = KrailTheme.typography.labelLarge,
             color = KrailTheme.colors.label,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LabelNameNormalizerTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LabelNameNormalizerTest.kt
@@ -51,6 +51,32 @@ class LabelNameNormalizerTest {
     }
 
     @Test
+    fun `normaliseLabelName caps length at LABEL_NAME_MAX_LENGTH`() {
+        val tooLong = "A".repeat(LABEL_NAME_MAX_LENGTH + 10)
+        val result = normaliseLabelName(tooLong)
+        assertEquals(LABEL_NAME_MAX_LENGTH, result.length)
+        assertEquals("A".repeat(LABEL_NAME_MAX_LENGTH), result)
+    }
+
+    @Test
+    fun `normaliseLabelName leaves no trailing space when truncation lands on a word boundary`() {
+        // 21 'A's + space + 'B' — truncating at 20 chars alone would land exactly on
+        // the space, leaving a trailing space; the result must be re-trimmed.
+        val input = "A".repeat(LABEL_NAME_MAX_LENGTH - 1) + " B"
+        val result = normaliseLabelName(input)
+        assertEquals("A".repeat(LABEL_NAME_MAX_LENGTH - 1), result)
+        assertFalse(result.endsWith(" "))
+    }
+
+    @Test
+    fun `normaliseLabelName enforces length cap even without going through the TextField`() {
+        // This is the actual defense-in-depth case: a direct call (e.g. from a
+        // ViewModel handler) with no TextField involved must still be capped.
+        val direct = normaliseLabelName("This name is way way way too long for a pill")
+        assertTrue(direct.length <= LABEL_NAME_MAX_LENGTH)
+    }
+
+    @Test
     fun `labelNamesMatch is case-insensitive`() {
         assertTrue(labelNamesMatch("Home", "home"))
         assertTrue(labelNamesMatch("HOME", "home"))

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LabelNameNormalizerTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LabelNameNormalizerTest.kt
@@ -94,4 +94,42 @@ class LabelNameNormalizerTest {
         assertFalse(labelNamesMatch("Home", "Work"))
         assertFalse(labelNamesMatch("Home", "Homely"))
     }
+
+    // region filterLabelNameInput
+
+    @Test
+    fun `filterLabelNameInput keeps letters and digits`() {
+        assertEquals("Gym2", filterLabelNameInput("Gym2").toString())
+    }
+
+    @Test
+    fun `filterLabelNameInput keeps apostrophes hyphens and underscores`() {
+        assertEquals("Mum's place", filterLabelNameInput("Mum's place").toString())
+        assertEquals("Co-Working", filterLabelNameInput("Co-Working").toString())
+        assertEquals("My_Spot", filterLabelNameInput("My_Spot").toString())
+    }
+
+    @Test
+    fun `filterLabelNameInput drops emoji and other punctuation`() {
+        assertEquals("Home", filterLabelNameInput("🏠Home!!!").toString())
+        assertEquals("Home Sweet Home", filterLabelNameInput("Home, Sweet, Home").toString())
+    }
+
+    @Test
+    fun `filterLabelNameInput does not trim or collapse whitespace, unlike normaliseLabelName`() {
+        // This runs per-keystroke on the raw TextField value — collapsing whitespace
+        // here would fight the user's cursor mid-type (e.g. deleting a just-typed
+        // trailing space before they've finished the next word). Whitespace collapse
+        // only happens once, at save time, via normaliseLabelName.
+        assertEquals("  Home  ", filterLabelNameInput("  Home  ").toString())
+        assertEquals("My   Place", filterLabelNameInput("My   Place").toString())
+    }
+
+    @Test
+    fun `filterLabelNameInput returns empty for input that's only emoji or punctuation`() {
+        assertEquals("", filterLabelNameInput("🏠").toString())
+        assertEquals("", filterLabelNameInput("!!!").toString())
+    }
+
+    // endregion
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/managestoplabels/ResolveRenameSaveActionTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/managestoplabels/ResolveRenameSaveActionTest.kt
@@ -1,0 +1,63 @@
+package xyz.ksharma.krail.trip.planner.ui.managestoplabels
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ResolveRenameSaveActionTest {
+
+    @Test
+    fun `blank typed name collapses only`() {
+        val action = resolveRenameSaveAction(
+            typedName = "   ",
+            currentName = "Work",
+            existingLabelNames = listOf("Home", "Work"),
+        )
+        assertIs<RenameSaveAction.CollapseOnly>(action)
+    }
+
+    @Test
+    fun `unchanged name collapses only`() {
+        val action = resolveRenameSaveAction(
+            typedName = "Work",
+            currentName = "Work",
+            existingLabelNames = listOf("Home", "Work"),
+        )
+        assertIs<RenameSaveAction.CollapseOnly>(action)
+    }
+
+    @Test
+    fun `name matching another existing label is a duplicate`() {
+        val action = resolveRenameSaveAction(
+            typedName = "home",
+            currentName = "Work",
+            existingLabelNames = listOf("Home", "Work"),
+        )
+        val duplicate = assertIs<RenameSaveAction.Duplicate>(action)
+        assertEquals("home", duplicate.cleanedName)
+    }
+
+    @Test
+    fun `case-only change against the row's own current name is not a duplicate`() {
+        // "work" vs current "Work" fails the case-sensitive unchanged-check, so it's
+        // a real edit — and it must not be blocked as colliding with itself.
+        val action = resolveRenameSaveAction(
+            typedName = "  work  ",
+            currentName = "Work",
+            existingLabelNames = listOf("Home", "Work"),
+        )
+        val save = assertIs<RenameSaveAction.Save>(action)
+        assertEquals("work", save.trimmedName)
+    }
+
+    @Test
+    fun `genuinely new name resolves to Save with the trimmed value`() {
+        val action = resolveRenameSaveAction(
+            typedName = "  Gym  ",
+            currentName = "Work",
+            existingLabelNames = listOf("Home", "Work"),
+        )
+        val save = assertIs<RenameSaveAction.Save>(action)
+        assertEquals("Gym", save.trimmedName)
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRulesTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopRulesTest.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import kotlinx.collections.immutable.persistentListOf
 import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import kotlin.test.Test
@@ -23,37 +24,62 @@ class SearchStopRulesTest {
         stopId = "stop_central",
         transportModeType = persistentListOf(TransportMode.Train),
     )
+    private val homeUnset = StopLabel(emoji = "🏠", label = "Home")
+    private val homeSet = StopLabel(
+        emoji = "🏠",
+        label = "Home",
+        stopId = "stop_central",
+        stopName = "Central Station",
+    )
 
     @Test
     fun `pill row hidden on fresh Recent state with no recents`() {
-        assertFalse(shouldShowPillRow(ListState.Recent, recentStops = emptyList()))
+        assertFalse(shouldShowPillRow(ListState.Recent, recentStops = emptyList(), stopLabels = listOf(homeSet)))
     }
 
     @Test
-    fun `pill row visible in Recent state once at least one recent exists`() {
-        assertTrue(shouldShowPillRow(ListState.Recent, recentStops = listOf(centralRecent)))
+    fun `pill row visible in Recent state once at least one recent exists and a label is set`() {
+        assertTrue(
+            shouldShowPillRow(ListState.Recent, recentStops = listOf(centralRecent), stopLabels = listOf(homeSet)),
+        )
     }
 
     @Test
     fun `pill row hidden during Results loading with no results yet`() {
         val state = ListState.Results(results = persistentListOf(), isLoading = true)
-        assertFalse(shouldShowPillRow(state, recentStops = listOf(centralRecent)))
+        assertFalse(shouldShowPillRow(state, recentStops = listOf(centralRecent), stopLabels = listOf(homeSet)))
     }
 
     @Test
-    fun `pill row visible when Results state has at least one result`() {
+    fun `pill row visible when Results state has at least one result and a label is set`() {
         val state = ListState.Results(results = persistentListOf(centralResult), isLoading = false)
-        assertTrue(shouldShowPillRow(state, recentStops = emptyList()))
+        assertTrue(shouldShowPillRow(state, recentStops = emptyList(), stopLabels = listOf(homeSet)))
     }
 
     @Test
     fun `pill row hidden in NoMatch state`() {
-        assertFalse(shouldShowPillRow(ListState.NoMatch, recentStops = listOf(centralRecent)))
+        assertFalse(shouldShowPillRow(ListState.NoMatch, recentStops = listOf(centralRecent), stopLabels = listOf(homeSet)))
     }
 
     @Test
     fun `pill row hidden in Error state`() {
-        assertFalse(shouldShowPillRow(ListState.Error, recentStops = listOf(centralRecent)))
+        assertFalse(shouldShowPillRow(ListState.Error, recentStops = listOf(centralRecent), stopLabels = listOf(homeSet)))
+    }
+
+    @Test
+    fun `pill row hidden when no label is set yet, even with recents`() {
+        // Fresh install: Home/Work are seeded but unset. No pills to show, so no
+        // point showing the trailing Manage button either.
+        assertFalse(
+            shouldShowPillRow(ListState.Recent, recentStops = listOf(centralRecent), stopLabels = listOf(homeUnset)),
+        )
+    }
+
+    @Test
+    fun `pill row hidden when stopLabels is empty`() {
+        assertFalse(
+            shouldShowPillRow(ListState.Recent, recentStops = listOf(centralRecent), stopLabels = emptyList()),
+        )
     }
 
     // endregion

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
@@ -16,6 +16,7 @@ import xyz.ksharma.krail.core.testing.fakes.FakeSandook
 import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
 import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.trip.planner.ui.components.LABEL_NAME_MAX_LENGTH
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
@@ -351,6 +352,29 @@ class SearchStopViewModelLabelHandlersTest {
 
                 val state = expectMostRecentItem()
                 assertNotNull(state.stopLabels.firstOrNull { it.label == "Garage" })
+            }
+        }
+
+    @Test
+    fun `Given name longer than the max length When CreateLabel fires Then name is truncated`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                // Defense in depth: the TextField already caps input at
+                // LABEL_NAME_MAX_LENGTH, but the VM must enforce it independently
+                // for any caller that skips the UI.
+                val tooLong = "A".repeat(LABEL_NAME_MAX_LENGTH + 10)
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = tooLong, emoji = "🚗"))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                val stored = state.stopLabels.firstOrNull { it.label.startsWith("A") }
+                assertNotNull(stored)
+                assertTrue(stored.label.length <= LABEL_NAME_MAX_LENGTH)
+
+                val rows = fakeSandook.observeStopLabels().first()
+                assertTrue(rows.all { it.label.length <= LABEL_NAME_MAX_LENGTH })
             }
         }
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/Button.kt
@@ -285,6 +285,11 @@ private fun buttonTextStyle(dimensions: ButtonDimensions) =
         ButtonDefaults.smallButtonSize() -> KrailTheme.typography.titleSmall
         ButtonDefaults.mediumButtonSize() -> KrailTheme.typography.titleMedium
         ButtonDefaults.largeButtonSize() -> KrailTheme.typography.titleLarge
+        // chipButtonSize()'s own doc says it matches "the existing pill geometry...
+        // Home / Work / set + unset label pills" — those pills render at labelLarge
+        // (20sp line-height), not titleSmall (18sp). Falling through to the titleSmall
+        // default here was the actual bug behind the height mismatch.
+        ButtonDefaults.chipButtonSize() -> KrailTheme.typography.labelLarge
         else -> KrailTheme.typography.titleSmall
     }
 


### PR DESCRIPTION
## Summary

Follow-up polish on the stop-label assign/manage flow shipped in #1699:

- **Label name max length**: capped at 20 chars (`LABEL_NAME_MAX_LENGTH`), enforced both at the `TextField` (`maxLength`) and inside `normaliseLabelName` itself — the latter is the actual DB-write path (`CreateLabel`/`RenameLabel` call it before persisting), so the cap holds even for a caller that skips the UI.
- **`ManageStopLabelRow`'s rename field** was missing the emoji/punctuation keystroke filter that `AssignNewLabelSheet` already had; both now share one `filterLabelNameInput` function instead of two copies of the same predicate.
- **Manage button no longer shows when no label is set yet**. `shouldShowPillRow` only checked `recentStops`/results existence, not whether any label was actually set — since Home/Work are always seeded (unset) on install, `stopLabels` was never empty, so a fresh install showed a floating "Manage" button with no pills next to it.
- **Manage button height mismatch fixed**: `chipButtonSize()`'s text style was silently falling through to `titleSmall` (18sp line-height) instead of `labelLarge` (20sp) that the pills use — the 2sp gap was the visible height mismatch. `chipButtonSize()`'s own doc comment already said it should match pill geometry; `buttonTextStyle()`'s mapping just never had a case for it.
- Fully-qualified `Text(` call in `StopLabelAssignRow.kt` replaced with a proper import.

## Also investigated (no change needed)

**Spaces in label names**: confirmed safe. `StopLabels.label` is `TEXT NOT NULL PRIMARY KEY`; SQLite/SQLDelight handles UTF-8 and spaces natively, all queries use bound params (no injection surface), and matching is exact-string throughout. The only real risk was normalization consistency, which #1699 already fixed.

## Refactor note

Adding the keystroke filter to `ManageStopLabelRow`'s rename field pushed `ExpandedRenameContent` over the `CyclomaticComplexMethod` threshold. Extracted the Save-button branching into a pure `resolveRenameSaveAction` function (own unit test file) rather than suppressing — per project convention, zero tolerance on suppressing that rule.

## Test plan

- [x] `./gradlew :feature:trip-planner:ui:testAndroidHostTest :feature:track:ui:testAndroidHostTest :taj:testAndroidHostTest --continue` green
- [x] `./gradlew detekt --continue` green, no auto-corrects needed
- [x] Manual: type an over-length / emoji-heavy label name in both Assign and Manage-rename flows, confirm capped/filtered live
- [x] Manual: fresh install (or clear all label assignments) — confirm no floating Manage button until a label is actually set
- [x] Manual: eyeball Manage button vs pill height side by side
