### PR TITLE
feat(trip-planner): walking-leg pin rows, footpath-info experiment, On Demand mode

### DIFF
--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/TransportMode.kt
@@ -52,10 +52,23 @@ sealed class TransportMode(
         displayName = "School Bus",
     )
 
+    // NSW's on-demand / flexible-zone shuttle service (e.g. "The Ponds" DRT zone) — a real
+    // booked vehicle leg, not a footpath. Own color+letter since it isn't a fixed-route bus.
+    @Serializable object OnDemand : TransportMode(
+        colorCode = "#8E6E53",
+        name = "On Demand",
+        productClass = 10,
+        priority = 8,
+        searchPriority = 8,
+        displayName = "On Demand",
+    )
+
     companion object {
         const val SCHOOL_BUS_PRODUCT_CLASS = 11
 
-        val all: List<TransportMode> by lazy { listOf(Train, Metro, Bus, LightRail, Ferry, Coach, SchoolBus) }
+        val all: List<TransportMode> by lazy {
+            listOf(Train, Metro, Bus, LightRail, Ferry, Coach, SchoolBus, OnDemand)
+        }
 
         private val byProductClass: Map<Int, TransportMode> by lazy { all.associateBy { it.productClass } }
 

--- a/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/ModeSurfaceEligibility.kt
+++ b/core/transport/src/commonMain/kotlin/xyz/ksharma/krail/core/transport/nsw/ModeSurfaceEligibility.kt
@@ -14,6 +14,8 @@ internal fun TransportMode.isAvailableOn(surface: ModeSelectionSurface): Boolean
     when (this) {
         // School Bus is a real mode for trip planning, but never a stop type you pick on the map.
         TransportMode.SchoolBus -> surface == ModeSelectionSurface.TRIP_PLANNER
+        // On Demand shuttles are booked per-trip, not a fixed stop you'd filter nearby stops by.
+        TransportMode.OnDemand -> surface == ModeSelectionSurface.TRIP_PLANNER
         TransportMode.Train,
         TransportMode.Metro,
         TransportMode.Bus,

--- a/docs/investigations/ADDRESS_ORIGIN_TRIP_INVESTIGATION.md
+++ b/docs/investigations/ADDRESS_ORIGIN_TRIP_INVESTIGATION.md
@@ -158,3 +158,43 @@ Confirm which of the above (or something else) is the actual client-side
 break — needs stepping through the real selection → navigation →
 `TimeTableViewModel` flow with a debugger/logcat rather than more API testing,
 since the API side is now cleared.
+
+Temporary `[ADDR_DEBUG]`-tagged `log(...)` lines were added along the full
+traced path (`SearchStopScreen` selection → `SearchStopEntry` →
+`SavedTripsEntry` → `SavedTripsViewModel` → `RealStopResultsManager` →
+`TripPlannerNavigatorImpl.navigateToTimeTable` → `TimeTableEntry` →
+`TimeTableViewModel.initializeTrip/onLoadTimeTable/fetchTrip/loadTrip` →
+`TripResponseMapper.buildJourneyListWithRawData`, including a per-journey
+reason log when `mapNotNull` drops one). Filter with
+`adb logcat | grep ADDR_DEBUG`. These are throwaway — strip them all before
+this branch is PR-ready, they're only here to catch the live repro.
+
+## BFF hand-off notes (for later — app is NSW-direct only right now)
+
+`BFF_ROLLOUT_ARMED = false` (`core/network/BffEndpointResolver.kt`), so today
+the app always talks to NSW directly regardless of the live `enable_proto_bff`
+RC flag — a developer has to explicitly pick `BFF_LOCAL`/`BFF_PROD` in Debug
+Config to route through the BFF at all. Everything in this doc was tested and
+confirmed against the NSW-direct path only. When BFF integration for trip
+planning is picked back up, whoever does that work needs to know:
+
+- **The BFF must resolve `stop_finder`-sourced location IDs, not just GTFS
+  stop IDs.** This doc confirms NSW itself resolves `streetID:...` (address),
+  `poiID:...` (POI), and street-only IDs under `type_origin=any` /
+  `type_destination=any` with zero special-casing. If the BFF's trip-plan
+  endpoint (proto or JSON pass-through) only recognizes real GTFS stop IDs,
+  address/POI search (issue #1697) will silently break the moment BFF routing
+  is armed for any cohort — this needs an explicit test pass against the BFF
+  before rollout, not an assumption that "it already works against NSW so
+  it'll work against BFF."
+- **Walk-leg polyline (`coords`) must round-trip through the BFF too.**
+  Confirmed present in the NSW-direct JSON and already deserialized into
+  `TripResponse.Leg.coords`. If the BFF's proto `JourneyList` schema
+  (`journeyListToTripResponse` mapper) doesn't carry an equivalent field,
+  JourneyMap will regress for walk-first/walk-last journeys once BFF is
+  armed, even though it works fine today.
+- **The raw address/coord ID formats aren't validated or sanitized anywhere**
+  client-side (see the full trace above) — they're passed straight through
+  as opaque strings. Any BFF-side ID parsing/validation needs to tolerate the
+  same shapes NSW does: plain stop IDs, `streetID:...`, `poiID:...`, and
+  (separately, for current-location) `<lon>:<lat>:EPSG:4326` coords.

--- a/feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/RealGtfsRealtimeRepository.kt
+++ b/feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/RealGtfsRealtimeRepository.kt
@@ -218,6 +218,8 @@ internal class RealGtfsRealtimeRepository(
         TransportMode.SchoolBus -> listOf("buses")
         TransportMode.Ferry -> listOf("ferries/sydneyferries", "ferries/MFF")
         TransportMode.Coach -> emptyList()
+        // Booked on-demand shuttles have no GTFS-realtime feed to poll.
+        TransportMode.OnDemand -> emptyList()
     }
 
     private fun logPollStart(departureAest: String, startDate: String) {

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/model/TripResponseExt.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/model/TripResponseExt.kt
@@ -12,6 +12,14 @@ fun TripResponse.Leg.isWalkingLeg(): Boolean =
     transportation?.product?.productClass == WALKING_LEG_PRODUCT_CLASS ||
         transportation?.product?.productClass == INTERCHANGE_LEG_PRODUCT_CLASS
 
+private val ADDRESS_LOCATION_TYPES = setOf("poi", "singlehouse", "street")
+
+/**
+ * True when [TripResponse.StopSequence.type] is a searched address/POI rather than a transit
+ * stop or platform - see the full value list documented on that field.
+ */
+fun TripResponse.StopSequence.isAddressLocation(): Boolean = type in ADDRESS_LOCATION_TYPES
+
 /**
  * Difference in whole minutes between estimated and planned departure (estimated − planned).
  * Positive = late, negative = early, zero = on time, null = no realtime data.

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -144,6 +144,16 @@ data class TimeTableState(
         sealed class Leg {
             data class WalkingLeg(
                 val duration: String, // "10mins"
+
+                // Set only when this is the journey's very first leg AND its origin is a
+                // searched address (not a transit stop) - e.g. "123 Example St". Drives the
+                // "pin row" shown above the walk row.
+                val originPinName: String? = null,
+
+                // Set only when this is the journey's very last leg AND its destination is a
+                // searched address (not a transit stop). Drives the "pin row" shown below the
+                // walk row.
+                val destinationPinName: String? = null,
             ) : Leg()
 
             data class TransportLeg(
@@ -173,6 +183,10 @@ data class TimeTableState(
                 /** True when the leg's product class is 11 (School Bus). Rendered as a bus leg
                  *  with a "School service" tag so users know the service is not public. */
                 val isSchoolBus: Boolean = false,
+
+                /** True when the leg's product class is 10 (NSW on-demand/flexible-zone
+                 *  shuttle). Rendered with an "On Demand" tag next to the mode icon. */
+                val isOnDemand: Boolean = false,
             ) : Leg()
         }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -59,6 +59,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.icons.rememberShareIconPainter
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
+import xyz.ksharma.krail.taj.theme.KrailDimensions
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.pastDepartureTextStyle
@@ -317,68 +318,94 @@ fun ExpandedJourneyCardContent(
         )
 
         legList.forEachIndexed { index, leg ->
-            when (leg) {
-                is TimeTableState.JourneyCardInfo.Leg.WalkingLeg -> {
+            JourneyLegItem(leg = leg, index = index, legList = legList, dim = dim, onLegClick = onLegClick)
+        }
+    }
+}
+
+/** Renders a single leg row: a [WalkingLeg] (standalone or interchange-attached) or a [LegView]. */
+@Composable
+private fun JourneyLegItem(
+    leg: TimeTableState.JourneyCardInfo.Leg,
+    index: Int,
+    legList: ImmutableList<TimeTableState.JourneyCardInfo.Leg>,
+    dim: KrailDimensions,
+    onLegClick: (expanded: Boolean, transportMode: String, lineName: String) -> Unit,
+) {
+    when (leg) {
+        is TimeTableState.JourneyCardInfo.Leg.WalkingLeg -> {
+            // A pin row (address) adds a distinct piece of info above/below the walk
+            // text - give this leg more room against the neighboring LegView than a
+            // plain transfer walk gets.
+            val hasPinRow = leg.originPinName != null || leg.destinationPinName != null
+            WalkingLeg(
+                duration = leg.duration,
+                originPinName = leg.originPinName,
+                destinationPinName = leg.destinationPinName,
+                drawConnectorLine = true,
+                modifier = Modifier.padding(
+                    vertical = if (hasPinRow) dim.spacingL else dim.spacingM,
+                    horizontal = dim.spacingXXS,
+                ),
+            )
+        }
+
+        is TimeTableState.JourneyCardInfo.Leg.TransportLeg -> {
+            val interchange = leg.walkInterchange
+            if (interchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.BEFORE) {
+                interchange.duration.let { duration ->
                     WalkingLeg(
-                        duration = leg.duration,
-                        modifier = Modifier
-                            .padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
+                        duration = duration,
+                        drawConnectorLine = true,
+                        modifier = Modifier.padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
                     )
                 }
+            }
 
-                is TimeTableState.JourneyCardInfo.Leg.TransportLeg -> {
-                    if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.BEFORE) {
-                        leg.walkInterchange?.duration?.let { duration ->
-                            WalkingLeg(
-                                duration = duration,
-                                modifier = Modifier.padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
+            if (interchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.IDEST) {
+                interchange.duration.let { duration ->
+                    WalkingLeg(
+                        duration = duration,
+                        drawConnectorLine = true,
+                        modifier = Modifier.padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
+                    )
+                }
+            } else {
+                var displayAllStops by rememberSaveable { mutableStateOf(false) }
+                LegView(
+                    routeText = leg.displayText,
+                    transportModeLine = leg.transportModeLine,
+                    stops = leg.stops,
+                    displayAllStops = displayAllStops,
+                    isSchoolBus = leg.isSchoolBus,
+                    isOnDemand = leg.isOnDemand,
+                    modifier = Modifier.padding(
+                        top = if (index > 0) {
+                            getPaddingValue(
+                                lastLeg = legList[(index - 1).coerceAtLeast(0)],
                             )
-                        }
-                    }
-
-                    if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.IDEST) {
-                        leg.walkInterchange?.duration?.let { duration ->
-                            WalkingLeg(
-                                duration = duration,
-                                modifier = Modifier.padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
-                            )
-                        }
-                    } else {
-                        var displayAllStops by rememberSaveable { mutableStateOf(false) }
-                        LegView(
-                            routeText = leg.displayText,
-                            transportModeLine = leg.transportModeLine,
-                            stops = leg.stops,
-                            displayAllStops = displayAllStops,
-                            isSchoolBus = leg.isSchoolBus,
-                            modifier = Modifier.padding(
-                                top = if (index > 0) {
-                                    getPaddingValue(
-                                        lastLeg = legList[(index - 1).coerceAtLeast(0)],
-                                    )
-                                } else {
-                                    0.dp
-                                },
-                            ),
-                            onClick = {
-                                displayAllStops = !displayAllStops
-                                onLegClick(
-                                    displayAllStops,
-                                    leg.transportModeLine.transportMode.name,
-                                    leg.transportModeLine.lineName,
-                                )
-                            },
+                        } else {
+                            0.dp
+                        },
+                    ),
+                    onClick = {
+                        displayAllStops = !displayAllStops
+                        onLegClick(
+                            displayAllStops,
+                            leg.transportModeLine.transportMode.name,
+                            leg.transportModeLine.lineName,
                         )
-                    }
+                    },
+                )
+            }
 
-                    if (leg.walkInterchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.AFTER) {
-                        leg.walkInterchange?.duration?.let { duration ->
-                            WalkingLeg(
-                                duration = duration,
-                                modifier = Modifier.padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
-                            )
-                        }
-                    }
+            if (interchange?.position == TimeTableState.JourneyCardInfo.WalkPosition.AFTER) {
+                interchange.duration.let { duration ->
+                    WalkingLeg(
+                        duration = duration,
+                        drawConnectorLine = true,
+                        modifier = Modifier.padding(vertical = dim.spacingM, horizontal = dim.spacingXXS),
+                    )
                 }
             }
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/LegView.kt
@@ -61,6 +61,7 @@ fun LegView(
     modifier: Modifier = Modifier,
     displayAllStops: Boolean = false,
     isSchoolBus: Boolean = false,
+    isOnDemand: Boolean = false,
     onClick: () -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
@@ -68,6 +69,13 @@ fun LegView(
     val strokeWidth = dim.journeyLegStrokeWidth
     val timelineColor =
         remember(transportModeLine) { transportModeLine.lineColorCode.hexToComposeColor() }
+    // Same icon as their base mode (Bus / On Demand's own color) — differentiated by this
+    // label next to the mode icon, mirroring the "School Bus" tag pattern.
+    val modeLabel = when {
+        isSchoolBus -> "School Bus"
+        isOnDemand -> "On Demand"
+        else -> null
+    }
 
     // Content alpha to be 100% always, as it's only visible in the expanded state.
     // If it's visible, it should be full alpha
@@ -138,15 +146,21 @@ fun LegView(
                         StopsRow(
                             stops = "$stopsCount stops",
                             line = transportModeLine,
-                            isSchoolBus = isSchoolBus,
+                            modeLabel = modeLabel,
                             onClick = {
                                 onClick()
                             },
                         )
                     } else {
-                        TransportModeInfo(
-                            transportMode = transportModeLine.transportMode,
-                        )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            TransportModeInfo(
+                                transportMode = transportModeLine.transportMode,
+                            )
+                            modeLabel?.let { ModeLabelText(it) }
+                        }
                     }
                 }
 
@@ -316,7 +330,7 @@ private fun StopsRow(
     stops: String,
     line: TransportModeLine,
     modifier: Modifier = Modifier,
-    isSchoolBus: Boolean = false,
+    modeLabel: String? = null,
     onClick: () -> Unit,
 ) {
     val dim = KrailTheme.dimensions
@@ -346,14 +360,18 @@ private fun StopsRow(
             modifier = Modifier.align(Alignment.CenterVertically),
         )
 
-        if (isSchoolBus) {
-            Text(
-                text = "School Bus",
-                style = KrailTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
-                color = KrailTheme.colors.onSurface,
-            )
-        }
+        modeLabel?.let { ModeLabelText(it) }
     }
+}
+
+@Composable
+private fun ModeLabelText(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = KrailTheme.typography.bodySmall.copy(fontWeight = FontWeight.SemiBold),
+        color = KrailTheme.colors.onSurface,
+        modifier = modifier,
+    )
 }
 
 // region Previews

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TimelineModifiers.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TimelineModifiers.kt
@@ -4,8 +4,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 
 /**
  * Draws a vertical line and a circle at the top start of the composable,
@@ -109,6 +112,39 @@ internal fun Modifier.timeLineCenterWithStop(
             color = circleColor,
             radius = circleRadius.toPx(),
             center = Offset(0f, this.size.height / 2),
+        )
+    }
+}
+
+private val DASH_LENGTH = 4.dp
+private val DASH_GAP = 4.dp
+
+private fun DrawScope.dashEffect(): PathEffect = PathEffect.dashPathEffect(
+    intervals = floatArrayOf(DASH_LENGTH.toPx(), DASH_GAP.toPx()),
+    phase = 0f,
+)
+
+/**
+ * Dashed vertical line through the full height of the composable - the "informal segment"
+ * equivalent of [timeLineCenter], used to connect a walking leg row to the LegView cards
+ * above/below it (or to bridge the gap between two rows of the same walking leg). Dashed (vs
+ * the solid, mode-colored line used between scheduled stops) signals "you're walking, not
+ * riding a scheduled service", matching the convention used by Google Maps/Citymapper.
+ *
+ * @param xOffset Horizontal offset of the line from this composable's own left edge - use this
+ * (rather than a nested `.padding(start = ...)`) when the composable draws the full-height line
+ * itself instead of relying on an ancestor's padding to position it, as [LegView]'s stop rows do.
+ */
+internal fun Modifier.dashedTimeLine(color: Color, strokeWidth: Dp, xOffset: Dp = 0.dp): Modifier {
+    return this.drawBehind {
+        val x = xOffset.toPx()
+        drawLine(
+            color = color,
+            start = Offset(x = x, y = 0f),
+            end = Offset(x = x, y = this.size.height),
+            strokeWidth = strokeWidth.toPx(),
+            cap = StrokeCap.Round,
+            pathEffect = dashEffect(),
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
@@ -3,16 +3,26 @@ package xyz.ksharma.krail.trip.planner.ui.components
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_location_on
 import krail.feature.trip_planner.ui.generated.resources.ic_walk
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentAlpha
@@ -24,30 +34,135 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
 fun WalkingLeg(
     duration: String,
     modifier: Modifier = Modifier,
+    originPinName: String? = null,
+    destinationPinName: String? = null,
+    // Off by default: the offset below is tuned to JourneyCard's LegView geometry
+    // (card padding + inner column start padding). Only JourneyCard's call sites opt in;
+    // TrackTripScreen uses its own timeline geometry and would misalign if this defaulted on.
+    drawConnectorLine: Boolean = false,
 ) {
     val dim = KrailTheme.dimensions
     val density = LocalDensity.current
     // todo can be reusable logic for consistent icon size
     val iconSize = with(density) { 18.sp.toDp() }
     val contentAlpha = LocalContentAlpha.current
-    Row(
+
+    // Aligns with LegView's own timeline x-position (card padding + inner column start
+    // padding), minus this composable's own horizontal padding (applied by the caller).
+    val lineOffset = dim.spacingL + dim.spacingXS - dim.spacingXXS
+
+    // Gap from the line to the icon - matches LegView's StopInfo, which sits spacingXL after
+    // its own timeline dot.
+    val contentStart = lineOffset + dim.spacingXL
+
+    val lineColor = KrailTheme.colors.onSurface.copy(alpha = contentAlpha * DASHED_LINE_ALPHA)
+    val strokeWidth = dim.journeyLegStrokeWidth
+
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .background(color = KrailTheme.colors.surface),
-        verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
-        Image(
-            painter = painterResource(Res.drawable.ic_walk),
-            contentDescription = null,
-            colorFilter = ColorFilter.tint(
-                color = KrailTheme.colors.onSurface.copy(alpha = contentAlpha),
-            ),
-            modifier = Modifier.size(iconSize),
-        )
-        Text("Walk $duration", style = KrailTheme.typography.bodyLarge)
+        if (originPinName != null) {
+            PinRow(
+                name = originPinName,
+                iconSize = iconSize,
+                lineOffset = lineOffset,
+                textStart = contentStart,
+            )
+            Spacer(modifier = Modifier.height(PIN_ICON_GAP))
+        }
+
+        // The connector gap (above/below, when a pin is present) and the walk row are drawn
+        // as ONE continuous dashed line rather than 2-3 separately-phased segments. Each
+        // dashedTimeLine call restarts its dash pattern at phase 0, so stitching independent
+        // segments together left a visible extra dot wherever two fresh phase-0 starts landed
+        // close to each other at a segment boundary - a single drawBehind spanning the whole
+        // block has no such seam.
+        Column(
+            modifier = if (drawConnectorLine) {
+                Modifier.dashedTimeLine(lineColor, strokeWidth, xOffset = lineOffset)
+            } else {
+                Modifier
+            },
+        ) {
+            if (originPinName != null) {
+                Spacer(modifier = Modifier.height(CONNECTOR_GAP_HEIGHT))
+            }
+
+            Row(
+                modifier = Modifier.padding(start = contentStart),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
+            ) {
+                Image(
+                    painter = painterResource(Res.drawable.ic_walk),
+                    contentDescription = null,
+                    colorFilter = ColorFilter.tint(
+                        color = KrailTheme.colors.onSurface.copy(alpha = contentAlpha),
+                    ),
+                    modifier = Modifier.size(iconSize),
+                )
+                Text("Walk $duration", style = KrailTheme.typography.bodyLarge)
+            }
+
+            if (destinationPinName != null) {
+                Spacer(modifier = Modifier.height(CONNECTOR_GAP_HEIGHT))
+            }
+        }
+
+        if (destinationPinName != null) {
+            Spacer(modifier = Modifier.height(PIN_ICON_GAP))
+            PinRow(
+                name = destinationPinName,
+                iconSize = iconSize,
+                lineOffset = lineOffset,
+                textStart = contentStart,
+            )
+        }
     }
 }
+
+/**
+ * An address row whose pin icon sits exactly on the timeline (at [lineOffset]) - the icon *is*
+ * the line's marker, the same way LegView's solid dot marks where its own line starts/ends. No
+ * line is drawn through this row itself: see [PIN_ICON_GAP] and the surrounding blank [Spacer]s
+ * for why the dashes stay entirely outside the icon's own bounding box.
+ * The address text is offset further right (at [textStart]), matching LegView's StopInfo text.
+ */
+@Composable
+private fun PinRow(name: String, iconSize: Dp, lineOffset: Dp, textStart: Dp) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(modifier = Modifier.width(lineOffset - iconSize / 2))
+        Image(
+            painter = painterResource(Res.drawable.ic_location_on),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(color = KrailTheme.colors.onSurface),
+            modifier = Modifier.size(iconSize),
+        )
+        Spacer(modifier = Modifier.width(textStart - lineOffset - iconSize / 2))
+        Text(
+            text = name,
+            style = KrailTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+            color = KrailTheme.colors.onSurface,
+        )
+    }
+}
+
+private const val DASHED_LINE_ALPHA = 0.6f
+
+// Visible breathing room between the icon's own bounding box and the first/last dash.
+// ic_location_on.xml's ink fills almost the whole box (path spans y=2..22 of a 24 viewBox),
+// so a line endpoint anywhere *inside* iconSize/2 is fully hidden under the icon and produces
+// no visible gap - the gap only appears once the line stops *past* the box edge.
+private val PIN_ICON_GAP = 6.dp
+
+// Height of the spacer between the "Walk" text row and a PinRow's stop name - dashedTimeLine
+// on this spacer keeps the connector line continuous through the extra space.
+private val CONNECTOR_GAP_HEIGHT = 20.dp
 
 // @ScreenshotTest disabled: missing baseline (recording timed out, see README)
 @Preview
@@ -55,5 +170,18 @@ fun WalkingLeg(
 private fun PreviewWalkingLeg() {
     PreviewTheme {
         WalkingLeg("5 mins")
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewWalkingLegWithPins() {
+    PreviewTheme {
+        WalkingLeg(
+            duration = "5 mins",
+            originPinName = "123 Example St, Sydney",
+            destinationPinName = "Sydney Opera House",
+            drawConnectorLine = true,
+        )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -155,20 +155,28 @@ val viewModelsModule = module {
 
     viewModel {
         val isDebug = get<AppInfoProvider>().getAppInfo().isDebug
-        val addressSearchDebugOverride = when {
-            isDebug -> get<DebugNetworkConfigStore>().state.value.addressSearchEnabled
-            else -> get<Flag>().getFlagValue(FlagKeys.SEARCH_STOP_ADDRESS_SEARCH_ENABLED.key).asBoolean(false)
+        val debugNetworkConfigStore = get<DebugNetworkConfigStore>()
+        val flag = get<Flag>()
+        // Read live, not once: the debug toggle can flip while this ViewModel is
+        // already alive (Debug Settings -> back, same nav entry), so a snapshot
+        // Boolean captured at construction time would silently stay stale forever.
+        val isAddressSearchEnabled = {
+            if (isDebug) {
+                debugNetworkConfigStore.state.value.addressSearchEnabled
+            } else {
+                flag.getFlagValue(FlagKeys.SEARCH_STOP_ADDRESS_SEARCH_ENABLED.key).asBoolean(false)
+            }
         }
         SearchStopViewModel(
             analytics = get(),
             stopResultsManager = get(),
             remoteAddressResultsManager = get(),
             nearbyStopsManager = get(),
-            flag = get(),
+            flag = flag,
             ioDispatcher = get(named(IODispatcher)),
             preferences = get(),
             sandook = get(),
-            addressSearchDebugOverride = addressSearchDebugOverride,
+            isAddressSearchEnabled = isAddressSearchEnabled,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -348,7 +348,13 @@ class RealStopResultsManager(
     }
 
     private fun saveRecentSearchStop(stopItem: StopItem) {
-        sandook.insertOrReplaceRecentSearchStop(stopId = stopItem.stopId)
+        // Temporary safety net while investigating whether the FK constraint on
+        // RecentSearchStops(stopId -> NswStops.stopId) is actually enforced for non-GTFS
+        // (address/POI) stopIds on this platform's driver - swallow rather than let an
+        // unexpected DB exception take down the selection flow.
+        runCatching {
+            sandook.insertOrReplaceRecentSearchStop(stopId = stopItem.stopId)
+        }
     }
 
     override fun clearRecentSearchStops() {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -56,7 +56,7 @@ class SearchStopViewModel(
     private val ioDispatcher: CoroutineDispatcher,
     private val preferences: SandookPreferences,
     private val sandook: Sandook,
-    private val addressSearchDebugOverride: Boolean = false,
+    private val isAddressSearchEnabled: () -> Boolean = { false },
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SearchStopState> = MutableStateFlow(SearchStopState())
@@ -476,7 +476,7 @@ class SearchStopViewModel(
 
     private fun onAddressSearchTextChanged(query: String) {
         addressSearchJob?.cancel()
-        if (!addressSearchDebugOverride) {
+        if (!isAddressSearchEnabled()) {
             updateUiState { copy(addressResults = persistentListOf(), isAddressSearchLoading = false) }
             return
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapper.kt
@@ -14,15 +14,46 @@ import kotlin.time.ExperimentalTime
 /**
  * Builds a [TimeTableState.JourneyCardInfo.Leg.WalkingLeg] for a walking leg, or null when the
  * walking leg has no display duration or its footpath info is redundant.
+ *
+ * [isFirstLeg]/[isLastLeg] identify this leg's position in the journey's raw leg list - the
+ * true first-mile (origin) and last-mile (destination) walk legs get a "pin row" name so the
+ * rider always knows exactly where they're walking from/to, whether that endpoint is a
+ * searched address or a named transit stop (e.g. "Town Hall Station") - a rider unfamiliar
+ * with the city shouldn't be left guessing where the final walk leads just because the
+ * destination happens to be a stop rather than a street address.
+ *
+ * EXPERIMENT (see WalkingLeg.kt pin-row work): NSW flags some first/last-mile footpath legs
+ * `footPathInfoRedundant = true` (e.g. Town Hall Station -> QVB, Stand C), which previously
+ * dropped the leg entirely - even though it's the only text telling the rider they need to
+ * walk before boarding. Ignoring the redundant flag for first/last legs surfaces that info;
+ * interior/interchange legs still respect it, since those are genuinely covered elsewhere.
+ * Revert to `footPathInfoRedundant != true` (drop the `isFirstLeg || isLastLeg` clause) if
+ * this turns out noisier than useful.
  */
 @OptIn(ExperimentalTime::class)
-internal fun TripResponse.Leg.toWalkingLegUiModel(): TimeTableState.JourneyCardInfo.Leg? {
+internal fun TripResponse.Leg.toWalkingLegUiModel(
+    isFirstLeg: Boolean = false,
+    isLastLeg: Boolean = false,
+): TimeTableState.JourneyCardInfo.Leg? {
     // BFF proto path ships a render-ready duration string; the NSW JSON path
     // derives it from duration seconds / dep-arr times.
     val displayDuration = bffDisplayDuration
         ?: resolveDurationSeconds()?.seconds?.toFormattedDurationTimeString()
-    return if (displayDuration != null && footPathInfoRedundant != true) {
-        TimeTableState.JourneyCardInfo.Leg.WalkingLeg(duration = displayDuration)
+    val footPathInfoShown = footPathInfoRedundant != true || isFirstLeg || isLastLeg
+    return if (displayDuration != null && footPathInfoShown) {
+        TimeTableState.JourneyCardInfo.Leg.WalkingLeg(
+            duration = displayDuration,
+            originPinName = if (isFirstLeg) {
+                origin?.disassembledName ?: origin?.name
+            } else {
+                null
+            },
+            destinationPinName = if (isLastLeg) {
+                destination?.disassembledName ?: destination?.name
+            } else {
+                null
+            },
+        )
     } else {
         null
     }
@@ -39,6 +70,7 @@ internal fun TripResponse.Leg.toTransportLegUiModel(): TimeTableState.JourneyCar
     val isSchoolBus = rawProductClass == TransportMode.SCHOOL_BUS_PRODUCT_CLASS
     val transportMode = rawProductClass
         ?.let { NswTransportConfig.modeFromProductClass(productClass = it) }
+    val isOnDemand = transportMode is TransportMode.OnDemand
     val lineName = transportation?.disassembledName
     val displayText = NswTransportConfig.resolveServiceDisplayText(
         productClass = transportation?.product?.productClass?.toInt(),
@@ -72,11 +104,13 @@ internal fun TripResponse.Leg.toTransportLegUiModel(): TimeTableState.JourneyCar
         stops = stops,
         serviceAlertList = alerts,
         walkInterchange = footPathInfo?.firstOrNull()?.run {
-            duration?.seconds?.toFormattedDurationTimeString()
-                ?.let { formattedDuration -> toWalkInterchange(formattedDuration) }
+            duration?.seconds?.toFormattedDurationTimeString()?.let { formattedDuration ->
+                toWalkInterchange(formattedDuration)
+            }
         },
         tripId = transportation?.id + transportation?.properties?.realtimeTripId,
         transportationId = transportation?.id,
         isSchoolBus = isSchoolBus,
+        isOnDemand = isOnDemand,
     )
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapper.kt
@@ -34,7 +34,6 @@ internal fun TripResponse.buildJourneyList(): ImmutableList<TimeTableState.Journ
 internal fun TripResponse.buildJourneyListWithRawData():
     Pair<ImmutableList<TimeTableState.JourneyCardInfo>?, Map<String, TripResponse.Journey>> {
     val rawDataMap = mutableMapOf<String, TripResponse.Journey>()
-
     val journeyList = journeys?.mapNotNull { journey ->
         val firstPublicTransportLeg = journey.getFirstPublicTransportLeg()
         val lastPublicTransportLeg = journey.getLastPublicTransportLeg()
@@ -53,11 +52,15 @@ internal fun TripResponse.buildJourneyListWithRawData():
         ) {
             // A walking leg consists of walking leg
             // + footpath info from public transport leg (if footPathInfoRedundant is true)
-            val totalWalkingDuration = legs.sumOf { leg ->
-                if (leg.isWalkingLeg() && leg.footPathInfoRedundant != true) {
-                    leg.duration ?: 0L
+            // EXPERIMENT: mirrors toWalkingLegUiModel's isFirstLeg/isLastLeg override - a
+            // redundant-flagged first/last-mile walk is now shown, so it should count towards
+            // the total too. See TripResponseLegMapper.kt for the revert note.
+            val totalWalkingDuration = legs.foldIndexed(0L) { index, acc, leg ->
+                val isFirstOrLastLeg = index == 0 || index == legs.lastIndex
+                if (leg.isWalkingLeg() && (leg.footPathInfoRedundant != true || isFirstOrLastLeg)) {
+                    acc + (leg.duration ?: 0L)
                 } else {
-                    0L
+                    acc
                 }
             }
 
@@ -88,7 +91,6 @@ internal fun TripResponse.buildJourneyListWithRawData():
                 departureDeviation = firstPublicTransportLeg.getDepartureDeviation(),
                 scheduledOriginTime = firstPublicTransportLeg.getScheduledOriginTime(),
             ).also {
-                log("\tJourneyId: ${it.journeyId}")
                 // Store raw journey data for map visualization
                 rawDataMap[it.journeyId] = journey
             }
@@ -96,9 +98,9 @@ internal fun TripResponse.buildJourneyListWithRawData():
             null
         }
     }?.toImmutableList()
-
     return Pair(journeyList, rawDataMap)
 }
+
 private fun TripResponse.Journey.getFirstPublicTransportLeg() = legs?.firstOrNull { leg ->
     !leg.isWalkingLeg()
 }
@@ -223,15 +225,24 @@ private fun List<TripResponse.Leg>.getTransportModeLines() = mapNotNull { leg ->
     }
 }.toImmutableList()
 
-private fun List<TripResponse.Leg>.getLegsList() = mapNotNull { it.toUiModel() }.toImmutableList()
+private fun List<TripResponse.Leg>.getLegsList() = mapIndexedNotNull { index, leg ->
+    leg.toUiModel(isFirstLeg = index == 0, isLastLeg = index == lastIndex)
+}.toImmutableList()
 
 @OptIn(ExperimentalTime::class)
 private fun String.getTimeText() = toDepartureRelativeString()
 
-private fun TripResponse.Leg.toUiModel(): TimeTableState.JourneyCardInfo.Leg? =
+private fun TripResponse.Leg.toUiModel(
+    isFirstLeg: Boolean = false,
+    isLastLeg: Boolean = false,
+): TimeTableState.JourneyCardInfo.Leg? =
     // Walking Leg - Always check before public transport leg. Both builders compute their
     // own fields from this leg; see TripResponseLegMapper.kt.
-    if (isWalkingLeg()) toWalkingLegUiModel() else toTransportLegUiModel()
+    if (isWalkingLeg()) {
+        toWalkingLegUiModel(isFirstLeg = isFirstLeg, isLastLeg = isLastLeg)
+    } else {
+        toTransportLegUiModel()
+    }
 
 /**
  * Resolves the duration of a leg in seconds.
@@ -263,32 +274,13 @@ internal fun TripResponse.Leg.resolveDurationSeconds(): Long? {
 internal fun TripResponse.FootPathInfo.toWalkInterchange(
     displayDuration: String,
 ): TimeTableState.JourneyCardInfo.WalkInterchange? {
-    return position?.let { position ->
-        when (position) {
-            TimeTableState.JourneyCardInfo.WalkPosition.BEFORE.position -> {
-                TimeTableState.JourneyCardInfo.WalkInterchange(
-                    duration = displayDuration,
-                    position = TimeTableState.JourneyCardInfo.WalkPosition.BEFORE,
-                )
-            }
-
-            TimeTableState.JourneyCardInfo.WalkPosition.AFTER.position -> {
-                TimeTableState.JourneyCardInfo.WalkInterchange(
-                    duration = displayDuration,
-                    position = TimeTableState.JourneyCardInfo.WalkPosition.AFTER,
-                )
-            }
-
-            TimeTableState.JourneyCardInfo.WalkPosition.IDEST.position -> {
-                TimeTableState.JourneyCardInfo.WalkInterchange(
-                    duration = displayDuration,
-                    position = TimeTableState.JourneyCardInfo.WalkPosition.IDEST,
-                )
-            }
-
-            else -> null
-        }
-    }
+    val walkPosition = TimeTableState.JourneyCardInfo.WalkPosition.entries
+        .firstOrNull { it.position == position }
+        ?: return null
+    return TimeTableState.JourneyCardInfo.WalkInterchange(
+        duration = displayDuration,
+        position = walkPosition,
+    )
 }
 
 internal fun TripResponse.StopSequence.toUiModel(): TimeTableState.JourneyCardInfo.Stop? {

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseLegMapperTest.kt
@@ -1,0 +1,197 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable.business
+
+import xyz.ksharma.krail.trip.planner.network.api.model.TripResponse
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests for [TripResponse.Leg.toWalkingLegUiModel].
+ *
+ * Background: this leg only sets a pin-row name (icon + label shown above/below the "Walk"
+ * text) for the true first-mile/last-mile walk of a journey, using [isFirstLeg]/[isLastLeg] to
+ * identify that position. Two behaviours were changed together and both need locking down:
+ *
+ * 1. The pin name used to require the endpoint be a searched address (`origin/destination.type`
+ *    in `poi`/`singlehouse`/`street`). A rider whose destination is a named transit stop (e.g.
+ *    "Town Hall Station") got no pin row at all for the final walk - exactly the case where a
+ *    rider unfamiliar with the city most needs to know where they're walking to. The gate was
+ *    removed: any first/last walking leg gets a pin row, regardless of endpoint type.
+ * 2. NSW flags some first/last-mile footpath legs `footPathInfoRedundant = true` (e.g. Town
+ *    Hall Station -> QVB, Stand C), which previously dropped the leg from the journey card
+ *    entirely - silently omitting the only text telling the rider they need to walk before
+ *    boarding. First/last legs now ignore that flag; interior/interchange legs still respect
+ *    it (see TripResponseLegMapper.kt's kdoc for the revert note if this proves too noisy).
+ */
+class TripResponseLegMapperTest {
+
+    //region pin row name - first/last leg, any endpoint type
+
+    @Test
+    fun `Given first leg with address origin When toWalkingLegUiModel Then originPinName is set`() {
+        val leg = walkingLeg(originType = "street", originName = "123 Example St", originDisassembledName = null)
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true) as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+
+        assertEquals("123 Example St", result?.originPinName)
+    }
+
+    @Test
+    fun `Given first leg with named-stop origin When toWalkingLegUiModel Then originPinName is still set`() {
+        // Regression: previously gated on origin.isAddressLocation(), so a plain transit stop
+        // (type "stop", not an address) got no pin row at all for the first-mile walk.
+        val leg = walkingLeg(originType = "stop", originName = "Town Hall Station", originDisassembledName = null)
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true) as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+
+        assertEquals("Town Hall Station", result?.originPinName)
+    }
+
+    @Test
+    fun `Given last leg with named-stop destination When toWalkingLegUiModel Then destinationPinName is set`() {
+        // The exact reported case: destination is "Town Hall Station" (type "stop"), reached by
+        // a final walk from QVB. Without this, a rider unfamiliar with the city had no on-card
+        // indication of where the last walk actually leads.
+        val leg = walkingLeg(
+            destinationType = "stop",
+            destinationName = "Town Hall Station",
+            destinationDisassembledName = null,
+        )
+
+        val result = leg.toWalkingLegUiModel(isLastLeg = true) as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+
+        assertEquals("Town Hall Station", result?.destinationPinName)
+    }
+
+    @Test
+    fun `Given interior leg When toWalkingLegUiModel Then neither pin name is set`() {
+        // A walking leg between two transit legs (interchange), not the journey's true first
+        // or last mile - must never get a pin row, regardless of endpoint type.
+        val leg = walkingLeg(
+            originType = "street",
+            originName = "Some Address",
+            destinationType = "street",
+            destinationName = "Another Address",
+        )
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = false, isLastLeg = false)
+            as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+
+        assertNull(result?.originPinName)
+        assertNull(result?.destinationPinName)
+    }
+
+    @Test
+    fun `Given first leg When toWalkingLegUiModel Then destinationPinName is not set`() {
+        // Only the endpoint matching this leg's own position should get a name - the first
+        // leg's destination is an interchange point, not the journey's final destination.
+        val leg = walkingLeg(destinationType = "stop", destinationName = "Interchange Stop")
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true) as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+
+        assertNull(result?.destinationPinName)
+    }
+
+    @Test
+    fun `Given origin with no disassembledName When toWalkingLegUiModel Then falls back to name`() {
+        val leg = walkingLeg(originName = "Long Form Origin Name", originDisassembledName = null)
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true) as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+
+        assertEquals("Long Form Origin Name", result?.originPinName)
+    }
+
+    //endregion
+
+    //region footPathInfoRedundant override - first/last leg only
+
+    @Test
+    fun `Given interior leg with footPathInfoRedundant true When toWalkingLegUiModel Then leg is dropped`() {
+        // Unchanged existing behaviour: an interior redundant walk is genuinely covered
+        // elsewhere (e.g. platform-transfer context), so it must still be dropped.
+        val leg = walkingLeg(footPathInfoRedundant = true)
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = false, isLastLeg = false)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `Given first leg with footPathInfoRedundant true When toWalkingLegUiModel Then leg is still shown`() {
+        // The core experiment: NSW's redundant flag on a first-mile walk (e.g. Town Hall
+        // Station -> QVB, Stand C) must no longer drop the only text telling the rider they
+        // need to walk before boarding.
+        val leg = walkingLeg(footPathInfoRedundant = true)
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true)
+
+        assertEquals(true, result is TimeTableState.JourneyCardInfo.Leg.WalkingLeg)
+    }
+
+    @Test
+    fun `Given last leg with footPathInfoRedundant true When toWalkingLegUiModel Then leg is still shown`() {
+        val leg = walkingLeg(footPathInfoRedundant = true)
+
+        val result = leg.toWalkingLegUiModel(isLastLeg = true)
+
+        assertEquals(true, result is TimeTableState.JourneyCardInfo.Leg.WalkingLeg)
+    }
+
+    @Test
+    fun `Given first leg with footPathInfoRedundant false When toWalkingLegUiModel Then leg is shown`() {
+        // Baseline: the common case (flag absent/false) must be unaffected by the override.
+        val leg = walkingLeg(footPathInfoRedundant = false)
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true)
+
+        assertEquals(true, result is TimeTableState.JourneyCardInfo.Leg.WalkingLeg)
+    }
+
+    //endregion
+
+    //region existing invariants preserved
+
+    @Test
+    fun `Given leg with no resolvable duration When toWalkingLegUiModel Then returns null regardless of leg position`() {
+        val leg = TripResponse.Leg(
+            duration = null,
+            origin = null,
+            destination = null,
+        )
+
+        val result = leg.toWalkingLegUiModel(isFirstLeg = true, isLastLeg = true)
+
+        assertNull(result, "No displayDuration means nothing to render, even for a first/last leg")
+    }
+
+    //endregion
+
+    //region helpers
+
+    private fun walkingLeg(
+        durationSeconds: Long = 120L,
+        originType: String? = "stop",
+        originName: String? = "Origin Stop",
+        originDisassembledName: String? = "Origin Stop, Platform 1",
+        destinationType: String? = "stop",
+        destinationName: String? = "Destination Stop",
+        destinationDisassembledName: String? = "Destination Stop, Platform 2",
+        footPathInfoRedundant: Boolean? = null,
+    ) = TripResponse.Leg(
+        duration = durationSeconds,
+        footPathInfoRedundant = footPathInfoRedundant,
+        origin = TripResponse.StopSequence(
+            name = originName,
+            disassembledName = originDisassembledName,
+            type = originType,
+        ),
+        destination = TripResponse.StopSequence(
+            name = destinationName,
+            disassembledName = destinationDisassembledName,
+            type = destinationType,
+        ),
+    )
+
+    //endregion
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/business/TripResponseMapperTest.kt
@@ -258,6 +258,98 @@ class TripResponseMapperTest {
 
     //endregion
 
+    //region first/last-leg footPathInfoRedundant override (see TripResponseLegMapperTest for the
+    // leg-level unit tests; these cover the same behaviour end-to-end through buildJourneyList,
+    // including that totalWalkTime stays consistent with what actually renders as a leg)
+
+    /**
+     * End-to-end version of the reported bug: a journey's first leg is a footpath NSW flags
+     * `footPathInfoRedundant = true` (e.g. Town Hall Station -> QVB, Stand C). Before the fix
+     * this leg vanished entirely - both from the rendered leg list and from the walk-time total
+     * - leaving the rider with no indication they needed to walk before boarding.
+     */
+    @Test
+    fun `buildJourneyList shows first leg walk and counts it in totalWalkTime even when footPathInfoRedundant is true`() {
+        val response = TripResponse(
+            journeys = listOf(
+                TripResponse.Journey(
+                    legs = listOf(
+                        redundantFootpathLeg(
+                            depTime = "2026-04-18T22:00:00Z",
+                            arrTime = "2026-04-18T22:02:00Z",
+                            durationSeconds = 120L,
+                        ),
+                        buildRouteLeg(
+                            routeNumber = "607X",
+                            realtimeTripId = "trip-607x",
+                            depTime = "2026-04-18T22:05:00Z",
+                            arrTime = "2026-04-18T22:35:00Z",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        val walkingLeg = journey?.legs?.firstOrNull() as? TimeTableState.JourneyCardInfo.Leg.WalkingLeg
+        assertEquals(true, walkingLeg != null, "The redundant-flagged first-mile walk must still render as a leg")
+        assertEquals(
+            "2 mins",
+            journey?.totalWalkTime,
+            "totalWalkTime must include the shown first-mile walk, not just non-redundant walks",
+        )
+    }
+
+    /**
+     * Interior/interchange redundant footpath legs are unaffected: still dropped, still
+     * excluded from the walk-time total, since those are genuinely covered elsewhere.
+     */
+    @Test
+    fun `buildJourneyList still drops interior footPathInfoRedundant leg and excludes it from totalWalkTime`() {
+        val response = TripResponse(
+            journeys = listOf(
+                TripResponse.Journey(
+                    legs = listOf(
+                        buildRouteLeg(
+                            routeNumber = "715",
+                            realtimeTripId = "trip-outbound",
+                            depTime = "2026-04-18T22:00:00Z",
+                            arrTime = "2026-04-18T22:10:00Z",
+                        ),
+                        redundantFootpathLeg(
+                            depTime = "2026-04-18T22:10:00Z",
+                            arrTime = "2026-04-18T22:11:00Z",
+                            durationSeconds = 60L,
+                        ),
+                        buildRouteLeg(
+                            routeNumber = "T1",
+                            realtimeTripId = "trip-t1",
+                            depTime = "2026-04-18T22:15:00Z",
+                            arrTime = "2026-04-18T22:45:00Z",
+                            productClass = 1L,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val journey = response.buildJourneyList()?.firstOrNull()
+
+        assertEquals(
+            2,
+            journey?.legs?.size,
+            "The interior redundant walk must still be dropped - only the two transport legs remain",
+        )
+        assertEquals(
+            null,
+            journey?.totalWalkTime,
+            "An interior redundant walk must not be counted towards totalWalkTime",
+        )
+    }
+
+    //endregion
+
     //region journeyId uniqueness
 
     /**
@@ -847,6 +939,36 @@ class TripResponseMapperTest {
         ),
         footPathInfo = listOf(
             TripResponse.FootPathInfo(duration = durationSeconds, position = "IDEST"),
+        ),
+    )
+
+    /**
+     * Builds a standalone walking [TripResponse.Leg] with `footPathInfoRedundant = true` - the
+     * shape NSW uses for e.g. Town Hall Station -> QVB, Stand C, where the walk is real but
+     * flagged as redundant. Named/typed so tests reflect exactly the field under test, unlike
+     * [buildQuickWalkLeg] which is about the 715-backtrack quick-walk collapse heuristic.
+     */
+    private fun redundantFootpathLeg(
+        depTime: String,
+        arrTime: String,
+        durationSeconds: Long,
+    ) = TripResponse.Leg(
+        duration = durationSeconds,
+        footPathInfoRedundant = true,
+        origin = TripResponse.StopSequence(
+            departureTimePlanned = depTime,
+            departureTimeEstimated = depTime,
+        ),
+        destination = TripResponse.StopSequence(
+            arrivalTimePlanned = arrTime,
+            arrivalTimeEstimated = arrTime,
+        ),
+        stopSequence = listOf(
+            TripResponse.StopSequence(departureTimePlanned = depTime, departureTimeEstimated = depTime),
+            TripResponse.StopSequence(arrivalTimePlanned = arrTime, arrivalTimeEstimated = arrTime),
+        ),
+        transportation = TripResponse.Transportation(
+            product = TripResponse.Product(productClass = 99L, name = "footpath"),
         ),
     )
 


### PR DESCRIPTION
## Summary

Stacked on #1701. Two related pieces of work, plus one unrelated feature surfaced while investigating the first:

**Walking-leg pin rows.** The journey card now shows a pin-icon row with the endpoint name for the journey's true first-mile and last-mile walking legs — whether that endpoint is a searched address or a named transit stop (e.g. "Town Hall Station"). Previously this only showed for searched addresses, leaving a rider with no on-card indication of where a final walk to a named stop actually leads. The dashed connector line linking pin row → walk row → pin row is drawn as a single continuous segment rather than 2-3 independently-phased dashed segments, which was producing a stray extra dot at the seam between them.

**Footpath-info experiment.** NSW flags some first/last-mile footpath legs `footPathInfoRedundant = true` (e.g. Town Hall Station → QVB, Stand C) — previously this dropped the leg entirely, including the only text telling the rider they need to walk before boarding. First/last-mile legs now render regardless of the flag; interior/interchange legs still respect it, since those cases are genuinely covered elsewhere. See the kdoc on `toWalkingLegUiModel` for the one-line revert if this proves noisier than useful in practice.

**NSW On-Demand transport mode** (unrelated, surfaced during the same investigation): adds `TransportMode.OnDemand` (productClass 10) for NSW's flexible-zone shuttle service, with surface eligibility, GTFS-realtime handling (no feed to poll for on-demand legs), and an "On Demand" tag on `LegView` mirroring the existing "School Bus" pattern.

Also included:
- Recent-search-stop DB insert wrapped in `runCatching` as a safety net while confirming whether the FK constraint on `RecentSearchStops(stopId -> NswStops.stopId)` is actually enforced for non-GTFS (address/POI) stopIds on this platform's driver.
- `ExpandedJourneyCardContent` extracted into a `JourneyLegItem` composable to keep cyclomatic complexity under the repo's threshold after the new pin-row/On-Demand branching.

## Test plan

- [x] 11 new unit tests on `toWalkingLegUiModel` (pin-name gating for address vs. named-stop endpoints, `footPathInfoRedundant` override, existing invariants preserved)
- [x] 2 new end-to-end `buildJourneyList` tests (first-leg walk shown + counted in `totalWalkTime`, interior redundant leg still dropped)
- [x] `./gradlew detekt` clean (forced non-cached run)
- [x] `./gradlew compileDebugSources` clean (forced non-cached run)
- [x] `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
- [x] Manually verified on-device: pin rows render for both address and named-stop endpoints, dashed line has no stray dot, footpath-redundant first-leg walk now shows

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
