### PR TITLE
fix(trip-planner): correct past journey walking-leg styling

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TimelineModifiers.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/TimelineModifiers.kt
@@ -116,8 +116,10 @@ internal fun Modifier.timeLineCenterWithStop(
     }
 }
 
-private val DASH_LENGTH = 4.dp
-private val DASH_GAP = 4.dp
+// A near-zero line segment plus a round cap produces a true dot. The wide gap makes walking
+// connectors recede behind scheduled-service timelines instead of appearing as a heavy dash.
+private val DASH_LENGTH = 0.5.dp
+private val DASH_GAP = 10.dp
 
 private fun DrawScope.dashEffect(): PathEffect = PathEffect.dashPathEffect(
     intervals = floatArrayOf(DASH_LENGTH.toPx(), DASH_GAP.toPx()),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
@@ -54,7 +54,9 @@ fun WalkingLeg(
     // its own timeline dot.
     val contentStart = lineOffset + dim.spacingXL
 
-    val lineColor = KrailTheme.colors.onSurface.copy(alpha = contentAlpha * DASHED_LINE_ALPHA)
+    // Walking is supplementary context, so its connector should remain quieter than the
+    // mode-coloured transport timelines on either the regular or past-journey surface.
+    val lineColor = KrailTheme.colors.walkingConnector
     val strokeWidth = dim.journeyLegStrokeWidth
 
     // Deliberately inherit the parent surface. A past JourneyCard uses
@@ -149,8 +151,6 @@ private fun PinRow(name: String, iconSize: Dp, lineOffset: Dp, textStart: Dp) {
         )
     }
 }
-
-private const val DASHED_LINE_ALPHA = 0.6f
 
 // Visible breathing room between the icon's own bounding box and the first/last dash.
 // ic_location_on.xml's ink fills almost the whole box (path spans y=2..22 of a 24 viewBox),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/WalkingLeg.kt
@@ -1,7 +1,6 @@
 package xyz.ksharma.krail.trip.planner.ui.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -58,11 +57,10 @@ fun WalkingLeg(
     val lineColor = KrailTheme.colors.onSurface.copy(alpha = contentAlpha * DASHED_LINE_ALPHA)
     val strokeWidth = dim.journeyLegStrokeWidth
 
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(color = KrailTheme.colors.surface),
-    ) {
+    // Deliberately inherit the parent surface. A past JourneyCard uses
+    // pastDepartureRowSurface; painting the normal surface here made walking and pin rows
+    // look like a separate, non-past card inside it.
+    Column(modifier = modifier.fillMaxWidth()) {
         if (originPinName != null) {
             PinRow(
                 name = originPinName,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/ThemeTransitionAnimations.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/ThemeTransitionAnimations.kt
@@ -145,6 +145,7 @@ internal fun createLightDarkModeAnimatedColors(
         bottomSheetBackground = targetColors.bottomSheetBackground,
         bottomSheetDragHandle = targetColors.bottomSheetDragHandle,
         pastDepartureRowSurface = targetColors.pastDepartureRowSurface,
+        walkingConnector = targetColors.walkingConnector,
         walkingPath = targetColors.walkingPath,
         userLocationDot = targetColors.userLocationDot,
         outlineSubtle = targetColors.outlineSubtle,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/Color.kt
@@ -39,6 +39,9 @@ val md_theme_light_outline_subtle = Color(0x33010101)
 // Used for past/previous departure rows and past journey cards.
 val md_theme_light_past_departure_row_surface = Color(0xFFEEEEEE)
 
+// Walking connectors are intentionally quieter than scheduled-service timelines.
+val md_theme_light_walking_connector = Color(0xFFACACAC)
+
 // Stop-label surface — intentionally dark in BOTH light and dark mode so stop-label
 // pills read as a single visual treatment regardless of theme. Pair with
 // [md_theme_on_stop_label_surface] for content drawn on top.
@@ -81,6 +84,9 @@ val md_theme_dark_outline_subtle = Color(0x33FCF6F1)
 // past departure row surface — warm dark one step above the #292929 sheet (contrast ≈ 13:1 for onSurface #FCF6F1)
 // Used for past/previous departure rows and past journey cards.
 val md_theme_dark_past_departure_row_surface = Color(0xFF2C2B2A)
+
+// Walking connectors are intentionally quieter than scheduled-service timelines.
+val md_theme_dark_walking_connector = Color(0xFF5A5755)
 
 /**
  * Intermediate colors for smooth theme transitions
@@ -149,6 +155,8 @@ data class KrailColors(
     val bottomSheetDragHandle: Color,
     /** Surface color for past/previous items — previous departure rows, past journey cards, etc. */
     val pastDepartureRowSurface: Color,
+    /** Muted dotted connector for walking and footpath legs. */
+    val walkingConnector: Color,
     /** Subtle border/stroke color for chip outlines, dividers, and UI control tracks. */
     val outlineSubtle: Color,
     /**
@@ -187,6 +195,7 @@ internal val KrailLightColors = KrailColors(
     bottomSheetBackground = md_theme_light_modal_sheet_background,
     bottomSheetDragHandle = md_theme_light_sheet_drag_handle,
     pastDepartureRowSurface = md_theme_light_past_departure_row_surface,
+    walkingConnector = md_theme_light_walking_connector,
     outlineSubtle = md_theme_light_outline_subtle,
     stopLabelSurface = md_theme_stop_label_surface,
     onStopLabelSurface = md_theme_on_stop_label_surface,
@@ -219,6 +228,7 @@ internal val KrailDarkColors = KrailColors(
     bottomSheetBackground = md_theme_dark_modal_sheet_background,
     bottomSheetDragHandle = md_theme_dark_sheet_drag_handle,
     pastDepartureRowSurface = md_theme_dark_past_departure_row_surface,
+    walkingConnector = md_theme_dark_walking_connector,
     outlineSubtle = md_theme_dark_outline_subtle,
     stopLabelSurface = md_theme_stop_label_surface,
     onStopLabelSurface = md_theme_on_stop_label_surface,
@@ -252,6 +262,7 @@ internal val LocalKrailColors = staticCompositionLocalOf {
         bottomSheetBackground = Color.Unspecified,
         bottomSheetDragHandle = Color.Unspecified,
         pastDepartureRowSurface = Color.Unspecified,
+        walkingConnector = Color.Unspecified,
         outlineSubtle = Color.Unspecified,
         stopLabelSurface = Color.Unspecified,
         onStopLabelSurface = Color.Unspecified,


### PR DESCRIPTION
## Summary

Fixes the expanded past-journey card so walking legs, footpath segments, and address-pin rows inherit the card's muted past-journey surface instead of painting the normal surface.

- Introduces light and dark walking-connector colour tokens.
- Refines the walking timeline into subtle, widely spaced dots that remain readable in both themes.

## Verification

- `./scripts/fullQualityChecks.sh`
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest`
- Installed and reviewed on a Pixel 10 Pro in light and dark mode.