### PR TITLE
Test recent search location migration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -133,6 +133,7 @@ composeCompiler-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler
 
 # Database
 db-sqlAndroidDriver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
+db-sqlJdbcDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }
 db-sqlNativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqlDelight" }
 db-sqlRuntime = { module = "app.cash.sqldelight:runtime", version.ref = "sqlDelight" }
 db-sqlCoroutinesExtensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }

--- a/sandook/build.gradle.kts
+++ b/sandook/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
         namespace = "xyz.ksharma.krail.sandook"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
+
+        withHostTest {}
     }
 
     iosArm64()
@@ -49,6 +51,15 @@ kotlin {
                 implementation(libs.db.sqlCoroutinesExtensions)
 
                 api(libs.di.koinComposeViewmodel)
+            }
+        }
+
+        getByName("androidHostTest") {
+            kotlin.srcDir("src/androidHostTest/kotlin")
+            dependencies {
+                implementation(libs.db.sqlJdbcDriver)
+                implementation(libs.test.kotlin)
+                implementation(libs.test.robolectric)
             }
         }
 

--- a/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/RecentSearchLocationsMigrationTest.kt
+++ b/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/RecentSearchLocationsMigrationTest.kt
@@ -1,0 +1,115 @@
+package xyz.ksharma.krail.sandook
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.sqldelight.db.QueryResult
+import kotlin.test.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RecentSearchLocationsMigrationTest {
+
+    @Test
+    fun `migration copies visible legacy recents then removes the legacy table`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        createVersionTenTables(driver)
+        insertLegacyRecent(driver)
+
+        KrailSandook.Schema.migrate(
+            driver = driver,
+            oldVersion = VERSION_TEN,
+            newVersion = KrailSandook.Schema.version,
+        )
+
+        assertEquals(
+            listOf(
+                "200060",
+                "Central Station",
+                "TRANSIT_STOP",
+                null,
+                "1,2",
+                "2026-07-13 09:30:00",
+            ),
+            driver.migratedLocation(),
+        )
+        assertEquals(
+            0L,
+            driver.longValue(
+                """
+                SELECT COUNT(*)
+                FROM sqlite_master
+                WHERE type = 'table' AND name = 'RecentSearchStops'
+                """.trimIndent(),
+            ),
+        )
+
+        driver.close()
+    }
+
+    private fun createVersionTenTables(driver: JdbcSqliteDriver) {
+        driver.execute(
+            identifier = null,
+            sql = "CREATE TABLE RecentSearchStops(stopId TEXT NOT NULL PRIMARY KEY, timestamp TEXT)",
+            parameters = 0,
+        )
+        driver.execute(
+            identifier = null,
+            sql = "CREATE TABLE NswStops(stopId TEXT NOT NULL PRIMARY KEY, stopName TEXT NOT NULL)",
+            parameters = 0,
+        )
+        driver.execute(
+            identifier = null,
+            sql = "CREATE TABLE NswStopProductClass(stopId TEXT NOT NULL, productClass INTEGER NOT NULL)",
+            parameters = 0,
+        )
+    }
+
+    private fun insertLegacyRecent(driver: JdbcSqliteDriver) {
+        driver.execute(
+            identifier = null,
+            sql = "INSERT INTO NswStops VALUES ('200060', 'Central Station')",
+            parameters = 0,
+        )
+        driver.execute(
+            identifier = null,
+            sql = "INSERT INTO NswStopProductClass VALUES ('200060', 1), ('200060', 2)",
+            parameters = 0,
+        )
+        driver.execute(
+            identifier = null,
+            sql = "INSERT INTO RecentSearchStops VALUES ('200060', '2026-07-13 09:30:00')",
+            parameters = 0,
+        )
+    }
+
+    private fun JdbcSqliteDriver.migratedLocation(): List<String?> =
+        executeQuery(
+            identifier = null,
+            sql = """
+                SELECT locationId, displayName, kind, addressType, productClasses, timestamp
+                FROM RecentSearchLocations
+            """.trimIndent(),
+            mapper = { cursor ->
+                check(cursor.next().value)
+                QueryResult.Value(List(LOCATION_COLUMN_COUNT, cursor::getString))
+            },
+            parameters = 0,
+        ).value
+
+    private fun JdbcSqliteDriver.longValue(sql: String): Long =
+        executeQuery(
+            identifier = null,
+            sql = sql,
+            mapper = { cursor ->
+                check(cursor.next().value)
+                QueryResult.Value(cursor.getLong(0) ?: error("Expected a count"))
+            },
+            parameters = 0,
+        ).value
+
+    private companion object {
+        const val LOCATION_COLUMN_COUNT = 6
+        const val VERSION_TEN = 10L
+    }
+}


### PR DESCRIPTION
## Summary

- Add a host-level SQLDelight migration fixture that starts from the version-10 recent-stop schema.
- Verify the upgrade preserves the visible legacy stop's name, product classes, and timestamp in `RecentSearchLocations`.
- Verify the legacy `RecentSearchStops` table is dropped after its data is copied.

## Validation

- `./gradlew :sandook:testAndroidHostTest --continue`
- `./gradlew detekt --continue`
