### PR TITLE
feat(search-stop): add address search eligibility gate, cache, and staleness guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,9 @@ that contradicts the doc should also update the doc in the same change.
 
 - `feature/trip-planner/ui/SEARCH_STOP_UX.md` — SearchStopScreen (labels, save sheet,
   edit mode, conflict warnings, contextual banner, state persistence).
+- `feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md` — address/POI search gate,
+  cache, and staleness-token classes in `searchstop/address/`; read before changing
+  `onAddressSearchTextChanged` or the `search_stop_address_*` Remote Config contract.
 - `docs/TABLET_FOLDABLE_UX.md` — adaptive layout rules for tablets, foldables, and phone
   landscape (per-screen dual-pane behaviour, compact-height adaptations, breakpoint contract).
 - `docs/POLLING_LIFECYCLE.md` — WhileSubscribed polling rules: `repeatOnLifecycle(STARTED)`

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -164,6 +164,10 @@ object RemoteConfigDefaults {
                 first = FlagKeys.SEARCH_STOP_ADDRESS_SEARCH_ENABLED.key,
                 second = false,
             ),
+            Pair(
+                first = FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+                second = 6,
+            ),
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -66,4 +66,14 @@ enum class FlagKeys(val key: String) {
      * search is completely unaffected regardless of this flag's value.
      */
     SEARCH_STOP_ADDRESS_SEARCH_ENABLED("search_stop_address_search_enabled"),
+
+    /**
+     * Minimum trimmed-query length (characters) before [SEARCH_STOP_ADDRESS_SEARCH_ENABLED]
+     * is allowed to fire an address/POI request. Bounded integer `2..12`; a missing,
+     * malformed, or out-of-range value falls back to `6` client-side rather than being
+     * clamped. Independent of the boolean kill switch above — this only tunes *when* an
+     * already-enabled search fires, it cannot enable the feature by itself. See
+     * docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md.
+     */
+    SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH("search_stop_address_min_query_length"),
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -73,7 +73,7 @@ enum class FlagKeys(val key: String) {
      * malformed, or out-of-range value falls back to `6` client-side rather than being
      * clamped. Independent of the boolean kill switch above — this only tunes *when* an
      * already-enabled search fires, it cannot enable the feature by itself. See
-     * docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md.
+     * feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md.
      */
     SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH("search_stop_address_min_query_length"),
 }

--- a/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
+++ b/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
@@ -1,0 +1,70 @@
+# Address search eligibility, cache, and staleness
+
+Implements the policy in `docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md`. Read that doc
+first for the "why" (data-backed threshold, rejected alternatives, rollout plan); this
+file documents the classes that came out of it and what they deliberately don't do.
+
+## Classes
+
+All in `searchstop/address/` (`:feature:trip-planner:ui`):
+
+| Class | Kind | Responsibility |
+|---|---|---|
+| `AddressSearchGate` | enum | The four possible eligibility outcomes. |
+| `AddressSearchEligibility` | pure object | `evaluate(normalizedQuery, isAddressSearchEnabled, minQueryLength) -> AddressSearchGate`. No I/O, no state. |
+| `AddressSearchQueryNormalizer.kt` | pure functions | `normalizeAddressQuery` (trim) and `addressSearchCacheKey` (trim + lowercase). |
+| `AddressSearchMinQueryLength.kt` | pure function | `resolveAddressSearchMinQueryLength(flag)` — reads and validates the Remote Config integer. |
+| `AddressSearchCache` | stateful class | Per-`SearchStopViewModel` bounded LRU with per-entry TTL. |
+
+Each is independently unit-testable without a ViewModel, Koin, or a fake network layer —
+that was the point of splitting them out rather than growing
+`SearchStopViewModel.onAddressSearchTextChanged` in place.
+
+## Gate order
+
+`AddressSearchEligibility.evaluate` checks, in order: kill switch off -> blank -> below
+threshold -> eligible. `SearchStopViewModel.onAddressSearchTextChanged` calls this
+**before** creating a loading state or a coroutine, and again after the 350ms debounce
+(a flag flip or further edit mid-debounce must not fire a now-stale request).
+
+## Cache
+
+Keyed by `addressSearchCacheKey` (case-folded, trimmed). Two TTLs: 120s for a non-empty
+result, 30s for an empty one (`AddressSearchCache` companion constants). Checked after
+the eligibility gate and before the debounce delay — a cache hit renders immediately
+with no loading flicker and no network call.
+
+The cache lives on the ViewModel instance, not behind DI — it must not outlive the
+screen or be shared across `SearchStopViewModel` instances (see "Session cache
+proposal" in the policy doc: no persistence, no cross-session sharing).
+
+## Staleness guard, not request coalescing
+
+`SearchStopViewModel` keeps a single monotonic `addressSearchRequestToken` (an `Int`
+incremented each time a request is scheduled). A response only updates UI state if the
+token it captured is still current. This satisfies the policy doc's "a late result has
+no query-version check" concern.
+
+**Deliberately not implemented**: `Deferred`-based duplicate-request coalescing (the
+policy doc's "a request for that exact normalized query is already pending" row).
+`SearchStopViewModel` only ever has one live `addressSearchJob`, and it is cancelled
+before every new one is launched — so two concurrent in-flight requests for the same
+query cannot occur under the current architecture. Adding coalescing machinery for a
+race that can't happen would be speculative complexity. Revisit only if the ViewModel's
+single-job-cancel-and-replace invariant changes (e.g. a future multi-source merge).
+
+## Redaction
+
+Both the ViewModel's and `RealRemoteAddressResultsManager`'s failure logs record
+`normalizedQuery.length`, never the query text — addresses can be personal data (see
+policy doc's release gates).
+
+## Remote Config
+
+| Key | Type | Fallback | Valid range |
+|---|---|---|---|
+| `search_stop_address_search_enabled` | Boolean | `false` | - |
+| `search_stop_address_min_query_length` | Integer | `6` | `2..12`, else fallback |
+
+`resolveAddressSearchMinQueryLength` range-checks in `Long` space before narrowing to
+`Int`, so an oversized remote value can't wrap around into a false in-range result.

--- a/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
+++ b/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
@@ -1,8 +1,8 @@
 # Address search eligibility, cache, and staleness
 
-Implements the policy in `docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md`. Read that doc
-first for the "why" (data-backed threshold, rejected alternatives, rollout plan); this
-file documents the classes that came out of it and what they deliberately don't do.
+Documents the address/POI search call decision for SearchStopScreen: when
+`onAddressSearchTextChanged` is allowed to call the NSW `stop_finder` API, what gets
+cached, and how a late response is prevented from clobbering newer UI state.
 
 ## Classes
 
@@ -30,34 +30,47 @@ threshold -> eligible. `SearchStopViewModel.onAddressSearchTextChanged` calls th
 ## Cache
 
 Keyed by `addressSearchCacheKey` (case-folded, trimmed). Two TTLs: 120s for a non-empty
-result, 30s for an empty one (`AddressSearchCache` companion constants). Checked after
-the eligibility gate and before the debounce delay — a cache hit renders immediately
-with no loading flicker and no network call.
+result, 30s for a genuinely empty one (`AddressSearchCache` companion constants).
+Checked after the eligibility gate and before the debounce delay — a cache hit renders
+immediately with no loading flicker and no network call.
 
 The cache lives on the ViewModel instance, not behind DI — it must not outlive the
-screen or be shared across `SearchStopViewModel` instances (see "Session cache
-proposal" in the policy doc: no persistence, no cross-session sharing).
+screen or be shared across `SearchStopViewModel` instances: no persistence, no
+cross-session sharing.
+
+**A failed request is never cached.** `RealRemoteAddressResultsManager` deliberately
+does not catch its own exceptions — it lets them propagate so `SearchStopViewModel` can
+tell "the call failed" apart from "the call succeeded with zero results." Only
+`Result.success` reaches `addressSearchCache.put(...)`; a failure still resolves to an
+empty `addressResults` list for the UI (this is an optional section, so it never shows
+an error state), but the *next* identical query is free to retry immediately rather
+than being blocked by a 30s empty-result TTL that was never earned. Caching a transient
+failure as "no results" was a real bug caught late in review — the fix is
+`fetchResult.onSuccess { addressSearchCache.put(cacheKey, it) }` gating the cache write,
+not the `getOrElse { emptyList() }` that produces the UI-facing value.
 
 ## Staleness guard, not request coalescing
 
 `SearchStopViewModel` keeps a single monotonic `addressSearchRequestToken` (an `Int`
 incremented each time a request is scheduled). A response only updates UI state if the
-token it captured is still current. This satisfies the policy doc's "a late result has
-no query-version check" concern.
+token it captured is still current — this guards against a late response overwriting a
+newer query's UI state even if the underlying HTTP call doesn't cancel promptly.
 
-**Deliberately not implemented**: `Deferred`-based duplicate-request coalescing (the
-policy doc's "a request for that exact normalized query is already pending" row).
-`SearchStopViewModel` only ever has one live `addressSearchJob`, and it is cancelled
-before every new one is launched — so two concurrent in-flight requests for the same
-query cannot occur under the current architecture. Adding coalescing machinery for a
-race that can't happen would be speculative complexity. Revisit only if the ViewModel's
-single-job-cancel-and-replace invariant changes (e.g. a future multi-source merge).
+**Deliberately not implemented**: `Deferred`-based duplicate-request coalescing (i.e.
+detecting "a request for this exact normalized query is already pending" and reusing
+it). `SearchStopViewModel` only ever has one live `addressSearchJob`, and it is
+cancelled before every new one is launched — so two concurrent in-flight requests for
+the same query cannot occur under the current architecture. Adding coalescing machinery
+for a race that can't happen would be speculative complexity. Revisit only if the
+ViewModel's single-job-cancel-and-replace invariant changes (e.g. a future multi-source
+merge).
 
 ## Redaction
 
-Both the ViewModel's and `RealRemoteAddressResultsManager`'s failure logs record
-`normalizedQuery.length`, never the query text — addresses can be personal data (see
-policy doc's release gates).
+`SearchStopViewModel`'s failure log records `normalizedQuery.length`, never the query
+text — addresses can be personal data. `RealRemoteAddressResultsManager` no longer logs
+at all (see Cache section above: it propagates failures instead of catching them), so
+there is a single redacted log site, not two.
 
 ## Remote Config
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -29,6 +29,7 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RemoteAddressResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.resolveAddressSearchMinQueryLength
 import xyz.ksharma.krail.trip.planner.ui.searchstop.fuzzy.DefaultFuzzyStopRanker
 import xyz.ksharma.krail.trip.planner.ui.searchstop.fuzzy.FuzzyStopRanker
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.NearbyStopsManager
@@ -167,6 +168,9 @@ val viewModelsModule = module {
                 flag.getFlagValue(FlagKeys.SEARCH_STOP_ADDRESS_SEARCH_ENABLED.key).asBoolean(false)
             }
         }
+        // Read live, not once, same reasoning as isAddressSearchEnabled above - Remote
+        // Config can push a new threshold while this ViewModel is already alive.
+        val addressSearchMinQueryLength = { resolveAddressSearchMinQueryLength(flag) }
         SearchStopViewModel(
             analytics = get(),
             stopResultsManager = get(),
@@ -177,6 +181,7 @@ val viewModelsModule = module {
             preferences = get(),
             sandook = get(),
             isAddressSearchEnabled = isAddressSearchEnabled,
+            addressSearchMinQueryLength = addressSearchMinQueryLength,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealRemoteAddressResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealRemoteAddressResultsManager.kt
@@ -28,7 +28,10 @@ class RealRemoteAddressResultsManager(
         runCatching {
             tripPlanningService.stopFinder(stopSearchQuery = safeQuery, stopType = StopType.ANY)
         }.onFailure {
-            log("RemoteAddressResultsManager - stopFinder failed for query=\"$safeQuery\": ${it.message}")
+            log(
+                "RemoteAddressResultsManager - stopFinder failed for query of length " +
+                    "${safeQuery.length}: ${it.message}",
+            )
         }.getOrNull()
             ?.locations
             ?.filter { location -> location.type != STOP_TYPE && location.id != null }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealRemoteAddressResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealRemoteAddressResultsManager.kt
@@ -2,7 +2,6 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.trip.planner.network.api.model.StopType
 import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
@@ -10,9 +9,13 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 /**
  * `stop_finder` always uses `type_sf=any` here — that's what unlocks address/POI hits
  * on top of transit stops. Any `stop`-typed location in the response is filtered out:
- * transit stops are local-DB only, always (see [RealStopResultsManager]). A failed or
- * slow network call resolves to an empty list rather than throwing, so a flaky remote
- * search can never surface as an error state on this optional section.
+ * transit stops are local-DB only, always (see [RealStopResultsManager]).
+ *
+ * Deliberately does **not** catch here: a failed call must propagate as an exception so
+ * the caller's `AddressSearchCache` can tell "the request failed" apart from "the
+ * request succeeded with zero results" and skip caching the former. The caller
+ * (`SearchStopViewModel`) is the single place that turns a failure into an empty list
+ * for the UI - see feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md.
  */
 class RealRemoteAddressResultsManager(
     private val tripPlanningService: TripPlanningService,
@@ -25,15 +28,8 @@ class RealRemoteAddressResultsManager(
         val safeQuery = query.take(MAX_QUERY_LENGTH).trim()
         if (safeQuery.length < MIN_QUERY_LENGTH) return@withContext emptyList()
 
-        runCatching {
-            tripPlanningService.stopFinder(stopSearchQuery = safeQuery, stopType = StopType.ANY)
-        }.onFailure {
-            log(
-                "RemoteAddressResultsManager - stopFinder failed for query of length " +
-                    "${safeQuery.length}: ${it.message}",
-            )
-        }.getOrNull()
-            ?.locations
+        tripPlanningService.stopFinder(stopSearchQuery = safeQuery, stopType = StopType.ANY)
+            .locations
             ?.filter { location -> location.type != STOP_TYPE && location.id != null }
             ?.map { location ->
                 SearchStopState.SearchResult.Address(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -524,13 +524,15 @@ class SearchStopViewModel(
             if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) return@launch
 
             updateUiState { copy(isAddressSearchLoading = true) }
-            val addressResults = runCatching {
-                remoteAddressResultsManager.fetchAddressResults(normalizedQuery)
-            }.getOrElse {
+            val fetchResult = runCatching { remoteAddressResultsManager.fetchAddressResults(normalizedQuery) }
+            // A transient failure must not be cached as "no results" - that would block
+            // the next identical query from retrying for the empty-result TTL. Only a
+            // real response (including a genuine empty one) is cache-worthy.
+            fetchResult.onSuccess { addressSearchCache.put(cacheKey, it) }
+            val addressResults = fetchResult.getOrElse {
                 log("Address search failed for query of length ${normalizedQuery.length}: ${it.message}")
                 emptyList()
             }
-            addressSearchCache.put(cacheKey, addressResults)
 
             // A newer keystroke may have started (and even completed) another request
             // while this one was in flight; only the most recent request may still win.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -34,6 +34,7 @@ import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportConfig
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
+import xyz.ksharma.krail.coroutines.ext.suspendSafeResult
 import xyz.ksharma.krail.sandook.RecentSearchLocation
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
@@ -524,7 +525,12 @@ class SearchStopViewModel(
             if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) return@launch
 
             updateUiState { copy(isAddressSearchLoading = true) }
-            val fetchResult = runCatching { remoteAddressResultsManager.fetchAddressResults(normalizedQuery) }
+            // suspendSafeResult, not runCatching: a cancelled coroutine (e.g. this job
+            // getting replaced by the next keystroke) must propagate CancellationException
+            // rather than have it swallowed into a Result.failure.
+            val fetchResult = suspendSafeResult(ioDispatcher) {
+                remoteAddressResultsManager.fetchAddressResults(normalizedQuery)
+            }
             // A transient failure must not be cached as "no results" - that would block
             // the next identical query from retrying for the empty-result TTL. Only a
             // real response (including a genuine empty one) is cache-worthy.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -38,6 +38,12 @@ import xyz.ksharma.krail.sandook.RecentSearchLocation
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.trip.planner.ui.components.normaliseLabelName
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchCache
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchEligibility
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchGate
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.addressSearchCacheKey
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.normalizeAddressQuery
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.MapStateHelper
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.NearbyStopsManager
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
@@ -60,6 +66,7 @@ class SearchStopViewModel(
     private val preferences: SandookPreferences,
     private val sandook: Sandook,
     private val isAddressSearchEnabled: () -> Boolean = { false },
+    private val addressSearchMinQueryLength: () -> Int = { DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH },
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SearchStopState> = MutableStateFlow(SearchStopState())
@@ -89,6 +96,11 @@ class SearchStopViewModel(
     private var searchJob: Job? = null
     private var addressSearchJob: Job? = null
     private var fetchRecentStopsJob: Job? = null
+
+    // Per-ViewModel session cache/staleness-guard for the address pipeline only — local
+    // stop search has no equivalent because it has no remote round-trip to protect.
+    private val addressSearchCache = AddressSearchCache()
+    private var addressSearchRequestToken = 0
 
     @Suppress("LongMethod", "ReturnCount")
     fun onEvent(event: SearchStopUiEvent) {
@@ -487,19 +499,42 @@ class SearchStopViewModel(
 
     private fun onAddressSearchTextChanged(query: String) {
         addressSearchJob?.cancel()
-        if (!isAddressSearchEnabled()) {
+        val normalizedQuery = normalizeAddressQuery(query)
+
+        if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) {
             updateUiState { copy(addressResults = persistentListOf(), isAddressSearchLoading = false) }
             return
         }
+
+        val cacheKey = addressSearchCacheKey(normalizedQuery)
+        val cached = addressSearchCache.get(cacheKey)
+        if (cached != null) {
+            updateUiState {
+                copy(addressResults = cached.toImmutableList(), isAddressSearchLoading = false)
+            }
+            return
+        }
+
+        val requestToken = ++addressSearchRequestToken
         addressSearchJob = viewModelScope.launch {
             delay(ADDRESS_SEARCH_DEBOUNCE_MS)
+
+            // A flag flip or further edit during the debounce must not fire a now-stale
+            // request - re-check the same gate the caller already passed.
+            if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) return@launch
+
             updateUiState { copy(isAddressSearchLoading = true) }
             val addressResults = runCatching {
-                remoteAddressResultsManager.fetchAddressResults(query)
+                remoteAddressResultsManager.fetchAddressResults(normalizedQuery)
             }.getOrElse {
-                log("Address search failed for query=\"$query\": ${it.message}")
+                log("Address search failed for query of length ${normalizedQuery.length}: ${it.message}")
                 emptyList()
             }
+            addressSearchCache.put(cacheKey, addressResults)
+
+            // A newer keystroke may have started (and even completed) another request
+            // while this one was in flight; only the most recent request may still win.
+            if (requestToken != addressSearchRequestToken) return@launch
             updateUiState {
                 copy(
                     addressResults = addressResults.toImmutableList(),
@@ -508,6 +543,13 @@ class SearchStopViewModel(
             }
         }
     }
+
+    private fun currentAddressSearchGate(normalizedQuery: String): AddressSearchGate =
+        AddressSearchEligibility.evaluate(
+            normalizedQuery = normalizedQuery,
+            isAddressSearchEnabled = isAddressSearchEnabled(),
+            minQueryLength = addressSearchMinQueryLength(),
+        )
 
     private fun StopItem.productClasses(): String =
         when (locationKind) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchCache.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchCache.kt
@@ -1,0 +1,57 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * In-memory, per-`SearchStopViewModel` LRU cache for address/POI results, keyed by
+ * [addressSearchCacheKey]. Never persisted to disk — see "Session cache proposal" in
+ * docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md. A successful (non-empty) result and an
+ * empty result get different TTLs so a broad no-match prefix isn't treated as durable
+ * truth for as long as a real result would be.
+ *
+ * Not thread-safe: callers on this codebase's single-threaded ViewModel dispatch
+ * pattern only, same assumption as the rest of `SearchStopViewModel`'s mutable state.
+ */
+@OptIn(ExperimentalTime::class)
+class AddressSearchCache(
+    private val maxEntries: Int = MAX_ENTRIES,
+    private val successTtlMillis: Long = SUCCESS_TTL_MILLIS,
+    private val emptyResultTtlMillis: Long = EMPTY_RESULT_TTL_MILLIS,
+    private val nowMillis: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+
+    // Iteration order tracks recency: put()/get() both re-insert on access, so the
+    // first key is always the least-recently-used one.
+    private val entries = LinkedHashMap<String, Entry>()
+
+    fun get(key: String): List<SearchStopState.SearchResult.Address>? {
+        val entry = entries.remove(key) ?: return null
+        if (nowMillis() >= entry.expiresAtMillis) {
+            return null
+        }
+        entries[key] = entry
+        return entry.results
+    }
+
+    fun put(key: String, results: List<SearchStopState.SearchResult.Address>) {
+        entries.remove(key)
+        val ttlMillis = if (results.isEmpty()) emptyResultTtlMillis else successTtlMillis
+        entries[key] = Entry(results, nowMillis() + ttlMillis)
+        if (entries.size > maxEntries) {
+            entries.remove(entries.keys.first())
+        }
+    }
+
+    private data class Entry(
+        val results: List<SearchStopState.SearchResult.Address>,
+        val expiresAtMillis: Long,
+    )
+
+    private companion object {
+        const val MAX_ENTRIES = 20
+        const val SUCCESS_TTL_MILLIS = 120_000L
+        const val EMPTY_RESULT_TTL_MILLIS = 30_000L
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchCache.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchCache.kt
@@ -6,10 +6,10 @@ import kotlin.time.ExperimentalTime
 
 /**
  * In-memory, per-`SearchStopViewModel` LRU cache for address/POI results, keyed by
- * [addressSearchCacheKey]. Never persisted to disk — see "Session cache proposal" in
- * docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md. A successful (non-empty) result and an
- * empty result get different TTLs so a broad no-match prefix isn't treated as durable
- * truth for as long as a real result would be.
+ * [addressSearchCacheKey]. Never persisted to disk — see
+ * feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md. A successful (non-empty)
+ * result and an empty result get different TTLs so a broad no-match prefix isn't
+ * treated as durable truth for as long as a real result would be.
  *
  * Not thread-safe: callers on this codebase's single-threaded ViewModel dispatch
  * pattern only, same assumption as the rest of `SearchStopViewModel`'s mutable state.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibility.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibility.kt
@@ -1,0 +1,23 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+/**
+ * Pure eligibility gate for the address/POI search API call. Evaluated at the
+ * ViewModel boundary before any loading state or network job is created — see
+ * "Recommended eligibility policy" in docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md.
+ *
+ * Deliberately does not know about caching or in-flight requests: those are
+ * [AddressSearchCache]'s and the ViewModel's concerns, not an eligibility question.
+ */
+object AddressSearchEligibility {
+
+    fun evaluate(
+        normalizedQuery: String,
+        isAddressSearchEnabled: Boolean,
+        minQueryLength: Int,
+    ): AddressSearchGate = when {
+        !isAddressSearchEnabled -> AddressSearchGate.DISABLED
+        normalizedQuery.isBlank() -> AddressSearchGate.BLANK
+        normalizedQuery.length < minQueryLength -> AddressSearchGate.BELOW_THRESHOLD
+        else -> AddressSearchGate.ELIGIBLE
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibility.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibility.kt
@@ -3,7 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop.address
 /**
  * Pure eligibility gate for the address/POI search API call. Evaluated at the
  * ViewModel boundary before any loading state or network job is created — see
- * "Recommended eligibility policy" in docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md.
+ * feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md.
  *
  * Deliberately does not know about caching or in-flight requests: those are
  * [AddressSearchCache]'s and the ViewModel's concerns, not an eligibility question.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchGate.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchGate.kt
@@ -1,0 +1,13 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+/**
+ * Outcome of [AddressSearchEligibility.evaluate]. Only [ELIGIBLE] may schedule a
+ * debounced address/POI request; every other value clears the address section
+ * without a loading state or a network call.
+ */
+enum class AddressSearchGate {
+    DISABLED,
+    BLANK,
+    BELOW_THRESHOLD,
+    ELIGIBLE,
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMinQueryLength.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMinQueryLength.kt
@@ -1,0 +1,26 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.asNumber
+
+const val DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH = 6
+private val VALID_ADDRESS_SEARCH_MIN_QUERY_LENGTH_RANGE = 2L..12L
+
+/**
+ * Resolves `search_stop_address_min_query_length` with the bounds contract from
+ * docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md: a missing, malformed, or
+ * out-of-range remote value falls back to [DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH]
+ * rather than being silently clamped into range. The range check happens in `Long`
+ * space before narrowing to `Int`, so an oversized remote value can't wrap around
+ * into a false in-range result.
+ */
+fun resolveAddressSearchMinQueryLength(flag: Flag): Int {
+    val raw = flag.getFlagValue(FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key)
+        .asNumber(DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH.toLong())
+    return if (raw in VALID_ADDRESS_SEARCH_MIN_QUERY_LENGTH_RANGE) {
+        raw.toInt()
+    } else {
+        DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMinQueryLength.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMinQueryLength.kt
@@ -9,7 +9,7 @@ private val VALID_ADDRESS_SEARCH_MIN_QUERY_LENGTH_RANGE = 2L..12L
 
 /**
  * Resolves `search_stop_address_min_query_length` with the bounds contract from
- * docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md: a missing, malformed, or
+ * feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md: a missing, malformed, or
  * out-of-range remote value falls back to [DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH]
  * rather than being silently clamped into range. The range check happens in `Long`
  * space before narrowing to `Int`, so an oversized remote value can't wrap around

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchQueryNormalizer.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchQueryNormalizer.kt
@@ -1,0 +1,16 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+/**
+ * Trims leading/trailing whitespace only. Used for eligibility, request construction,
+ * and as the basis for [addressSearchCacheKey] — the NSW API receives this exact
+ * value, case preserved.
+ */
+fun normalizeAddressQuery(rawQuery: String): String = rawQuery.trim()
+
+/**
+ * Case-folded cache/coalescing key derived from an already-[normalizeAddressQuery]d
+ * query. Kept separate from the request value itself: the doc calls for a
+ * case-insensitive cache key "unless NSW API testing proves case-insensitivity" of the
+ * request, so the two must not be conflated.
+ */
+fun addressSearchCacheKey(normalizedQuery: String): String = normalizedQuery.lowercase()


### PR DESCRIPTION
Implements docs/plans/ADDRESS_SEARCH_API_CALL_POLICY.md: split the address/POI
search call decision into small, independently unit-testable classes
(AddressSearchEligibility, AddressSearchMinQueryLength, AddressSearchCache,
AddressSearchQueryNormalizer) instead of growing SearchStopViewModel in place.

- Eligibility gate checked before a loading state or network job is created,
  and re-checked after the debounce so a flag flip or edit mid-wait can't
  fire a stale request.
- Per-ViewModel LRU cache (20 entries, 120s/30s TTL for hit/empty) avoids a
  repeat network call for an identical query.
- Monotonic request token guards against a late response overwriting a
  newer query's UI state.
- Failure logs now record query length, never the raw query text.
- New Remote Config int search_stop_address_min_query_length (default 6,
  valid range 2..12, malformed/out-of-range falls back to 6).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>