### PR TITLE
test(search-stop): cover address search eligibility, cache, and threshold resolution

### DIFF
--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -565,6 +565,44 @@ class SearchStopViewModelTest {
         }
 
     @Test
+    fun `GIVEN a failed address request WHEN the exact same query is searched again THEN a second network call is made`() =
+        runTest {
+            fakeRemoteAddressResultsManager.shouldThrowError = true
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+                assertEquals(1, fakeRemoteAddressResultsManager.callCount)
+                assertTrue(addressViewModel.uiState.value.addressResults.isEmpty())
+
+                // The first call failed - a failure must never be cached as "no
+                // results", or the retry below would be wrongly served from cache
+                // instead of hitting the network again.
+                fakeRemoteAddressResultsManager.shouldThrowError = false
+                fakeRemoteAddressResultsManager.results = listOf(
+                    SearchStopState.SearchResult.Address(
+                        addressId = "addr-1",
+                        displayName = "Sydney Opera House",
+                        addressType = "poi",
+                    ),
+                )
+
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged(""))
+                advanceUntilIdle()
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                assertEquals(2, fakeRemoteAddressResultsManager.callCount)
+                assertEquals(1, addressViewModel.uiState.value.addressResults.size)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `GIVEN address search disabled by default constructor WHEN query is long enough THEN no address request is made`() =
         runTest {
             fakeRemoteAddressResultsManager.results = listOf(

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -464,4 +464,128 @@ class SearchStopViewModelTest {
         }
 
     // endregion SelectOnMapButtonClicked
+
+    // region Address search eligibility
+
+    private fun addressAwareViewModel(minQueryLength: Int = 6) = SearchStopViewModel(
+        analytics = fakeAnalytics,
+        stopResultsManager = fakeStopResultsManager,
+        remoteAddressResultsManager = fakeRemoteAddressResultsManager,
+        flag = fakeFlag,
+        nearbyStopsManager = fakeNearbyStopsManager,
+        ioDispatcher = testDispatcher,
+        preferences = fakePreferences,
+        sandook = fakeSandook,
+        isAddressSearchEnabled = { true },
+        addressSearchMinQueryLength = { minQueryLength },
+    )
+
+    @Test
+    fun `GIVEN address search enabled WHEN query is below threshold THEN no address request is made`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Opera House",
+                    addressType = "poi",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Syd"))
+                advanceUntilIdle()
+
+                assertEquals(0, fakeRemoteAddressResultsManager.callCount)
+                assertTrue(addressViewModel.uiState.value.addressResults.isEmpty())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN address search enabled WHEN query meets threshold THEN address request is made and results shown`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Opera House",
+                    addressType = "poi",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                assertEquals(1, fakeRemoteAddressResultsManager.callCount)
+                assertEquals("Sydney", fakeRemoteAddressResultsManager.lastQuery)
+                assertEquals(1, addressViewModel.uiState.value.addressResults.size)
+                assertFalse(addressViewModel.uiState.value.isAddressSearchLoading)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a cached query WHEN the exact same query is searched again THEN no second network call is made`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Opera House",
+                    addressType = "poi",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+                assertEquals(1, fakeRemoteAddressResultsManager.callCount)
+
+                // Clear then retype the identical query - the normalized/case-folded
+                // cache key is the same, so this must be served from cache, not the
+                // network.
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged(""))
+                advanceUntilIdle()
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                assertEquals(1, fakeRemoteAddressResultsManager.callCount)
+                assertEquals(1, addressViewModel.uiState.value.addressResults.size)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN address search disabled by default constructor WHEN query is long enough THEN no address request is made`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Opera House",
+                    addressType = "poi",
+                ),
+            )
+
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney Opera House"))
+                advanceUntilIdle()
+
+                assertEquals(0, fakeRemoteAddressResultsManager.callCount)
+                assertTrue(viewModel.uiState.value.addressResults.isEmpty())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion Address search eligibility
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchCacheTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchCacheTest.kt
@@ -1,0 +1,84 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AddressSearchCacheTest {
+
+    private fun address(id: String) = SearchStopState.SearchResult.Address(
+        addressId = id,
+        displayName = "Display $id",
+        addressType = "street",
+    )
+
+    @Test
+    fun `GIVEN empty cache WHEN get THEN null`() {
+        val cache = AddressSearchCache(nowMillis = { 0L })
+        assertNull(cache.get("sydney"))
+    }
+
+    @Test
+    fun `GIVEN a put WHEN get before ttl expiry THEN returns cached results`() {
+        var now = 0L
+        val cache = AddressSearchCache(successTtlMillis = 1_000L, nowMillis = { now })
+        val results = listOf(address("1"))
+        cache.put("sydney", results)
+        now = 999L
+        assertEquals(results, cache.get("sydney"))
+    }
+
+    @Test
+    fun `GIVEN a successful put WHEN get after ttl expiry THEN null`() {
+        var now = 0L
+        val cache = AddressSearchCache(successTtlMillis = 1_000L, nowMillis = { now })
+        cache.put("sydney", listOf(address("1")))
+        now = 1_000L
+        assertNull(cache.get("sydney"))
+    }
+
+    @Test
+    fun `GIVEN an empty-result put WHEN get after empty ttl expiry THEN null`() {
+        var now = 0L
+        val cache = AddressSearchCache(emptyResultTtlMillis = 500L, nowMillis = { now })
+        cache.put("nowhere", emptyList())
+        now = 500L
+        assertNull(cache.get("nowhere"))
+    }
+
+    @Test
+    fun `GIVEN an empty-result put WHEN get before empty ttl expiry THEN empty list not null`() {
+        var now = 0L
+        val cache = AddressSearchCache(emptyResultTtlMillis = 500L, nowMillis = { now })
+        cache.put("nowhere", emptyList())
+        now = 499L
+        assertEquals(emptyList(), cache.get("nowhere"))
+    }
+
+    @Test
+    fun `GIVEN cache at max size WHEN put another entry THEN least recently used is evicted`() {
+        val cache = AddressSearchCache(maxEntries = 2, nowMillis = { 0L })
+        cache.put("a", listOf(address("a")))
+        cache.put("b", listOf(address("b")))
+        cache.put("c", listOf(address("c")))
+
+        assertNull(cache.get("a"))
+        assertEquals(listOf(address("b")), cache.get("b"))
+        assertEquals(listOf(address("c")), cache.get("c"))
+    }
+
+    @Test
+    fun `GIVEN cache at max size WHEN recently accessed entry is kept fresh THEN it survives eviction`() {
+        val cache = AddressSearchCache(maxEntries = 2, nowMillis = { 0L })
+        cache.put("a", listOf(address("a")))
+        cache.put("b", listOf(address("b")))
+        // Touch "a" so "b" becomes the least-recently-used entry instead.
+        cache.get("a")
+        cache.put("c", listOf(address("c")))
+
+        assertEquals(listOf(address("a")), cache.get("a"))
+        assertNull(cache.get("b"))
+        assertEquals(listOf(address("c")), cache.get("c"))
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibilityTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibilityTest.kt
@@ -1,0 +1,79 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddressSearchEligibilityTest {
+
+    @Test
+    fun `GIVEN kill switch disabled WHEN evaluate THEN DISABLED regardless of query`() {
+        assertEquals(
+            AddressSearchGate.DISABLED,
+            AddressSearchEligibility.evaluate(
+                normalizedQuery = "Sydney Opera House",
+                isAddressSearchEnabled = false,
+                minQueryLength = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN blank normalized query WHEN evaluate THEN BLANK`() {
+        assertEquals(
+            AddressSearchGate.BLANK,
+            AddressSearchEligibility.evaluate(
+                normalizedQuery = "",
+                isAddressSearchEnabled = true,
+                minQueryLength = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN query shorter than threshold WHEN evaluate THEN BELOW_THRESHOLD`() {
+        assertEquals(
+            AddressSearchGate.BELOW_THRESHOLD,
+            AddressSearchEligibility.evaluate(
+                normalizedQuery = "Syd",
+                isAddressSearchEnabled = true,
+                minQueryLength = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN query exactly at threshold WHEN evaluate THEN ELIGIBLE`() {
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            AddressSearchEligibility.evaluate(
+                normalizedQuery = "Sydney",
+                isAddressSearchEnabled = true,
+                minQueryLength = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN query longer than threshold WHEN evaluate THEN ELIGIBLE`() {
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            AddressSearchEligibility.evaluate(
+                normalizedQuery = "Sydney Opera House",
+                isAddressSearchEnabled = true,
+                minQueryLength = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN disabled AND blank AND below threshold WHEN evaluate THEN disabled wins`() {
+        assertEquals(
+            AddressSearchGate.DISABLED,
+            AddressSearchEligibility.evaluate(
+                normalizedQuery = "",
+                isAddressSearchEnabled = false,
+                minQueryLength = 6,
+            ),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMinQueryLengthTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMinQueryLengthTest.kt
@@ -1,0 +1,80 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddressSearchMinQueryLengthTest {
+
+    private val fakeFlag = FakeFlag()
+
+    @Test
+    fun `GIVEN no remote value WHEN resolve THEN default six`() {
+        assertEquals(6, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN in-range remote value WHEN resolve THEN that value`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.NumberValue(8),
+        )
+        assertEquals(8, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN lower bound remote value WHEN resolve THEN that value`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.NumberValue(2),
+        )
+        assertEquals(2, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN upper bound remote value WHEN resolve THEN that value`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.NumberValue(12),
+        )
+        assertEquals(12, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN below-range remote value WHEN resolve THEN fallback to default`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.NumberValue(1),
+        )
+        assertEquals(6, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN above-range remote value WHEN resolve THEN fallback to default`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.NumberValue(13),
+        )
+        assertEquals(6, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN wildly oversized remote value WHEN resolve THEN fallback to default not a wrapped Int`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.NumberValue(Long.MAX_VALUE),
+        )
+        assertEquals(6, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN malformed non-numeric remote value WHEN resolve THEN fallback to default`() {
+        fakeFlag.setFlagValue(
+            FlagKeys.SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH.key,
+            FlagValue.StringValue("six"),
+        )
+        assertEquals(6, resolveAddressSearchMinQueryLength(fakeFlag))
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchQueryNormalizerTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchQueryNormalizerTest.kt
@@ -1,0 +1,30 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddressSearchQueryNormalizerTest {
+
+    @Test
+    fun `GIVEN leading and trailing whitespace WHEN normalizeAddressQuery THEN trimmed`() {
+        assertEquals("Sydney", normalizeAddressQuery("  Sydney  "))
+    }
+
+    @Test
+    fun `GIVEN internal whitespace WHEN normalizeAddressQuery THEN preserved`() {
+        assertEquals("George Street", normalizeAddressQuery(" George Street "))
+    }
+
+    @Test
+    fun `GIVEN normalized query WHEN addressSearchCacheKey THEN lowercased`() {
+        assertEquals("sydney opera house", addressSearchCacheKey("Sydney Opera House"))
+    }
+
+    @Test
+    fun `GIVEN different casing of same query WHEN addressSearchCacheKey THEN same key`() {
+        assertEquals(
+            addressSearchCacheKey("SYDNEY"),
+            addressSearchCacheKey("sydney"),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeRemoteAddressResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeRemoteAddressResultsManager.kt
@@ -6,8 +6,14 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 class FakeRemoteAddressResultsManager : RemoteAddressResultsManager {
     var results: List<SearchStopState.SearchResult.Address> = emptyList()
     var shouldThrowError = false
+    var callCount: Int = 0
+        private set
+    var lastQuery: String? = null
+        private set
 
     override suspend fun fetchAddressResults(query: String): List<SearchStopState.SearchResult.Address> {
+        callCount++
+        lastQuery = query
         if (shouldThrowError) {
             throw RuntimeException("Error fetching address results")
         }


### PR DESCRIPTION
Unit tests for the classes added in the parent commit: gate table-driven
tests (disabled/blank/below-threshold/eligible precedence), Remote Config
threshold resolution (missing/malformed/out-of-range/oversized-Long
fallback), LRU cache TTL and eviction, cache-key normalization, and
ViewModel-level coverage for the gate/cache/staleness wiring end to end
(cached repeat query makes no second network call, below-threshold query
never calls the network, disabled-by-default constructor stays disabled).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>