### PR TITLE
feat(analytics): add location_kind and address_type to stop_selected

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -113,14 +113,42 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val stopId: String,
         val isRecentSearch: Boolean = false,
         val searchQuery: String? = null,
+        val locationKind: LocationKind = LocationKind.TRANSIT_STOP,
+        val addressType: AddressType? = null,
     ) : AnalyticsEvent(
         name = "stop_selected",
         properties = buildMap {
             put(PROP_STOP_ID, stopId)
             put("isRecentSearch", isRecentSearch)
             searchQuery?.let { put("searchQuery", it) }
+            put("locationKind", locationKind.value)
+            addressType?.let { put("addressType", it.value) }
         },
-    )
+    ) {
+        /** Mirrors `StopItem.LocationKind` (feature/trip-planner/state) - redefined here
+         * so `core/analytics` doesn't depend on a feature-layer model. Map at the call
+         * site instead of adding a cross-module dependency. */
+        enum class LocationKind(val value: String) {
+            TRANSIT_STOP("transit_stop"),
+            ADDRESS("address"),
+        }
+
+        /** Allowlisted NSW `stop_finder` location types - never pass the raw API string
+         * through; anything not in this set folds to [UNKNOWN]. Values match the
+         * existing UI mapping in `AddressSearchListItem.kt`'s `addressTypeLabel`. */
+        enum class AddressType(val value: String) {
+            SINGLEHOUSE("singlehouse"),
+            STREET("street"),
+            POI("poi"),
+            UNKNOWN("unknown"),
+            ;
+
+            companion object {
+                fun from(rawType: String?): AddressType =
+                    entries.find { it.value == rawType } ?: UNKNOWN
+            }
+        }
+    }
 
     data class SearchStopQuery(
         val query: String,

--- a/docs/plans/ADDRESS_SEARCH_OBSERVABILITY_AND_ROLLOUT.md
+++ b/docs/plans/ADDRESS_SEARCH_OBSERVABILITY_AND_ROLLOUT.md
@@ -33,21 +33,26 @@ outcome, and consume analytics volume without helping a product decision. The
 project has a lifetime Firebase event-name cap of 500, so a new event requires
 the checklist and registry step in `docs/ANALYTICS_EVENTS.md`.
 
-The smallest product-analytics change, if the feature is rolled out, is to
-extend the existing `stop_selected` event with bounded properties:
+**Implemented**: the existing `stop_selected` event (`AnalyticsEvent.kt`) now carries
+bounded properties:
 
 | Property | Values | Product question |
 |---|---|---|
-| `location_kind` | `transit_stop`, `address` | Are address/POI results selected at all? |
-| `address_type` | Allowlisted NSW types such as `street`, `singlehouse`, `poi`, `unknown`; omitted for transit stops | Which result category provides value? |
-| `selection_surface` | `search_results`, `recent` | Are returned results useful now and later via recents? |
+| `locationKind` | `transit_stop`, `address` | Are address/POI results selected at all? |
+| `addressType` | Allowlisted NSW types `singlehouse`, `street`, `poi`, `unknown`; omitted for transit stops | Which result category provides value? |
 
-This reuses a user-outcome event rather than minting a request event. It also
-needs a privacy review of the existing `stopId` and `searchQuery` properties for
-address selections. Prefer an allowlisted classification property over sending
-the opaque address ID or text. Any resulting parameter or event change must be
-registered in the external KRAIL Analytics `EVENT_REGISTRY.md` before merge and
-must pass the no-double-counting check.
+`selection_surface` (`search_results`/`recent`) from the original proposal was
+deliberately **not** added — `stop_selected` already carries `isRecentSearch: Boolean`,
+which answers the same recent-vs-live-search question. Adding a second field for it
+would have been a redundant param per `docs/ANALYTICS_EVENTS.md`'s own decision
+checklist.
+
+This reuses a user-outcome event rather than minting a request event, and sends only an
+allowlisted classification, never the opaque address ID or text — `AddressType.from()`
+folds any unrecognised raw NSW type to `UNKNOWN` rather than passing it through. Still
+outstanding: registering `locationKind`/`addressType` in the external KRAIL-Analytics
+`EVENT_REGISTRY.md` (see the open question on its exact location in the stop-label
+analytics handoff).
 
 ## Operational API health is separate
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -114,6 +114,11 @@ class SearchStopViewModel(
                         stopId = event.stopItem.stopId,
                         isRecentSearch = event.isRecentSearch,
                         searchQuery = event.searchQuery,
+                        locationKind = when (event.stopItem.locationKind) {
+                            LocationKind.TRANSIT_STOP -> StopSelectedEvent.LocationKind.TRANSIT_STOP
+                            LocationKind.ADDRESS -> StopSelectedEvent.LocationKind.ADDRESS
+                        },
+                        addressType = event.stopItem.addressType?.let(StopSelectedEvent.AddressType::from),
                     ),
                 )
             }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -173,6 +173,51 @@ class SearchStopViewModelTest {
             assertIs<AnalyticsEvent.StopSelectedEvent>(event)
             assertEquals("stopID", event.stopId)
             assertEquals(false, event.isRecentSearch)
+            assertEquals(AnalyticsEvent.StopSelectedEvent.LocationKind.TRANSIT_STOP, event.locationKind)
+            assertEquals(null, event.addressType)
+        }
+
+    @Test
+    fun `GIVEN an address stop item WHEN StopSelected is triggered THEN analytics event carries location kind and address type`() =
+        runTest {
+            viewModel.onEvent(
+                SearchStopUiEvent.TrackStopSelected(
+                    StopItem(
+                        stopName = "123 Example St",
+                        stopId = "streetID:123",
+                        locationKind = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.LocationKind.ADDRESS,
+                        addressType = "street",
+                    ),
+                    isRecentSearch = false,
+                ),
+            )
+
+            assertTrue(fakeAnalytics is FakeAnalytics)
+            val event = fakeAnalytics.getTrackedEvent("stop_selected")
+            assertIs<AnalyticsEvent.StopSelectedEvent>(event)
+            assertEquals(AnalyticsEvent.StopSelectedEvent.LocationKind.ADDRESS, event.locationKind)
+            assertEquals(AnalyticsEvent.StopSelectedEvent.AddressType.STREET, event.addressType)
+        }
+
+    @Test
+    fun `GIVEN an address stop item with an unrecognised raw type WHEN StopSelected is triggered THEN address type folds to UNKNOWN`() =
+        runTest {
+            viewModel.onEvent(
+                SearchStopUiEvent.TrackStopSelected(
+                    StopItem(
+                        stopName = "Some POI",
+                        stopId = "poiID:456",
+                        locationKind = xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.LocationKind.ADDRESS,
+                        addressType = "some-new-nsw-type-we-dont-know-about",
+                    ),
+                    isRecentSearch = false,
+                ),
+            )
+
+            assertTrue(fakeAnalytics is FakeAnalytics)
+            val event = fakeAnalytics.getTrackedEvent("stop_selected")
+            assertIs<AnalyticsEvent.StopSelectedEvent>(event)
+            assertEquals(AnalyticsEvent.StopSelectedEvent.AddressType.UNKNOWN, event.addressType)
         }
 
     @Test


### PR DESCRIPTION
stop_selected was identical whether the tapped item was a transit stop, a
recent address, or a live address/POI search result - the data layer
(StopItem.locationKind, RecentSearchLocation.kind/addressType) already
distinguished them, but the analytics event dropped that information at
the single construction site in SearchStopViewModel.

- StopSelectedEvent gains locationKind (transit_stop|address, default
  transit_stop for back-compat with historical rows) and addressType
  (allowlisted singlehouse|street|poi|unknown - never the raw NSW type
  string, folds unrecognised values to unknown via AddressType.from()).
- Deliberately did not add selection_surface from the original proposal
  in ADDRESS_SEARCH_OBSERVABILITY_AND_ROLLOUT.md: isRecentSearch already
  answers the same recent-vs-live-search question, so a second field
  would be a redundant param per docs/ANALYTICS_EVENTS.md's own checklist.
- 0 new event names - stop_selected is reused, not replaced.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>