### PR TITLE
feat(analytics): stop sending raw search query text

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -112,7 +112,6 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class StopSelectedEvent(
         val stopId: String,
         val isRecentSearch: Boolean = false,
-        val searchQuery: String? = null,
         val locationKind: LocationKind = LocationKind.TRANSIT_STOP,
         val addressType: AddressType? = null,
     ) : AnalyticsEvent(
@@ -120,7 +119,6 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         properties = buildMap {
             put(PROP_STOP_ID, stopId)
             put("isRecentSearch", isRecentSearch)
-            searchQuery?.let { put("searchQuery", it) }
             put("locationKind", locationKind.value)
             addressType?.let { put("addressType", it.value) }
         },
@@ -150,20 +148,42 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         }
     }
 
+    /**
+     * Fired when a settled search query finishes resolving. Never carries the raw
+     * typed text by default: a query can be a street address, which identifies a home
+     * or workplace, and the privacy policy promises analytics hold no personally
+     * identifiable data.
+     *
+     * [zeroResultQuery] is the single, deliberately narrow exception, kept for
+     * fuzzy-matcher diagnostics (the "townhall returned nothing" workflow). Callers
+     * must resolve it through `SearchQueryAnalyticsRedaction.zeroResultQueryOrNull`,
+     * which requires zero results everywhere, no digits, and a short length. It lands
+     * in the same "query" property historical dashboards already read.
+     *
+     * @param queryLength     Character count of the typed query - shape signal, no text.
+     * @param searchSessionId Random ID minted per settled query; joins this event to
+     *                        [StopSelectedEvent] so funnels work without query text.
+     * @param resultsCount    Result count on success.
+     * @param isError         True when the search pipeline threw.
+     * @param zeroResultQuery Raw text only under the redaction carve-out, else null.
+     */
     data class SearchStopQuery(
-        val query: String,
+        val queryLength: Int,
+        val searchSessionId: String,
         val resultsCount: Int? = null,
         val isError: Boolean = false,
+        val zeroResultQuery: String? = null,
     ) : AnalyticsEvent(
         name = "search_stop_query",
-        properties = mutableMapOf<String, Any>(
-            "query" to query,
-        ).apply {
+        properties = buildMap {
+            put("queryLength", queryLength)
+            put("searchSessionId", searchSessionId)
             if (isError) {
                 put("isError", isError)
             } else if (resultsCount != null) {
                 put("resultsCount", resultsCount)
             }
+            zeroResultQuery?.let { put("query", it) }
         },
     )
 

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -29,6 +29,10 @@ either; most changes should be params on an existing event, not a new name.
 |---|---|---|---|---|---|---|---|
 | 2026-07-14 | `stop_selected` | `locationKind` | `transit_stop｜address` (default `transit_stop`) | A stop, address, or POI is selected from search results, recents, empty-state, or trip-stop click | [#1711](https://github.com/ksharma-xyz/KRAIL/pull/1711) | Registered | — |
 | 2026-07-14 | `stop_selected` | `addressType` | Allowlisted `singlehouse｜street｜poi｜unknown`; omitted for transit stops | Same as above, only present when `locationKind = address` | [#1711](https://github.com/ksharma-xyz/KRAIL/pull/1711) | Registered | — |
+| 2026-07-15 | `search_stop_query` | `queryLength` | Int, character count of typed query | Settled search query resolves (success or error) | TBD | Pending | — |
+| 2026-07-15 | `search_stop_query` | `searchSessionId` | Random hex string per settled query; joins to `stop_selected` | Same as above | TBD | Pending | — |
+| 2026-07-15 | `search_stop_query` | `query` (semantics change) | Raw text now sent ONLY under the zero-result carve-out: zero results everywhere, no digits, ≤ 25 chars (`SearchQueryAnalyticsRedaction`). Previously sent on every firing | Zero-result fuzzy-diagnostics carve-out only | TBD | Pending | — |
+| 2026-07-15 | `stop_selected` | `searchQuery` (REMOVED) | Param deleted: carried raw typed text, which can be a street address (privacy policy promises no PII in analytics) | No longer fires | TBD | Pending | — |
 
 Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table,
 2026-07-14.

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
@@ -9,7 +9,6 @@ sealed interface SearchStopUiEvent {
     data class TrackStopSelected(
         val stopItem: StopItem,
         val isRecentSearch: Boolean = false,
-        val searchQuery: String? = null,
     ) : SearchStopUiEvent
 
     data class ClearRecentSearchStops(val recentSearchCount: Int) : SearchStopUiEvent

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedaction.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedaction.kt
@@ -1,0 +1,45 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+/**
+ * Decides whether a raw search query may be attached to analytics.
+ *
+ * Default is never: typed text can be a street address, which identifies a home or
+ * workplace, and the privacy policy promises analytics contain no personally
+ * identifiable data. The one carve-out exists for fuzzy-matcher diagnostics: a query
+ * that matched nothing anywhere, contains no digits (house and unit numbers are the
+ * identifying part of an address), and is short. "townhall" returning zero results
+ * stays diagnosable; "4 fulton place" is never sent.
+ *
+ * Call-site contract: when the address pipeline is eligible for the query, the
+ * carve-out decision belongs to the address pipeline's completion site (which knows
+ * the real address result count) - the local pipeline must not call this with
+ * [addressResultsCount] = null in that case.
+ */
+object SearchQueryAnalyticsRedaction {
+
+    const val MAX_ZERO_RESULT_QUERY_LENGTH = 25
+
+    /**
+     * Returns the trimmed query when every carve-out condition holds, else null.
+     *
+     * @param localResultsCount   Local stop-search result count for the query.
+     * @param addressResultsCount Address-pipeline result count for the same query, or
+     *                            null when the address pipeline did not run (flag off
+     *                            or below the minimum query length).
+     */
+    fun zeroResultQueryOrNull(
+        query: String,
+        localResultsCount: Int,
+        addressResultsCount: Int?,
+    ): String? {
+        val trimmed = query.trim()
+        val addressRecognisedNothing = addressResultsCount == null || addressResultsCount == 0
+        return trimmed.takeIf {
+            localResultsCount == 0 &&
+                addressRecognisedNothing &&
+                it.isNotEmpty() &&
+                it.length <= MAX_ZERO_RESULT_QUERY_LENGTH &&
+                it.none(Char::isDigit)
+        }
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -710,14 +710,12 @@ private fun SearchStopListContent(
                         onLabelPillClick = onLabelPillClick,
                         onNewLabelClick = onNewLabelClick,
                         onEvent = onEvent,
-                        searchQuery = searchStopState.searchQuery,
                     )
                     addressResultsSection(
                         addressResults = searchStopState.addressResults,
                         isLoading = searchStopState.isAddressSearchLoading,
                         keyboard = keyboard,
                         focusRequester = focusRequester,
-                        searchQuery = searchStopState.searchQuery,
                         onStopSelect = onStopSelect,
                         onEvent = onEvent,
                     )
@@ -750,7 +748,6 @@ private fun SearchStopListContent(
                         isLoading = searchStopState.isAddressSearchLoading,
                         keyboard = keyboard,
                         focusRequester = focusRequester,
-                        searchQuery = searchStopState.searchQuery,
                         onStopSelect = onStopSelect,
                         onEvent = onEvent,
                     )
@@ -815,7 +812,6 @@ private fun LazyListScope.searchResultsList(
     searchResults: List<SearchStopState.SearchResult>,
     keyboard: androidx.compose.ui.platform.SoftwareKeyboardController?,
     focusRequester: FocusRequester,
-    searchQuery: String,
     stopLabels: ImmutableList<StopLabel>,
     expandedStopKey: String?,
     onToggleExpandStop: (String) -> Unit,
@@ -850,10 +846,7 @@ private fun LazyListScope.searchResultsList(
                         focusRequester.freeFocus()
                         onStopSelect(stopItem)
                         onEvent(
-                            SearchStopUiEvent.TrackStopSelected(
-                                stopItem = stopItem,
-                                searchQuery = searchQuery,
-                            ),
+                            SearchStopUiEvent.TrackStopSelected(stopItem = stopItem),
                         )
                     },
                     onLabelPillClick = { label -> onLabelPillClick(stopItem, label) },
@@ -915,7 +908,6 @@ private fun LazyListScope.addressResultsSection(
     isLoading: Boolean,
     keyboard: androidx.compose.ui.platform.SoftwareKeyboardController?,
     focusRequester: FocusRequester,
-    searchQuery: String,
     onStopSelect: (StopItem) -> Unit,
     onEvent: (SearchStopUiEvent) -> Unit,
 ) {
@@ -959,10 +951,7 @@ private fun LazyListScope.addressResultsSection(
                 focusRequester.freeFocus()
                 onStopSelect(stopItem)
                 onEvent(
-                    SearchStopUiEvent.TrackStopSelected(
-                        stopItem = stopItem,
-                        searchQuery = searchQuery,
-                    ),
+                    SearchStopUiEvent.TrackStopSelected(stopItem = stopItem),
                 )
             },
             modifier = Modifier.fillMaxWidth(),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -55,6 +55,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.LocationKind
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import kotlin.random.Random
 
 @Suppress("TooManyFunctions", "LongParameterList")
 class SearchStopViewModel(
@@ -103,6 +104,11 @@ class SearchStopViewModel(
     private val addressSearchCache = AddressSearchCache()
     private var addressSearchRequestToken = 0
 
+    // Random ID minted per settled query; sent on search analytics events so funnels
+    // can be joined per query instance without carrying the typed text (which can be
+    // a street address — see SearchQueryAnalyticsRedaction).
+    private var currentSearchSessionId: String = newSearchSessionId()
+
     @Suppress("LongMethod", "ReturnCount")
     fun onEvent(event: SearchStopUiEvent) {
         when (event) {
@@ -113,7 +119,6 @@ class SearchStopViewModel(
                     StopSelectedEvent(
                         stopId = event.stopItem.stopId,
                         isRecentSearch = event.isRecentSearch,
-                        searchQuery = event.searchQuery,
                         locationKind = when (event.stopItem.locationKind) {
                             LocationKind.TRANSIT_STOP -> StopSelectedEvent.LocationKind.TRANSIT_STOP
                             LocationKind.ADDRESS -> StopSelectedEvent.LocationKind.ADDRESS
@@ -479,6 +484,9 @@ class SearchStopViewModel(
         // Non-empty query -> set loading and start search
         updateUiState { displayLoading() }
 
+        currentSearchSessionId = newSearchSessionId()
+        val searchSessionId = currentSearchSessionId
+
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
             delay(100) // debounce / small throttle on VM side
@@ -487,13 +495,24 @@ class SearchStopViewModel(
                 updateUiState { displayData(stopResults) }
                 analytics.track(
                     AnalyticsEvent.SearchStopQuery(
-                        query = query,
+                        queryLength = query.length,
+                        searchSessionId = searchSessionId,
                         resultsCount = stopResults.size,
+                        zeroResultQuery = resolveZeroResultQuery(
+                            query = query,
+                            localResultsCount = stopResults.size,
+                        ),
                     ),
                 )
             }.getOrElse {
                 updateUiState { displayError() }
-                analytics.track(AnalyticsEvent.SearchStopQuery(query = query, isError = true))
+                analytics.track(
+                    AnalyticsEvent.SearchStopQuery(
+                        queryLength = query.length,
+                        searchSessionId = searchSessionId,
+                        isError = true,
+                    ),
+                )
             }
         }
 
@@ -563,6 +582,22 @@ class SearchStopViewModel(
             isAddressSearchEnabled = isAddressSearchEnabled(),
             minQueryLength = addressSearchMinQueryLength(),
         )
+
+    /**
+     * Local-pipeline carve-out site. When the address pipeline is eligible for this
+     * query, it resolves later and owns the carve-out decision (the query may be a
+     * real address the NSW API recognises), so this returns null.
+     */
+    private fun resolveZeroResultQuery(query: String, localResultsCount: Int): String? {
+        if (currentAddressSearchGate(normalizeAddressQuery(query)) == AddressSearchGate.ELIGIBLE) {
+            return null
+        }
+        return SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+            query = query,
+            localResultsCount = localResultsCount,
+            addressResultsCount = null,
+        )
+    }
 
     private fun StopItem.productClasses(): String =
         when (locationKind) {
@@ -728,5 +763,7 @@ class SearchStopViewModel(
         // Longer than local search's 100ms debounce - network round-trip is inherently
         // slower, and there's no benefit to firing it as eagerly as the local DB query.
         const val ADDRESS_SEARCH_DEBOUNCE_MS = 350L
+
+        fun newSearchSessionId(): String = Random.nextLong().toULong().toString(radix = 16)
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -365,7 +365,6 @@ private fun MapContent(
                                     SearchStopUiEvent.TrackStopSelected(
                                         stopItem = stopItem,
                                         isRecentSearch = false,
-                                        searchQuery = null,
                                     ),
                                 )
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedactionTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedactionTest.kt
@@ -1,0 +1,112 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SearchQueryAnalyticsRedactionTest {
+
+    @Test
+    fun `zero results everywhere, no digits, short - query is kept`() {
+        assertEquals(
+            "townhall",
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "townhall",
+                localResultsCount = 0,
+                addressResultsCount = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `address pipeline recognised nothing - query is kept`() {
+        assertEquals(
+            "townhall",
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "townhall",
+                localResultsCount = 0,
+                addressResultsCount = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `query is trimmed before length and emptiness checks`() {
+        assertEquals(
+            "townhall",
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "  townhall  ",
+                localResultsCount = 0,
+                addressResultsCount = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `any digit blocks the query - house numbers are the PII carrier`() {
+        assertNull(
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "4 fulton place",
+                localResultsCount = 0,
+                addressResultsCount = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `local results present blocks the query`() {
+        assertNull(
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "townhall",
+                localResultsCount = 3,
+                addressResultsCount = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `address results present blocks the query`() {
+        assertNull(
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "fulton place",
+                localResultsCount = 0,
+                addressResultsCount = 5,
+            ),
+        )
+    }
+
+    @Test
+    fun `over max length blocks the query`() {
+        assertNull(
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "a".repeat(SearchQueryAnalyticsRedaction.MAX_ZERO_RESULT_QUERY_LENGTH + 1),
+                localResultsCount = 0,
+                addressResultsCount = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `exactly max length is kept`() {
+        val query = "a".repeat(SearchQueryAnalyticsRedaction.MAX_ZERO_RESULT_QUERY_LENGTH)
+        assertEquals(
+            query,
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = query,
+                localResultsCount = 0,
+                addressResultsCount = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `blank query is never kept`() {
+        assertNull(
+            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                query = "   ",
+                localResultsCount = 0,
+                addressResultsCount = null,
+            ),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -465,6 +465,106 @@ class SearchStopViewModelTest {
 
     // endregion SelectOnMapButtonClicked
 
+    // region Search query analytics redaction
+
+    @Test
+    fun `GIVEN a query with results WHEN search completes THEN search_stop_query carries no raw text`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Central"))
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val event = fakeAnalytics.getTrackedEvent("search_stop_query")
+                assertIs<AnalyticsEvent.SearchStopQuery>(event)
+                assertEquals("Central".length, event.queryLength)
+                assertEquals(1, event.resultsCount)
+                assertTrue(event.searchSessionId.isNotBlank())
+                assertFalse(event.properties.orEmpty().containsKey("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN zero results and address pipeline off WHEN query has no digits THEN carve-out keeps the query`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("townhall"))
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val event = fakeAnalytics.getTrackedEvent("search_stop_query")
+                assertIs<AnalyticsEvent.SearchStopQuery>(event)
+                assertEquals(0, event.resultsCount)
+                assertEquals("townhall", event.zeroResultQuery)
+                assertEquals("townhall", event.properties?.get("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN zero results WHEN query contains digits THEN carve-out never keeps the query`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("4 fulton place"))
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val event = fakeAnalytics.getTrackedEvent("search_stop_query")
+                assertIs<AnalyticsEvent.SearchStopQuery>(event)
+                assertEquals(0, event.resultsCount)
+                assertEquals(null, event.zeroResultQuery)
+                assertFalse(event.properties.orEmpty().containsKey("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN address pipeline eligible WHEN local results are zero THEN local event defers the carve-out`() =
+        runTest {
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("townhall"))
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val event = fakeAnalytics.getTrackedEvent("search_stop_query")
+                assertIs<AnalyticsEvent.SearchStopQuery>(event)
+                assertEquals(null, event.zeroResultQuery)
+                assertFalse(event.properties.orEmpty().containsKey("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN search fails WHEN error event fires THEN it carries no raw text`() =
+        runTest {
+            fakeStopResultsManager.shouldThrowError = true
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("townhall"))
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val event = fakeAnalytics.getTrackedEvent("search_stop_query")
+                assertIs<AnalyticsEvent.SearchStopQuery>(event)
+                assertTrue(event.isError)
+                assertFalse(event.properties.orEmpty().containsKey("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion Search query analytics redaction
+
     // region Address search eligibility
 
     private fun addressAwareViewModel(minQueryLength: Int = 6) = SearchStopViewModel(


### PR DESCRIPTION
search_stop_query and stop_selected both carried the raw typed query. With
address search shipping, that text can be a street address tied to a pseudo
user ID, which contradicts the privacy policy's no-PII commitment. Replace
the text with queryLength plus a random searchSessionId that joins the two
events per query instance.

One narrow carve-out remains for fuzzy-matcher diagnostics: a query that
returned zero results everywhere, contains no digits, and is 25 chars or
less is still sent in the existing "query" property, so the
top-zero-result-queries dashboard keeps working (SearchQueryAnalyticsRedaction).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
