### PR TITLE
feat(analytics): fire search_stop_query from the address pipeline

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -166,6 +166,9 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      * @param resultsCount    Result count on success.
      * @param isError         True when the search pipeline threw.
      * @param zeroResultQuery Raw text only under the redaction carve-out, else null.
+     * @param resultSource    Which pipeline resolved: local stop search or the remote
+     *                        NSW address/POI pipeline. One firing per pipeline per
+     *                        settled query; join on [searchSessionId].
      */
     data class SearchStopQuery(
         val queryLength: Int,
@@ -173,11 +176,13 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val resultsCount: Int? = null,
         val isError: Boolean = false,
         val zeroResultQuery: String? = null,
+        val resultSource: ResultSource = ResultSource.LOCAL,
     ) : AnalyticsEvent(
         name = "search_stop_query",
         properties = buildMap {
             put("queryLength", queryLength)
             put("searchSessionId", searchSessionId)
+            put("resultSource", resultSource.value)
             if (isError) {
                 put("isError", isError)
             } else if (resultsCount != null) {
@@ -185,7 +190,12 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             }
             zeroResultQuery?.let { put("query", it) }
         },
-    )
+    ) {
+        enum class ResultSource(val value: String) {
+            LOCAL("local"),
+            ADDRESS("address"),
+        }
+    }
 
     data class ClearRecentSearchClickEvent(
         val recentSearchCount: Int,

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAnalytics.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeAnalytics.kt
@@ -17,6 +17,10 @@ class FakeAnalytics : Analytics {
         return trackedEvents.find { it.name == eventName }
     }
 
+    fun getTrackedEvents(eventName: String): List<AnalyticsEvent> {
+        return trackedEvents.filter { it.name == eventName }
+    }
+
     override fun track(event: AnalyticsEvent) {
         println("Tracking event: $event")
         trackedEvents.add(event)

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -33,6 +33,7 @@ either; most changes should be params on an existing event, not a new name.
 | 2026-07-15 | `search_stop_query` | `searchSessionId` | Random hex string per settled query; joins to `stop_selected` | Same as above | TBD | Pending | — |
 | 2026-07-15 | `search_stop_query` | `query` (semantics change) | Raw text now sent ONLY under the zero-result carve-out: zero results everywhere, no digits, ≤ 25 chars (`SearchQueryAnalyticsRedaction`). Previously sent on every firing | Zero-result fuzzy-diagnostics carve-out only | TBD | Pending | — |
 | 2026-07-15 | `stop_selected` | `searchQuery` (REMOVED) | Param deleted: carried raw typed text, which can be a street address (privacy policy promises no PII in analytics) | No longer fires | TBD | Pending | — |
+| 2026-07-15 | `search_stop_query` | `resultSource` | `local｜address` (default `local`) | New second firing per settled query from the address pipeline on fetch completion (cache hits excluded); join firings on `searchSessionId` | TBD | Pending | — |
 
 Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table,
 2026-07-14.

--- a/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
+++ b/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
@@ -72,6 +72,18 @@ text — addresses can be personal data. `RealRemoteAddressResultsManager` no lo
 at all (see Cache section above: it propagates failures instead of catching them), so
 there is a single redacted log site, not two.
 
+## Analytics
+
+Each resolved, non-stale address fetch fires `search_stop_query` with
+`resultSource = address`, `queryLength`, `resultsCount` (or `isError` on failure), and
+the same `searchSessionId` as the local pipeline's firing for that query. Cache hits do
+not fire - the event counts real network calls, which is the number the API cost model
+cares about. Raw query text is never sent, with one exception: the zero-result
+carve-out in `SearchQueryAnalyticsRedaction` (zero results in both pipelines, no
+digits, 25 chars or fewer) - the address completion site owns that decision for
+address-eligible queries because only it knows both pipelines' counts. See
+`docs/ANALYTICS_REGISTRY_HANDOFF.md` for the param registry status.
+
 ## Remote Config
 
 | Key | Type | Fallback | Valid range |

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -525,6 +525,7 @@ class SearchStopViewModel(
     private fun onAddressSearchTextChanged(query: String) {
         addressSearchJob?.cancel()
         val normalizedQuery = normalizeAddressQuery(query)
+        val searchSessionId = currentSearchSessionId
 
         if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) {
             updateUiState { copy(addressResults = persistentListOf(), isAddressSearchLoading = false) }
@@ -573,7 +574,41 @@ class SearchStopViewModel(
                     isAddressSearchLoading = false,
                 )
             }
+            trackAddressSearchResolved(
+                normalizedQuery = normalizedQuery,
+                searchSessionId = searchSessionId,
+                addressResults = if (fetchResult.isSuccess) addressResults else null,
+            )
         }
+    }
+
+    /**
+     * One firing per resolved (non-stale) address fetch; cache hits are excluded so
+     * `resultSource = address` counts network calls, the number the API cost model
+     * cares about. This is also the carve-out site for address-eligible queries -
+     * only here are both pipelines' result counts known (see [resolveZeroResultQuery]).
+     */
+    private fun trackAddressSearchResolved(
+        normalizedQuery: String,
+        searchSessionId: String,
+        addressResults: List<SearchStopState.SearchResult.Address>?,
+    ) {
+        analytics.track(
+            AnalyticsEvent.SearchStopQuery(
+                queryLength = normalizedQuery.length,
+                searchSessionId = searchSessionId,
+                resultSource = AnalyticsEvent.SearchStopQuery.ResultSource.ADDRESS,
+                resultsCount = addressResults?.size,
+                isError = addressResults == null,
+                zeroResultQuery = addressResults?.let {
+                    SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                        query = normalizedQuery,
+                        localResultsCount = _uiState.value.searchResults.size,
+                        addressResultsCount = it.size,
+                    )
+                },
+            ),
+        )
     }
 
     private fun currentAddressSearchGate(normalizedQuery: String): AddressSearchGate =

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -565,6 +565,131 @@ class SearchStopViewModelTest {
 
     // endregion Search query analytics redaction
 
+    // region Address search analytics
+
+    private fun addressEvents(): List<AnalyticsEvent.SearchStopQuery> =
+        (fakeAnalytics as FakeAnalytics).getTrackedEvents("search_stop_query")
+            .filterIsInstance<AnalyticsEvent.SearchStopQuery>()
+            .filter { it.resultSource == AnalyticsEvent.SearchStopQuery.ResultSource.ADDRESS }
+
+    @Test
+    fun `GIVEN an address fetch WHEN it resolves THEN one address-source event fires with the local session id`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Opera House",
+                    addressType = "poi",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                val addressEvent = addressEvents().single()
+                assertEquals(1, addressEvent.resultsCount)
+                assertFalse(addressEvent.isError)
+                assertFalse(addressEvent.properties.orEmpty().containsKey("query"))
+
+                val localEvent = (fakeAnalytics as FakeAnalytics)
+                    .getTrackedEvents("search_stop_query")
+                    .filterIsInstance<AnalyticsEvent.SearchStopQuery>()
+                    .single { it.resultSource == AnalyticsEvent.SearchStopQuery.ResultSource.LOCAL }
+                assertEquals(localEvent.searchSessionId, addressEvent.searchSessionId)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN zero results in both pipelines WHEN query has no digits THEN address event carries the carve-out`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = emptyList()
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("fulton place"))
+                advanceUntilIdle()
+
+                val addressEvent = addressEvents().single()
+                assertEquals(0, addressEvent.resultsCount)
+                assertEquals("fulton place", addressEvent.zeroResultQuery)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN the address pipeline recognises the query WHEN results return THEN the carve-out stays off`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Fulton Place",
+                    addressType = "street",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("fulton place"))
+                advanceUntilIdle()
+
+                val addressEvent = addressEvents().single()
+                assertEquals(null, addressEvent.zeroResultQuery)
+                assertFalse(addressEvent.properties.orEmpty().containsKey("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN the address fetch fails WHEN the event fires THEN it is an error with no raw text`() =
+        runTest {
+            fakeRemoteAddressResultsManager.shouldThrowError = true
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("fulton place"))
+                advanceUntilIdle()
+
+                val addressEvent = addressEvents().single()
+                assertTrue(addressEvent.isError)
+                assertEquals(null, addressEvent.zeroResultQuery)
+                assertFalse(addressEvent.properties.orEmpty().containsKey("query"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a cached query WHEN searched again THEN no second address event fires`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = emptyList()
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                assertEquals(1, fakeRemoteAddressResultsManager.callCount)
+                assertEquals(1, addressEvents().size)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    // endregion Address search analytics
+
     // region Address search eligibility
 
     private fun addressAwareViewModel(minQueryLength: Int = 6) = SearchStopViewModel(


### PR DESCRIPTION
The address pipeline previously emitted no analytics at all: API error rate,
zero-result rate, and call volume were invisible in the field, and failure is
deliberately silent in the UI. Each resolved, non-stale fetch now fires
search_stop_query with resultSource=address and the same searchSessionId as
the local pipeline's firing, so the two can be joined per query instance.
Cache hits do not fire - the count matches real network calls, which is what
the stop_finder cost model cares about.

This is also the carve-out site for address-eligible queries: only here are
both pipelines' result counts known, so a query like "townhall" that
returned nothing anywhere stays diagnosable while a recognised address never
carries its text.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
