### PR TITLE
feat(analytics): add selection context to stop_selected

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -109,11 +109,24 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     // region SearchStop
 
+    /**
+     * @param searchSessionId      Joins the selection to its [SearchStopQuery] firings.
+     *                             Null when the selection had no live query (recents,
+     *                             empty-state stops, map picks).
+     * @param displayedLocalCount  Bucketed count of local results on screen at
+     *                             selection time; null without a live query.
+     * @param displayedAddressCount Same for the address/POI section. Together these
+     *                             answer "how many options were showing when the user
+     *                             picked" without carrying any query text.
+     */
     data class StopSelectedEvent(
         val stopId: String,
         val isRecentSearch: Boolean = false,
         val locationKind: LocationKind = LocationKind.TRANSIT_STOP,
         val addressType: AddressType? = null,
+        val searchSessionId: String? = null,
+        val displayedLocalCount: CountBucket? = null,
+        val displayedAddressCount: CountBucket? = null,
     ) : AnalyticsEvent(
         name = "stop_selected",
         properties = buildMap {
@@ -121,8 +134,33 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             put("isRecentSearch", isRecentSearch)
             put("locationKind", locationKind.value)
             addressType?.let { put("addressType", it.value) }
+            searchSessionId?.let { put("searchSessionId", it) }
+            displayedLocalCount?.let { put("displayedLocalCount", it.value) }
+            displayedAddressCount?.let { put("displayedAddressCount", it.value) }
         },
     ) {
+        /** Bounded so dashboards group cleanly; raw counts add cardinality without
+         * answering anything the buckets can't. */
+        enum class CountBucket(val value: String) {
+            ZERO("0"),
+            ONE_TO_THREE("1_3"),
+            FOUR_TO_TEN("4_10"),
+            ELEVEN_PLUS("11_plus"),
+            ;
+
+            companion object {
+                private const val MAX_ONE_TO_THREE = 3
+                private const val MAX_FOUR_TO_TEN = 10
+
+                fun from(count: Int): CountBucket = when {
+                    count <= 0 -> ZERO
+                    count <= MAX_ONE_TO_THREE -> ONE_TO_THREE
+                    count <= MAX_FOUR_TO_TEN -> FOUR_TO_TEN
+                    else -> ELEVEN_PLUS
+                }
+            }
+        }
+
         /** Mirrors `StopItem.LocationKind` (feature/trip-planner/state) - redefined here
          * so `core/analytics` doesn't depend on a feature-layer model. Map at the call
          * site instead of adding a cross-module dependency. */

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -49,6 +49,33 @@ Separate names force every dashboard and derivation to UNION two event names to 
 one feature across a change. Missing param on historical rows = "before the change",
 which gives before/after splits for free.
 
+## Search funnel join model: `searchSessionId`
+
+Analytics never carry raw search query text (a typed query can be a street address;
+see `SearchQueryAnalyticsRedaction` in `:feature:trip-planner:ui` for the one narrow
+zero-result carve-out). The correlation the text used to provide comes from
+`searchSessionId` instead: a random 64-bit hex string minted in
+`SearchStopViewModel.onSearchTextChanged` for every settled non-blank query.
+
+Semantics:
+
+- **One ID per settled query.** Typing "cen" then "central" mints two IDs. Every
+  event describing the same query instance carries the same ID.
+- **Carried by** `search_stop_query` (both the `resultSource = local` and
+  `resultSource = address` firings) and `stop_selected`.
+- **Null when there is no live query.** Selections from recents, empty-state stops,
+  and map picks attach no ID; joining them to a search would be wrong.
+- **Meaningless by design.** Not stored on device, not derived from anything, adds
+  zero information about the user. It only links events to each other.
+- **Not `ga_session_id`.** Firebase's session ID spans a whole app sitting (many
+  searches); `searchSessionId` is per query, which is where "were the results any
+  good" lives.
+
+What it buys: joining the three events per query instance answers "N local and M
+address results were on screen, the user picked an address" without any query text.
+Rows before 2026-07-15 have no `searchSessionId`; treat missing as "pre-join era",
+only app-session-level funnels are possible there.
+
 ## Registration gate
 
 Every new event or param must be registered in `docs/EVENT_REGISTRY.md` in the

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -34,6 +34,9 @@ either; most changes should be params on an existing event, not a new name.
 | 2026-07-15 | `search_stop_query` | `query` (semantics change) | Raw text now sent ONLY under the zero-result carve-out: zero results everywhere, no digits, ≤ 25 chars (`SearchQueryAnalyticsRedaction`). Previously sent on every firing | Zero-result fuzzy-diagnostics carve-out only | TBD | Pending | — |
 | 2026-07-15 | `stop_selected` | `searchQuery` (REMOVED) | Param deleted: carried raw typed text, which can be a street address (privacy policy promises no PII in analytics) | No longer fires | TBD | Pending | — |
 | 2026-07-15 | `search_stop_query` | `resultSource` | `local｜address` (default `local`) | New second firing per settled query from the address pipeline on fetch completion (cache hits excluded); join firings on `searchSessionId` | TBD | Pending | — |
+| 2026-07-15 | `stop_selected` | `searchSessionId` | Random hex string; joins to `search_stop_query` firings | Only when selection happens with a live (non-blank) query; recents/map picks omit it | TBD | Pending | — |
+| 2026-07-15 | `stop_selected` | `displayedLocalCount` | Bucket `0｜1_3｜4_10｜11_plus` | Local results on screen at selection time; omitted without a live query | TBD | Pending | — |
+| 2026-07-15 | `stop_selected` | `displayedAddressCount` | Bucket `0｜1_3｜4_10｜11_plus` | Address/POI results on screen at selection time; omitted without a live query | TBD | Pending | — |
 
 Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table,
 2026-07-14.

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -29,14 +29,14 @@ either; most changes should be params on an existing event, not a new name.
 |---|---|---|---|---|---|---|---|
 | 2026-07-14 | `stop_selected` | `locationKind` | `transit_stop｜address` (default `transit_stop`) | A stop, address, or POI is selected from search results, recents, empty-state, or trip-stop click | [#1711](https://github.com/ksharma-xyz/KRAIL/pull/1711) | Registered | — |
 | 2026-07-14 | `stop_selected` | `addressType` | Allowlisted `singlehouse｜street｜poi｜unknown`; omitted for transit stops | Same as above, only present when `locationKind = address` | [#1711](https://github.com/ksharma-xyz/KRAIL/pull/1711) | Registered | — |
-| 2026-07-15 | `search_stop_query` | `queryLength` | Int, character count of typed query | Settled search query resolves (success or error) | TBD | Pending | — |
-| 2026-07-15 | `search_stop_query` | `searchSessionId` | Random hex string per settled query; joins to `stop_selected` | Same as above | TBD | Pending | — |
-| 2026-07-15 | `search_stop_query` | `query` (semantics change) | Raw text now sent ONLY under the zero-result carve-out: zero results everywhere, no digits, ≤ 25 chars (`SearchQueryAnalyticsRedaction`). Previously sent on every firing | Zero-result fuzzy-diagnostics carve-out only | TBD | Pending | — |
-| 2026-07-15 | `stop_selected` | `searchQuery` (REMOVED) | Param deleted: carried raw typed text, which can be a street address (privacy policy promises no PII in analytics) | No longer fires | TBD | Pending | — |
-| 2026-07-15 | `search_stop_query` | `resultSource` | `local｜address` (default `local`) | New second firing per settled query from the address pipeline on fetch completion (cache hits excluded); join firings on `searchSessionId` | TBD | Pending | — |
-| 2026-07-15 | `stop_selected` | `searchSessionId` | Random hex string; joins to `search_stop_query` firings | Only when selection happens with a live (non-blank) query; recents/map picks omit it | TBD | Pending | — |
-| 2026-07-15 | `stop_selected` | `displayedLocalCount` | Bucket `0｜1_3｜4_10｜11_plus` | Local results on screen at selection time; omitted without a live query | TBD | Pending | — |
-| 2026-07-15 | `stop_selected` | `displayedAddressCount` | Bucket `0｜1_3｜4_10｜11_plus` | Address/POI results on screen at selection time; omitted without a live query | TBD | Pending | — |
+| 2026-07-15 | `search_stop_query` | `queryLength` | Int, character count of typed query | Settled search query resolves (success or error) | [#1715](https://github.com/ksharma-xyz/KRAIL/pull/1715) | Registered | — |
+| 2026-07-15 | `search_stop_query` | `searchSessionId` | Random hex string per settled query; joins to `stop_selected` | Same as above | [#1715](https://github.com/ksharma-xyz/KRAIL/pull/1715) | Registered | — |
+| 2026-07-15 | `search_stop_query` | `query` (semantics change) | Raw text now sent ONLY under the zero-result carve-out: zero results everywhere, no digits, ≤ 25 chars (`SearchQueryAnalyticsRedaction`). Previously sent on every firing | Zero-result fuzzy-diagnostics carve-out only | [#1715](https://github.com/ksharma-xyz/KRAIL/pull/1715) | Registered | — |
+| 2026-07-15 | `stop_selected` | `searchQuery` (REMOVED) | Param deleted: carried raw typed text, which can be a street address (privacy policy promises no PII in analytics) | No longer fires | [#1715](https://github.com/ksharma-xyz/KRAIL/pull/1715) | Registered | — |
+| 2026-07-15 | `search_stop_query` | `resultSource` | `local｜address` (default `local`) | New second firing per settled query from the address pipeline on fetch completion (cache hits excluded); join firings on `searchSessionId` | [#1716](https://github.com/ksharma-xyz/KRAIL/pull/1716) | Registered | — |
+| 2026-07-15 | `stop_selected` | `searchSessionId` | Random hex string; joins to `search_stop_query` firings | Only when selection happens with a live (non-blank) query; recents/map picks omit it | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
+| 2026-07-15 | `stop_selected` | `displayedLocalCount` | Bucket `0｜1_3｜4_10｜11_plus` | Local results on screen at selection time; omitted without a live query | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
+| 2026-07-15 | `stop_selected` | `displayedAddressCount` | Bucket `0｜1_3｜4_10｜11_plus` | Address/POI results on screen at selection time; omitted without a live query | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
 
 Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table,
 2026-07-14.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -115,6 +115,11 @@ class SearchStopViewModel(
             is SearchStopUiEvent.SearchTextChanged -> onSearchTextChanged(event.query)
 
             is SearchStopUiEvent.TrackStopSelected -> {
+                // Selection context only makes sense mid-search: for recents,
+                // empty-state stops, and map picks the displayed result counts
+                // belong to a previous (or no) query, so send nothing.
+                val state = _uiState.value
+                val fromLiveQuery = state.searchQuery.isNotBlank()
                 analytics.track(
                     StopSelectedEvent(
                         stopId = event.stopItem.stopId,
@@ -124,6 +129,13 @@ class SearchStopViewModel(
                             LocationKind.ADDRESS -> StopSelectedEvent.LocationKind.ADDRESS
                         },
                         addressType = event.stopItem.addressType?.let(StopSelectedEvent.AddressType::from),
+                        searchSessionId = currentSearchSessionId.takeIf { fromLiveQuery },
+                        displayedLocalCount = StopSelectedEvent.CountBucket
+                            .from(state.searchResults.size)
+                            .takeIf { fromLiveQuery },
+                        displayedAddressCount = StopSelectedEvent.CountBucket
+                            .from(state.addressResults.size)
+                            .takeIf { fromLiveQuery },
                     ),
                 )
             }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -565,6 +565,74 @@ class SearchStopViewModelTest {
 
     // endregion Search query analytics redaction
 
+    // region Stop selected context
+
+    @Test
+    fun `GIVEN a live query WHEN a stop is selected THEN the event joins the query session and carries buckets`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Central"))
+                advanceUntilIdle()
+                viewModel.onEvent(
+                    SearchStopUiEvent.TrackStopSelected(
+                        StopItem(stopName = "Central Station", stopId = "10101"),
+                    ),
+                )
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val selected = fakeAnalytics.getTrackedEvent("stop_selected")
+                assertIs<AnalyticsEvent.StopSelectedEvent>(selected)
+                val query = fakeAnalytics.getTrackedEvent("search_stop_query")
+                assertIs<AnalyticsEvent.SearchStopQuery>(query)
+                assertEquals(query.searchSessionId, selected.searchSessionId)
+                assertEquals(
+                    AnalyticsEvent.StopSelectedEvent.CountBucket.ONE_TO_THREE,
+                    selected.displayedLocalCount,
+                )
+                assertEquals(
+                    AnalyticsEvent.StopSelectedEvent.CountBucket.ZERO,
+                    selected.displayedAddressCount,
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN no live query WHEN a stop is selected THEN no session or bucket params are attached`() =
+        runTest {
+            viewModel.onEvent(
+                SearchStopUiEvent.TrackStopSelected(
+                    StopItem(stopName = "Central Station", stopId = "10101"),
+                    isRecentSearch = true,
+                ),
+            )
+            advanceUntilIdle()
+
+            assertTrue(fakeAnalytics is FakeAnalytics)
+            val selected = fakeAnalytics.getTrackedEvent("stop_selected")
+            assertIs<AnalyticsEvent.StopSelectedEvent>(selected)
+            assertEquals(null, selected.searchSessionId)
+            assertEquals(null, selected.displayedLocalCount)
+            assertEquals(null, selected.displayedAddressCount)
+            assertFalse(selected.properties.orEmpty().containsKey("searchSessionId"))
+        }
+
+    @Test
+    fun `CountBucket boundaries`() {
+        val bucket = AnalyticsEvent.StopSelectedEvent.CountBucket.Companion::from
+        assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.ZERO, bucket(0))
+        assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.ONE_TO_THREE, bucket(1))
+        assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.ONE_TO_THREE, bucket(3))
+        assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.FOUR_TO_TEN, bucket(4))
+        assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.FOUR_TO_TEN, bucket(10))
+        assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.ELEVEN_PLUS, bucket(11))
+    }
+
+    // endregion Stop selected context
+
     // region Address search analytics
 
     private fun addressEvents(): List<AnalyticsEvent.SearchStopQuery> =


### PR DESCRIPTION
When a stop or address is picked mid-search, stop_selected now carries the
query's searchSessionId plus bucketed displayed-result counts for both the
local and address sections. Joined with search_stop_query this answers
"10 local and 20 address results were showing, the user picked an address"
without any query text. Selections without a live query (recents,
empty-state stops, map picks) attach nothing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
