### PR TITLE
feat(analytics): bounded stop-label creation and assignment params

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -249,79 +249,113 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     // region StopLabels
 
     /**
-     * Fired when the user creates a new custom stop label via the save / create-label sheet.
-     * Use to measure adoption: how many users actually create labels, and which semantics
-     * they reach for (e.g. "Gym", "Airport", "Mom's").
+     * Bounded classification of a label. Raw label names never leave the device:
+     * a custom label ("Mum's", "Gym") plus a pinned stop can identify a person or
+     * place, and the privacy policy promises analytics hold no PII.
+     */
+    enum class StopLabelKind(val value: String) {
+        PROTECTED_DEFAULT("protected_default"),
+        CUSTOM("custom"),
+    }
+
+    /** Which row kind hosted a label create/assign action. Registered values -
+     * `address_result` is reserved for when address rows gain label support. */
+    enum class StopLabelSurface(val value: String) {
+        SEARCH_RESULT("search_result"),
+        RECENT("recent"),
+        EMPTY_STATE("empty_state"),
+        ADDRESS_RESULT("address_result"),
+    }
+
+    /** How many labels the user has, bucketed - splits casual (1-2) from power users. */
+    enum class StopLabelCountBucket(val value: String) {
+        ONE("1"),
+        TWO("2"),
+        THREE_TO_FIVE("3_5"),
+        SIX_PLUS("6_plus"),
+        ;
+
+        companion object {
+            private const val MAX_THREE_TO_FIVE = 5
+
+            fun from(count: Int): StopLabelCountBucket = when {
+                count <= 1 -> ONE
+                count == 2 -> TWO
+                count <= MAX_THREE_TO_FIVE -> THREE_TO_FIVE
+                else -> SIX_PLUS
+            }
+        }
+    }
+
+    /**
+     * Fired when a new custom stop label is successfully persisted.
      *
      * Aggregations this enables:
-     *  - "What % of users ever create a custom label?" → distinct user count on event name.
-     *  - "Which label names are most common?" → group by [labelName].
-     *  - "Are power users emerging?" → bucket [totalLabelsCountAfter] (1, 2, 3-5, 6+).
-     *  - "What emoji do people pick?" → group by [emoji].
+     *  - "What % of users ever create a custom label?" - distinct user count on event name.
+     *  - "Where do users create labels?" - group by [creationSurface].
+     *  - "Are power users emerging?" - group by [labelCountBucket].
      *
-     * @param labelName             The normalised label text persisted to the DB
-     *                              (emoji and whitespace already stripped).
-     * @param emoji                 The emoji chosen in the picker.
-     * @param totalLabelsCountAfter Total number of labels the user has *after* this creation —
-     *                              lets us split casual users (1–2 labels) from heavy users.
+     * Historical rows (before 2026-07-15) instead carried raw `labelName`/`emoji` and a
+     * raw `totalLabelsCountAfter` int; treat missing new params as the pre-redesign era.
+     *
+     * @param creationSurface  Row kind whose "+ New label" chip opened the create sheet.
+     * @param labelCountBucket Total labels the user has *after* this creation, bucketed.
      */
     data class StopLabelCreatedEvent(
-        val labelName: String,
-        val emoji: String,
-        val totalLabelsCountAfter: Int,
+        val creationSurface: StopLabelSurface,
+        val labelCountBucket: StopLabelCountBucket,
     ) : AnalyticsEvent(
         name = "stop_label_created",
         properties = mapOf(
-            PROP_LABEL_NAME to labelName,
-            "emoji" to emoji,
-            "totalLabelsCountAfter" to totalLabelsCountAfter,
+            "creationSurface" to creationSurface.value,
+            "labelCountBucket" to labelCountBucket.value,
         ),
     )
 
     /**
-     * Fired when the user pins a stop to a label — the core "label is being used" signal.
-     * This is the moment a label transitions from empty to actionable.
+     * Fired when the user pins a location to a label - the core "label is being used"
+     * signal. This is the moment a label transitions from empty to actionable.
      *
      * Aggregations this enables:
-     *  - "Which labels actually get filled?" → group by [labelName].
-     *  - "Which stops are most pinned?" → group by [PROP_STOP_ID].
-     *  - "Are users replacing existing pins or filling empty slots?" → filter [isReassignment].
-     *  - "Does the protected Home label behave differently from custom labels?"
-     *    → filter [isProtectedLabel].
+     *  - "Which surface converts: search result, recent, or empty-state?" - group by
+     *    [assignmentSurface].
+     *  - "Do users create a label at the moment of assignment or fill Home/Work?" -
+     *    group by [assignmentMode].
+     *  - "Are users replacing existing pins or filling empty slots?" - filter
+     *    [isReassignment].
+     *  - "Does the protected Home label behave differently?" - filter [labelKind].
      *
-     * @param labelName         The label receiving the stop.
-     * @param stopId            NSW Transport stop ID being pinned.
-     * @param stopName          Human-readable stop name.
-     * @param isReassignment    `true` if the label already had a different stop pinned and
-     *                          this assignment is overwriting it.
-     * @param isProtectedLabel  `true` for the protected Home label (special-cased
-     *                          throughout the app — non-deletable).
-     * @param source            [SOURCE_CHOOSE_MODE] for a direct row tap while a label's
-     *                          "choose your stop" mode is active (story A1), [SOURCE_STAR_SHEET]
-     *                          for the star icon → save-as-label sheet flow. Historical events
-     *                          (pre-A1) carry no `source` — treat null as star_sheet.
+     * Historical rows (before 2026-07-15) carried raw `labelName`/`stopId`/`stopName`
+     * and a `source` param whose values (`choose_mode`, `star_sheet`) refer to deleted
+     * v2/v3 flows - do not reinterpret them as the new surfaces.
+     *
+     * @param assignmentSurface Row kind hosting the assign action.
+     * @param assignmentMode    [AssignmentMode.NEW_LABEL] when the assignment
+     *                          immediately follows the New Label sheet, else
+     *                          [AssignmentMode.EXISTING_LABEL].
+     * @param locationKind      Transit stop or address/POI being pinned.
+     * @param labelKind         Protected default (Home) vs custom label.
+     * @param isReassignment    `true` if the label already had a different stop pinned.
      */
     data class StopLabelStopAssignedEvent(
-        val labelName: String,
-        val stopId: String,
-        val stopName: String,
+        val assignmentSurface: StopLabelSurface,
+        val assignmentMode: AssignmentMode,
+        val locationKind: StopSelectedEvent.LocationKind,
+        val labelKind: StopLabelKind,
         val isReassignment: Boolean,
-        val isProtectedLabel: Boolean,
-        val source: String = SOURCE_STAR_SHEET,
     ) : AnalyticsEvent(
         name = "stop_label_stop_assigned",
         properties = mapOf(
-            PROP_LABEL_NAME to labelName,
-            PROP_STOP_ID to stopId,
-            PROP_STOP_NAME to stopName,
+            "assignmentSurface" to assignmentSurface.value,
+            "assignmentMode" to assignmentMode.value,
+            "locationKind" to locationKind.value,
+            "labelKind" to labelKind.value,
             "isReassignment" to isReassignment,
-            "isProtectedLabel" to isProtectedLabel,
-            PROP_SOURCE to source,
         ),
     ) {
-        companion object {
-            const val SOURCE_CHOOSE_MODE = "choose_mode"
-            const val SOURCE_STAR_SHEET = "star_sheet"
+        enum class AssignmentMode(val value: String) {
+            EXISTING_LABEL("existing_label"),
+            NEW_LABEL("new_label"),
         }
     }
 

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -37,6 +37,8 @@ either; most changes should be params on an existing event, not a new name.
 | 2026-07-15 | `stop_selected` | `searchSessionId` | Random hex string; joins to `search_stop_query` firings | Only when selection happens with a live (non-blank) query; recents/map picks omit it | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
 | 2026-07-15 | `stop_selected` | `displayedLocalCount` | Bucket `0｜1_3｜4_10｜11_plus` | Local results on screen at selection time; omitted without a live query | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
 | 2026-07-15 | `stop_selected` | `displayedAddressCount` | Bucket `0｜1_3｜4_10｜11_plus` | Address/POI results on screen at selection time; omitted without a live query | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
+| 2026-07-15 | `stop_label_created` | `creationSurface`, `labelCountBucket`; REMOVED `labelName`/`emoji`/`totalLabelsCountAfter` | `search_result｜recent｜empty_state｜address_result`; bucket `1｜2｜3_5｜6_plus` | New custom label persisted; raw label text dropped (privacy) | TBD | Pending | — |
+| 2026-07-15 | `stop_label_stop_assigned` | `assignmentSurface`, `assignmentMode`, `locationKind`, `labelKind`; REMOVED `labelName`/`stopId`/`stopName`/`source` | Surfaces as above; `existing_label｜new_label`; `transit_stop｜address`; `protected_default｜custom`. Historical `source` values (`choose_mode｜star_sheet`) refer to deleted v2/v3 flows, do not reinterpret | Location pinned to a label; raw stop identity dropped (privacy) | TBD | Pending | — |
 
 Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table,
 2026-07-14.

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
@@ -84,23 +84,26 @@ sealed interface SearchStopUiEvent {
     /**
      * Saves [stopItem] as the stop for an existing label identified by [labelKey].
      *
-     * @param source [SOURCE_CHOOSE_MODE] when fired by a direct row tap while the label's
-     * "choose your stop" mode is active (story A1); [SOURCE_STAR_SHEET] for the star icon →
-     * save-as-label sheet flow (including its conflict-resolution and create-new-label paths).
+     * @param surface    Which row kind hosted the assign action; set at the UI boundary
+     *                   where the source row is known. Mapped to a bounded analytics
+     *                   value in the ViewModel - never sent as free-form text.
+     * @param isNewLabel True when this assignment immediately follows [CreateLabel]
+     *                   from the New Label sheet (analytics `assignment_mode = new_label`).
      */
     data class AssignLabelStop(
         val labelKey: String,
         val stopItem: StopItem,
-        val source: String = SOURCE_STAR_SHEET,
-    ) : SearchStopUiEvent {
-        companion object {
-            const val SOURCE_CHOOSE_MODE = "choose_mode"
-            const val SOURCE_STAR_SHEET = "star_sheet"
-        }
-    }
+        val surface: LabelAssignSurface,
+        val isNewLabel: Boolean = false,
+    ) : SearchStopUiEvent
 
-    /** Creates a new label (with no stop yet). */
-    data class CreateLabel(val name: String, val emoji: String) : SearchStopUiEvent
+    /** Creates a new label (with no stop yet). [surface] is the row kind whose
+     * "+ New label" chip opened the sheet. */
+    data class CreateLabel(
+        val name: String,
+        val emoji: String,
+        val surface: LabelAssignSurface,
+    ) : SearchStopUiEvent
 
     /** Clears the stop on a label (label name kept, stop reset to null). */
     data class ClearLabelStop(val labelKey: String) : SearchStopUiEvent
@@ -113,4 +116,17 @@ sealed interface SearchStopUiEvent {
 
     /** Moves [labelKey] to sit at [targetLabelKey]'s position; sort orders for all labels are renumbered. */
     data class MoveLabelToIndex(val labelKey: String, val targetLabelKey: String) : SearchStopUiEvent
+}
+
+/**
+ * The row kind hosting a label assign/create action. UI-boundary enum; the ViewModel
+ * maps it to the registered analytics values (`search_result` etc.). ADDRESS_RESULT
+ * is reserved for when address rows gain a label assign affordance - nothing sends
+ * it yet.
+ */
+enum class LabelAssignSurface {
+    SEARCH_RESULT,
+    RECENT,
+    EMPTY_STATE,
+    ADDRESS_RESULT,
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalytics.kt
@@ -1,0 +1,54 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchGate
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+
+/**
+ * One firing per resolved (non-stale) address fetch; cache hits are excluded so
+ * `resultSource = address` counts network calls, the number the API cost model cares
+ * about. This is also the carve-out site for address-eligible queries - only here are
+ * both pipelines' result counts known. [addressResults] is null when the fetch failed.
+ */
+internal fun Analytics.trackAddressSearchResolved(
+    normalizedQuery: String,
+    searchSessionId: String,
+    localResultsCount: Int,
+    addressResults: List<SearchStopState.SearchResult.Address>?,
+) {
+    track(
+        AnalyticsEvent.SearchStopQuery(
+            queryLength = normalizedQuery.length,
+            searchSessionId = searchSessionId,
+            resultSource = AnalyticsEvent.SearchStopQuery.ResultSource.ADDRESS,
+            resultsCount = addressResults?.size,
+            isError = addressResults == null,
+            zeroResultQuery = addressResults?.let {
+                SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+                    query = normalizedQuery,
+                    localResultsCount = localResultsCount,
+                    addressResultsCount = it.size,
+                )
+            },
+        ),
+    )
+}
+
+/**
+ * Local-pipeline carve-out site. When the address pipeline is eligible for the query,
+ * it resolves later and owns the carve-out decision (the query may be a real address
+ * the NSW API recognises), so this returns null.
+ */
+internal fun resolveLocalZeroResultQuery(
+    query: String,
+    localResultsCount: Int,
+    addressSearchGate: AddressSearchGate,
+): String? {
+    if (addressSearchGate == AddressSearchGate.ELIGIBLE) return null
+    return SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
+        query = query,
+        localResultsCount = localResultsCount,
+        addressResultsCount = null,
+    )
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -90,6 +90,7 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.SearchStopMap
 import xyz.ksharma.krail.trip.planner.ui.state.mapstopselection.MapStopSelectionEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.LabelAssignSurface
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
@@ -178,11 +179,17 @@ fun SearchStopScreen(
     // v4 inline assign handler, shared by every StopLabelAssignRow (search results,
     // recents, empty-state stops). The row's wall only ever shows unset labels, so
     // there's no conflict to classify here — every tap is a direct, no-confirm assign.
-    val onLabelPillClick: (StopItem, StopLabel) -> Unit = { stopItem, label ->
-        onEvent(SearchStopUiEvent.AssignLabelStop(labelKey = label.label, stopItem = stopItem))
+    val onLabelPillClick: (StopItem, StopLabel, LabelAssignSurface) -> Unit = { stopItem, label, surface ->
+        onEvent(
+            SearchStopUiEvent.AssignLabelStop(
+                labelKey = label.label,
+                stopItem = stopItem,
+                surface = surface,
+            ),
+        )
     }
-    val onNewLabelClick: (StopItem, List<TransportMode>) -> Unit = { stopItem, modes ->
-        newLabelTarget = NewLabelTarget(stop = stopItem, transportModeSet = modes)
+    val onNewLabelClick: (StopItem, List<TransportMode>, LabelAssignSurface) -> Unit = { stopItem, modes, surface ->
+        newLabelTarget = NewLabelTarget(stop = stopItem, transportModeSet = modes, surface = surface)
     }
 
     AdaptiveScreenContent(
@@ -253,8 +260,21 @@ fun SearchStopScreen(
                 // calling onSave, so CreateLabel's stored key and this AssignLabelStop's
                 // labelKey are guaranteed to match — see AssignNewLabelSheetContent.
                 if (name.isNotBlank()) {
-                    onEvent(SearchStopUiEvent.CreateLabel(name = name, emoji = NEW_LABEL_DEFAULT_EMOJI))
-                    onEvent(SearchStopUiEvent.AssignLabelStop(labelKey = name, stopItem = newLabelStop.stop))
+                    onEvent(
+                        SearchStopUiEvent.CreateLabel(
+                            name = name,
+                            emoji = NEW_LABEL_DEFAULT_EMOJI,
+                            surface = newLabelStop.surface,
+                        ),
+                    )
+                    onEvent(
+                        SearchStopUiEvent.AssignLabelStop(
+                            labelKey = name,
+                            stopItem = newLabelStop.stop,
+                            surface = newLabelStop.surface,
+                            isNewLabel = true,
+                        ),
+                    )
                 }
             },
         )
@@ -263,8 +283,13 @@ fun SearchStopScreen(
 
 private const val NEW_LABEL_DEFAULT_EMOJI = "📍"
 
-/** The stop (+ its transport modes, for the sheet's mode roundel) creating a brand-new label. */
-internal data class NewLabelTarget(val stop: StopItem, val transportModeSet: List<TransportMode>)
+/** The stop (+ its transport modes, for the sheet's mode roundel) creating a brand-new label.
+ * [surface] is the row kind whose "+ New label" chip opened the sheet. */
+internal data class NewLabelTarget(
+    val stop: StopItem,
+    val transportModeSet: List<TransportMode>,
+    val surface: LabelAssignSurface,
+)
 
 // region Savers — keep UI orchestration state alive across rotation / process death.
 //
@@ -293,6 +318,7 @@ private val NewLabelTargetSaver: Saver<NewLabelTarget?, Any> = Saver(
                 "stopId" to it.stop.stopId,
                 "stopName" to it.stop.stopName,
                 "productClasses" to it.transportModeSet.map { mode -> mode.productClass },
+                "surface" to it.surface.name,
             )
         }
     },
@@ -307,6 +333,9 @@ private val NewLabelTargetSaver: Saver<NewLabelTarget?, Any> = Saver(
             transportModeSet = (map["productClasses"] as List<Int>).mapNotNull { productClass ->
                 TransportMode.fromProductClass(productClass)
             },
+            surface = (map["surface"] as? String)
+                ?.let { name -> LabelAssignSurface.entries.firstOrNull { e -> e.name == name } }
+                ?: LabelAssignSurface.SEARCH_RESULT,
         )
     },
 )
@@ -332,8 +361,8 @@ private fun SearchStopScreenSinglePane(
     expandedStopKey: String?,
     onToggleExpandStop: (String) -> Unit,
     onStopSelect: (StopItem) -> Unit,
-    onLabelPillClick: (StopItem, StopLabel) -> Unit,
-    onNewLabelClick: (StopItem, List<TransportMode>) -> Unit,
+    onLabelPillClick: (StopItem, StopLabel, LabelAssignSurface) -> Unit,
+    onNewLabelClick: (StopItem, List<TransportMode>, LabelAssignSurface) -> Unit,
     onManageClick: () -> Unit,
     onEvent: (SearchStopUiEvent) -> Unit,
     modifier: Modifier = Modifier,
@@ -515,8 +544,8 @@ private fun SearchStopScreenDualPane(
     expandedStopKey: String?,
     onToggleExpandStop: (String) -> Unit,
     onStopSelect: (StopItem) -> Unit,
-    onLabelPillClick: (StopItem, StopLabel) -> Unit,
-    onNewLabelClick: (StopItem, List<TransportMode>) -> Unit,
+    onLabelPillClick: (StopItem, StopLabel, LabelAssignSurface) -> Unit,
+    onNewLabelClick: (StopItem, List<TransportMode>, LabelAssignSurface) -> Unit,
     onManageClick: () -> Unit,
     onEvent: (SearchStopUiEvent) -> Unit,
     modifier: Modifier = Modifier,
@@ -608,8 +637,8 @@ private fun SearchStopListContent(
     isMapsAvailable: Boolean,
     onOpenMap: () -> Unit,
     onStopSelect: (StopItem) -> Unit,
-    onLabelPillClick: (StopItem, StopLabel) -> Unit,
-    onNewLabelClick: (StopItem, List<TransportMode>) -> Unit,
+    onLabelPillClick: (StopItem, StopLabel, LabelAssignSurface) -> Unit,
+    onNewLabelClick: (StopItem, List<TransportMode>, LabelAssignSurface) -> Unit,
     onManageClick: () -> Unit,
     onEvent: (SearchStopUiEvent) -> Unit,
     modifier: Modifier = Modifier,
@@ -652,8 +681,20 @@ private fun SearchStopListContent(
                         expandedStopKey = expandedStopKey,
                         onToggleExpandStop = onToggleExpandStop,
                         onStopSelect = onStopSelect,
-                        onLabelPillClick = onLabelPillClick,
-                        onNewLabelClick = onNewLabelClick,
+                        onLabelPillClick = { stopItem, label ->
+                            onLabelPillClick(
+                                stopItem,
+                                label,
+                                LabelAssignSurface.RECENT,
+                            )
+                        },
+                        onNewLabelClick = { stopItem, modes ->
+                            onNewLabelClick(
+                                stopItem,
+                                modes,
+                                LabelAssignSurface.RECENT,
+                            )
+                        },
                         onEvent = onEvent,
                     )
                     emptyStateStopsList(
@@ -664,8 +705,20 @@ private fun SearchStopListContent(
                         expandedStopKey = expandedStopKey,
                         onToggleExpandStop = onToggleExpandStop,
                         onStopSelect = onStopSelect,
-                        onLabelPillClick = onLabelPillClick,
-                        onNewLabelClick = onNewLabelClick,
+                        onLabelPillClick = { stopItem, label ->
+                            onLabelPillClick(
+                                stopItem,
+                                label,
+                                LabelAssignSurface.EMPTY_STATE,
+                            )
+                        },
+                        onNewLabelClick = { stopItem, modes ->
+                            onNewLabelClick(
+                                stopItem,
+                                modes,
+                                LabelAssignSurface.EMPTY_STATE,
+                            )
+                        },
                         onEvent = onEvent,
                     )
                     publicTransportNoteItem()
@@ -707,8 +760,20 @@ private fun SearchStopListContent(
                         expandedStopKey = expandedStopKey,
                         onToggleExpandStop = onToggleExpandStop,
                         onStopSelect = onStopSelect,
-                        onLabelPillClick = onLabelPillClick,
-                        onNewLabelClick = onNewLabelClick,
+                        onLabelPillClick = { stopItem, label ->
+                            onLabelPillClick(
+                                stopItem,
+                                label,
+                                LabelAssignSurface.SEARCH_RESULT,
+                            )
+                        },
+                        onNewLabelClick = { stopItem, modes ->
+                            onNewLabelClick(
+                                stopItem,
+                                modes,
+                                LabelAssignSurface.SEARCH_RESULT,
+                            )
+                        },
                         onEvent = onEvent,
                     )
                     addressResultsSection(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -288,13 +288,18 @@ class SearchStopViewModel(
                 }
                 analytics.track(
                     StopLabelStopAssignedEvent(
-                        labelName = event.labelKey,
-                        stopId = event.stopItem.stopId,
-                        stopName = event.stopItem.stopName,
+                        assignmentSurface = event.surface.toAnalyticsSurface(),
+                        assignmentMode = if (event.isNewLabel) {
+                            StopLabelStopAssignedEvent.AssignmentMode.NEW_LABEL
+                        } else {
+                            StopLabelStopAssignedEvent.AssignmentMode.EXISTING_LABEL
+                        },
+                        locationKind = when (event.stopItem.locationKind) {
+                            LocationKind.TRANSIT_STOP -> StopSelectedEvent.LocationKind.TRANSIT_STOP
+                            LocationKind.ADDRESS -> StopSelectedEvent.LocationKind.ADDRESS
+                        },
+                        labelKind = labelKindOf(event.labelKey),
                         isReassignment = isReassignment,
-                        isProtectedLabel = event.labelKey
-                            .equals(StopLabel.PROTECTED_LABEL, ignoreCase = true),
-                        source = event.source,
                     ),
                 )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
@@ -334,9 +339,9 @@ class SearchStopViewModel(
                         }
                         analytics.track(
                             StopLabelCreatedEvent(
-                                labelName = cleanedName,
-                                emoji = event.emoji,
-                                totalLabelsCountAfter = _uiState.value.stopLabels.size,
+                                creationSurface = event.surface.toAnalyticsSurface(),
+                                labelCountBucket = AnalyticsEvent.StopLabelCountBucket
+                                    .from(_uiState.value.stopLabels.size),
                             ),
                         )
                         viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
@@ -510,9 +515,10 @@ class SearchStopViewModel(
                         queryLength = query.length,
                         searchSessionId = searchSessionId,
                         resultsCount = stopResults.size,
-                        zeroResultQuery = resolveZeroResultQuery(
+                        zeroResultQuery = resolveLocalZeroResultQuery(
                             query = query,
                             localResultsCount = stopResults.size,
+                            addressSearchGate = currentAddressSearchGate(normalizeAddressQuery(query)),
                         ),
                     ),
                 )
@@ -586,41 +592,13 @@ class SearchStopViewModel(
                     isAddressSearchLoading = false,
                 )
             }
-            trackAddressSearchResolved(
+            analytics.trackAddressSearchResolved(
                 normalizedQuery = normalizedQuery,
                 searchSessionId = searchSessionId,
+                localResultsCount = _uiState.value.searchResults.size,
                 addressResults = if (fetchResult.isSuccess) addressResults else null,
             )
         }
-    }
-
-    /**
-     * One firing per resolved (non-stale) address fetch; cache hits are excluded so
-     * `resultSource = address` counts network calls, the number the API cost model
-     * cares about. This is also the carve-out site for address-eligible queries -
-     * only here are both pipelines' result counts known (see [resolveZeroResultQuery]).
-     */
-    private fun trackAddressSearchResolved(
-        normalizedQuery: String,
-        searchSessionId: String,
-        addressResults: List<SearchStopState.SearchResult.Address>?,
-    ) {
-        analytics.track(
-            AnalyticsEvent.SearchStopQuery(
-                queryLength = normalizedQuery.length,
-                searchSessionId = searchSessionId,
-                resultSource = AnalyticsEvent.SearchStopQuery.ResultSource.ADDRESS,
-                resultsCount = addressResults?.size,
-                isError = addressResults == null,
-                zeroResultQuery = addressResults?.let {
-                    SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                        query = normalizedQuery,
-                        localResultsCount = _uiState.value.searchResults.size,
-                        addressResultsCount = it.size,
-                    )
-                },
-            ),
-        )
     }
 
     private fun currentAddressSearchGate(normalizedQuery: String): AddressSearchGate =
@@ -629,22 +607,6 @@ class SearchStopViewModel(
             isAddressSearchEnabled = isAddressSearchEnabled(),
             minQueryLength = addressSearchMinQueryLength(),
         )
-
-    /**
-     * Local-pipeline carve-out site. When the address pipeline is eligible for this
-     * query, it resolves later and owns the carve-out decision (the query may be a
-     * real address the NSW API recognises), so this returns null.
-     */
-    private fun resolveZeroResultQuery(query: String, localResultsCount: Int): String? {
-        if (currentAddressSearchGate(normalizeAddressQuery(query)) == AddressSearchGate.ELIGIBLE) {
-            return null
-        }
-        return SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-            query = query,
-            localResultsCount = localResultsCount,
-            addressResultsCount = null,
-        )
-    }
 
     private fun StopItem.productClasses(): String =
         when (locationKind) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopLabelAnalyticsMapping.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopLabelAnalyticsMapping.kt
@@ -1,0 +1,25 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.LabelAssignSurface
+
+/**
+ * UI-boundary enum to registered analytics value. Kept as an exhaustive `when` so a
+ * new surface fails compilation here instead of silently sending nothing.
+ */
+internal fun LabelAssignSurface.toAnalyticsSurface(): AnalyticsEvent.StopLabelSurface =
+    when (this) {
+        LabelAssignSurface.SEARCH_RESULT -> AnalyticsEvent.StopLabelSurface.SEARCH_RESULT
+        LabelAssignSurface.RECENT -> AnalyticsEvent.StopLabelSurface.RECENT
+        LabelAssignSurface.EMPTY_STATE -> AnalyticsEvent.StopLabelSurface.EMPTY_STATE
+        LabelAssignSurface.ADDRESS_RESULT -> AnalyticsEvent.StopLabelSurface.ADDRESS_RESULT
+    }
+
+/** Bounded label classification - raw label names never reach analytics. */
+internal fun labelKindOf(labelKey: String): AnalyticsEvent.StopLabelKind =
+    if (labelKey.equals(StopLabel.PROTECTED_LABEL, ignoreCase = true)) {
+        AnalyticsEvent.StopLabelKind.PROTECTED_DEFAULT
+    } else {
+        AnalyticsEvent.StopLabelKind.CUSTOM
+    }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
@@ -20,6 +20,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.components.LABEL_NAME_MAX_LENGTH
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.LabelAssignSurface
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import kotlin.test.AfterTest
@@ -103,7 +104,7 @@ class SearchStopViewModelLabelHandlersTest {
                 advanceUntilIdle()
 
                 val central = StopItem(stopId = "stop_central", stopName = "Central Station")
-                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central, LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val state = expectMostRecentItem()
@@ -127,7 +128,7 @@ class SearchStopViewModelLabelHandlersTest {
                 advanceUntilIdle()
 
                 val central = StopItem(stopId = "stop_central", stopName = "Central Station")
-                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central, LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 // Pinning to recents is the contract that means tapping a saved pill
@@ -282,7 +283,7 @@ class SearchStopViewModelLabelHandlersTest {
             viewModel.uiState.test {
                 advanceUntilIdle()
 
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "Gym", emoji = "🏋"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "Gym", emoji = "🏋", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val state = expectMostRecentItem()
@@ -304,7 +305,7 @@ class SearchStopViewModelLabelHandlersTest {
 
                 // "home" should match seeded "Home" case-insensitively after
                 // normaliseLabelName — duplicate must silently no-op.
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "home", emoji = "🏠"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "home", emoji = "🏠", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val state = expectMostRecentItem()
@@ -319,7 +320,7 @@ class SearchStopViewModelLabelHandlersTest {
             advanceUntilIdle()
             val before = expectMostRecentItem().stopLabels.size
 
-            viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "   ", emoji = "🌀"))
+            viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "   ", emoji = "🌀", surface = LabelAssignSurface.SEARCH_RESULT))
             advanceUntilIdle()
 
             // Blank input is treated like no input — no new emission. expectNoEvents()
@@ -339,7 +340,7 @@ class SearchStopViewModelLabelHandlersTest {
 
                 // The save-sheet text field allows free typing; the VM is the
                 // canonicaliser. "🚗 Garage 🚗" should land as "Garage" in the DB.
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "🚗 Garage 🚗", emoji = "🚗"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "🚗 Garage 🚗", emoji = "🚗", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val state = expectMostRecentItem()
@@ -357,7 +358,7 @@ class SearchStopViewModelLabelHandlersTest {
                 // LABEL_NAME_MAX_LENGTH, but the VM must enforce it independently
                 // for any caller that skips the UI.
                 val tooLong = "A".repeat(LABEL_NAME_MAX_LENGTH + 10)
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = tooLong, emoji = "🚗"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = tooLong, emoji = "🚗", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val state = expectMostRecentItem()
@@ -381,7 +382,7 @@ class SearchStopViewModelLabelHandlersTest {
 
             // Set Home first so there's something to clear.
             val central = StopItem(stopId = "stop_central", stopName = "Central Station")
-            viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+            viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central, LabelAssignSurface.SEARCH_RESULT))
             advanceUntilIdle()
 
             viewModel.onEvent(SearchStopUiEvent.ClearLabelStop("Home"))
@@ -575,16 +576,19 @@ class SearchStopViewModelLabelHandlersTest {
             viewModel.uiState.test {
                 advanceUntilIdle()
 
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "Gym", emoji = "🏋"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "Gym", emoji = "🏋", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val tracked = fakeAnalytics.getTrackedEvent("stop_label_created")
                 assertNotNull(tracked, "expected stop_label_created to fire")
                 val event = assertIs<AnalyticsEvent.StopLabelCreatedEvent>(tracked)
-                assertEquals("Gym", event.labelName)
-                assertEquals("🏋", event.emoji)
+                assertEquals(AnalyticsEvent.StopLabelSurface.SEARCH_RESULT, event.creationSurface)
                 // Seeded Home + Work + new Gym = 3.
-                assertEquals(3, event.totalLabelsCountAfter)
+                assertEquals(AnalyticsEvent.StopLabelCountBucket.THREE_TO_FIVE, event.labelCountBucket)
+                assertFalse(
+                    event.properties.orEmpty().keys.any { it == "labelName" || it == "emoji" },
+                    "created event must not carry raw label text",
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -595,7 +599,7 @@ class SearchStopViewModelLabelHandlersTest {
             viewModel.uiState.test {
                 advanceUntilIdle()
 
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "home", emoji = "🏠"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "home", emoji = "🏠", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 // Duplicate path is a silent no-op — analytics must mirror that, otherwise
@@ -611,7 +615,7 @@ class SearchStopViewModelLabelHandlersTest {
             viewModel.uiState.test {
                 advanceUntilIdle()
 
-                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "   ", emoji = "🌀"))
+                viewModel.onEvent(SearchStopUiEvent.CreateLabel(name = "   ", emoji = "🌀", surface = LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 assertFalse(fakeAnalytics.isEventTracked("stop_label_created"))
@@ -626,28 +630,36 @@ class SearchStopViewModelLabelHandlersTest {
                 advanceUntilIdle()
 
                 val central = StopItem(stopId = "stop_central", stopName = "Central Station")
-                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central, LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val tracked = fakeAnalytics.getTrackedEvent("stop_label_stop_assigned")
                 assertNotNull(tracked)
                 val event = assertIs<AnalyticsEvent.StopLabelStopAssignedEvent>(tracked)
-                assertEquals("Home", event.labelName)
-                assertEquals("stop_central", event.stopId)
-                assertEquals("Central Station", event.stopName)
-                assertFalse(event.isReassignment, "first pin should not be a reassignment")
-                assertTrue(event.isProtectedLabel, "Home is the protected label")
+                assertEquals(AnalyticsEvent.StopLabelSurface.SEARCH_RESULT, event.assignmentSurface)
                 assertEquals(
-                    AnalyticsEvent.StopLabelStopAssignedEvent.SOURCE_STAR_SHEET,
-                    event.source,
-                    "default source is the star -> sheet flow",
+                    AnalyticsEvent.StopLabelStopAssignedEvent.AssignmentMode.EXISTING_LABEL,
+                    event.assignmentMode,
+                )
+                assertEquals(AnalyticsEvent.StopSelectedEvent.LocationKind.TRANSIT_STOP, event.locationKind)
+                assertFalse(event.isReassignment, "first pin should not be a reassignment")
+                assertEquals(
+                    AnalyticsEvent.StopLabelKind.PROTECTED_DEFAULT,
+                    event.labelKind,
+                    "Home is the protected label",
+                )
+                assertFalse(
+                    event.properties.orEmpty().keys.any {
+                        it == "labelName" || it == "stopId" || it == "stopName"
+                    },
+                    "assigned event must not carry raw label or stop identity",
                 )
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `Given choose-mode source When AssignLabelStop fires Then assigned event carries it through`() =
+    fun `Given recent-surface new-label assign When AssignLabelStop fires Then event carries surface and mode`() =
         runTest {
             viewModel.uiState.test {
                 advanceUntilIdle()
@@ -657,7 +669,8 @@ class SearchStopViewModelLabelHandlersTest {
                     SearchStopUiEvent.AssignLabelStop(
                         labelKey = "Home",
                         stopItem = central,
-                        source = SearchStopUiEvent.AssignLabelStop.SOURCE_CHOOSE_MODE,
+                        surface = LabelAssignSurface.RECENT,
+                        isNewLabel = true,
                     ),
                 )
                 advanceUntilIdle()
@@ -665,7 +678,11 @@ class SearchStopViewModelLabelHandlersTest {
                 val event = assertIs<AnalyticsEvent.StopLabelStopAssignedEvent>(
                     fakeAnalytics.getTrackedEvent("stop_label_stop_assigned"),
                 )
-                assertEquals(AnalyticsEvent.StopLabelStopAssignedEvent.SOURCE_CHOOSE_MODE, event.source)
+                assertEquals(AnalyticsEvent.StopLabelSurface.RECENT, event.assignmentSurface)
+                assertEquals(
+                    AnalyticsEvent.StopLabelStopAssignedEvent.AssignmentMode.NEW_LABEL,
+                    event.assignmentMode,
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -681,19 +698,21 @@ class SearchStopViewModelLabelHandlersTest {
                 // "filling empty slots" from "swapping pins".
                 val central = StopItem(stopId = "stop_central", stopName = "Central Station")
                 val townHall = StopItem(stopId = "stop_townhall", stopName = "Town Hall")
-                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Work", central))
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Work", central, LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
                 fakeAnalytics.clear()
-                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Work", townHall))
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Work", townHall, LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
 
                 val tracked = fakeAnalytics.getTrackedEvent("stop_label_stop_assigned")
                 assertNotNull(tracked)
                 val event = assertIs<AnalyticsEvent.StopLabelStopAssignedEvent>(tracked)
-                assertEquals("Work", event.labelName)
-                assertEquals("stop_townhall", event.stopId)
                 assertTrue(event.isReassignment, "second pin overwrote a different stop")
-                assertFalse(event.isProtectedLabel, "Work is a default but not protected")
+                assertEquals(
+                    AnalyticsEvent.StopLabelKind.CUSTOM,
+                    event.labelKind,
+                    "Work is a default but not protected",
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -705,7 +724,7 @@ class SearchStopViewModelLabelHandlersTest {
                 advanceUntilIdle()
 
                 val central = StopItem(stopId = "stop_central", stopName = "Central Station")
-                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central))
+                viewModel.onEvent(SearchStopUiEvent.AssignLabelStop("Home", central, LabelAssignSurface.SEARCH_RESULT))
                 advanceUntilIdle()
                 fakeAnalytics.clear()
                 viewModel.onEvent(SearchStopUiEvent.ClearLabelStop("Home"))


### PR DESCRIPTION
stop_label_created and stop_label_stop_assigned carried raw label text,
emoji, and stop identity - a label called Home pinned to a real stop ID
identifies where a user lives - and the assignment source values
(choose_mode / star_sheet) referred to v2/v3 flows deleted in the v4
redesign, so the data described screens that no longer exist.

Both events now carry only bounded values: creationSurface /
assignmentSurface (search_result / recent / empty_state, address_result
reserved), assignmentMode (existing_label / new_label, set by the New
Label sheet path), locationKind, labelKind (protected_default / custom),
and a label count bucket. Surfaces are typed at the UI boundary
(LabelAssignSurface) and mapped to registered analytics values in one
exhaustive place.

Also extracts the address-pipeline analytics helpers out of
SearchStopViewModel (LargeClass) into SearchQueryAnalytics.kt.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
