### PR TITLE
feat(analytics): manage-labels removal, drag-end reorder, screen view

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/AnalyticsScreen.kt
@@ -10,6 +10,7 @@ sealed class AnalyticsScreen(val name: String) {
     data object PlanTrip : AnalyticsScreen(name = "PlanTrip")
     data object ThemeSelection : AnalyticsScreen(name = "ThemeSelection")
     data object SearchStop : AnalyticsScreen(name = "SearchStop")
+    data object ManageStopLabels : AnalyticsScreen(name = "ManageStopLabels")
     data object ServiceAlerts : AnalyticsScreen(name = "ServiceAlerts")
     data object Intro : AnalyticsScreen(name = "Intro")
     data object OurStory : AnalyticsScreen(name = "OurStory")

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -10,7 +10,9 @@ private const val PROP_VARIANT = "variant"
 private const val PROP_SOURCE = "source"
 private const val PROP_EXPAND = "expand"
 private const val PROP_STOP_NAME = "stopName"
-private const val PROP_LABEL_NAME = "labelName"
+private const val PROP_SURFACE = "surface"
+private const val PROP_LABEL_KIND = "labelKind"
+private const val SURFACE_MANAGE_LABELS = "manage_labels"
 private const val PROP_FROM_STOP_ID = "fromStopId"
 private const val PROP_TO_STOP_ID = "toStopId"
 private const val PROP_PREVIOUS_INDEX = "previousIndex"
@@ -349,7 +351,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
             "assignmentSurface" to assignmentSurface.value,
             "assignmentMode" to assignmentMode.value,
             "locationKind" to locationKind.value,
-            "labelKind" to labelKind.value,
+            PROP_LABEL_KIND to labelKind.value,
             "isReassignment" to isReassignment,
         ),
     ) {
@@ -365,30 +367,30 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      * "label cleanup behaviour" question without joining two streams.
      *
      * Aggregations this enables:
-     *  - "Are users removing labels or just clearing them?" → group by [action].
-     *  - "Are users deleting labels they never filled?" → filter [action] = DELETE,
+     *  - "Are users removing labels or just clearing them?" - group by [action].
+     *  - "Are users deleting labels they never filled?" - filter [action] = DELETE,
      *    [hadStop] = false.
-     *  - "Do users churn through the same label name?" → join with
-     *    [StopLabelCreatedEvent] on [labelName].
      *
      * Note: protected Home label deletions are silently no-op'd by the handler, so this
-     * event does not fire for them — keeps the data clean from defensive UI calls.
+     * event does not fire for them - keeps the data clean from defensive UI calls.
+     * Historical rows (before 2026-07-15) carried a raw `labelName`.
      *
-     * @param labelName Label being removed.
      * @param action    [Action.DELETE] when the entire label is removed,
      *                  [Action.CLEAR] when only the stop is unlinked.
      * @param hadStop   Whether the label had a stop attached at the moment of removal.
+     * @param labelKind Protected default (Home) vs custom label.
      */
     data class StopLabelRemovedEvent(
-        val labelName: String,
         val action: Action,
         val hadStop: Boolean,
+        val labelKind: StopLabelKind,
     ) : AnalyticsEvent(
         name = "stop_label_removed",
         properties = mapOf(
-            PROP_LABEL_NAME to labelName,
             PROP_ACTION to action.value,
             "hadStop" to hadStop,
+            PROP_LABEL_KIND to labelKind.value,
+            PROP_SURFACE to SURFACE_MANAGE_LABELS,
         ),
     ) {
         enum class Action(val value: String) {
@@ -398,39 +400,53 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     }
 
     /**
-     * Fired when the user reorders a stop label pill by drag-and-drop.
+     * Fired once per completed drag in Manage Labels whose final order differs from
+     * the starting order - never per intermediate swap, so one long drag is one event.
      *
      * Aggregations this enables:
      *  - "Are stop labels actually being reordered, or do users leave Home/Work in
-     *    the seeded order?" → presence/count of this event.
-     *  - "Are users moving the protected Home label around?" → filter
-     *    [isProtectedLabel] = true. Useful because Home is non-deletable but is
-     *    still draggable; this answers "do users want it elsewhere".
-     *  - "Promotion vs shuffle behaviour" → [newIndex] distribution.
+     *    the seeded order?" - presence/count of this event.
+     *  - "Are users moving the protected Home label around?" - filter [labelKind].
+     *  - "Promotion vs shuffle behaviour" - [moveDistanceBucket] distribution.
      *
-     * @param labelName        Label that was moved.
-     * @param previousIndex    Index before the move.
-     * @param newIndex         Index after the move.
-     * @param totalCount       Total labels in the list at reorder time.
-     * @param isProtectedLabel `true` for the Home label (non-deletable but
-     *                         still draggable).
+     * Historical rows (before 2026-07-15) fired once per swap mid-drag with raw
+     * `labelName`/`previousIndex`/`newIndex`/`totalCount` - counts from that era are
+     * inflated and not comparable.
+     *
+     * @param labelKind          Protected default (Home) vs custom label.
+     * @param moveDistanceBucket How far the label travelled, bucketed.
+     * @param setLabelCountBucket How many set (draggable) labels existed at drag time.
      */
     data class StopLabelReorderedEvent(
-        val labelName: String,
-        val previousIndex: Int,
-        val newIndex: Int,
-        val totalCount: Int,
-        val isProtectedLabel: Boolean,
+        val labelKind: StopLabelKind,
+        val moveDistanceBucket: MoveDistanceBucket,
+        val setLabelCountBucket: StopLabelCountBucket,
     ) : AnalyticsEvent(
         name = "stop_label_reordered",
         properties = mapOf(
-            PROP_LABEL_NAME to labelName,
-            PROP_PREVIOUS_INDEX to previousIndex,
-            PROP_NEW_INDEX to newIndex,
-            PROP_TOTAL_COUNT to totalCount,
-            "isProtectedLabel" to isProtectedLabel,
+            PROP_LABEL_KIND to labelKind.value,
+            "moveDistanceBucket" to moveDistanceBucket.value,
+            "setLabelCountBucket" to setLabelCountBucket.value,
+            PROP_SURFACE to SURFACE_MANAGE_LABELS,
         ),
-    )
+    ) {
+        enum class MoveDistanceBucket(val value: String) {
+            ONE("1"),
+            TWO_TO_THREE("2_3"),
+            FOUR_PLUS("4_plus"),
+            ;
+
+            companion object {
+                private const val MAX_TWO_TO_THREE = 3
+
+                fun from(distance: Int): MoveDistanceBucket = when {
+                    distance <= 1 -> ONE
+                    distance <= MAX_TWO_TO_THREE -> TWO_TO_THREE
+                    else -> FOUR_PLUS
+                }
+            }
+        }
+    }
 
     // endregion
 

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -39,6 +39,9 @@ either; most changes should be params on an existing event, not a new name.
 | 2026-07-15 | `stop_selected` | `displayedAddressCount` | Bucket `0｜1_3｜4_10｜11_plus` | Address/POI results on screen at selection time; omitted without a live query | [#1717](https://github.com/ksharma-xyz/KRAIL/pull/1717) | Registered | — |
 | 2026-07-15 | `stop_label_created` | `creationSurface`, `labelCountBucket`; REMOVED `labelName`/`emoji`/`totalLabelsCountAfter` | `search_result｜recent｜empty_state｜address_result`; bucket `1｜2｜3_5｜6_plus` | New custom label persisted; raw label text dropped (privacy) | TBD | Pending | — |
 | 2026-07-15 | `stop_label_stop_assigned` | `assignmentSurface`, `assignmentMode`, `locationKind`, `labelKind`; REMOVED `labelName`/`stopId`/`stopName`/`source` | Surfaces as above; `existing_label｜new_label`; `transit_stop｜address`; `protected_default｜custom`. Historical `source` values (`choose_mode｜star_sheet`) refer to deleted v2/v3 flows, do not reinterpret | Location pinned to a label; raw stop identity dropped (privacy) | TBD | Pending | — |
+| 2026-07-15 | `stop_label_removed` | `labelKind`, `surface`; REMOVED `labelName` | `protected_default｜custom`; `surface` always `manage_labels` | Assignment cleared or label deleted in Manage Labels | TBD | Pending | — |
+| 2026-07-15 | `stop_label_reordered` | `labelKind`, `moveDistanceBucket`, `setLabelCountBucket`, `surface`; REMOVED `labelName`/`previousIndex`/`newIndex`/`totalCount` | Distance `1｜2_3｜4_plus`; set-count `1｜2｜3_5｜6_plus`; `manage_labels`. NOW FIRES ONCE PER COMPLETED CHANGED DRAG - historical rows fired per swap, counts inflated, not comparable | Drag released in Manage Labels with a different final order | TBD | Pending | — |
+| 2026-07-15 | `view_screen` | `name = ManageStopLabels` (new value) | Existing screen-view event, new screen name | ManageStopLabelsScreen becomes visible (once per entry, rotation-safe) | TBD | Pending | — |
 
 Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table,
 2026-07-14.
@@ -55,7 +58,7 @@ Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table
 
 ## Not yet in this ledger (scoped, not implemented)
 
-The stop-label lifecycle analytics work (`docs/plans/STOP_LABEL_ANALYTICS_PLAN.md`) has
-been scoped — 4 existing events get new params, 0 new event names — but nothing has
-shipped yet. It will get rows here once a PR actually merges, not before. See that plan
-doc for the full proposed param table in the meantime.
+Nothing at the moment. The stop-label lifecycle analytics work
+(`docs/plans/STOP_LABEL_ANALYTICS_PLAN.md`) shipped 2026-07-15 - all four events
+reshaped to bounded params, reorder moved to drag completion, Manage screen view
+added; rows above.

--- a/docs/plans/STOP_LABEL_ANALYTICS_PLAN.md
+++ b/docs/plans/STOP_LABEL_ANALYTICS_PLAN.md
@@ -2,9 +2,12 @@
 
 ## Status
 
-Exploratory design only. This document defines the measurement model for the
-stop-label lifecycle: creation, assignment, removal, deletion, renaming, and
-reordering. It makes no analytics or runtime change.
+**Implemented 2026-07-15.** All four events reshaped to the bounded params below
+(raw label/stop identity dropped), reorder fires once per completed changed drag,
+and ManageStopLabelsScreen joined the screen-view taxonomy. Rename stays
+untracked per the decision below. This document remains as the measurement-model
+rationale; the registered param list lives in KRAIL-Analytics
+`docs/EVENT_REGISTRY.md`.
 
 Read `docs/ANALYTICS_EVENTS.md` and register every approved parameter in the
 KRAIL-Analytics `EVENT_REGISTRY.md` before implementation.

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/searchstop/SearchStopUiEvent.kt
@@ -116,6 +116,21 @@ sealed interface SearchStopUiEvent {
 
     /** Moves [labelKey] to sit at [targetLabelKey]'s position; sort orders for all labels are renumbered. */
     data class MoveLabelToIndex(val labelKey: String, val targetLabelKey: String) : SearchStopUiEvent
+
+    /**
+     * Fired once when a Manage Labels drag gesture ends. Analytics-only -
+     * [MoveLabelToIndex] already mutated state per swap during the drag; this reports
+     * the completed gesture so one drag is one analytics event, however many swaps it
+     * passed through. [fromIndex]/[toIndex] are positions within the set-labels list.
+     */
+    data class LabelReorderDragCompleted(
+        val labelKey: String,
+        val fromIndex: Int,
+        val toIndex: Int,
+    ) : SearchStopUiEvent
+
+    /** Fired once when ManageStopLabelsScreen becomes visible. Analytics-only. */
+    data object ManageLabelsScreenViewed : SearchStopUiEvent
 }
 
 /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/managestoplabels/ManageStopLabelsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/managestoplabels/ManageStopLabelsScreen.kt
@@ -61,9 +61,15 @@ internal fun ManageStopLabelsScreen(
     onRemoveAssignment: (StopLabel) -> Unit,
     onDeleteLabel: (StopLabel) -> Unit,
     onMove: (labelKey: String, targetLabelKey: String) -> Unit,
+    // Fired once when a drag gesture ends; indices are within the set-labels list.
+    // onMove already mutated state per swap - this exists so analytics can count one
+    // completed drag as one event.
+    onDragCompleted: (labelKey: String, fromIndex: Int, toIndex: Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var isReorderMode by remember { mutableStateOf(false) }
+    // Set-labels index captured when a drag starts; -1 when no drag is in flight.
+    var dragStartIndex by remember { mutableStateOf(-1) }
     // Screen-wide so only one row is ever open at a time — expanding a second row
     // collapses whichever was open, across both the set and not-set sections.
     var expandedLabelKey by rememberSaveable { mutableStateOf<String?>(null) }
@@ -156,7 +162,17 @@ internal fun ManageStopLabelsScreen(
                         onRemoveAssignment = { onRemoveAssignment(label) },
                         onDeleteLabel = { onDeleteLabel(label) },
                         dragHandleModifier = Modifier.longPressDraggableHandle(
-                            onDragStarted = { haptic.performHapticFeedback(HapticFeedbackType.LongPress) },
+                            onDragStarted = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                dragStartIndex = setLabels.indexOfFirst { it.label == label.label }
+                            },
+                            onDragStopped = {
+                                val endIndex = setLabels.indexOfFirst { it.label == label.label }
+                                if (dragStartIndex >= 0 && endIndex >= 0) {
+                                    onDragCompleted(label.label, dragStartIndex, endIndex)
+                                }
+                                dragStartIndex = -1
+                            },
                         ),
                         // Without this, expanding/collapsing a row snaps the rows below
                         // into place instead of sliding — they'd flash out of order and
@@ -240,6 +256,7 @@ private fun PreviewManageStopLabelsScreen_Normal() {
             onRemoveAssignment = {},
             onDeleteLabel = {},
             onMove = { _, _ -> },
+            onDragCompleted = { _, _, _ -> },
         )
     }
 }
@@ -255,6 +272,7 @@ private fun PreviewManageStopLabelsScreen_FreshInstall() {
             onRemoveAssignment = {},
             onDeleteLabel = {},
             onMove = { _, _ -> },
+            onDragCompleted = { _, _, _ -> },
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/ManageStopLabelsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/ManageStopLabelsEntry.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.navigation.entries
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
@@ -32,6 +33,15 @@ internal fun EntryProviderScope<NavKey>.ManageStopLabelsEntry(
         val viewModel: SearchStopViewModel = koinViewModel()
         val searchStopState by viewModel.uiState.collectAsStateWithLifecycle()
 
+        // rememberSaveable so rotation / process death doesn't double-count the view.
+        var screenViewTracked by rememberSaveable { mutableStateOf(false) }
+        LaunchedEffect(Unit) {
+            if (!screenViewTracked) {
+                screenViewTracked = true
+                viewModel.onEvent(SearchStopUiEvent.ManageLabelsScreenViewed)
+            }
+        }
+
         // Delete needs a confirm (J7); Remove assignment fires instantly.
         var pendingDeleteLabel by rememberSaveable(stateSaver = StopLabelSaver) {
             mutableStateOf<StopLabel?>(null)
@@ -50,6 +60,15 @@ internal fun EntryProviderScope<NavKey>.ManageStopLabelsEntry(
             onMove = { labelKey, targetLabelKey ->
                 viewModel.onEvent(
                     SearchStopUiEvent.MoveLabelToIndex(labelKey = labelKey, targetLabelKey = targetLabelKey),
+                )
+            },
+            onDragCompleted = { labelKey, fromIndex, toIndex ->
+                viewModel.onEvent(
+                    SearchStopUiEvent.LabelReorderDragCompleted(
+                        labelKey = labelKey,
+                        fromIndex = fromIndex,
+                        toIndex = toIndex,
+                    ),
                 )
             },
         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -55,6 +55,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.LocationKind
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import kotlin.math.abs
 import kotlin.random.Random
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -367,9 +368,9 @@ class SearchStopViewModel(
                 }
                 analytics.track(
                     StopLabelRemovedEvent(
-                        labelName = event.labelKey,
                         action = StopLabelRemovedEvent.Action.CLEAR,
                         hadStop = hadStop,
+                        labelKind = labelKindOf(event.labelKey),
                     ),
                 )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
@@ -418,14 +419,35 @@ class SearchStopViewModel(
                 }
                 analytics.track(
                     StopLabelRemovedEvent(
-                        labelName = event.labelKey,
                         action = StopLabelRemovedEvent.Action.DELETE,
                         hadStop = hadStop,
+                        labelKind = labelKindOf(event.labelKey),
                     ),
                 )
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                     sandook.deleteStopLabel(event.labelKey)
                 }
+            }
+
+            is SearchStopUiEvent.LabelReorderDragCompleted -> {
+                // Only a drag whose final order differs is a reorder; a drag that
+                // returns to its start position is a no-op, matching the plan's
+                // "fire once per completed changed drag" rule.
+                if (event.fromIndex != event.toIndex) {
+                    analytics.track(
+                        StopLabelReorderedEvent(
+                            labelKind = labelKindOf(event.labelKey),
+                            moveDistanceBucket = StopLabelReorderedEvent.MoveDistanceBucket
+                                .from(abs(event.fromIndex - event.toIndex)),
+                            setLabelCountBucket = AnalyticsEvent.StopLabelCountBucket
+                                .from(_uiState.value.stopLabels.count { it.isSet }),
+                        ),
+                    )
+                }
+            }
+
+            SearchStopUiEvent.ManageLabelsScreenViewed -> {
+                analytics.trackScreenViewEvent(screen = AnalyticsScreen.ManageStopLabels)
             }
 
             is SearchStopUiEvent.MoveLabelToIndex -> {
@@ -443,16 +465,8 @@ class SearchStopViewModel(
                 current.add(target, moved)
                 val reordered = current.toImmutableList()
                 updateUiState { copy(stopLabels = reordered) }
-                analytics.track(
-                    StopLabelReorderedEvent(
-                        labelName = moved.label,
-                        previousIndex = sourceIndex,
-                        newIndex = target,
-                        totalCount = reordered.size,
-                        isProtectedLabel = moved.label
-                            .equals(StopLabel.PROTECTED_LABEL, ignoreCase = true),
-                    ),
-                )
+                // No analytics here: MoveLabelToIndex fires once per swap mid-drag.
+                // LabelReorderDragCompleted reports the finished gesture instead.
                 viewModelScope.launchWithExceptionHandler<SearchStopViewModel>(ioDispatcher) {
                     // One transaction per firing, not one write per label — onMove fires
                     // per swap mid-drag, not just once on drop, so an unbatched loop here

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
@@ -733,9 +733,14 @@ class SearchStopViewModelLabelHandlersTest {
                 val tracked = fakeAnalytics.getTrackedEvent("stop_label_removed")
                 assertNotNull(tracked)
                 val event = assertIs<AnalyticsEvent.StopLabelRemovedEvent>(tracked)
-                assertEquals("Home", event.labelName)
                 assertEquals(AnalyticsEvent.StopLabelRemovedEvent.Action.CLEAR, event.action)
                 assertTrue(event.hadStop, "label had a pinned stop before clear")
+                assertEquals(AnalyticsEvent.StopLabelKind.PROTECTED_DEFAULT, event.labelKind)
+                assertEquals("manage_labels", event.properties?.get("surface"))
+                assertFalse(
+                    event.properties.orEmpty().containsKey("labelName"),
+                    "removed event must not carry raw label text",
+                )
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -752,8 +757,8 @@ class SearchStopViewModelLabelHandlersTest {
                 val tracked = fakeAnalytics.getTrackedEvent("stop_label_removed")
                 assertNotNull(tracked)
                 val event = assertIs<AnalyticsEvent.StopLabelRemovedEvent>(tracked)
-                assertEquals("Work", event.labelName)
                 assertEquals(AnalyticsEvent.StopLabelRemovedEvent.Action.DELETE, event.action)
+                assertEquals(AnalyticsEvent.StopLabelKind.CUSTOM, event.labelKind)
                 // Seeded Work has no pinned stop, so hadStop must be false. This keeps
                 // the "users delete labels they never used" funnel honest.
                 assertFalse(event.hadStop)
@@ -778,24 +783,87 @@ class SearchStopViewModelLabelHandlersTest {
         }
 
     @Test
-    fun `Given two labels When MoveLabelToIndex moves Home to position 1 Then reordered event is tracked`() =
+    fun `Given MoveLabelToIndex swaps When drag is mid-flight Then no reordered event is tracked`() =
         runTest {
             viewModel.uiState.test {
                 advanceUntilIdle()
 
+                // Per-swap moves fire during the drag; only the completed gesture
+                // (LabelReorderDragCompleted) may produce an analytics event,
+                // otherwise one long drag inflates the reorder count.
                 viewModel.onEvent(SearchStopUiEvent.MoveLabelToIndex("Home", "Work"))
                 advanceUntilIdle()
 
-                val tracked = fakeAnalytics.getTrackedEvent("stop_label_reordered")
-                assertNotNull(tracked)
-                val event = assertIs<AnalyticsEvent.StopLabelReorderedEvent>(tracked)
-                assertEquals("Home", event.labelName)
-                assertEquals(0, event.previousIndex)
-                assertEquals(1, event.newIndex)
-                assertEquals(2, event.totalCount)
-                // Home is the protected label; flag must be true so the dashboard can
-                // separate "user moved Home" from "user moved a custom label".
-                assertTrue(event.isProtectedLabel)
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_reordered"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given completed changed drag When LabelReorderDragCompleted fires Then one reordered event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(
+                    SearchStopUiEvent.LabelReorderDragCompleted(
+                        labelKey = "Home",
+                        fromIndex = 0,
+                        toIndex = 2,
+                    ),
+                )
+                advanceUntilIdle()
+
+                val events = fakeAnalytics.getTrackedEvents("stop_label_reordered")
+                assertEquals(1, events.size)
+                val event = assertIs<AnalyticsEvent.StopLabelReorderedEvent>(events.single())
+                assertEquals(AnalyticsEvent.StopLabelKind.PROTECTED_DEFAULT, event.labelKind)
+                assertEquals(
+                    AnalyticsEvent.StopLabelReorderedEvent.MoveDistanceBucket.TWO_TO_THREE,
+                    event.moveDistanceBucket,
+                )
+                assertFalse(
+                    event.properties.orEmpty().containsKey("labelName"),
+                    "reordered event must not carry raw label text",
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given drag returned to start When LabelReorderDragCompleted fires Then no reordered event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                viewModel.onEvent(
+                    SearchStopUiEvent.LabelReorderDragCompleted(
+                        labelKey = "Home",
+                        fromIndex = 1,
+                        toIndex = 1,
+                    ),
+                )
+                advanceUntilIdle()
+
+                assertFalse(fakeAnalytics.isEventTracked("stop_label_reordered"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `Given ManageLabelsScreenViewed When fired Then screen view event is tracked`() =
+        runTest {
+            viewModel.uiState.test {
+                advanceUntilIdle()
+                fakeAnalytics.clear()
+
+                viewModel.onEvent(SearchStopUiEvent.ManageLabelsScreenViewed)
+                advanceUntilIdle()
+
+                val event = assertIs<AnalyticsEvent.ScreenViewEvent>(
+                    fakeAnalytics.getTrackedEvent("view_screen"),
+                )
+                assertEquals("ManageStopLabels", event.screen.name)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
Completes the stop-label analytics plan (STOP_LABEL_ANALYTICS_PLAN.md):

- stop_label_removed drops raw labelName; carries labelKind and
  surface=manage_labels.
- stop_label_reordered now fires once per completed changed drag via a new
  LabelReorderDragCompleted UI event from the drag handle's onDragStopped,
  instead of once per swap from MoveLabelToIndex - one long drag was
  previously several events, inflating reorder counts. Payload is bounded:
  labelKind, moveDistanceBucket, setLabelCountBucket.
- ManageStopLabelsScreen finally joins the screen-view taxonomy
  (view_screen name=ManageStopLabels), fired once per entry and guarded
  with rememberSaveable so rotation doesn't double-count.
- Plan doc status flipped to implemented; ledger rows added.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
