### PR TITLE
refactor(settings): remove social links row from Settings screen

### DIFF
--- a/feature/trip-planner/state/build.gradle.kts
+++ b/feature/trip-planner/state/build.gradle.kts
@@ -36,8 +36,6 @@ kotlin {
                 implementation(projects.core.maps.state)
                 implementation(projects.core.transport)
                 implementation(projects.infoTile.state)
-                implementation(projects.social.network.api)
-                implementation(projects.social.state)
                 implementation(projects.taj)
 
                 implementation(libs.kotlinx.collections.immutable)

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/SettingsEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/settings/SettingsEvent.kt
@@ -1,7 +1,0 @@
-package xyz.ksharma.krail.trip.planner.ui.state.settings
-
-import xyz.ksharma.krail.social.state.KrailSocialType
-
-sealed interface SettingsEvent {
-    data class SocialLinkClick(val krailSocialType: KrailSocialType) : SettingsEvent
-}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SettingsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SettingsEntry.kt
@@ -14,7 +14,6 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.SettingsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsScreen
 import xyz.ksharma.krail.trip.planner.ui.settings.SettingsViewModel
-import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsEvent
 
 /**
  * Settings Entry, Detail Screen in List-Detail pattern.
@@ -57,9 +56,6 @@ internal fun EntryProviderScope<NavKey>.SettingsEntry(
             },
             onDebugConfigClick = {
                 tripPlannerNavigator.navigateToDebugConfig()
-            },
-            onSocialLinkClick = { socialType ->
-                viewModel.onEvent(SettingsEvent.SocialLinkClick(socialType))
             },
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -34,10 +34,7 @@ import krail.feature.trip_planner.ui.generated.resources.ic_heart
 import krail.feature.trip_planner.ui.generated.resources.ic_info
 import krail.feature.trip_planner.ui.generated.resources.ic_paint
 import krail.feature.trip_planner.ui.generated.resources.ic_pen
-import krail.feature.trip_planner.ui.generated.resources.ic_wifi
 import org.jetbrains.compose.resources.painterResource
-import xyz.ksharma.krail.social.state.KrailSocialType
-import xyz.ksharma.krail.social.ui.SocialConnectionRow
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
@@ -58,7 +55,6 @@ fun SettingsScreen(
     onAboutUsClick: () -> Unit = {},
     onIntroClick: () -> Unit = {},
     onDebugConfigClick: () -> Unit = {},
-    onSocialLinkClick: (KrailSocialType) -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
     Box(
@@ -128,21 +124,6 @@ fun SettingsScreen(
                     )
                 }
 
-                item {
-                    SettingsItem(
-                        icon = painterResource(Res.drawable.ic_wifi),
-                        text = "Stay connected",
-                        detailContent = {
-                            SocialConnectionRow(
-                                socialLinks = KrailSocialType.entries,
-                                modifier = Modifier
-                                    .padding(start = SOCIAL_ROW_START_PADDING, end = dim.spacingXL),
-                                onClick = { onSocialLinkClick(it) },
-                            )
-                        },
-                    )
-                }
-
                 if (showDebugConfig) {
                     item(key = "settings-debug-config") {
                         SettingsItem(
@@ -176,30 +157,6 @@ fun SettingsScreen(
         }
     }
 }
-
-/*
-@Composable
-private fun SocialConnectionBox(
-    type: SocialType,
-    onSocialLinkClick: (SocialType) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit = {},
-) {
-    Box(
-        modifier = modifier
-            .size(44.dp)
-            .klickable(
-                indication = null,
-                onClick = {
-                    onSocialLinkClick(type)
-                },
-            )
-            .semantics(mergeDescendants = true) {},
-        contentAlignment = Alignment.Center,
-    ) {
-        content()
-    }
-}*/
 
 @Composable
 private fun SettingsItem(
@@ -250,5 +207,4 @@ private fun SettingsItem(
 
 private val CONTENT_BOTTOM_PADDING = 104.dp
 private val SECTION_TITLE_HORIZONTAL_PADDING = 26.dp
-private val SOCIAL_ROW_START_PADDING = 46.dp
 private val FOOTER_SPACER_HEIGHT = 108.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsViewModel.kt
@@ -11,13 +11,10 @@ import kotlinx.coroutines.flow.update
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
-import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.platform.ops.PlatformOps
-import xyz.ksharma.krail.social.ui.toAnalyticsEventPlatform
 import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
-import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsEvent
 import xyz.ksharma.krail.trip.planner.ui.state.settings.SettingsState
 
 class SettingsViewModel(
@@ -32,20 +29,6 @@ class SettingsViewModel(
             fetchAppVersion()
             analytics.trackScreenViewEvent(screen = AnalyticsScreen.Settings)
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SettingsState())
-
-    fun onEvent(event: SettingsEvent) {
-        when (event) {
-            is SettingsEvent.SocialLinkClick -> {
-                platformOps.openUrl(url = event.krailSocialType.url)
-                analytics.track(
-                    event = SocialConnectionLinkClickEvent(
-                        socialPlatformType = event.krailSocialType.toAnalyticsEventPlatform(),
-                        source = SocialConnectionLinkClickEvent.SocialConnectionSource.SETTINGS,
-                    ),
-                )
-            }
-        }
-    }
 
     private fun fetchAppVersion() {
         val appInfo = appInfoProvider.getAppInfo()


### PR DESCRIPTION
## What

Removes the "Stay connected" social links row from the Settings screen.

## Changes

- Remove the Stay connected item and `SocialConnectionRow` from `SettingsScreen`, along with the `onSocialLinkClick` callback
- Delete `SettingsEvent` (`SocialLinkClick` was its only member) and the ViewModel `onEvent` handler
- Drop now-unused social module deps from `trip-planner:state`
- Remove commented-out `SocialConnectionBox` dead code

`SocialConnectionLinkClickEvent` stays in `AnalyticsEvent.kt` as Discover still tracks it.

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green
- detekt clean on both touched modules
- Android compile verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)