### PR TITLE
docs: add v1.25.0 release notes

### DIFF
--- a/docs/release-notes/v1.25.0.md
+++ b/docs/release-notes/v1.25.0.md
@@ -1,0 +1,31 @@
+# KRAIL v1.25.0 — Release Notes
+
+## Android — Google Play Store
+
+v1.25.0
+
+Your stops, your words.
+
+🏷️ Stop Labels: "Central Station Platform 16" is now just "Work". Name the stops you use every day and they'll jump straight to the top of your search. Tidy them up anytime in Manage Labels.
+
+📍 Address Search: Don't know the stop? Type the address — "32 York St" or "Opera House" — and KRAIL finds the closest stops for you.
+
+🔁 Swap stops mid-trip: Tap any stop name at the top of your timetable to change it. No starting over.
+
+Let's KRAIL.
+
+---
+
+## iOS — App Store
+
+v1.25.0
+
+Your stops, your words.
+
+1. Stop Labels: "Central Station Platform 16" is now just "Work". Name the stops you use every day and they'll jump straight to the top of your search. The new Manage Labels screen keeps them tidy.
+
+2. Address Search: Don't know the stop name? Type the address — "32 York St" or "Opera House" — and KRAIL finds the closest stops for you. Recent addresses stick around in your search history.
+
+3. Swap stops mid-trip: Tap any stop name at the top of your timetable to change it, without starting your search over.
+
+Let's KRAIL.


### PR DESCRIPTION
## What

Adds the release notes file for v1.25.0 with Play Store and App Store copy.

## Changes

- New file `docs/release-notes/v1.25.0.md` covering stop labels, address search, and timetable header stop editing

## Testing

- Docs-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)