### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in KRAIL, please report it
+privately. **Do not open a public issue, pull request, or discussion for security
+problems.**
+
+### How to report
+
+- **Preferred:** Use GitHub's [private vulnerability reporting](https://github.com/ksharma-xyz/KRAIL/security/advisories/new)
+  ("Report a vulnerability" under the repository's **Security** tab). This keeps the
+  report confidential and lets us collaborate on a fix and coordinated disclosure.
+- **Email:** [hey@krail.app](mailto:hey@krail.app) if you are unable to use GitHub's
+  reporting flow.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce (proof of concept, affected screens/endpoints, sample input).
+- The app version, platform (Android / iOS), and OS version where you observed it.
+
+### What to expect
+
+- We aim to acknowledge new reports within **5 business days**.
+- We will keep you informed of progress toward a fix and let you know when it ships.
+- We support coordinated disclosure: please give us reasonable time to release a fix
+  before disclosing details publicly. We are happy to credit reporters who wish to be
+  named.
+
+## Scope
+
+This policy covers the KRAIL app source in this repository. KRAIL uses public NSW
+Transport open-data APIs; issues in those upstream services should be reported to their
+respective providers.
+
+Thank you for helping keep KRAIL and its riders safe.


### PR DESCRIPTION
## What

Adds a `SECURITY.md` so the repository has a defined vulnerability reporting policy.

## Changes

- New `SECURITY.md` at repo root: private reporting via GitHub security advisories, email fallback, required report details, response expectations, and scope.

## Testing

- Docs-only change. No code, no build or test impact.
