### PR TITLE
ci: add CodeQL workflow for GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds a CodeQL workflow that scans GitHub Actions workflow files for security issues.

## Changes

- New `.github/workflows/codeql.yml` analyzing the `actions` language with `build-mode: none`.
- Java/Kotlin is intentionally excluded. CodeQL's Kotlin extractor requires a full Gradle build to see any source; the project cannot build in the scanning runner without the proto submodule and gitignored config, and `build-mode: none` does not extract Kotlin. The prior default setup failed for exactly this reason.

## Testing

- CI-config change. The workflow runs on this PR and on `main`.
