### PR TITLE
refactor(search-stop): remove public-transport-only disclaimer

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -721,7 +721,6 @@ private fun SearchStopListContent(
                         },
                         onEvent = onEvent,
                     )
-                    publicTransportNoteItem()
                 }
                 SearchingDotsHeader(
                     isLoading = isLoading,
@@ -784,7 +783,6 @@ private fun SearchStopListContent(
                         onStopSelect = onStopSelect,
                         onEvent = onEvent,
                     )
-                    publicTransportNoteItem()
                 }
                 SearchingDotsHeader(
                     isLoading = listState.isLoading,
@@ -865,11 +863,6 @@ private fun LazyListScope.selectOnMapItem(
     item(key = "select-on-map") {
         SelectOnMapItem(onOpenMap = onOpenMap)
     }
-}
-
-/** Trailing PT-only-stops disclaimer at the bottom of the list. */
-private fun LazyListScope.publicTransportNoteItem() {
-    item(key = "pt-note") { PublicTransportNote() }
 }
 
 @Suppress("LongMethod", "LongParameterList")
@@ -1238,19 +1231,6 @@ private fun LabelShortcutsRow(
             }
         }
     }
-}
-
-@Composable
-private fun PublicTransportNote(modifier: Modifier = Modifier) {
-    Text(
-        text = "You can only select public transport stops on KRAIL\u00A0App.",
-        style = KrailTheme.typography.bodySmall,
-        color = KrailTheme.colors.label,
-        modifier = modifier.padding(
-            horizontal = KrailTheme.dimensions.pageHorizontalPadding,
-            vertical = KrailTheme.dimensions.spacingL,
-        ),
-    )
 }
 
 @Composable


### PR DESCRIPTION
## What

Remove the "You can only select public transport stops on KRAIL App." disclaimer that rendered at the bottom of the stop search list.

## Changes

- Delete the `PublicTransportNote` composable in `SearchStopScreen.kt`
- Delete the `publicTransportNoteItem()` LazyListScope helper and both call sites (search results + address results lists)

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green
- `:feature:trip-planner:ui:detekt` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
