### PR TITLE
feat(saved-trips): back exits edit mode instead of app

### DIFF
--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -107,6 +107,7 @@ kotlin {
                 implementation(libs.compose.foundation)
                 implementation(libs.material.icons.core)
                 implementation(libs.compose.ui)
+                implementation(libs.compose.ui.backhandler)
                 implementation(libs.reorderable)
 
                 api(libs.di.koinComposeViewmodel)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -53,7 +53,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.onSizeChanged
@@ -85,6 +87,7 @@ import app.krail.taj.resources.Res as TajRes
 
 private const val LAZY_COLUMN_BOTTOM_PADDING = 300
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun SavedTripsScreen(
     savedTripsState: SavedTripsState,
@@ -137,6 +140,9 @@ fun SavedTripsScreen(
 
     // Edit mode for trip cards — long-press enters, Done button exits.
     var editing by rememberSaveable { mutableStateOf(false) }
+
+    // While editing, the system back gesture exits edit mode instead of the app.
+    BackHandler(enabled = editing) { editing = false }
 
     val lazyListState = rememberLazyListState()
     val reorderState = rememberReorderableLazyListState(lazyListState) { from, to ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-multiplatform" }
 compose-material = { module = "org.jetbrains.compose.material:material", version.ref = "compose-multiplatform" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
+compose-ui-backhandler = { module = "org.jetbrains.compose.ui:ui-backhandler", version.ref = "compose-multiplatform" }
 compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "compose-multiplatform" }
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }


### PR DESCRIPTION
## What

In the saved-trips list, a system back press while in long-press edit/reorder mode now exits edit mode instead of leaving the app.

## Changes

- `SavedTripsScreen.kt`: add `BackHandler(enabled = editing) { editing = false }` gated on the existing `editing` state; opt in to `ExperimentalComposeUiApi`
- Add `compose-ui-backhandler` dependency (version catalog + module `build.gradle.kts`) for the common `androidx.compose.ui.backhandler.BackHandler` API

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green
- `:feature:trip-planner:ui:detekt` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
