### PR TITLE
ci: skip signing builds on Dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Dependabot pull requests run with the Dependabot secret store, so `secrets.*` and
+# `vars.*` from the Actions store both resolve to empty strings. That makes the signing
+# builds impossible: `core/network/build.gradle.kts` fails configuration with
+# "Register API key and put in local.properties as `ANDROID_NSW_TRANSPORT_API_KEY`",
+# and build-android.yml has no `vars.ANDROID_VERSION_CODE` to read. Those jobs are
+# therefore skipped for Dependabot; `code-quality` still runs (it compiles, runs host
+# tests, and substitutes placeholder API keys via the CI quality-check flag), and it is
+# the only required status check.
 jobs:
   code-quality:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/code-quality.yml
 
   build-android-debug:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && github.actor != 'dependabot[bot]'
     needs: code-quality
     uses: ./.github/workflows/build-android.yml
     with:
@@ -28,7 +38,9 @@ jobs:
     secrets: inherit
 
   build-android-release:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && github.actor != 'dependabot[bot]'
     needs: code-quality
     uses: ./.github/workflows/build-android.yml
     with:
@@ -36,7 +48,9 @@ jobs:
     secrets: inherit
 
   build-ios:
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && github.actor != 'dependabot[bot]'
     needs: code-quality
     uses: ./.github/workflows/build-ios.yml
     secrets: inherit


### PR DESCRIPTION
## What

Skips the three signing build jobs in `Krail App CI` when the pull request author is `dependabot[bot]`.

Dependabot pull requests run with the Dependabot secret store, so every `secrets.*` and `vars.*` lookup against the Actions store resolves to an empty string. `build-android-debug`, `build-android-release`, and `build-ios` then all fail during Gradle configuration in `core/network/build.gradle.kts`:

```
FAILURE: Build failed with an exception.
* Where:
Build file '/home/runner/work/KRAIL/KRAIL/core/network/build.gradle.kts' line: 112
* What went wrong:
Register API key and put in local.properties as `ANDROID_NSW_TRANSPORT_API_KEY`
```

`build-android.yml` hits the same class of problem a step earlier, since `vars.ANDROID_VERSION_CODE` is also empty.

## Changes

- `.github/workflows/build.yml`: add `&& github.actor != 'dependabot[bot]'` to the `if` on `build-android-debug`, `build-android-release`, and `build-ios`. Existing draft-PR condition is preserved, wrapped in parentheses.
- Added a comment above the `jobs:` block explaining why these jobs cannot run on Dependabot pull requests.
- `code-quality` is intentionally left running on Dependabot pull requests. It compiles, runs host tests, and substitutes placeholder API keys through the CI quality-check flag in `core/network/build.gradle.kts`, so it works without real secrets. It is also the only required status check on `main`.
- The alternative fix, mirroring the keystore, Firebase config, and PAT into the Dependabot secret store, was not taken: it would expose signing material to builds triggered by dependency updates on a public repository.

## Testing

- No Kotlin or Gradle source changed, so detekt and unit tests were not run.
- `.github/workflows/build.yml` parsed with a YAML parser; the three `if` expressions resolve to the intended condition.
- Verified against run 29665962993 that `code-quality / detekt` passes on a Dependabot pull request while all three build jobs fail at Gradle configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
