### PR TITLE
ci: move Dependabot build gate into the reusable workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,6 +9,16 @@ on:
 
 jobs:
   build:
+    # Dependabot pull requests run with the Dependabot secret store, so `secrets.*` and
+    # `vars.*` from the Actions store both resolve to empty strings. The build then dies
+    # during Gradle configuration in core/network/build.gradle.kts with "Register API key
+    # and put in local.properties as `ANDROID_NSW_TRANSPORT_API_KEY`", and there is no
+    # `vars.ANDROID_VERSION_CODE` to read either. The gate is on this inner job rather
+    # than on the caller in build.yml so the required status context
+    # "build-android-<variant> / build" is still reported (as skipped) on those pull
+    # requests. Compilation and host tests are still covered by code-quality.yml, which
+    # substitutes placeholder API keys via its CI quality-check flag.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     environment: Firebase
     permissions:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -5,6 +5,11 @@ on:
 
 jobs:
   build:
+    # See build-android.yml for the full explanation: Dependabot pull requests cannot
+    # read `secrets.*`, so Gradle configuration fails on the missing NSW transport API
+    # key. The gate sits on this inner job so the required status context
+    # "build-ios / build" is still reported (as skipped) on those pull requests.
+    if: github.actor != 'dependabot[bot]'
     runs-on: macos-latest
     environment: Firebase
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,23 +14,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Dependabot pull requests run with the Dependabot secret store, so `secrets.*` and
-# `vars.*` from the Actions store both resolve to empty strings. That makes the signing
-# builds impossible: `core/network/build.gradle.kts` fails configuration with
-# "Register API key and put in local.properties as `ANDROID_NSW_TRANSPORT_API_KEY`",
-# and build-android.yml has no `vars.ANDROID_VERSION_CODE` to read. Those jobs are
-# therefore skipped for Dependabot; `code-quality` still runs (it compiles, runs host
-# tests, and substitutes placeholder API keys via the CI quality-check flag), and it is
-# the only required status check.
+# The Dependabot gate lives inside build-android.yml and build-ios.yml, not here. The
+# branch ruleset for `main` requires the contexts "build-android-debug / build",
+# "build-android-release / build" and "build-ios / build", which are named after the
+# inner job of the reusable workflow. Skipping a caller job below emits a check run
+# named only "build-android-debug", so the required context never reports and the pull
+# request stays blocked. Skipping the inner job still emits the fully qualified name
+# with a skipped conclusion, which does satisfy the requirement.
 jobs:
   code-quality:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/code-quality.yml
 
   build-android-debug:
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-      && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: code-quality
     uses: ./.github/workflows/build-android.yml
     with:
@@ -38,9 +35,7 @@ jobs:
     secrets: inherit
 
   build-android-release:
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-      && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: code-quality
     uses: ./.github/workflows/build-android.yml
     with:
@@ -48,9 +43,7 @@ jobs:
     secrets: inherit
 
   build-ios:
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-      && github.actor != 'dependabot[bot]'
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs: code-quality
     uses: ./.github/workflows/build-ios.yml
     secrets: inherit


### PR DESCRIPTION
## What

Follow-up to #1738. Moves the `github.actor != 'dependabot[bot]'` condition off the caller jobs in `build.yml` and onto the `build` job inside `build-android.yml` and `build-ios.yml`.

The branch ruleset for `main` requires these status contexts:

```
build-android-debug / build
build-android-release / build
build-ios / build
```

Those names are `<caller job> / <inner job>`. #1738 skipped the caller job, which emits a check run named only `build-android-debug`, so the required contexts never reported at all. The result on PR #1734 was every check green or skipped but `mergeStateStatus: BLOCKED`, permanently.

Gating the inner job instead still invokes the reusable workflow, so the fully qualified context is reported with a `skipped` conclusion, which does satisfy a required status check.

## Changes

- `.github/workflows/build-android.yml`: add `if: github.actor != 'dependabot[bot]'` to the `build` job, with a comment explaining both the empty-secret failure and why the gate sits on the inner job.
- `.github/workflows/build-ios.yml`: same gate, comment cross-references `build-android.yml`.
- `.github/workflows/build.yml`: restore the plain draft-PR condition on `build-android-debug`, `build-android-release` and `build-ios`; replace the block comment with one describing the context-naming constraint.
- `code-quality` is still unconditional on Dependabot pull requests: it compiles, runs host tests, and substitutes placeholder API keys via the CI quality-check flag in `core/network/build.gradle.kts`.

## Testing

- No Kotlin or Gradle source changed, so detekt and unit tests were not run.
- All three workflow files parsed with a YAML parser; the `if` expressions resolve to the intended conditions.
- Confirmed the naming problem empirically against PR #1734 head `ead1edd`: the check-runs API listed `build-android-debug | completed | skipped`, while the ruleset requires `build-android-debug / build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
