### PR TITLE
ci(analytics): cross-check event names against the ledger diff

### DIFF
--- a/.github/workflows/analytics-ledger-guard.yml
+++ b/.github/workflows/analytics-ledger-guard.yml
@@ -26,13 +26,55 @@ jobs:
           set -euo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          LEDGER='docs/ANALYTICS_REGISTRY_HANDOFF.md'
           CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
           echo "Changed files:"
           echo "$CHANGED"
-          if echo "$CHANGED" | grep -q 'docs/ANALYTICS_REGISTRY_HANDOFF.md'; then
-            echo "OK: ANALYTICS_REGISTRY_HANDOFF.md updated alongside AnalyticsEvent.kt."
+          if echo "$CHANGED" | grep -q "$LEDGER"; then
+            echo "OK: $LEDGER updated alongside AnalyticsEvent.kt."
           else
-            echo "::error::AnalyticsEvent.kt changed but docs/ANALYTICS_REGISTRY_HANDOFF.md was not."
+            echo "::error::AnalyticsEvent.kt changed but $LEDGER was not."
             echo "::error::Add a ledger row for every added/changed event or param (see CLAUDE.md 'Analytics events')."
+            exit 1
+          fi
+
+      # Touching the ledger is not the same as documenting the change. Every event name
+      # this PR introduces must actually appear in the ledger lines the PR added — a
+      # rename shows up here too, because it adds a new `name = "..."` literal.
+      - name: Fail if a new event name is missing from the ledger diff
+        run: |
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          KT='core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt'
+          LEDGER='docs/ANALYTICS_REGISTRY_HANDOFF.md'
+
+          ADDED_NAMES=$(git diff "$BASE_SHA...$HEAD_SHA" -- "$KT" \
+            | grep -E '^\+' \
+            | grep -oE 'name = "[a-z0-9_]+"' \
+            | sed -E 's/.*"(.*)"/\1/' \
+            | sort -u || true)
+
+          if [ -z "$ADDED_NAMES" ]; then
+            echo "No new event-name literals in this PR (param-only change). Nothing to cross-check."
+            exit 0
+          fi
+
+          LEDGER_ADDED=$(git diff "$BASE_SHA...$HEAD_SHA" -- "$LEDGER" | grep -E '^\+' || true)
+
+          MISSING=''
+          for NAME in $ADDED_NAMES; do
+            if echo "$LEDGER_ADDED" | grep -q "\`$NAME\`"; then
+              echo "OK: $NAME documented in the ledger diff."
+            else
+              MISSING="$MISSING $NAME"
+            fi
+          done
+
+          if [ -n "$MISSING" ]; then
+            for NAME in $MISSING; do
+              echo "::error file=$KT::Event '$NAME' is added in this PR but no ledger row mentions it."
+            done
+            echo "::error::Add a row to $LEDGER for each name above, with the event wrapped in backticks."
             exit 1
           fi

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -75,6 +75,13 @@ analytics side so this class of gap cannot silently reopen.
 - ~~`EVENT_REGISTRY.md` exact path unconfirmed~~ — **Resolved**: it already existed at
   `docs/EVENT_REGISTRY.md`, and now has a "Params registry" table added specifically
   for this handoff.
+- **`park_ride_card_click` loses its `facilityId` param.** Firebase rejects the parameter
+  and drops it, appending `firebase_error` / `error_value = facilityId` to the event
+  instead. The event itself arrives fine, so nothing downstream noticed — but the param
+  is absent on essentially every firing since the event shipped, and Park & Ride facility
+  analysis has no data behind it. Needs an app-side fix (check the param name and value
+  against Firebase's naming and length limits at the call site in the P&R card handler).
+  Historical facility data cannot be recovered; it was never recorded.
 - **`no_entries_detected` is firing.** Its KDoc says the event should stay silent after
   the `resetRoot()` / duplicate `toEntries()` fixes, and that the `NoEntriesUI` fallback
   can be removed if it does. It is arriving in production data, most recently 2026-07-19.


### PR DESCRIPTION
## Why

`analytics-ledger-guard.yml` passes as long as `docs/ANALYTICS_REGISTRY_HANDOFF.md` was touched at all. A PR can add a new event and satisfy the gate with an unrelated edit to that file — the gate proves a file changed, not that the change was documented.

## What

Second step in the same workflow:

1. Extract every `name = "..."` literal the PR **adds** to `AnalyticsEvent.kt`.
2. Require each one to appear, backticked, in the lines the PR **adds** to the ledger.
3. Param-only changes add no name literal, so they fall through to the existing file-touched check unchanged.

A rename is caught too — it introduces a new `name = "..."` literal, which is exactly the case that has bitten the analytics side before (`journey_card_expand` → `journey_card_toggle`, `dep_board_stop_click` → `dep_board_toggle`).

Verified the extraction against #1694 (`save_trip_prompt_shown` / `save_trip_prompt_action`): both names extracted, unchanged context lines correctly ignored.

## Open item recorded

While auditing the exported data: **`park_ride_card_click` loses its `facilityId` param.**

Firebase rejects the parameter and drops it, appending `firebase_error` / `error_value = facilityId` to the event instead. The event itself arrives fine, so nothing downstream noticed — but the param is absent on essentially every firing since the event shipped, and Park & Ride facility analysis has no data behind it.

Needs an app-side fix at the P&R card call site (check the param name and value against Firebase's naming and length limits). Historical facility data cannot be recovered; it was never recorded. Recorded under "Open items for KRAIL-Analytics maintainers" rather than fixed here, since the fix belongs with whoever owns that screen.

## Scope

Workflow + docs. No `AnalyticsEvent.kt` change, no app behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMN4pRckETuX4EjHTAw2R9