### PR TITLE
feat(taj): let TextField take a colour set, and add an inverted variant

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
@@ -71,6 +71,9 @@ fun TextField(
     imeAction: ImeAction = ImeAction.Default,
     filter: (CharSequence) -> CharSequence = { it },
     maxLength: Int = Int.MAX_VALUE,
+    // Same shape as ButtonDefaults: callers override the whole colour set rather than passing
+    // one-off colours. Defaults keep every existing call site unchanged.
+    colors: TextFieldColors = TextFieldDefaults.colors(),
     onTextChange: (CharSequence) -> Unit = {},
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -82,8 +85,8 @@ fun TextField(
     // their own state so the field is not rekeyed and focus / IME are preserved.
     val textFieldState = state ?: rememberTextFieldState(initialText.orEmpty())
     val textSelectionColors = TextSelectionColors(
-        handleColor = KrailTheme.colors.onSurface,
-        backgroundColor = KrailTheme.colors.onSurface.copy(alpha = TextSelectionBackgroundOpacity),
+        handleColor = colors.cursorColor,
+        backgroundColor = colors.cursorColor.copy(alpha = TextSelectionBackgroundOpacity),
     )
 
     LaunchedEffect(textFieldState.text) {
@@ -95,7 +98,7 @@ fun TextField(
     }
 
     CompositionLocalProvider(
-        LocalTextColor provides KrailTheme.colors.onSurface,
+        LocalTextColor provides colors.contentColor,
         LocalTextStyle provides KrailTheme.typography.titleLarge.copy(fontWeight = FontWeight.Normal),
         LocalTextSelectionColors provides textSelectionColors,
         LocalContentAlpha provides contentAlpha,
@@ -120,7 +123,7 @@ fun TextField(
             lineLimits = TextFieldLineLimits.SingleLine,
             readOnly = readOnly,
             interactionSource = interactionSource,
-            cursorBrush = SolidColor(KrailTheme.colors.onSurface),
+            cursorBrush = SolidColor(colors.cursorColor),
             // Workaround: Using an anonymous object instead of a lambda
             // https://youtrack.jetbrains.com/projects/CMP/issues/CMP-9456/Reference-to-lambda-in-lambda-in-function-TextField-can-not-be-evaluated
             decorator = object : TextFieldDecorator {
@@ -131,7 +134,7 @@ fun TextField(
                         modifier = Modifier
                             .background(
                                 shape = RoundedCornerShape(TextFieldHeight.div(2)),
-                                color = KrailTheme.colors.surface,
+                                color = colors.containerColor,
                             )
                             .padding(vertical = SpacingTokens.XS)
                             .padding(
@@ -149,10 +152,16 @@ fun TextField(
                         if (textFieldState.text.isEmpty() && isFocused) {
                             Box {
                                 innerTextFieldContent() // Displays cursor
-                                TextFieldPlaceholder(placeholder = placeholder)
+                                TextFieldPlaceholder(
+                                    placeholder = placeholder,
+                                    color = colors.placeholderColor,
+                                )
                             }
                         } else if (textFieldState.text.isEmpty()) {
-                            TextFieldPlaceholder(placeholder = placeholder)
+                            TextFieldPlaceholder(
+                                placeholder = placeholder,
+                                color = colors.placeholderColor,
+                            )
                         } else {
                             innerTextFieldContent()
                         }
@@ -184,6 +193,47 @@ fun ThemeTextFieldPlaceholderText(
             modifier = modifier,
         )
     }
+}
+
+/**
+ * Colour set for [TextField], overridable the same way [ButtonColors] is.
+ */
+@Immutable
+data class TextFieldColors(
+    val containerColor: Color,
+    val contentColor: Color,
+    val placeholderColor: Color,
+    val cursorColor: Color,
+)
+
+object TextFieldDefaults {
+
+    private const val INVERTED_PLACEHOLDER_ALPHA = 0.7f
+
+    /** The field sits on the page surface and reads as part of it. */
+    @Composable
+    fun colors(): TextFieldColors = TextFieldColors(
+        containerColor = KrailTheme.colors.surface,
+        contentColor = KrailTheme.colors.onSurface,
+        placeholderColor = KrailTheme.colors.softLabel,
+        cursorColor = KrailTheme.colors.onSurface,
+    )
+
+    /**
+     * Flips the surface: a dark bar on a light page, a light bar on a dark one.
+     *
+     * For search fields sitting directly on the page surface, where matching that surface
+     * would leave the control with no visible edge at all. Built from `onSurface` / `surface`
+     * rather than fixed black and white, so it inverts correctly in both themes and stays
+     * legible by construction.
+     */
+    @Composable
+    fun invertedColors(): TextFieldColors = TextFieldColors(
+        containerColor = KrailTheme.colors.onSurface,
+        contentColor = KrailTheme.colors.surface,
+        placeholderColor = KrailTheme.colors.surface.copy(alpha = INVERTED_PLACEHOLDER_ALPHA),
+        cursorColor = KrailTheme.colors.surface,
+    )
 }
 
 @Immutable

--- a/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/ThemeContrastTest.kt
+++ b/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/ThemeContrastTest.kt
@@ -1,0 +1,57 @@
+package xyz.ksharma.krail.taj
+
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.contrastRatio
+import xyz.ksharma.krail.taj.theme.getForegroundColor
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Every theme's glyph-on-theme-colour pairing must clear WCAG AA.
+ *
+ * Components that fill a shape with the user's theme colour and draw on top of it (the
+ * Park & Ride add toggle, the `P` icon, theme chips) derive their foreground from
+ * `getForegroundColor`. That contract only holds if it actually produces a legible colour
+ * for every theme we ship, including any added later — hence iterating the enum rather
+ * than asserting a fixed list.
+ */
+class ThemeContrastTest {
+
+    @Test
+    fun `every theme colour yields a legible foreground`() {
+        KrailThemeStyle.entries.forEach { style ->
+            val background = style.hexColorCode.hexToComposeColor()
+            val foreground = getForegroundColor(backgroundColor = background)
+            val ratio = foreground.contrastRatio(background)
+
+            assertTrue(
+                ratio >= WCAG_AA_NORMAL_TEXT,
+                "${style.name}: contrast $ratio is below WCAG AA ($WCAG_AA_NORMAL_TEXT)",
+            )
+        }
+    }
+
+    @Test
+    fun `a low-contrast preferred foreground is replaced, not passed through`() {
+        // The toggle passes LocalThemeContentColor as the preferred glyph colour. When that
+        // local is unset (previews default it to opaque black) it can collide with a dark
+        // theme colour, so the helper has to override it rather than honour the preference.
+        KrailThemeStyle.entries.forEach { style ->
+            val background = style.hexColorCode.hexToComposeColor()
+            val preferred = unspecifiedColor.hexToComposeColor()
+            val resolved = getForegroundColor(
+                backgroundColor = background,
+                foregroundColor = preferred,
+            )
+
+            assertTrue(
+                resolved.contrastRatio(background) >= WCAG_AA_NORMAL_TEXT,
+                "${style.name}: resolved glyph colour is below WCAG AA",
+            )
+        }
+    }
+
+    private companion object {
+        const val WCAG_AA_NORMAL_TEXT = 4.5f
+    }
+}


### PR DESCRIPTION
## What

Gives `TextField` an overridable colour set, in the same shape `ButtonColors` already uses, and adds an inverted variant for fields that sit directly on the page surface.

## Changes

- `TextFieldColors` and `TextFieldDefaults` added. `TextFieldDefaults.colors()` reproduces today's appearance exactly, so every existing call site is unchanged.
- `TextFieldDefaults.invertedColors()` flips the surface: a dark bar on a light page, a light bar on a dark one. Built from `onSurface`/`surface` rather than fixed black and white, so it inverts correctly in both themes and stays legible by construction.
- The placeholder and cursor now follow the colour set. The placeholder previously ignored it, which would have left unreadable hint text on an inverted field.
- `ThemeContrastTest` asserts every `KrailThemeStyle` yields a foreground clearing WCAG AA, and that a low-contrast preferred foreground is replaced rather than honoured. It iterates the enum, so a theme added later is covered without touching the test.

## Why this is needed

`TextField` hardcoded the page surface as its container, so a search field placed on that same surface had no visible edge at all.

## Testing

- `./gradlew :taj:testAndroidHostTest` green
- `./scripts/fullQualityChecks.sh` green

## Snapshots

No screen changes in this PR; the new colour set is not used by any caller yet. The screen that consumes it is in a later PR in this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
