### PR TITLE
feat(platform): open directions in the device's default maps app

### DIFF
--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakePlatformOps.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakePlatformOps.kt
@@ -6,6 +6,7 @@ class FakePlatformOps : PlatformOps {
     var lastSharedText: String? = null
     var lastShareTitle: String? = null
     var lastOpenedUrl: String? = null
+    var lastMapDirections: MapDirections? = null
 
     override fun sharePlainText(text: String, title: String) {
         lastSharedText = text
@@ -15,4 +16,10 @@ class FakePlatformOps : PlatformOps {
     override fun openUrl(url: String) {
         lastOpenedUrl = url
     }
+
+    override fun openMapDirections(latitude: Double, longitude: Double, label: String) {
+        lastMapDirections = MapDirections(latitude = latitude, longitude = longitude, label = label)
+    }
+
+    data class MapDirections(val latitude: Double, val longitude: Double, val label: String)
 }

--- a/platform/ops/src/androidMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.android.kt
+++ b/platform/ops/src/androidMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.android.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
 import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.core.log.logError
 
 class AndroidPlatformOps(private val context: Context) : PlatformOps {
 
@@ -22,6 +23,25 @@ class AndroidPlatformOps(private val context: Context) : PlatformOps {
         }
         context.startActivity(intent)
     }
+
+    override fun openMapDirections(latitude: Double, longitude: Double, label: String) {
+        log("openMapDirections: $latitude,$longitude")
+        // `google.navigation:` would force Google Maps; the `geo:` scheme lets the system
+        // offer whatever maps apps are installed, honouring the rider's default.
+        val encodedLabel = label.encodeGeoLabel()
+        val uri = "geo:$latitude,$longitude?q=$latitude,$longitude($encodedLabel)"
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            data = uri.toUri()
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        // No maps app at all is possible (bare emulators, stripped devices), and an unhandled
+        // intent would otherwise crash the app.
+        runCatching { context.startActivity(intent) }
+            .onFailure { logError("No app available to handle map directions", it) }
+    }
+
+    /** Parentheses terminate the `geo:` label, so they cannot survive inside it. */
+    private fun String.encodeGeoLabel(): String = replace("(", "").replace(")", "").trim()
 }
 
 // https://developer.android.com/training/sharing/send#why-to-use-system-sharesheet

--- a/platform/ops/src/commonMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.kt
+++ b/platform/ops/src/commonMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.kt
@@ -15,4 +15,16 @@ interface PlatformOps {
      * @param url - the URL to open
      */
     fun openUrl(url: String)
+
+    /**
+     * Opens turn-by-turn directions to a coordinate in whichever maps app the device treats as
+     * default.
+     *
+     * Deliberately not a plain [openUrl] with a hardcoded provider URL: that would send every
+     * rider to Google Maps in a browser regardless of what they actually use. Each platform
+     * builds the URI its own launcher understands, so the system picks the app.
+     *
+     * @param label human-readable destination name, shown as the pin title where supported.
+     */
+    fun openMapDirections(latitude: Double, longitude: Double, label: String)
 }

--- a/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
+++ b/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
@@ -5,7 +5,12 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.cValue
 import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRect
+import platform.Foundation.NSCharacterSet
+import platform.Foundation.NSString
 import platform.Foundation.NSURL
+import platform.Foundation.URLQueryAllowedCharacterSet
+import platform.Foundation.create
+import platform.Foundation.stringByAddingPercentEncodingWithAllowedCharacters
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.UIKit.popoverPresentationController
@@ -35,6 +40,16 @@ class IosPlatformOps : PlatformOps {
                 },
             )
         }
+    }
+
+    override fun openMapDirections(latitude: Double, longitude: Double, label: String) {
+        // Apple Maps owns the `maps://` scheme, and iOS routes it to the user's default maps
+        // app where one is set.
+        val allowed = NSCharacterSet.URLQueryAllowedCharacterSet
+        val encoded = NSString.create(string = label)
+        val encodedLabel = encoded.stringByAddingPercentEncodingWithAllowedCharacters(allowed)
+            ?: label
+        openUrl("maps://?daddr=$latitude,$longitude&q=$encodedLabel")
     }
 
     @OptIn(ExperimentalForeignApi::class)


### PR DESCRIPTION
## What

Adds `PlatformOps.openMapDirections`, so a screen can hand a coordinate to whichever maps app the device treats as default.

## Changes

- New interface method plus Android and iOS implementations.
- Android builds a `geo:` URI so the system offers the installed maps apps. `google.navigation:` would have forced one vendor.
- iOS uses `maps://`, percent-encoding the label.
- Android wraps `startActivity` in `runCatching`, so a device with no maps app logs and moves on instead of crashing on an unhandled intent.
- `FakePlatformOps` records the last request, so callers can be tested without launching anything.

## Why not `openUrl` with a maps URL

A hardcoded provider URL sends every rider to one vendor in a browser regardless of what they actually use. URL construction is platform knowledge, so it belongs behind the platform interface.

## Testing

- `./scripts/fullQualityChecks.sh` green (Android compile, iOS Simulator compile, detekt)
- Behaviour is covered from the calling side in a later PR in this stack, via `FakePlatformOps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
