### PR TITLE
feat(park-ride): add picker row, add-row and add-toggle components

### DIFF
--- a/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/AddParkRideCard.kt
+++ b/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/AddParkRideCard.kt
@@ -1,0 +1,81 @@
+package xyz.ksharma.krail.park.ride.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+
+/**
+ * The always-present entry point into the Park & Ride picker.
+ *
+ * Deliberately an action, not an empty state: when a user has no Park & Ride stations this is
+ * the only thing in the section, so it has to offer the next step rather than report that
+ * there is nothing to show. It keeps the same shape once cards exist, where [label] becomes
+ * the "add another" wording.
+ *
+ * Deliberately has no container: filling it the same way as [ParkRideCard] made an action
+ * look identical to a card carrying live parking data. A plain row keeps the filled card
+ * treatment meaning "this holds data", and this meaning "this does something".
+ */
+@Composable
+fun AddParkRideCard(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            // Clip before klickable: the ripple takes the clip bounds, so without this the
+            // touch feedback is a full-width rectangle on a row that has no container.
+            .clip(RoundedCornerShape(percent = PILL_CORNER_PERCENT))
+            .klickable(onClick = onClick)
+            .padding(horizontal = dim.spacingL, vertical = dim.spacingML)
+            // One node: the ring is decorative, the label is the whole meaning.
+            .semantics(mergeDescendants = true) { role = Role.Button },
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ParkRideAddToggle(added = false)
+
+        Text(
+            text = label,
+            style = KrailTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+        )
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun AddParkRideCardPreview() {
+    PreviewTheme {
+        AddParkRideCard(label = "Add Park & Ride", onClick = {})
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun AddParkRideCardAnotherPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        AddParkRideCard(label = "Add another", onClick = {})
+    }
+}
+
+private const val PILL_CORNER_PERCENT = 50

--- a/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkRideAddToggle.kt
+++ b/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkRideAddToggle.kt
@@ -1,0 +1,207 @@
+package xyz.ksharma.krail.park.ride.ui.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.theme.ensureMinimumContrast
+import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.taj.themeColor
+import xyz.ksharma.krail.taj.themeContentColor
+
+private val ToggleSize = 32.dp
+private val GlyphStrokeWidth = 2.dp
+private val RingStrokeWidth = 1.5.dp
+
+/**
+ * The trailing affordance on a Park & Ride picker row: a `+` that flips to a check once the
+ * facility is added. Drawn rather than iconified so it scales with the row and needs no
+ * drawable per state.
+ *
+ * The disc uses the user's selected theme colour ([themeColor]); the glyph starts from
+ * [themeContentColor] but is passed through [getForegroundColor], so a theme whose content
+ * colour is too low-contrast against its own fill falls back to white or black instead of
+ * rendering an unreadable glyph.
+ */
+@Composable
+fun ParkRideAddToggle(
+    added: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    // Not-added is an outline ring on the surface, so the row stays quiet and the accent is
+    // the only colour in it. Added flips to a filled disc, which reads as "done" at a glance
+    // rather than relying on telling a plus from a tick.
+    val accent = themeColor().ensureMinimumContrast(background = KrailTheme.colors.surface)
+    val glyphColor = if (added) {
+        getForegroundColor(backgroundColor = accent, foregroundColor = themeContentColor())
+    } else {
+        accent
+    }
+
+    val haptic = LocalHapticFeedback.current
+    // Buzz only on a real change, never on first composition and never when a row scrolls back
+    // into view. A tap that changes nothing (a station a saved trip is holding) therefore
+    // stays silent, which is the honest signal.
+    var previousAdded by remember { mutableStateOf(added) }
+    LaunchedEffect(added) {
+        if (added != previousAdded) {
+            previousAdded = added
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+    }
+
+    // The disc springs past its resting size on change, so the state flip is felt as well as
+    // seen. Spring rather than tween: it settles naturally if toggled rapidly.
+    val transition = updateTransition(targetState = added, label = "park-ride-toggle")
+    val discScale by transition.animateFloat(
+        transitionSpec = {
+            spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow)
+        },
+        label = "park-ride-toggle-pop",
+    ) { isAdded -> if (isAdded) TOGGLE_ADDED_SCALE else 1f }
+
+    Box(
+        modifier = modifier
+            // Purely a state indicator: the row it sits in owns the click and announces the
+            // state, so announcing it again here would just repeat.
+            .clearAndSetSemantics {}
+            .size(ToggleSize)
+            .scale(discScale)
+            .clip(CircleShape)
+            .then(
+                if (added) {
+                    Modifier.background(color = accent, shape = CircleShape)
+                } else {
+                    Modifier.border(width = RingStrokeWidth, color = accent, shape = CircleShape)
+                },
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        // The plus rotates a quarter turn out as the tick rotates in, so the two glyphs read
+        // as one control changing rather than two icons swapping.
+        AnimatedContent(
+            targetState = added,
+            transitionSpec = {
+                (scaleIn(initialScale = GLYPH_ENTER_SCALE) + fadeIn())
+                    .togetherWith(scaleOut(targetScale = GLYPH_EXIT_SCALE) + fadeOut())
+            },
+            label = "park-ride-toggle-glyph",
+        ) { isAdded ->
+            if (isAdded) {
+                CheckGlyph(color = glyphColor)
+            } else {
+                PlusGlyph(color = glyphColor)
+            }
+        }
+    }
+}
+
+private const val TOGGLE_ADDED_SCALE = 1.08f
+private const val GLYPH_ENTER_SCALE = 0.4f
+private const val GLYPH_EXIT_SCALE = 0.4f
+
+@Composable
+private fun PlusGlyph(color: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier.size(ToggleSize)) {
+        val stroke = GlyphStrokeWidth.toPx()
+        val inset = size.minDimension * PLUS_INSET_FRACTION
+        drawLine(
+            color = color,
+            start = Offset(x = inset, y = size.height / 2),
+            end = Offset(x = size.width - inset, y = size.height / 2),
+            strokeWidth = stroke,
+            cap = StrokeCap.Round,
+        )
+        drawLine(
+            color = color,
+            start = Offset(x = size.width / 2, y = inset),
+            end = Offset(x = size.width / 2, y = size.height - inset),
+            strokeWidth = stroke,
+            cap = StrokeCap.Round,
+        )
+    }
+}
+
+@Composable
+private fun CheckGlyph(color: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier = modifier.size(ToggleSize)) {
+        val stroke = GlyphStrokeWidth.toPx()
+        val w = size.width
+        val h = size.height
+        drawLine(
+            color = color,
+            start = Offset(x = w * CHECK_START_X, y = h * CHECK_START_Y),
+            end = Offset(x = w * CHECK_VERTEX_X, y = h * CHECK_VERTEX_Y),
+            strokeWidth = stroke,
+            cap = StrokeCap.Round,
+        )
+        drawLine(
+            color = color,
+            start = Offset(x = w * CHECK_VERTEX_X, y = h * CHECK_VERTEX_Y),
+            end = Offset(x = w * CHECK_END_X, y = h * CHECK_END_Y),
+            strokeWidth = stroke,
+            cap = StrokeCap.Round,
+        )
+    }
+}
+
+private const val PLUS_INSET_FRACTION = 0.3f
+private const val CHECK_START_X = 0.30f
+private const val CHECK_START_Y = 0.52f
+private const val CHECK_VERTEX_X = 0.44f
+private const val CHECK_VERTEX_Y = 0.66f
+private const val CHECK_END_X = 0.70f
+private const val CHECK_END_Y = 0.36f
+
+@PreviewComponent
+@Composable
+private fun ParkRideAddTogglePreview() {
+    PreviewTheme {
+        Box(modifier = Modifier.background(KrailTheme.colors.surface)) {
+            ParkRideAddToggle(added = false)
+        }
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun ParkRideAddToggleAddedPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        Box(modifier = Modifier.background(KrailTheme.colors.surface)) {
+            ParkRideAddToggle(added = true)
+        }
+    }
+}

--- a/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkRideFacilityRow.kt
+++ b/feature/park-ride/ui/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/ui/components/ParkRideFacilityRow.kt
@@ -1,0 +1,129 @@
+package xyz.ksharma.krail.park.ride.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.components.Divider
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.modifier.klickable
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+
+/**
+ * One selectable Park & Ride facility in the picker.
+ *
+ * The whole row is the tap target — a per-row "Add" button would stack a column of identical
+ * buttons down the screen. The trailing [ParkRideAddToggle] shows state rather than being its
+ * own control, so it carries no click of its own.
+ *
+ * Carries the same `P` identity as the home Park & Ride card, not a transport-mode letter,
+ * so a facility looks the same wherever it appears.
+ */
+@Composable
+fun ParkRideFacilityRow(
+    facilityName: String,
+    added: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    stopName: String? = null,
+    // Slot so callers in other modules can pass the exact badge their surface already uses —
+    // the picker passes trip-planner's `ParkRideIcon`, so a station looks identical in the
+    // picker and on the home Park & Ride card.
+    icon: @Composable () -> Unit = { ParkAndRideIcon() },
+    showDivider: Boolean = true,
+) {
+    val dim = KrailTheme.dimensions
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                // klickable sits before padding so the ripple covers the whole row width
+                // rather than just the padded content box.
+                .klickable(onClick = onClick)
+                .padding(horizontal = dim.pageHorizontalPadding, vertical = RowVerticalPadding)
+                // mergeDescendants so the badge, name, subtitle and toggle are announced as
+                // one row instead of four separate nodes. State goes in stateDescription
+                // rather than being concatenated into the label, so a screen reader reports
+                // it as the control's state and not as part of its name.
+                .semantics(mergeDescendants = true) {
+                    role = Role.Checkbox
+                    stateDescription = if (added) "Added" else "Not added"
+                },
+            horizontalArrangement = Arrangement.spacedBy(dim.spacingL),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            icon()
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(dim.spacingXXS),
+            ) {
+                // No line cap on either line: at large font scales a clamped station name is
+                // unreadable, and a taller row beats a name the rider cannot finish.
+                Text(
+                    text = facilityName,
+                    style = KrailTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
+                )
+
+                if (!stopName.isNullOrBlank() && stopName != facilityName) {
+                    Text(
+                        text = stopName,
+                        style = KrailTheme.typography.bodySmall,
+                        color = KrailTheme.colors.secondaryLabel,
+                    )
+                }
+            }
+
+            ParkRideAddToggle(added = added)
+        }
+
+        // Aligned to the page gutter, so the rule starts level with the badge and the list
+        // reads as one column rather than an indented sub-list.
+        if (showDivider) {
+            Divider(modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding))
+        }
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun ParkRideFacilityRowPreview() {
+    PreviewTheme {
+        ParkRideFacilityRow(
+            facilityName = "Gordon Henry St (north)",
+            stopName = "Gordon Station",
+            added = false,
+            onClick = {},
+        )
+    }
+}
+
+@PreviewComponent
+@Composable
+private fun ParkRideFacilityRowAddedPreview() {
+    PreviewTheme(themeStyle = KrailThemeStyle.BarbiePink) {
+        ParkRideFacilityRow(
+            facilityName = "Revesby",
+            stopName = "Revesby Station",
+            added = true,
+            onClick = {},
+        )
+    }
+}
+
+// A touch taller than spacingL so each row reads as its own block rather than a dense list.
+private val RowVerticalPadding = 20.dp


### PR DESCRIPTION
## What

Three reusable components for surfacing Park & Ride outside a saved trip. Nothing renders them yet.

## Changes

- `ParkRideAddToggle` - an outline ring carrying a drawn `+` that becomes a filled disc with a tick once added, so state reads at a glance rather than relying on telling a plus from a tick. The glyph runs through `getForegroundColor` / `ensureMinimumContrast`. It springs and fires haptic feedback only on a real state change, so a tap that changes nothing stays silent. Cleared from the accessibility tree, since the row it sits in owns the state.
- `ParkRideFacilityRow` - a selectable station. The whole row is the tap target; a per-row button would stack a column of identical controls. Full-bleed on the page surface with a divider rather than a card fill, so it never competes with a card carrying live data. Takes an icon slot so a caller can pass the exact badge its surface already uses.
- `AddParkRideCard` - the entry point into the picker. No container at all, and its ripple is clipped to a pill.

## Accessibility

- The row merges its descendants into one node, so a screen reader announces one control rather than the badge, title, subtitle and toggle as four separate items. State is in `stateDescription`, not concatenated into the label.
- Title and subtitle wrap rather than truncate, so large font scales stay readable.
- Glyph contrast is covered by `ThemeContrastTest` across every theme in light and dark.

## Testing

- `./scripts/fullQualityChecks.sh` green
- `@PreviewComponent` previews for each component in default and alternate themes

## Snapshots

New components with no prior state. Previews are included in the files; they render in both light and dark across the theme set via `@PreviewComponent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
