### PR TITLE
feat(park-ride): model picker stations, grouped from the raw catalogue

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/AddParkRideState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/AddParkRideState.kt
@@ -1,0 +1,175 @@
+package xyz.ksharma.krail.trip.planner.ui.state.savedtrip
+
+import androidx.compose.runtime.Stable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * UI state for the Park & Ride picker — the searchable list of stations the app supports.
+ */
+@Stable
+data class AddParkRideState(
+    val stations: ImmutableList<ParkRideStationPickerItem> = persistentListOf(),
+    val isLoading: Boolean = true,
+    /**
+     * Emoji and greeting for the loading state, from the same festival source the timetable
+     * uses — so a loading screen looks like the app, not like this one screen.
+     */
+    val loadingEmoji: LoadingEmoji? = null,
+    val error: ErrorKind? = null,
+    val query: String = "",
+    /** The station whose detail sheet is open, if any. */
+    val selectedStation: ParkRideStationPickerItem? = null,
+    /**
+     * Availability for [selectedStation]'s car parks, read from the local store.
+     *
+     * Empty until a fetch lands. Cached rows show immediately, so re-opening a station that
+     * was loaded recently is instant and costs no API call.
+     */
+    val selectedStationDetails: ImmutableList<ParkRideUiState.ParkRideFacilityDetail> =
+        persistentListOf(),
+    /** True only while a network fetch for [selectedStation] is in flight. */
+    val isLoadingSelectedStation: Boolean = false,
+) {
+
+    /**
+     * The rows the picker should render for the current [query].
+     *
+     * Matching is a plain case-insensitive contains over the station name, its car park names
+     * and the stop name — a rider searching "Tallawong" should find it whether the catalogue
+     * calls the car park "Tallawong P1" or names the station.
+     */
+    val visibleStations: List<ParkRideStationPickerItem>
+        get() = if (query.isBlank()) {
+            stations
+        } else {
+            stations.filter { it.matches(query) }
+        }
+
+    /**
+     * [visibleStations] split into address-book style alphabetical sections.
+     *
+     * Sections are derived rather than stored so they always match the current [query] —
+     * searching narrows the letters shown instead of leaving empty headers behind. Stations
+     * whose name does not start with a letter are collected under "#", so nothing is dropped.
+     */
+    val sections: List<StationSection>
+        get() = visibleStations
+            .groupBy { station -> station.sectionLetter() }
+            .map { (letter, stations) -> StationSection(letter = letter, stations = stations) }
+            // "#" sorts after Z, the way a contacts list orders it.
+            .sortedWith(compareBy({ it.letter == NON_ALPHA_SECTION }, { it.letter }))
+
+    @Stable
+    data class StationSection(
+        val letter: String,
+        val stations: List<ParkRideStationPickerItem>,
+    )
+
+    enum class ErrorKind {
+        /** Remote Config returned no facilities — nothing to offer, and retrying may help. */
+        NoFacilities,
+    }
+
+    /**
+     * One station in the picker, which may cover several car parks.
+     *
+     * A station is not the same thing as a stop ID or a facility ID: NSW data collides in both
+     * directions. Tallawong is one stop (`2155384`) with three car parks (P1/P2/P3), while
+     * Mona Vale is one car park (facility `12`) reachable from two stop IDs. Either shape
+     * would produce duplicate rows if the list were keyed on one ID alone, so entries are
+     * grouped into connected components over the (stopId, facilityId) pairs and shown once.
+     *
+     * @param stationId stable identity for the group, used as the list key.
+     * @param mappings every (stopId, facilityId) pair the group covers. Adding the station
+     * stores all of them, so the home card lists all of its car parks together.
+     * @param isUserAdded the rider added this station themselves (source `UserAdded`), so it
+     * is theirs to remove.
+     * @param isFromSavedTrip a saved trip passes through this station, so its card is on the
+     * home screen whether or not the rider added it. Shown as added, because it is, but it
+     * cannot be removed here — the trip owns it.
+     */
+    @Stable
+    data class ParkRideStationPickerItem(
+        val stationId: String,
+        val stationName: String,
+        val stopName: String,
+        val carParkNames: List<String>,
+        val mappings: List<ParkRideMapping>,
+        val isUserAdded: Boolean = false,
+        val isFromSavedTrip: Boolean = false,
+        /**
+         * Position of the station, read from the local GTFS stops table. Null when the stop ID
+         * is not in the local database, in which case the station is simply not plotted — the
+         * list row still works.
+         */
+        val position: StationPosition? = null,
+    ) {
+        /**
+         * Ticked when the station's card is on the home screen for any reason. Showing only
+         * user-added stations as ticked would claim "not added" for a station the rider can
+         * plainly see on their home screen.
+         */
+        val added: Boolean get() = isUserAdded || isFromSavedTrip
+
+        /** A saved trip is holding this station, so the picker cannot remove it. */
+        val isLockedBySavedTrip: Boolean get() = isFromSavedTrip && !isUserAdded
+
+        val carParkCount: Int get() = mappings.map { it.facilityId }.distinct().size
+
+        fun matches(query: String): Boolean =
+            stationName.contains(query, ignoreCase = true) ||
+                stopName.contains(query, ignoreCase = true) ||
+                carParkNames.any { it.contains(query, ignoreCase = true) }
+    }
+
+    @Stable
+    data class ParkRideMapping(
+        val stopId: String,
+        val facilityId: String,
+        val facilityName: String,
+    )
+
+    @Stable
+    data class StationPosition(val latitude: Double, val longitude: Double)
+
+    @Stable
+    data class LoadingEmoji(val emoji: String, val greeting: String)
+
+    companion object {
+        const val NON_ALPHA_SECTION = "#"
+    }
+}
+
+private fun AddParkRideState.ParkRideStationPickerItem.sectionLetter(): String {
+    val first = stationName.firstOrNull() ?: return AddParkRideState.NON_ALPHA_SECTION
+    return if (first.isLetter()) first.uppercase() else AddParkRideState.NON_ALPHA_SECTION
+}
+
+/**
+ * Events raised by the Park & Ride picker.
+ */
+sealed interface AddParkRideUiEvent {
+
+    data class SearchQueryChanged(val query: String) : AddParkRideUiEvent
+
+    /** Adds every car park at the station when not yet added, removes them all when added. */
+    data class ToggleStation(
+        val item: AddParkRideState.ParkRideStationPickerItem,
+    ) : AddParkRideUiEvent
+
+    /** A map pin was tapped: open its sheet and load availability if it is off cooldown. */
+    data class StationSelected(
+        val item: AddParkRideState.ParkRideStationPickerItem,
+    ) : AddParkRideUiEvent
+
+    data object StationDismissed : AddParkRideUiEvent
+
+    /** Hand off to the device's default maps app for driving directions. */
+    data class DirectionsClicked(
+        val position: AddParkRideState.StationPosition,
+        val stationName: String,
+    ) : AddParkRideUiEvent
+
+    data object Retry : AddParkRideUiEvent
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideStationGrouping.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideStationGrouping.kt
@@ -1,0 +1,125 @@
+package xyz.ksharma.krail.trip.planner.ui.parkride
+
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ParkRideMapping
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ParkRideStationPickerItem
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.StationPosition
+
+/**
+ * Collapses the raw Remote Config facility list into one entry per station.
+ *
+ * The NSW catalogue collides in both directions, and either shape produces duplicate rows if
+ * the list is keyed on a single ID:
+ *
+ * - one stop, several car parks — Tallawong (`2155384`) has P1, P2 and P3; likewise Penrith,
+ *   Campbelltown and Kellyville
+ * - one car park, several stops — Mona Vale (facility `12`) is reachable from `210318` and
+ *   `2103108`; likewise Sutherland, Hornsby and Manly Vale
+ *
+ * Grouping by `stopId` alone fixes the first and duplicates the second; grouping by
+ * `facilityId` alone does the reverse. So entries are treated as edges in a bipartite graph
+ * of stops and facilities, and each connected component becomes one station.
+ *
+ * Extracted to its own file so neither this nor `AddParkRideViewModel` grows past detekt's
+ * per-file function limit.
+ */
+internal fun List<NswParkRideFacility>.groupIntoStations(
+    stopNameLookup: (stopId: String) -> String?,
+    positionLookup: (stopIds: List<String>) -> Map<String, StationPosition> = { emptyMap() },
+): List<ParkRideStationPickerItem> {
+    val unionFind = UnionFind()
+
+    forEach { facility ->
+        unionFind.union(stopNode(facility.stopId), facilityNode(facility.parkRideFacilityId))
+    }
+
+    // One batched lookup for the whole catalogue rather than a query per station.
+    val positions = positionLookup(map { it.stopId }.distinct())
+
+    return groupBy { unionFind.find(stopNode(it.stopId)) }
+        .map { (_, facilities) -> facilities.toStation(stopNameLookup, positions) }
+        .sortedBy { it.stationName.lowercase() }
+}
+
+private fun List<NswParkRideFacility>.toStation(
+    stopNameLookup: (stopId: String) -> String?,
+    positions: Map<String, StationPosition>,
+): ParkRideStationPickerItem {
+    val mappings = map { facility ->
+        ParkRideMapping(
+            stopId = facility.stopId,
+            facilityId = facility.parkRideFacilityId,
+            facilityName = facility.parkRideName.toDisplayName(),
+        )
+    }
+    // Smallest stop ID keeps the identity stable regardless of Remote Config ordering.
+    val stationId = minOf { it.stopId }
+    val carParkNames = mappings.map { it.facilityName }.distinct()
+
+    return ParkRideStationPickerItem(
+        stationId = stationId,
+        stationName = commonStationName(carParkNames),
+        stopName = firstNotNullOfOrNull { stopNameLookup(it.stopId) }.orEmpty(),
+        carParkNames = carParkNames,
+        mappings = mappings,
+        isUserAdded = false,
+        isFromSavedTrip = false,
+        // Any stop in the group works: they are platforms of the same station, metres apart.
+        position = firstNotNullOfOrNull { positions[it.stopId] },
+    )
+}
+
+/**
+ * The name a rider would call the station, derived from its car park names.
+ *
+ * "Tallawong P1/P2/P3" becomes "Tallawong" and "Penrith (at-grade)/(multi-level)" becomes
+ * "Penrith". The common prefix alone is not enough — it can stop mid-word ("Tallawong P") —
+ * so a trailing partial word is dropped.
+ */
+internal fun commonStationName(names: List<String>): String {
+    if (names.size == 1) return names.first()
+
+    val prefix = names.reduce { acc, name -> acc.commonPrefixWith(name, ignoreCase = true) }
+        .trim()
+        .trimEnd { !it.isLetterOrDigit() }
+    if (prefix.isEmpty()) return names.first()
+
+    val endsAtWordBoundary = names.all { name ->
+        name.length == prefix.length || !name[prefix.length].isLetterOrDigit()
+    }
+    val name = if (endsAtWordBoundary) prefix else prefix.substringBeforeLast(' ', prefix)
+
+    return name.trim().ifEmpty { names.first() }
+}
+
+private fun String.toDisplayName(): String = removePrefix("Park&Ride - ").trim()
+
+private fun stopNode(stopId: String) = "stop:$stopId"
+
+private fun facilityNode(facilityId: String) = "facility:$facilityId"
+
+/** Minimal union-find over string nodes; the catalogue is a few dozen entries. */
+private class UnionFind {
+    private val parent = mutableMapOf<String, String>()
+
+    fun find(node: String): String {
+        var root = parent.getOrPut(node) { node }
+        while (root != parent.getValue(root)) {
+            root = parent.getValue(root)
+        }
+        // Path compression keeps repeated lookups flat.
+        var current = node
+        while (current != root) {
+            val next = parent.getValue(current)
+            parent[current] = root
+            current = next
+        }
+        return root
+    }
+
+    fun union(a: String, b: String) {
+        val rootA = find(a)
+        val rootB = find(b)
+        if (rootA != rootB) parent[rootA] = rootB
+    }
+}


### PR DESCRIPTION
## What

The picker's state model, and the grouping that turns the raw Remote Config facility list into one entry per station.

## Changes

- `AddParkRideState` with the station item, its mappings, position, loading/error states, derived `visibleStations` for the current query and derived alphabetical `sections`.
- `ParkRideStationGrouping` collapses the raw list by treating entries as edges in a bipartite graph of stops and facilities, so each connected component becomes one station.
- Station name comes from the common prefix of its car park names with a trailing partial word dropped.

## Why a graph rather than a key

The NSW catalogue collides in both directions, and either shape produces duplicate rows if the list is keyed on a single ID:

- one stop, several car parks: Tallawong (`2155384`) has P1, P2 and P3; likewise Penrith, Campbelltown, Kellyville
- one car park, several stops: Mona Vale (facility `12`) is reachable from `210318` and `2103108`; likewise Sutherland, Hornsby, Manly Vale

Grouping by `stopId` alone fixes the first and duplicates the second; grouping by `facilityId` alone does the reverse. The result matches what `toParkRideUiState()` already produces for the home card, so the picker and the card agree.

Sections are derived rather than stored, so searching narrows the headers instead of leaving empty ones behind, and `#` sorts after Z.

## Testing

- Covered directly by `ParkRideCatalogueTest` in a later PR in this stack, including both collision shapes.
- `./scripts/fullQualityChecks.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
