### PR TITLE
test(park-ride): cover the catalogue, the rate limit and selection

### DIFF
--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideSelectionTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideSelectionTest.kt
@@ -1,0 +1,209 @@
+package xyz.ksharma.krail.trip.planner.ui.parkride
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import xyz.ksharma.krail.core.analytics.Analytics
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeNswParkRideSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideFacilityManager
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideService
+import xyz.ksharma.krail.core.testing.fakes.FakePlatformOps
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+import xyz.ksharma.krail.sandook.NSWParkRideFacilityDetail
+import xyz.ksharma.krail.sandook.NswParkRideSandook
+import xyz.ksharma.krail.sandook.NswParkRideSandook.Companion.SavedParkRideSource.SavedTrips
+import xyz.ksharma.krail.sandook.NswParkRideSandook.Companion.SavedParkRideSource.UserAdded
+import xyz.ksharma.krail.sandook.SavedParkRide
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ErrorKind
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideUiEvent
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What a selected station shows, what it costs, and what survives a configuration
+ * change. Split from [AddParkRideViewModelTest] so neither file becomes a wall of
+ * unrelated setup.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddParkRideSelectionTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val parkRideSandook: NswParkRideSandook = FakeNswParkRideSandook()
+    private val facilityManager = FakeParkRideFacilityManager()
+    private val sandook = FakeSandook()
+    private val analytics: Analytics = FakeAnalytics()
+    private val platformOps = FakePlatformOps()
+    private lateinit var viewModel: AddParkRideViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = AddParkRideViewModel(
+            catalogue = RealParkRideCatalogue(
+                nswParkRideFacilityManager = facilityManager,
+                stopResultsManager = FakeStopResultsManager(),
+                sandook = sandook,
+                festivalManager = FakeFestivalManager(),
+            ),
+            parkRideSandook = parkRideSandook,
+            availabilityLoader = RealParkRideAvailabilityLoader(
+                parkRideSandook = parkRideSandook,
+                parkRideService = FakeParkRideService(),
+                flag = FakeFlag(),
+            ),
+            platformOps = platformOps,
+            analytics = analytics,
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `selecting a station shows its cached availability without an API call`() =
+        runTest(testDispatcher) {
+            facilityManager.facilities = TALLAWONG
+            // Cached row already stored, and its timestamp is now — so the facility is on
+            // cooldown and must be served from cache rather than refetched.
+            parkRideSandook.insertOrReplaceAll(
+                listOf(cachedDetail(facilityId = "26", spotsAvailable = 42)),
+            )
+            parkRideSandook.updateApiCallTimestamp("26", Clock.System.now().epochSeconds)
+
+            viewModel.uiState.test {
+                advanceUntilIdle()
+                val station = expectMostRecentItem().stations.first()
+
+                viewModel.onEvent(AddParkRideUiEvent.StationSelected(station))
+                advanceUntilIdle()
+
+                val state = expectMostRecentItem()
+                assertEquals(station.stationId, state.selectedStation?.stationId)
+                assertEquals(42, state.selectedStationDetails.first().spotsAvailable)
+                assertFalse(state.isLoadingSelectedStation)
+
+                // Dismissing clears the sheet so a stale station is never shown next time.
+                viewModel.onEvent(AddParkRideUiEvent.StationDismissed)
+                advanceUntilIdle()
+                val dismissed = expectMostRecentItem()
+                assertEquals(null, dismissed.selectedStation)
+                assertTrue(dismissed.selectedStationDetails.isEmpty())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `directions hand off the station's coordinates to the platform`() =
+        runTest(testDispatcher) {
+            facilityManager.facilities = TALLAWONG
+            sandook.insertNswStop(
+                stopId = "2155384",
+                stopName = "Tallawong Station",
+                stopLat = TALLAWONG_LAT,
+                stopLon = TALLAWONG_LON,
+                isParent = null,
+            )
+
+            viewModel.uiState.test {
+                advanceUntilIdle()
+                val station = expectMostRecentItem().stations.first()
+
+                viewModel.onEvent(
+                    AddParkRideUiEvent.DirectionsClicked(
+                        position = station.position!!,
+                        stationName = station.stationName,
+                    ),
+                )
+                advanceUntilIdle()
+
+                // Coordinates go to the platform's own launcher, not a hardcoded provider URL,
+                // so the device's default maps app handles it.
+                assertEquals(
+                    FakePlatformOps.MapDirections(TALLAWONG_LAT, TALLAWONG_LON, "Tallawong"),
+                    platformOps.lastMapDirections,
+                )
+                assertEquals(null, platformOps.lastOpenedUrl)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `a typed query and its filtered results survive a config change`() =
+        runTest(testDispatcher) {
+            facilityManager.facilities = TALLAWONG +
+                NswParkRideFacility("221210", "9", "Park&Ride - Revesby")
+
+            // First collection: the composition before rotation.
+            viewModel.uiState.test {
+                advanceUntilIdle()
+                viewModel.onEvent(AddParkRideUiEvent.SearchQueryChanged("tal"))
+                advanceUntilIdle()
+
+                val before = expectMostRecentItem()
+                assertEquals("tal", before.query)
+                assertEquals(listOf("Tallawong"), before.visibleStations.map { it.stationName })
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            // Rotation tears the composition down and rebuilds it, so uiState is dropped and
+            // re-collected. The rider must come back to exactly what they were looking at,
+            // not an unfiltered list.
+            viewModel.uiState.test {
+                advanceUntilIdle()
+
+                val after = expectMostRecentItem()
+                assertEquals("tal", after.query)
+                assertEquals(listOf("Tallawong"), after.visibleStations.map { it.stationName })
+                assertEquals(listOf("T"), after.sections.map { it.letter })
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @OptIn(ExperimentalTime::class)
+    private fun cachedDetail(facilityId: String, spotsAvailable: Int) = NSWParkRideFacilityDetail(
+        facilityId = facilityId,
+        spotsAvailable = spotsAvailable.toLong(),
+        totalSpots = 100,
+        facilityName = "Tallawong P1",
+        percentageFull = 58,
+        stopId = "2155384",
+        stopName = "Tallawong Station",
+        timeText = "8:00 AM",
+        suburb = "Rouse Hill",
+        address = "",
+        latitude = 0.0,
+        longitude = 0.0,
+        timestamp = Clock.System.now().epochSeconds,
+    )
+
+    private companion object {
+        const val TALLAWONG_LAT = -33.6919
+        const val TALLAWONG_LON = 150.9059
+
+        val TALLAWONG = listOf(
+            NswParkRideFacility("2155384", "26", "Park&Ride - Tallawong P1"),
+            NswParkRideFacility("2155384", "27", "Park&Ride - Tallawong P2"),
+            NswParkRideFacility("2155384", "28", "Park&Ride - Tallawong P3"),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideAvailabilityLoaderTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideAvailabilityLoaderTest.kt
@@ -1,0 +1,129 @@
+package xyz.ksharma.krail.trip.planner.ui.parkride
+
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeNswParkRideSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideService
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.model.ParkingStopBatchResponse
+import xyz.ksharma.krail.park.ride.network.service.ParkRideService
+import xyz.ksharma.krail.sandook.NswParkRideSandook
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.filterRefreshableFacilities
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.parkRideApiCooldown
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ParkRideMapping
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * The map sheet and the home Park & Ride card are two entry points onto one API budget.
+ *
+ * Both write and read the same `lastApiCallTimestamp` per facility and both gate on
+ * [filterRefreshableFacilities], so loading a station in the sheet must leave the home card
+ * with nothing to fetch. If these ever diverge, a rider opening the sheet and then expanding
+ * the card would spend two API calls for one piece of information — silently, since neither
+ * screen would look wrong.
+ */
+@OptIn(ExperimentalTime::class)
+class ParkRideAvailabilityLoaderTest {
+
+    private val parkRideSandook: NswParkRideSandook = FakeNswParkRideSandook()
+    private val service = CountingParkRideService()
+    private val loader = RealParkRideAvailabilityLoader(
+        parkRideSandook = parkRideSandook,
+        parkRideService = service,
+        flag = FakeFlag(),
+    )
+
+    private val mappings = listOf(
+        ParkRideMapping(stopId = "2153478", facilityId = "31", facilityName = "Bella Vista"),
+    )
+
+    @Test
+    fun `a first load calls the API once and records the call`() = runTest {
+        loader.refreshIfNeeded(mappings)
+
+        assertEquals(1, service.callCount)
+        // The timestamp is what every other surface gates on.
+        assertTrue((parkRideSandook.getLastApiCallTimestamp("31") ?: 0) > 0)
+    }
+
+    @Test
+    fun `expanding the home card after the sheet loaded makes no second call`() = runTest {
+        loader.refreshIfNeeded(mappings)
+        assertEquals(1, service.callCount)
+
+        // Exactly the gate SavedTripsViewModel applies when a card is expanded.
+        val refreshable = filterRefreshableFacilities(
+            parkRideSandook = parkRideSandook,
+            facilityIds = setOf("31"),
+            cooldown = parkRideApiCooldown(
+                peakTimeCooldownSeconds = PEAK_COOLDOWN_SECONDS,
+                nonPeakTimeCooldownSeconds = NON_PEAK_COOLDOWN_SECONDS,
+            ),
+            nowInstant = Clock.System.now(),
+        )
+
+        assertTrue(
+            refreshable.isEmpty(),
+            "Facility should be on cooldown after the sheet loaded it, so the home card " +
+                "serves cached data instead of refetching",
+        )
+
+        // And going through the loader again is a no-op rather than a second call.
+        loader.refreshIfNeeded(mappings)
+        assertEquals(1, service.callCount)
+    }
+
+    @Test
+    fun `a facility whose cooldown has elapsed is refetched`() = runTest {
+        loader.refreshIfNeeded(mappings)
+        assertEquals(1, service.callCount)
+
+        // Rewind the recorded call well past the longest cooldown.
+        parkRideSandook.updateApiCallTimestamp(
+            facilityId = "31",
+            timestamp = Instant.DISTANT_PAST.epochSeconds,
+        )
+
+        loader.refreshIfNeeded(mappings)
+        assertEquals(2, service.callCount)
+    }
+
+    @Test
+    fun `no mappings means no API call`() = runTest {
+        loader.refreshIfNeeded(emptyList())
+
+        assertEquals(0, service.callCount)
+    }
+
+    /** Wraps the shared fake purely to count network hits. */
+    private class CountingParkRideService(
+        private val delegate: ParkRideService = FakeParkRideService(),
+    ) : ParkRideService {
+        var callCount = 0
+            private set
+
+        override suspend fun fetchCarParkFacilities(
+            facilityId: String,
+        ): Result<CarParkFacilityDetailResponse> {
+            callCount++
+            return delegate.fetchCarParkFacilities(facilityId)
+        }
+
+        override suspend fun fetchCarParkFacilities(): Result<Map<String, String>> =
+            delegate.fetchCarParkFacilities()
+
+        override suspend fun fetchAvailabilityForStops(
+            stopIds: List<String>,
+        ): ParkingStopBatchResponse? = delegate.fetchAvailabilityForStops(stopIds)
+    }
+
+    private companion object {
+        const val PEAK_COOLDOWN_SECONDS = 120L
+        const val NON_PEAK_COOLDOWN_SECONDS = 600L
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideCatalogueTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideCatalogueTest.kt
@@ -1,0 +1,98 @@
+package xyz.ksharma.krail.trip.planner.ui.parkride
+
+import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideFacilityManager
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Direct coverage of the catalogue, rather than only reaching it through the ViewModel.
+ *
+ * The grouping it performs is the part most likely to break silently when the Remote Config
+ * list changes shape, so it is worth testing where it lives.
+ */
+class ParkRideCatalogueTest {
+
+    private val facilityManager = FakeParkRideFacilityManager()
+    private val sandook = FakeSandook()
+
+    private val catalogue = RealParkRideCatalogue(
+        nswParkRideFacilityManager = facilityManager,
+        stopResultsManager = FakeStopResultsManager(),
+        sandook = sandook,
+        festivalManager = FakeFestivalManager(),
+    )
+
+    @Test
+    fun `several car parks behind one stop collapse to one station`() {
+        facilityManager.facilities = listOf(
+            NswParkRideFacility("2155384", "26", "Park&Ride - Tallawong P1"),
+            NswParkRideFacility("2155384", "27", "Park&Ride - Tallawong P2"),
+            NswParkRideFacility("2155384", "28", "Park&Ride - Tallawong P3"),
+        )
+
+        val stations = catalogue.stations()
+
+        assertEquals(1, stations.size)
+        // The shared prefix names the station, with the trailing partial word dropped.
+        assertEquals("Tallawong", stations.first().stationName)
+        assertEquals(3, stations.first().carParkCount)
+    }
+
+    @Test
+    fun `one car park behind several stops collapses to one station`() {
+        facilityManager.facilities = listOf(
+            NswParkRideFacility("210318", "12", "Park&Ride - Mona Vale"),
+            NswParkRideFacility("2103108", "12", "Park&Ride - Mona Vale"),
+        )
+
+        val stations = catalogue.stations()
+
+        assertEquals(1, stations.size)
+        assertEquals("Mona Vale", stations.first().stationName)
+        // Both mappings are kept, so adding the station stores every pair.
+        assertEquals(2, stations.first().mappings.size)
+    }
+
+    @Test
+    fun `stations are sorted by name and carry local coordinates`() {
+        facilityManager.facilities = listOf(
+            NswParkRideFacility("221210", "9", "Park&Ride - Revesby"),
+            NswParkRideFacility("213110", "486", "Park&Ride - Ashfield"),
+        )
+        sandook.insertNswStop(
+            stopId = "213110",
+            stopName = "Ashfield Station",
+            stopLat = -33.8886,
+            stopLon = 151.1256,
+            isParent = null,
+        )
+
+        val stations = catalogue.stations()
+
+        assertEquals(listOf("Ashfield", "Revesby"), stations.map { it.stationName })
+        assertEquals(-33.8886, stations.first().position?.latitude)
+        // A stop the local table does not know is simply not plotted.
+        assertNull(stations.last().position)
+    }
+
+    @Test
+    fun `an empty remote config yields no stations`() {
+        facilityManager.facilities = emptyList()
+
+        assertTrue(catalogue.stations().isEmpty())
+    }
+
+    @Test
+    fun `loading emoji comes with a greeting`() {
+        val emoji = catalogue.loadingEmoji()
+
+        assertTrue(emoji.emoji.isNotBlank())
+        assertTrue(emoji.greeting.isNotBlank())
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeParkRideAvailabilityLoader.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeParkRideAvailabilityLoader.kt
@@ -1,0 +1,17 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import xyz.ksharma.krail.trip.planner.ui.parkride.ParkRideAvailabilityLoader
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ParkRideMapping
+
+/**
+ * Records what a caller asked to refresh, so a test can assert the ViewModel went through the
+ * rate-limited path without standing up a service and a cooldown behind it.
+ */
+class FakeParkRideAvailabilityLoader : ParkRideAvailabilityLoader {
+
+    val refreshedMappings = mutableListOf<List<ParkRideMapping>>()
+
+    override suspend fun refreshIfNeeded(mappings: List<ParkRideMapping>) {
+        refreshedMappings += mappings
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeParkRideCatalogue.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeParkRideCatalogue.kt
@@ -1,0 +1,19 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import xyz.ksharma.krail.trip.planner.ui.parkride.ParkRideCatalogue
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.LoadingEmoji
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ParkRideStationPickerItem
+
+/**
+ * Lets a ViewModel test state the stations it wants directly, instead of working backwards
+ * through Remote Config JSON and a stops table to produce them.
+ */
+class FakeParkRideCatalogue(
+    var stations: List<ParkRideStationPickerItem> = emptyList(),
+    var loadingEmoji: LoadingEmoji = LoadingEmoji(emoji = "🅿️", greeting = "Loading"),
+) : ParkRideCatalogue {
+
+    override fun stations(): List<ParkRideStationPickerItem> = stations
+
+    override fun loadingEmoji(): LoadingEmoji = loadingEmoji
+}


### PR DESCRIPTION
## What

Test coverage for the catalogue, the shared API budget, and selection behaviour. Adds fakes for both collaborators.

## Changes

- `ParkRideCatalogueTest` - both collision shapes, name sorting, coordinates from the local stops table, a stop the table does not know simply having no position, and an empty list yielding nothing.
- `ParkRideAvailabilityLoaderTest` - one call on a cold facility, no second call once on cooldown, a refetch once the cooldown genuinely elapses, and no call at all for an empty mapping list.
- `AddParkRideSelectionTest` - cached availability shown without an API call, directions handed to the platform rather than a provider URL, and a typed query with its filtered results surviving a configuration change.
- `FakeParkRideCatalogue` and `FakeParkRideAvailabilityLoader`, so a test can state the stations it wants directly instead of working backwards through Remote Config JSON.

## Why the budget test matters

Without it, a rider opening the map sheet and then expanding the home card would spend two API calls for one piece of information, silently, since neither screen would look wrong. The test asserts against the exact gate `SavedTripsViewModel` applies on card expand.

## Why the catalogue is tested directly

The grouping is the part most likely to break silently when the Remote Config list changes shape, so it is tested where it lives rather than only through the ViewModel.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green, 12 tests across the three classes
- `./scripts/fullQualityChecks.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
