### PR TITLE
feat(park-ride): add the Park & Ride picker screen

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideListSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideListSections.kt
@@ -1,0 +1,180 @@
+package xyz.ksharma.krail.trip.planner.ui.parkride
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.park.ride.ui.components.ParkRideFacilityRow
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.components.ActionData
+import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
+import xyz.ksharma.krail.trip.planner.ui.components.ParkRideIcon
+import xyz.ksharma.krail.trip.planner.ui.components.loading.LoadingEmojiAnim
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ErrorKind
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideUiEvent
+
+/**
+ * The LazyColumn body of the Park & Ride picker: loading, error and the sectioned station
+ * list.
+ *
+ * Kept out of [AddParkRideScreen] so neither file grows past detekt's per-file function
+ * limit, and so the list content can be read without the surrounding scaffold.
+ */
+
+internal fun LazyListScope.loadingRows(loadingEmoji: AddParkRideState.LoadingEmoji?) {
+    val emoji = loadingEmoji ?: return
+    item(key = "loading") {
+        // Same spinning-emoji treatment the timetable uses while it loads, so waiting looks
+        // like the rest of the app rather than a bespoke placeholder.
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            LoadingEmojiAnim(
+                emoji = emoji.emoji,
+                modifier = Modifier.padding(vertical = LOADING_VERTICAL_PADDING),
+            )
+
+            Text(
+                text = emoji.greeting,
+                style = KrailTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = KrailTheme.colors.onSurface,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = KrailTheme.dimensions.spacingXL),
+            )
+        }
+    }
+}
+
+internal fun LazyListScope.errorRow(
+    error: ErrorKind,
+    onEvent: (AddParkRideUiEvent) -> Unit,
+) {
+    item(key = "error") {
+        when (error) {
+            ErrorKind.NoFacilities -> ErrorMessage(
+                emoji = "🅿️",
+                title = "No stations yet",
+                message = "We couldn't load the list of Park & Ride stations. Check your " +
+                    "connection and try again.",
+                actionData = ActionData(
+                    actionText = "Try again",
+                    onActionClick = { onEvent(AddParkRideUiEvent.Retry) },
+                ),
+                modifier = Modifier.padding(vertical = KrailTheme.dimensions.spacingXL),
+            )
+        }
+    }
+}
+
+internal fun LazyListScope.stationRows(
+    state: AddParkRideState,
+    onEvent: (AddParkRideUiEvent) -> Unit,
+) {
+    item(key = "picker-description") {
+        Text(
+            // No em dash in rider-facing copy.
+            text = "Pick any Sydney car park and its live parking shows on your home screen.",
+            style = KrailTheme.typography.bodyMedium,
+            color = KrailTheme.colors.softLabel,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = KrailTheme.dimensions.pageHorizontalPadding)
+                .padding(top = KrailTheme.dimensions.spacingXS, bottom = KrailTheme.dimensions.spacingL),
+        )
+    }
+
+    if (state.visibleStations.isEmpty()) {
+        item(key = "no-results") {
+            // Same component and wording SearchStop uses for an empty result, so a failed
+            // search looks the same wherever the rider is in the app.
+            ErrorMessage(
+                title = "No match found!",
+                message = "Try something else. \uD83D\uDD0D✨",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = KrailTheme.dimensions.spacingXL),
+            )
+        }
+        return
+    }
+
+    // Address-book style: one sticky letter header per group, so a long list can be scanned
+    // and scrolled by initial rather than read end to end.
+    state.sections.forEach { section ->
+        stickyHeader(key = "section-${section.letter}") {
+            SectionHeader(letter = section.letter)
+        }
+
+        items(
+            items = section.stations,
+            key = { station -> station.stationId },
+        ) { station ->
+            ParkRideFacilityRow(
+                facilityName = station.stationName,
+                stopName = station.subtitle(),
+                added = station.added,
+                onClick = { onEvent(AddParkRideUiEvent.ToggleStation(station)) },
+                // Same badge the home Park & Ride card renders, so a station reads identically
+                // in the picker and on the home screen.
+                icon = { ParkRideIcon() },
+                modifier = Modifier.animateItem(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(letter: String, modifier: Modifier = Modifier) {
+    val dim = KrailTheme.dimensions
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            // Opaque so rows scrolling underneath the pinned header do not show through.
+            // Background is applied before the padding so the whole pinned strip, including
+            // the leading gap, stays opaque as rows pass behind it.
+            .background(KrailTheme.colors.surface)
+            // Generous space above each letter and little below: the header belongs to the
+            // group under it, so the gap should read as a break from the previous group.
+            .padding(top = dim.spacingXXL, bottom = dim.spacingXS)
+            .padding(horizontal = dim.pageHorizontalPadding)
+            .height(SectionHeaderHeight),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = letter,
+            style = KrailTheme.typography.titleSmall,
+            color = KrailTheme.colors.softLabel,
+        )
+    }
+}
+
+/**
+ * Explains the row's state in place of a transient message.
+ *
+ * A station held by a saved trip is ticked but cannot be un-ticked here, which would look
+ * broken without a reason. Saying so on the row means the rider knows before they tap, and
+ * the explanation stays on screen instead of vanishing like a snackbar.
+ */
+private fun AddParkRideState.ParkRideStationPickerItem.subtitle(): String = when {
+    isLockedBySavedTrip -> "Added by your saved trip"
+    carParkCount > 1 -> "$carParkCount car parks"
+    else -> stopName
+}
+
+// Matches TimeTableScreen so the loading state sits at the same height across screens.
+private val LOADING_VERTICAL_PADDING = 60.dp
+private val SectionHeaderHeight = 24.dp

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideScreen.kt
@@ -1,0 +1,199 @@
+package xyz.ksharma.krail.trip.planner.ui.parkride
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.persistentListOf
+import xyz.ksharma.krail.core.adaptiveui.DualPaneScaffold
+import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.components.TextField
+import xyz.ksharma.krail.taj.components.TextFieldDefaults
+import xyz.ksharma.krail.taj.components.TitleBar
+import xyz.ksharma.krail.taj.preview.PreviewScreen
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.parkride.map.ParkRideMapPane
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ErrorKind
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideUiEvent
+
+/**
+ * The searchable picker of supported Park & Ride stations — the one screen behind the home
+ * screen's "+ Add" card.
+ *
+ * Adding is a row tap, not a per-row button: the list is long enough that a button on every
+ * row would be a column of repeated controls. The trailing toggle reports state instead.
+ *
+ * Rows are full-bleed and separated by dividers rather than sat on cards, and are grouped
+ * under sticky alphabetical headers so a long list can be scanned by initial.
+ */
+@Composable
+internal fun AddParkRideScreen(
+    state: AddParkRideState,
+    onBackClick: () -> Unit,
+    onEvent: (AddParkRideUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dualPane = rememberAdaptiveLayoutInfo().shouldShowDualPane
+
+    // Hoisted ABOVE the dual-pane branch on purpose. The list is called from two different
+    // call sites, so rotating between single- and dual-pane moves it to a new composition
+    // slot and any state remembered inside it is dropped - which silently cleared whatever
+    // the rider had typed. Seeded from the ViewModel's query so it also survives process
+    // death and the ViewModel outliving the composition.
+    val searchFieldState = rememberTextFieldState(state.query)
+
+    // Map pane is a SIBLING of the list, never nested inside it — see DualPaneScaffold for
+    // the iOS compositing invariant that requires this.
+    if (dualPane) {
+        DualPaneScaffold(
+            modifier = modifier,
+            listPane = { AddParkRideListPane(state, searchFieldState, onBackClick, onEvent) },
+            rightPane = {
+                ParkRideMapPane(
+                    stations = state.visibleStations,
+                    selectedStation = state.selectedStation,
+                    details = state.selectedStationDetails,
+                    isLoadingDetails = state.isLoadingSelectedStation,
+                    onStationSelected = { onEvent(AddParkRideUiEvent.StationSelected(it)) },
+                    onDismissStation = { onEvent(AddParkRideUiEvent.StationDismissed) },
+                    onToggleStation = { onEvent(AddParkRideUiEvent.ToggleStation(it)) },
+                    onDirectionsClick = { position, name ->
+                        onEvent(AddParkRideUiEvent.DirectionsClicked(position, name))
+                    },
+                )
+            },
+        )
+    } else {
+        AddParkRideListPane(state, searchFieldState, onBackClick, onEvent, modifier)
+    }
+}
+
+@Composable
+private fun AddParkRideListPane(
+    state: AddParkRideState,
+    searchFieldState: TextFieldState,
+    onBackClick: () -> Unit,
+    onEvent: (AddParkRideUiEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val dim = KrailTheme.dimensions
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(KrailTheme.colors.surface)
+            .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
+    ) {
+        TitleBar(
+            modifier = Modifier.fillMaxWidth(),
+            onNavActionClick = onBackClick,
+            title = { Text(text = "Add Park & Ride") },
+        )
+
+        TextField(
+            state = searchFieldState,
+            placeholder = "Search",
+            imeAction = ImeAction.Search,
+            // Inverted against the page: a dark bar in light mode, a light bar in dark mode.
+            // Matching the surface left the field with no visible edge at all.
+            colors = TextFieldDefaults.invertedColors(),
+            onTextChange = { onEvent(AddParkRideUiEvent.SearchQueryChanged(it.toString())) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = dim.pageHorizontalPadding)
+                .padding(bottom = dim.spacingM),
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth(),
+            // No horizontal padding: rows and their dividers span the full width. Items that
+            // are not full-bleed (headers, messages) pad themselves.
+            contentPadding = PaddingValues(bottom = LIST_BOTTOM_PADDING),
+        ) {
+            val error = state.error
+            when {
+                state.isLoading -> loadingRows(state.loadingEmoji)
+                error != null -> errorRow(error, onEvent)
+                else -> stationRows(state, onEvent)
+            }
+        }
+    }
+}
+
+private val previewStations = persistentListOf(
+    previewStation(id = "2155384", name = "Tallawong", carParks = listOf("P1", "P2", "P3")),
+    previewStation(id = "207210", name = "Gordon Henry St (north)", carParks = listOf("Gordon")),
+    previewStation(id = "221210", name = "Revesby", carParks = listOf("Revesby"), isUserAdded = true),
+)
+
+private fun previewStation(
+    id: String,
+    name: String,
+    carParks: List<String>,
+    isUserAdded: Boolean = false,
+) = AddParkRideState.ParkRideStationPickerItem(
+    stationId = id,
+    stationName = name,
+    stopName = "$name Station",
+    carParkNames = carParks,
+    mappings = carParks.mapIndexed { index, carPark ->
+        AddParkRideState.ParkRideMapping(
+            stopId = id,
+            facilityId = "$id-$index",
+            facilityName = carPark,
+        )
+    },
+    isUserAdded = isUserAdded,
+)
+
+@PreviewScreen
+@Composable
+private fun AddParkRideScreenPreview() {
+    PreviewTheme {
+        AddParkRideScreen(
+            state = AddParkRideState(stations = previewStations, isLoading = false),
+            onBackClick = {},
+            onEvent = {},
+        )
+    }
+}
+
+@PreviewScreen
+@Composable
+private fun AddParkRideScreenLoadingPreview() {
+    PreviewTheme {
+        AddParkRideScreen(state = AddParkRideState(), onBackClick = {}, onEvent = {})
+    }
+}
+
+@PreviewScreen
+@Composable
+private fun AddParkRideScreenErrorPreview() {
+    PreviewTheme {
+        AddParkRideScreen(
+            state = AddParkRideState(isLoading = false, error = ErrorKind.NoFacilities),
+            onBackClick = {},
+            onEvent = {},
+        )
+    }
+}
+
+// Clear of the gesture area, and enough that the last row is never the screen edge.
+private val LIST_BOTTOM_PADDING = 96.dp


### PR DESCRIPTION
## What

The Park & Ride picker screen: a searchable, alphabetically sectioned list of the stations the app supports.

## Changes

- `AddParkRideScreen` with the search field, and `AddParkRideListSections` with the loading, error and station-list bodies.
- Sticky alphabetical section headers, address-book style, so a long catalogue can be scanned by initial.
- Adding is a row tap rather than a per-row button, since the list is long enough that a button on every row would be a column of repeated controls.
- Search field uses `TextFieldDefaults.invertedColors()`; matching the page surface left it with no visible edge.
- Loading reuses the timetable's festival emoji and greeting; an empty search reuses SearchStop's existing "No match found!" message rather than inventing a second wording for the same situation.
- Sections live in their own file to stay under detekt's per-file function limit.

## Configuration changes

The search field's state is hoisted above the dual-pane branch on purpose. The list is called from two call sites, so rotating between single- and dual-pane moves it to a new composition slot and anything remembered inside it is dropped, which silently cleared whatever the rider had typed. It is seeded from the ViewModel's query, so it also survives the ViewModel outliving the composition. Covered by a test in `AddParkRideSelectionTest`.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
- `./scripts/fullQualityChecks.sh` green
- Installed on a device: opened the screen, searched, rotated with text typed, checked light and dark

## Snapshots

New screen, no prior state. `@PreviewScreen` previews cover the populated, loading and error states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
