### PR TITLE
refactor(maps): share the location-button and camera-seeding helpers

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapLocationHelpers.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapLocationHelpers.kt
@@ -1,0 +1,62 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.map
+
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import org.maplibre.spatialk.geojson.Position
+import xyz.ksharma.aagya.permission.PermissionStatus
+import xyz.ksharma.krail.core.maps.data.location.UserLocationManager
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.maps.state.NearbyStopsConfig
+import xyz.ksharma.krail.core.maps.state.UserLocationConfig
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Location-button and camera-seeding behaviour shared by every full map surface (SearchStop,
+ * the Park & Ride picker).
+ *
+ * Extracted from `SearchStopMap` so a second map cannot drift into a slightly different
+ * permission flow or a different default camera — the behaviour riders see has to be the same
+ * wherever a map appears.
+ */
+internal fun LatLng.toPosition(): Position = Position(latitude = latitude, longitude = longitude)
+
+/**
+ * Recentres on a known fix, otherwise routes into the permission flow: a hard denial goes to
+ * system settings, anything else asks.
+ */
+internal suspend fun handleLocationButtonClick(
+    userLoc: LatLng?,
+    cameraState: CameraState,
+    userLocationManager: UserLocationManager,
+    onPermissionDenied: (PermissionStatus) -> Unit,
+    onRequestPermission: () -> Unit,
+) {
+    if (userLoc != null) {
+        cameraState.animateTo(
+            CameraPosition(target = userLoc.toPosition(), zoom = UserLocationConfig.RECENTER_ZOOM),
+            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
+        )
+    } else {
+        val status = userLocationManager.checkPermissionStatus()
+        if (status is PermissionStatus.Denied) {
+            onPermissionDenied(status)
+        } else {
+            onRequestPermission()
+        }
+    }
+}
+
+/**
+ * Seeds the camera from a known location so re-entry after a composition bounce (dual-pane
+ * layout shift, rotation) does not flash at the Sydney default.
+ */
+internal fun initialCameraPosition(knownLocation: LatLng?): CameraPosition =
+    knownLocation?.let {
+        CameraPosition(target = it.toPosition(), zoom = UserLocationConfig.AUTO_CENTER_ZOOM)
+    } ?: CameraPosition(
+        target = Position(
+            latitude = NearbyStopsConfig.DEFAULT_CENTER_LAT,
+            longitude = NearbyStopsConfig.DEFAULT_CENTER_LON,
+        ),
+        zoom = NearbyStopsConfig.DEFAULT_ZOOM,
+    )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -38,7 +38,6 @@ import org.maplibre.compose.map.MapOptions
 import org.maplibre.compose.map.MaplibreMap
 import org.maplibre.compose.map.OrnamentOptions
 import org.maplibre.compose.style.BaseStyle
-import org.maplibre.spatialk.geojson.Position
 import xyz.ksharma.aagya.permission.PermissionStatus
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
@@ -464,41 +463,6 @@ private fun MapSurface(
         }
     }
 }
-
-private fun LatLng.toPosition(): Position = Position(latitude = latitude, longitude = longitude)
-
-private suspend fun handleLocationButtonClick(
-    userLoc: LatLng?,
-    cameraState: org.maplibre.compose.camera.CameraState,
-    userLocationManager: xyz.ksharma.krail.core.maps.data.location.UserLocationManager,
-    onPermissionDenied: (xyz.ksharma.aagya.permission.PermissionStatus) -> Unit,
-    onRequestPermission: () -> Unit,
-) {
-    if (userLoc != null) {
-        cameraState.animateTo(
-            CameraPosition(target = userLoc.toPosition(), zoom = UserLocationConfig.RECENTER_ZOOM),
-            duration = UserLocationConfig.RECENTER_ANIMATION_MS.milliseconds,
-        )
-    } else {
-        val status = userLocationManager.checkPermissionStatus()
-        if (status is xyz.ksharma.aagya.permission.PermissionStatus.Denied) {
-            onPermissionDenied(status)
-        } else {
-            onRequestPermission()
-        }
-    }
-}
-
-private fun initialCameraPosition(knownLocation: LatLng?): CameraPosition =
-    knownLocation?.let {
-        CameraPosition(target = it.toPosition(), zoom = UserLocationConfig.AUTO_CENTER_ZOOM)
-    } ?: CameraPosition(
-        target = Position(
-            latitude = NearbyStopsConfig.DEFAULT_CENTER_LAT,
-            longitude = NearbyStopsConfig.DEFAULT_CENTER_LON,
-        ),
-        zoom = NearbyStopsConfig.DEFAULT_ZOOM,
-    )
 
 // region Previews
 


### PR DESCRIPTION
## What

Moves three private helpers out of `SearchStopMap` so a second map surface can share them.

## Changes

- `handleLocationButtonClick`, `initialCameraPosition` and `toPosition` move to `MapLocationHelpers`, unchanged.
- `SearchStopMap` imports them instead of declaring them.

## Why

They encode the location-button permission flow and the default camera seed. A second full map surface would otherwise reimplement both and drift from them the first time either changed. Behaviour on SearchStop is identical; this only makes it reusable.

## Testing

- `./scripts/fullQualityChecks.sh` green
- No behaviour change on SearchStop; the extraction is a pure move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
