### PR TITLE
feat(park-ride): surface Park & Ride on home without a saved trip

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/SerializationConfig.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/SerializationConfig.kt
@@ -6,7 +6,10 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.polymorphic
 import xyz.ksharma.krail.core.navigation.AppUpgradeRoute
 import xyz.ksharma.krail.core.navigation.SplashRoute
+import xyz.ksharma.krail.feature.debug.settings.ui.navigation.DebugConfigHomeRoute
+import xyz.ksharma.krail.feature.debug.settings.ui.navigation.DebugConfigNetworkRoute
 import xyz.ksharma.krail.feature.track.ui.navigation.TrackTripRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.AddParkRideRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.DiscoverRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
@@ -45,9 +48,14 @@ val krailNavSerializationConfig = SavedStateConfiguration {
             subclass(IntroRoute::class, IntroRoute.serializer())
             subclass(DiscoverRoute::class, DiscoverRoute.serializer())
             subclass(ManageStopLabelsRoute::class, ManageStopLabelsRoute.serializer())
+            subclass(AddParkRideRoute::class, AddParkRideRoute.serializer())
 
             // Track routes
             subclass(TrackTripRoute::class, TrackTripRoute.serializer())
+
+            // Debug settings routes
+            subclass(DebugConfigHomeRoute::class, DebugConfigHomeRoute.serializer())
+            subclass(DebugConfigNetworkRoute::class, DebugConfigNetworkRoute.serializer())
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -21,6 +21,9 @@ import xyz.ksharma.krail.trip.planner.ui.datetimeselector.DateTimeSelectorViewMo
 import xyz.ksharma.krail.trip.planner.ui.discover.DiscoverViewModel
 import xyz.ksharma.krail.trip.planner.ui.intro.IntroViewModel
 import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
+import xyz.ksharma.krail.trip.planner.ui.parkride.AddParkRideViewModel
+import xyz.ksharma.krail.trip.planner.ui.parkride.ParkRideAvailabilityLoader
+import xyz.ksharma.krail.trip.planner.ui.parkride.ParkRideCatalogue
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.InviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.RealInviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
@@ -77,6 +80,26 @@ val viewModelsModule = module {
             infoTileManager = get(),
             inviteFriendsTileManager = get(),
             trackingManager = get<TrackingManager>(),
+        )
+    }
+
+    viewModel {
+        AddParkRideViewModel(
+            catalogue = ParkRideCatalogue(
+                nswParkRideFacilityManager = get(),
+                stopResultsManager = get(),
+                sandook = get(),
+                festivalManager = get(),
+            ),
+            parkRideSandook = get(),
+            availabilityLoader = ParkRideAvailabilityLoader(
+                parkRideSandook = get(),
+                parkRideService = get(),
+                flag = get(),
+            ),
+            platformOps = get(),
+            analytics = get(),
+            ioDispatcher = get(named(IODispatcher)),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
@@ -22,6 +22,8 @@ interface TripPlannerNavigator {
     fun navigateToSettings()
     fun navigateToDiscover()
     fun navigateToManageStopLabels()
+
+    fun navigateToAddParkRide()
     fun navigateToThemeSelection()
     fun navigateToAlerts(journeyId: String)
     fun navigateToDateTimeSelector(json: String?)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
@@ -66,6 +66,10 @@ internal class TripPlannerNavigatorImpl(
         baseNavigator.goTo(ManageStopLabelsRoute)
     }
 
+    override fun navigateToAddParkRide() {
+        baseNavigator.goTo(AddParkRideRoute)
+    }
+
     override fun navigateToThemeSelection() {
         baseNavigator.goTo(ThemeSelectionRoute)
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
@@ -93,3 +93,9 @@ data object DiscoverRoute : TripPlannerRoute
  */
 @Serializable
 data object ManageStopLabelsRoute : TripPlannerRoute
+
+/**
+ * Detail route: pick a Park & Ride facility to follow on the home screen.
+ */
+@Serializable
+data object AddParkRideRoute : TripPlannerRoute

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/AddParkRideEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/AddParkRideEntry.kt
@@ -1,0 +1,28 @@
+package xyz.ksharma.krail.trip.planner.ui.navigation.entries
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import org.koin.compose.viewmodel.koinViewModel
+import xyz.ksharma.krail.trip.planner.ui.navigation.AddParkRideRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
+import xyz.ksharma.krail.trip.planner.ui.parkride.AddParkRideScreen
+import xyz.ksharma.krail.trip.planner.ui.parkride.AddParkRideViewModel
+
+@Composable
+internal fun EntryProviderScope<NavKey>.AddParkRideEntry(
+    tripPlannerNavigator: TripPlannerNavigator,
+) {
+    entry<AddParkRideRoute> {
+        val viewModel: AddParkRideViewModel = koinViewModel()
+        val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+        AddParkRideScreen(
+            state = state,
+            onBackClick = { tripPlannerNavigator.goBack() },
+            onEvent = viewModel::onEvent,
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -62,6 +62,7 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
             trackedJourney = trackedJourney,
             onTrackingCardClick = { tripPlannerNavigator.navigateToTrackTrip() },
             onStopTracking = { viewModel.onEvent(SavedTripUiEvent.StopTracking) },
+            onAddParkRideClick = { tripPlannerNavigator.navigateToAddParkRide() },
             fromButtonClick = {
                 viewModel.onEvent(SavedTripUiEvent.AnalyticsFromButtonClick)
                 tripPlannerNavigator.navigateToSearchStop(SearchStopFieldType.FROM)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TripPlannerEntries.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TripPlannerEntries.kt
@@ -27,6 +27,7 @@ fun EntryProviderScope<NavKey>.TripPlannerEntries(
     IntroEntry(tripPlannerNavigator)
     DiscoverEntry(tripPlannerNavigator)
     ManageStopLabelsEntry(tripPlannerNavigator)
+    AddParkRideEntry(tripPlannerNavigator)
     TrackTripEntry(
         onBack = { tripPlannerNavigator.goBack() },
     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -102,19 +101,12 @@ fun SavedTripsScreen(
     onEvent: (SavedTripUiEvent) -> Unit = {},
     onTrackingCardClick: () -> Unit = {},
     onStopTracking: () -> Unit = {},
+    onAddParkRideClick: () -> Unit = {},
     // Slot for the dual-pane right side. SavedTrips knows nothing about its content —
     // entry passes a MapStopSelectionPane (or anything else). Empty slot = blank pane.
     rightPane: @Composable BoxScope.() -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
-    val emptyStateTip = remember {
-        buildList {
-            add("Tap ★ on a trip to save it here.")
-            add("Saved trips also show Park & Ride.")
-            add("Find nearby stops on the map.")
-        }.random()
-    }
-
     // Adaptive search-row presentation:
     //   - Phone portrait, tablet, foldable-unfolded: SearchStopRow is ALWAYS expanded —
     //     these form factors have the vertical room, so the full search affordance stays
@@ -196,7 +188,6 @@ fun SavedTripsScreen(
                     savedTripsListBody(
                         savedTripsState = savedTripsState,
                         trackedJourney = trackedJourney,
-                        emptyStateTip = emptyStateTip,
                         pageHorizontalPadding = dim.pageHorizontalPadding,
                         onEvent = onEvent,
                         onSavedTripCardClick = onSavedTripCardClick,
@@ -206,6 +197,7 @@ fun SavedTripsScreen(
                         editing = editing,
                         reorderState = reorderState,
                         onEnterEditing = { editing = true },
+                        onAddParkRideClick = onAddParkRideClick,
                     )
                 }
             }
@@ -302,7 +294,6 @@ internal fun LazyListScope.savedTripsContent(
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit = { _, _ -> },
     onTrackingCardClick: () -> Unit = {},
     onStopTracking: () -> Unit = {},
-    expandedMap: SnapshotStateMap<String, Boolean>,
     editing: Boolean,
     reorderState: ReorderableLazyListState,
     onEnterEditing: () -> Unit,
@@ -386,12 +377,6 @@ internal fun LazyListScope.savedTripsContent(
             onDelete = { onEvent(SavedTripUiEvent.DeleteSavedTrip(trip)) },
         )
     }
-
-    parkRideSection(
-        savedTripsState = savedTripsState,
-        expandedMap = expandedMap,
-        onEvent = onEvent,
-    )
 }
 
 @Composable

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -34,6 +34,7 @@ import org.jetbrains.compose.resources.painterResource
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState
 import xyz.ksharma.krail.feature.track.TrackedJourney
+import xyz.ksharma.krail.park.ride.ui.components.AddParkRideCard
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
@@ -41,7 +42,6 @@ import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
-import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
 import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
 import xyz.ksharma.krail.trip.planner.ui.components.SearchStopRow
@@ -60,7 +60,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 internal fun LazyListScope.savedTripsListBody(
     savedTripsState: SavedTripsState,
     trackedJourney: TrackedJourney?,
-    emptyStateTip: String,
     pageHorizontalPadding: Dp,
     onEvent: (SavedTripUiEvent) -> Unit,
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit,
@@ -70,40 +69,56 @@ internal fun LazyListScope.savedTripsListBody(
     editing: Boolean,
     reorderState: ReorderableLazyListState,
     onEnterEditing: () -> Unit,
+    onAddParkRideClick: () -> Unit,
 ) {
-    when {
-        savedTripsState.isSavedTripsLoading -> Unit
+    if (savedTripsState.isSavedTripsLoading) return
 
-        savedTripsState.savedTrips.isEmpty() -> {
-            savedTripsInfoTiles(savedTripsState, onEvent)
-            item(key = "empty_state") {
-                ErrorMessage(
-                    emoji = "🌟",
-                    title = "Let's Go! Sydney",
-                    message = emptyStateTip,
-                    modifier = Modifier
-                        .padding(horizontal = pageHorizontalPadding)
-                        .animateItem(),
-                )
+    savedTripsInfoTiles(savedTripsState, onEvent)
+
+    if (savedTripsState.savedTrips.isEmpty()) {
+        // No hero: the bottom search row is already the "plan a trip" affordance, so a
+        // full-page star said nothing the screen was not saying, and pushed the real content
+        // into a corner. Saved Trips and Park & Ride are just two sections, one of which
+        // happens to be empty.
+        stickyHeader(key = "saved_trips_title") {
+            SavedTripsTitle {
+                Text(text = "Saved Trips")
             }
         }
 
-        savedTripsState.savedTrips.isNotEmpty() -> {
-            savedTripsInfoTiles(savedTripsState, onEvent)
-            savedTripsContent(
-                savedTripsState = savedTripsState,
-                trackedJourney = trackedJourney,
-                onEvent = onEvent,
-                onSavedTripCardClick = onSavedTripCardClick,
-                onTrackingCardClick = onTrackingCardClick,
-                onStopTracking = onStopTracking,
-                expandedMap = expandedMap,
-                editing = editing,
-                reorderState = reorderState,
-                onEnterEditing = onEnterEditing,
+        item(key = "saved_trips_empty_row") {
+            Text(
+                text = "Tap ★ on a trip to save it here.",
+                style = KrailTheme.typography.bodyMedium,
+                color = KrailTheme.colors.softLabel,
+                modifier = Modifier
+                    .padding(horizontal = pageHorizontalPadding)
+                    .padding(bottom = KrailTheme.dimensions.spacingXL)
+                    .animateItem(),
             )
         }
+    } else {
+        savedTripsContent(
+            savedTripsState = savedTripsState,
+            trackedJourney = trackedJourney,
+            onEvent = onEvent,
+            onSavedTripCardClick = onSavedTripCardClick,
+            onTrackingCardClick = onTrackingCardClick,
+            onStopTracking = onStopTracking,
+            editing = editing,
+            reorderState = reorderState,
+            onEnterEditing = onEnterEditing,
+        )
     }
+
+    // Outside the saved-trips branch on purpose: Park & Ride has to be reachable by a rider
+    // who has saved nothing, which is exactly the case the old empty branch skipped it in.
+    parkRideSection(
+        savedTripsState = savedTripsState,
+        expandedMap = expandedMap,
+        onEvent = onEvent,
+        onAddParkRideClick = onAddParkRideClick,
+    )
 }
 
 private fun LazyListScope.savedTripsInfoTiles(
@@ -120,13 +135,24 @@ private fun LazyListScope.savedTripsInfoTiles(
     }
 }
 
+/**
+ * The home screen's Park & Ride section.
+ *
+ * Always rendered, including for a rider with nothing saved: with no cards the section is
+ * just the "+ Add" card, so Park & Ride is discoverable without first saving a trip. The
+ * cards themselves are the existing [ParkRideCard] unchanged — whether a card came from a
+ * saved trip or an explicit add is internal, used only for de-duplication and removal, and is
+ * deliberately not surfaced on the card.
+ *
+ * Expansion still drives polling exactly as before: tapping a card raises
+ * [SavedTripUiEvent.ParkRideCardClick], and nothing here fetches on its own.
+ */
 internal fun LazyListScope.parkRideSection(
     savedTripsState: SavedTripsState,
     expandedMap: SnapshotStateMap<String, Boolean>,
     onEvent: (SavedTripUiEvent) -> Unit,
+    onAddParkRideClick: () -> Unit,
 ) {
-    if (savedTripsState.parkRideUiState.isEmpty()) return
-
     stickyHeader(key = "park_ride_title") {
         SavedTripsTitle {
             Text(text = "Park & Ride")
@@ -157,6 +183,31 @@ internal fun LazyListScope.parkRideSection(
         )
 
         Spacer(modifier = Modifier.height(dim.spacingXL))
+    }
+
+    item(key = "park_ride_add_card") {
+        val dim = KrailTheme.dimensions
+        val hasCards = savedTripsState.parkRideUiState.isNotEmpty()
+
+        Column(modifier = Modifier.padding(horizontal = dim.pageHorizontalPadding)) {
+            AddParkRideCard(
+                label = if (hasCards) "Add another" else "Add Park & Ride",
+                onClick = onAddParkRideClick,
+            )
+
+            // Only worth saying while the section has nothing in it. Once cards exist the
+            // rider has already found the feature and the line is just noise under it.
+            if (!hasCards) {
+                Text(
+                    text = "Save a trip and its station's parking shows here automatically.",
+                    style = KrailTheme.typography.bodySmall,
+                    color = KrailTheme.colors.softLabel,
+                    modifier = Modifier.padding(top = dim.spacingM),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(dim.spacingXL))
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
@@ -63,7 +61,6 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import kotlin.time.Clock.System
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -498,9 +495,15 @@ class SavedTripsViewModel(
                             address = "",
                             latitude = 0.0,
                             longitude = 0.0,
+                            // The mapping row already carries a resolved stop name, written
+                            // by the same priority chain updateParkRideStopIdsInDb uses. Fall
+                            // back to it before the raw stop ID, or a card whose stop is not
+                            // in the local search index shows "2153478" instead of
+                            // "Bella Vista" until its first availability fetch lands.
                             stopName = stopResultsManager.fetchStopResults(mapping.stopId)
                                 .filterIsInstance<SearchStopState.SearchResult.Stop>()
-                                .firstOrNull()?.stopName ?: mapping.stopId,
+                                .firstOrNull()?.stopName
+                                ?: mapping.stopName.ifBlank { mapping.stopId },
                             timestamp = Instant.DISTANT_PAST.epochSeconds,
                         )
                     }
@@ -603,25 +606,10 @@ class SavedTripsViewModel(
         }
     }
 
-    /**
-     * Checks if the current time is not peak time.
-     * Peak time is defined as 5am (05:00) to 10am (10:00), inclusive of 5am, exclusive of 10am.
-     */
-    @OptIn(ExperimentalTime::class)
-    private fun isNotPeakTime(): Boolean {
-        val now = System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-        val hour = now.hour
-        // Peak time: 5am (05:00) to 10am (10:00), inclusive of 5am, exclusive of 10am
-        return hour < 5 || hour >= 10
-    }
-
-    private fun getApiCooldownDuration(): Duration {
-        return if (isNotPeakTime()) {
-            nonPeakTimeCooldownSeconds.seconds
-        } else {
-            peakTimeCooldownSeconds.seconds
-        }
-    }
+    private fun getApiCooldownDuration(): Duration = parkRideApiCooldown(
+        peakTimeCooldownSeconds = peakTimeCooldownSeconds,
+        nonPeakTimeCooldownSeconds = nonPeakTimeCooldownSeconds,
+    )
 
     private suspend fun updateDiscoverState() {
         log("onStart - updateDiscoverState called")

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapperTest.kt
@@ -1,0 +1,82 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import xyz.ksharma.krail.sandook.NSWParkRideFacilityDetail
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the home Park & Ride card's display behaviour, which must not change.
+ *
+ * Keying `SavedParkRide` by source lets one station be held by both a saved trip and an
+ * explicit add, so the merge feeding this mapper can now contain the same facility twice.
+ * These cases prove that extra row stays invisible: the card list is still one entry per
+ * stop, with each facility appearing once.
+ */
+class ParkRideMapperTest {
+
+    @Test
+    fun `a facility held by two sources still produces a single card`() {
+        // The same facility arrives twice, as it does when a station is both saved-trip
+        // derived and user added.
+        val details = listOf(
+            facilityDetail(facilityId = "26", stopId = "2155384"),
+            facilityDetail(facilityId = "26", stopId = "2155384"),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(1, uiState.size)
+        assertEquals(1, uiState.first().facilities.size)
+        assertEquals("26", uiState.first().facilities.first().facilityId)
+    }
+
+    @Test
+    fun `several car parks at one stop stay on one card`() {
+        // Tallawong: three car parks behind a single stop.
+        val details = listOf(
+            facilityDetail(facilityId = "26", stopId = "2155384", facilityName = "Tallawong P1"),
+            facilityDetail(facilityId = "27", stopId = "2155384", facilityName = "Tallawong P2"),
+            facilityDetail(facilityId = "28", stopId = "2155384", facilityName = "Tallawong P3"),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(1, uiState.size)
+        assertEquals(3, uiState.first().facilities.size)
+    }
+
+    @Test
+    fun `one facility reached from two stops is not shown twice`() {
+        // Mona Vale: one car park, two stop IDs. The second stop has nothing left to show
+        // once the facility is claimed, so it must not produce an empty card.
+        val details = listOf(
+            facilityDetail(facilityId = "12", stopId = "210318"),
+            facilityDetail(facilityId = "12", stopId = "2103108"),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(1, uiState.size)
+        assertEquals(1, uiState.first().facilities.size)
+    }
+
+    private fun facilityDetail(
+        facilityId: String,
+        stopId: String,
+        facilityName: String = "Car park $facilityId",
+    ) = NSWParkRideFacilityDetail(
+        facilityId = facilityId,
+        spotsAvailable = 40,
+        totalSpots = 100,
+        facilityName = facilityName,
+        percentageFull = 60,
+        stopId = stopId,
+        stopName = "Station $stopId",
+        timeText = "8:00 AM",
+        suburb = "",
+        address = "",
+        latitude = 0.0,
+        longitude = 0.0,
+        timestamp = 0,
+    )
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
@@ -31,6 +31,7 @@ import xyz.ksharma.krail.info.tile.state.InfoTileData
 import xyz.ksharma.krail.park.ride.network.NswParkRideFacilityManager
 import xyz.ksharma.krail.park.ride.network.service.ParkRideService
 import xyz.ksharma.krail.sandook.NswParkRideSandook
+import xyz.ksharma.krail.sandook.SavedParkRide
 import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences.Companion.KEY_DISMISSED_INFO_TILES
 import xyz.ksharma.krail.feature.track.TrackingManager
@@ -916,4 +917,33 @@ class SavedTripsViewModelTest {
         }
 
     // endregion MoveSavedTrip
+
+    @Test
+    fun `a park ride card falls back to the stored stop name, never the raw stop id`() =
+        runTest(testDispatcher) {
+            // A mapping whose stop is not in the local search index. Before an availability
+            // fetch lands there is no facility detail row, so the card renders a placeholder.
+            fakeNswParkRideSandook.insertOrReplaceSavedParkRides(
+                parkRideInfoList = setOf(
+                    SavedParkRide(
+                        stopId = "2153478",
+                        facilityId = "31",
+                        stopName = "Bella Vista",
+                        facilityName = "Bella Vista",
+                        source = NswParkRideSandook.Companion.SavedParkRideSource.UserAdded.value,
+                    ),
+                ),
+                source = NswParkRideSandook.Companion.SavedParkRideSource.UserAdded,
+            )
+
+            viewModel.uiState.test {
+                advanceUntilIdle()
+                val parkRide = expectMostRecentItem().parkRideUiState.firstOrNull()
+
+                assertNotNull(parkRide)
+                // "2153478" here would be the raw ID leaking into the UI.
+                assertEquals("Bella Vista", parkRide.stopName)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }


### PR DESCRIPTION
## What

Surfaces Park & Ride on the home screen for riders with no saved trip, and wires the picker into navigation.

## Changes

- `parkRideSection` renders unconditionally with an always-present "Add Park & Ride" row, instead of only inside the saved-trips branch.
- `AddParkRideRoute`, navigator method, nav entry, DI registration, and the route registered in `SerializationConfig`.
- The saved-trips empty state is now section-scoped: "Saved Trips" header plus a one-line prompt, the same shape the Park & Ride section has.
- Fixes a card rendering its stop ID rather than its name.

## Why the hero went

"Let's Go! Sydney" was the saved-trips empty state rendered as a whole-page hero, so once Park & Ride cards existed it sat stranded above real content with dead space beneath it. The bottom search row is already the "plan a trip" affordance, so the hero said nothing the screen was not saying. Its random tip goes too: one of its three strings claimed "Saved trips also show Park & Ride" and could be drawn while a card was on screen contradicting it.

## Stop ID leak

A card showed its raw stop ID until the first availability fetch landed, for example `2153478` instead of "Bella Vista". The placeholder resolved names only through the local search index and fell straight back to the ID, which is exactly what Metro stops hit. The `SavedParkRide` mapping already carries a resolved name, so prefer it. Covered by a test confirmed to fail without the fix.

## Left untouched

`ParkRideCard` is unchanged. Whether a card came from a saved trip or an explicit add stays internal, used only for de-duplication and removal, and is never shown on the card. Polling is unchanged: expansion still drives the fetch and nothing in this section fetches on its own.

## Testing

- `ParkRideMapperTest` pins the card's grouping against the schema change: a facility held by both sources still produces one card, several car parks at one stop stay on one card, and one facility reached from two stops is not shown twice.
- `SavedTripsViewModelTest` covers the stop-name fallback.
- `./gradlew testAndroidHostTest --continue` green
- `./scripts/fullQualityChecks.sh` green
- Installed on device, rotated, checked light and dark

## Snapshots

| Screen | Before | After |
|---|---|---|
| Home, no saved trips | Star hero with a random tip, no Park & Ride section | "Saved Trips" prompt and a "Park & Ride" section with an add row |
| Home, station added | Card could show a raw stop ID | Card shows the station name |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
