### PR TITLE
analytics: shared event contract + ledger backfill registered

### DIFF
--- a/core/analytics/analytics-events.json
+++ b/core/analytics/analytics-events.json
@@ -1,0 +1,1246 @@
+{
+  "$schema": "./analytics-events.schema.json",
+  "version": 1,
+  "description": "Authoritative contract for KRAIL's Firebase Analytics events. AnalyticsEvent.kt is checked against this file by AnalyticsContractTest; KRAIL-Analytics generates its event registry, labels and metric groups from it. Edit this file in the same PR as any AnalyticsEvent.kt change.",
+  "firebaseEventNameBudget": 500,
+  "events": [
+    {
+      "name": "app_start",
+      "class": "AppStart",
+      "label": "App opened",
+      "metric": "app_open",
+      "params": [
+        {
+          "name": "appVersion",
+          "optional": false
+        },
+        {
+          "name": "deviceModel",
+          "optional": false
+        },
+        {
+          "name": "fontSize",
+          "optional": false
+        },
+        {
+          "name": "isDarkTheme",
+          "optional": false
+        },
+        {
+          "name": "krailTheme",
+          "optional": false
+        },
+        {
+          "name": "locale",
+          "optional": false
+        },
+        {
+          "name": "osVersion",
+          "optional": false
+        },
+        {
+          "name": "platformType",
+          "optional": false
+        },
+        {
+          "name": "timeStamp",
+          "optional": false
+        },
+        {
+          "name": "timeZone",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "back_click",
+      "class": "BackClickEvent",
+      "label": "Tap back",
+      "params": [
+        {
+          "name": "fromScreen",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "clear_recent_search_stops",
+      "class": "ClearRecentSearchClickEvent",
+      "label": "Clear recent searches",
+      "params": [
+        {
+          "name": "recentSearchCount",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "date_time_select",
+      "class": "DateTimeSelectEvent",
+      "label": "Select departure time",
+      "params": [
+        {
+          "name": "dayOfWeek",
+          "optional": false
+        },
+        {
+          "name": "isReset",
+          "optional": false
+        },
+        {
+          "name": "journeyOption",
+          "optional": false
+        },
+        {
+          "name": "time",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "delete_saved_trip_card_click",
+      "class": "DeleteSavedTripClickEvent",
+      "label": "Delete saved trip",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "dep_board_line_filter_click",
+      "class": "DepartureBoardLineFilterClickEvent",
+      "label": "Filter dep board by line",
+      "description": "Fired when the user taps a line chip to filter or clear departures.",
+      "params": [
+        {
+          "name": "lineNumber",
+          "optional": true
+        },
+        {
+          "name": "selected",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        },
+        {
+          "name": "transportMode",
+          "optional": true
+        }
+      ]
+    },
+    {
+      "name": "dep_board_screen_view",
+      "class": "DepartureBoardScreenViewEvent",
+      "label": "View departure board",
+      "description": "Fired when departure polling starts for a stop (i.e.",
+      "params": [
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        },
+        {
+          "name": "stopName",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "dep_board_show_previous",
+      "class": "DepartureBoardShowPreviousEvent",
+      "label": "Show earlier departures",
+      "description": "Fired when the user toggles the \"Show / Hide previous departures\" panel.",
+      "params": [
+        {
+          "name": "show",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "dep_board_status",
+      "class": "DepartureBoardStatusEvent",
+      "label": "Dep board load error/retry",
+      "description": "Fired for error/retry lifecycle events on the departure board.",
+      "params": [
+        {
+          "name": "action",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "dep_board_toggle",
+      "class": "DepartureBoardToggleEvent",
+      "label": "Open dep board from stop",
+      "description": "Fired when the user expands or collapses a departure board card on any surface.",
+      "metric": "dep_board_open",
+      "params": [
+        {
+          "name": "expand",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        },
+        {
+          "name": "stopName",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "discover_button_click",
+      "class": "DiscoverButtonClick",
+      "label": "Open Discover",
+      "params": []
+    },
+    {
+      "name": "discover_card_click",
+      "class": "DiscoverCardClick",
+      "label": "Click Discover card",
+      "params": [
+        {
+          "name": "cardId",
+          "optional": false
+        },
+        {
+          "name": "cardType",
+          "optional": false
+        },
+        {
+          "name": "location",
+          "optional": true
+        },
+        {
+          "name": "partnerSocialPlatformName",
+          "optional": true
+        },
+        {
+          "name": "partnerSocialPlatformUrl",
+          "optional": true
+        },
+        {
+          "name": "source",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "discover_filter_chip_selected",
+      "class": "DiscoverFilterChipSelected",
+      "label": "Filter Discover content",
+      "params": [
+        {
+          "name": "cardType",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "discover_session_complete",
+      "class": "DiscoverCardSessionComplete",
+      "label": "Complete Discover session",
+      "params": [
+        {
+          "name": "cardSeenCount",
+          "optional": false
+        },
+        {
+          "name": "location",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "from_field_click",
+      "class": "FromFieldClickEvent",
+      "label": "Tap From field",
+      "params": []
+    },
+    {
+      "name": "how_to_krail",
+      "class": "SettingsHowToUseClickEvent",
+      "label": "Read how-to guide",
+      "params": []
+    },
+    {
+      "name": "info_tile_interaction",
+      "class": "InfoTileInteraction",
+      "label": "Interact with info tile",
+      "params": [
+        {
+          "name": "cta_click",
+          "optional": true
+        },
+        {
+          "name": "dismiss",
+          "optional": true
+        },
+        {
+          "name": "expand",
+          "optional": true
+        },
+        {
+          "name": "key",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "intro_lets_krail",
+      "class": "IntroLetsKrailClickEvent",
+      "label": "Complete onboarding",
+      "description": "Analytics event for the refer friend button click in the intro screen.",
+      "params": [
+        {
+          "name": "completedOnPage",
+          "optional": false
+        },
+        {
+          "name": "completedOnPageNumber",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "journey_alert_click",
+      "class": "JourneyAlertClickEvent",
+      "label": "View service alert",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "journey_card_toggle",
+      "class": "JourneyCardToggleEvent",
+      "label": "Expand/collapse journey card",
+      "metric": "journey_expand",
+      "params": [
+        {
+          "name": "expanded",
+          "optional": false
+        },
+        {
+          "name": "hasStarted",
+          "optional": false
+        },
+        {
+          "name": "legCount",
+          "optional": false
+        },
+        {
+          "name": "transportModes",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "journey_leg_click",
+      "class": "JourneyLegClickEvent",
+      "label": "Expand journey leg",
+      "description": "Fired when the user taps a transport leg row inside an expanded journey card.",
+      "params": [
+        {
+          "name": "expanded",
+          "optional": false
+        },
+        {
+          "name": "lineName",
+          "optional": false
+        },
+        {
+          "name": "transportMode",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "load_timetable_click",
+      "class": "LoadTimeTableClickEvent",
+      "label": "Load timetable",
+      "metric": "load_timetable",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "location_permission_settings_click",
+      "class": "LocationPermissionSettingsClickEvent",
+      "label": "Open location settings",
+      "description": "Fired when the user taps \"Go to Settings\" on the location permission denied banner.",
+      "params": [
+        {
+          "name": "source",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "mode_click",
+      "class": "ModeClickEvent",
+      "label": "Tap transport mode",
+      "params": [
+        {
+          "name": "displayModeSelectionRow",
+          "optional": false
+        },
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "mode_selection_done",
+      "class": "ModeSelectionDoneEvent",
+      "label": "Apply mode filter",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        },
+        {
+          "name": "unselected",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "nearby_stop_click",
+      "class": "NearbyStopClickEvent",
+      "label": "Tap nearby stop on map",
+      "description": "Fired when the user taps a stop marker on the SearchStopMap (the bottom sheet opens).",
+      "params": [
+        {
+          "name": "stopId",
+          "optional": false
+        },
+        {
+          "name": "transportModesCount",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "no_entries_detected",
+      "class": "NoEntriesDetectedEvent",
+      "label": "Empty nav back stack (bug canary)",
+      "description": "Fired when the nav back stack produces zero entries, causing the NoEntriesUI fallback to appear.",
+      "params": [
+        {
+          "name": "topLevelRoute",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "our_story",
+      "class": "OurStoryClick",
+      "label": "Read our story",
+      "params": []
+    },
+    {
+      "name": "park_ride_card_click",
+      "class": "ParkRideCardClickEvent",
+      "label": "View Park & Ride",
+      "description": "Analytics event for the Park and Ride card click.",
+      "params": [
+        {
+          "name": "expand",
+          "optional": false
+        },
+        {
+          "name": "facilityId",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        },
+        {
+          "name": "time",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "plan_trip_click",
+      "class": "PlanTripClickEvent",
+      "label": "Plan a trip",
+      "metric": "plan_trip",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "refer_friend",
+      "class": "ReferFriend",
+      "label": "Refer a friend",
+      "description": "Analytics event for the refer friend button click.",
+      "metric": "refer_friend",
+      "params": [
+        {
+          "name": "entryPoint",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "reset_time_click",
+      "class": "ResetTimeClickEvent",
+      "label": "Reset departure time",
+      "params": []
+    },
+    {
+      "name": "retry_api",
+      "class": "RetryApiEvent",
+      "label": "Retry after load failure",
+      "description": "User taps Retry after an API/load failure.",
+      "params": [
+        {
+          "name": "source",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "reverse_stop_click",
+      "class": "ReverseStopClickEvent",
+      "label": "Swap From/To stops",
+      "params": []
+    },
+    {
+      "name": "reverse_time_table_click",
+      "class": "ReverseTimeTableClickEvent",
+      "label": "Reverse trip from timetable",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "save_trip_click",
+      "class": "SaveTripClickEvent",
+      "label": "Save a trip",
+      "metric": "save_trip",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "save_trip_prompt_action",
+      "class": "SaveTripPromptActionEvent",
+      "label": "Accept/dismiss save-trip prompt",
+      "description": "User acted on the \"Save this trip?\" prompt.",
+      "params": [
+        {
+          "name": "accepted",
+          "optional": false
+        },
+        {
+          "name": "dismissCount",
+          "optional": false
+        },
+        {
+          "name": "variant",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "save_trip_prompt_shown",
+      "class": "SaveTripPromptShownEvent",
+      "label": "See save-trip prompt",
+      "description": "\"Save this trip?\" prompt shown on the timetable after loading an unsaved origin-destination pair (the aha-moment save nudge).",
+      "params": [
+        {
+          "name": "variant",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "saved_trip_card_click",
+      "class": "SavedTripCardClickEvent",
+      "label": "Open saved trip card",
+      "metric": "saved_trip_open",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "saved_trip_card_reordered",
+      "class": "SavedTripCardReorderedEvent",
+      "label": "Reorder saved trip cards",
+      "description": "Fired when the user reorders a saved-trip card by drag-and-drop in edit mode.",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "newIndex",
+          "optional": false
+        },
+        {
+          "name": "previousIndex",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        },
+        {
+          "name": "totalCount",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "search_stop_map_options_opened",
+      "class": "MapOptionsOpenedEvent",
+      "label": "Open map options",
+      "description": "Fired when the user taps the Options button on the map (SearchStopMap only).",
+      "params": []
+    },
+    {
+      "name": "search_stop_map_options_saved",
+      "class": "MapOptionsSavedEvent",
+      "label": "Save map options",
+      "description": "Fired when the user taps \"Save\" on the MapOptionsBottomSheet.",
+      "params": [
+        {
+          "name": "modesChanged",
+          "optional": false
+        },
+        {
+          "name": "radiusChanged",
+          "optional": false
+        },
+        {
+          "name": "radiusKm",
+          "optional": false
+        },
+        {
+          "name": "showCompass",
+          "optional": false
+        },
+        {
+          "name": "showDistanceScale",
+          "optional": false
+        },
+        {
+          "name": "transportModes",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "search_stop_query",
+      "class": "SearchStopQuery",
+      "label": "Search for a stop",
+      "description": "Fired when a settled search query finishes resolving.",
+      "metric": "stop_search",
+      "params": [
+        {
+          "name": "isError",
+          "optional": false
+        },
+        {
+          "name": "query",
+          "optional": true
+        },
+        {
+          "name": "queryLength",
+          "optional": false
+        },
+        {
+          "name": "resultSource",
+          "optional": false
+        },
+        {
+          "name": "resultsCount",
+          "optional": true
+        },
+        {
+          "name": "searchSessionId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "select_on_map_button_click",
+      "class": "SelectOnMapButtonClickEvent",
+      "label": "Select on map",
+      "description": "Fired when the user taps the \"Select on map\" button in the SearchStop list.",
+      "params": []
+    },
+    {
+      "name": "settings_click",
+      "class": "SettingsClickEvent",
+      "label": "Open settings",
+      "params": []
+    },
+    {
+      "name": "share_journey_click",
+      "class": "ShareJourneyClickEvent",
+      "label": "Share a journey",
+      "description": "Fired when the user taps the \"Share with Friend\" button on an expanded journey card.",
+      "metric": "share_journey",
+      "params": [
+        {
+          "name": "isPastDeparture",
+          "optional": false
+        },
+        {
+          "name": "legCount",
+          "optional": false
+        },
+        {
+          "name": "lines",
+          "optional": false
+        },
+        {
+          "name": "originTime",
+          "optional": false
+        },
+        {
+          "name": "totalTravelTime",
+          "optional": false
+        },
+        {
+          "name": "transportModes",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "social_connection_link_click",
+      "class": "SocialConnectionLinkClickEvent",
+      "label": "Tap social link",
+      "params": [
+        {
+          "name": "socialPlatform",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "stop_label_created",
+      "class": "StopLabelCreatedEvent",
+      "label": "Create stop label",
+      "description": "Fired when a new custom stop label is successfully persisted.",
+      "params": [
+        {
+          "name": "creationSurface",
+          "optional": false
+        },
+        {
+          "name": "labelCountBucket",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "stop_label_removed",
+      "class": "StopLabelRemovedEvent",
+      "label": "Remove stop label",
+      "description": "Fired when the user either deletes a label entirely or clears the stop attached to it.",
+      "params": [
+        {
+          "name": "action",
+          "optional": false
+        },
+        {
+          "name": "hadStop",
+          "optional": false
+        },
+        {
+          "name": "labelKind",
+          "optional": false
+        },
+        {
+          "name": "surface",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "stop_label_reordered",
+      "class": "StopLabelReorderedEvent",
+      "label": "Reorder stop labels",
+      "description": "Fired once per completed drag in Manage Labels whose final order differs from the starting order - never per intermediate swap, so one long drag is one event.",
+      "params": [
+        {
+          "name": "labelKind",
+          "optional": false
+        },
+        {
+          "name": "moveDistanceBucket",
+          "optional": false
+        },
+        {
+          "name": "setLabelCountBucket",
+          "optional": false
+        },
+        {
+          "name": "surface",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "stop_label_stop_assigned",
+      "class": "StopLabelStopAssignedEvent",
+      "label": "Assign stop label",
+      "description": "Fired when the user pins a location to a label - the core \"label is being used\" signal.",
+      "params": [
+        {
+          "name": "assignmentMode",
+          "optional": false
+        },
+        {
+          "name": "assignmentSurface",
+          "optional": false
+        },
+        {
+          "name": "isReassignment",
+          "optional": false
+        },
+        {
+          "name": "labelKind",
+          "optional": false
+        },
+        {
+          "name": "locationKind",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "stop_selected",
+      "class": "StopSelectedEvent",
+      "label": "Select a stop",
+      "metric": "stop_select",
+      "params": [
+        {
+          "name": "addressType",
+          "optional": true
+        },
+        {
+          "name": "displayedAddressCount",
+          "optional": true
+        },
+        {
+          "name": "displayedLocalCount",
+          "optional": true
+        },
+        {
+          "name": "isRecentSearch",
+          "optional": false
+        },
+        {
+          "name": "locationKind",
+          "optional": false
+        },
+        {
+          "name": "searchSessionId",
+          "optional": true
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "stop_selected_from_map",
+      "class": "StopSelectedFromMapEvent",
+      "label": "Select stop from map",
+      "description": "Fired when the user selects a stop via the map's StopDetailsBottomSheet.",
+      "metric": "stop_select",
+      "params": [
+        {
+          "name": "enabledModesCount",
+          "optional": false
+        },
+        {
+          "name": "hadUserLocation",
+          "optional": false
+        },
+        {
+          "name": "nearbyStopsCount",
+          "optional": false
+        },
+        {
+          "name": "searchRadiusKm",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "theme_selected",
+      "class": "ThemeSelectedEvent",
+      "label": "Change theme",
+      "params": [
+        {
+          "name": "themeId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "timetable_load_more_click",
+      "class": "TimeTableLoadMoreClickEvent",
+      "label": "Load more timetable results",
+      "description": "Fired when the user taps \"Load more\" at the bottom of the timetable list to page in the next window of future trips.",
+      "params": [
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "isCustomDateTime",
+          "optional": false
+        },
+        {
+          "name": "latestVisibleDepartureMinutesFromNow",
+          "optional": false
+        },
+        {
+          "name": "loadMoreCount",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        },
+        {
+          "name": "visibleJourneyCount",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "timetable_load_previous_click",
+      "class": "TimeTableLoadPreviousClickEvent",
+      "label": "Load earlier timetable results",
+      "description": "Fired when the user taps \"Load previous\" at the top of the timetable list to page in trips that departed before the earliest currently shown departure.",
+      "params": [
+        {
+          "name": "earliestVisibleDepartureMinutesFromNow",
+          "optional": false
+        },
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "isCustomDateTime",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        },
+        {
+          "name": "visibleJourneyCount",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "timetable_stop_header_click",
+      "class": "TimeTableStopHeaderClickEvent",
+      "label": "Tap timetable stop header",
+      "description": "Fired when the user taps either affordance on a stop row in the timetable sticky header: the stop name (opens leg-scoped stop search, \"Change origin\" / \"Change destination\") or the departures icon (opens the departure-board sheet).",
+      "params": [
+        {
+          "name": "action",
+          "optional": false
+        },
+        {
+          "name": "fromStopId",
+          "optional": false
+        },
+        {
+          "name": "isOrigin",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        },
+        {
+          "name": "stopName",
+          "optional": false
+        },
+        {
+          "name": "toStopId",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "to_field_click",
+      "class": "ToFieldClickEvent",
+      "label": "Tap To field",
+      "params": []
+    },
+    {
+      "name": "user_location_button_click",
+      "class": "MapLocationButtonClickEvent",
+      "label": "Use my location",
+      "description": "Fired when the user taps the User Location button on any map screen.",
+      "params": [
+        {
+          "name": "isLocationActive",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        }
+      ]
+    },
+    {
+      "name": "view_screen",
+      "class": "ScreenViewEvent",
+      "label": "View screen",
+      "params": [
+        {
+          "name": "name",
+          "optional": false
+        }
+      ]
+    }
+  ],
+  "removed": [
+    {
+      "name": "journey_card_expand",
+      "removedIn": "1.22",
+      "replacedBy": "journey_card_toggle",
+      "note": "Folded into the toggle event with expanded=true."
+    },
+    {
+      "name": "journey_card_collapse",
+      "removedIn": "1.22",
+      "replacedBy": "journey_card_toggle",
+      "note": "Folded into the toggle event with expanded=false."
+    },
+    {
+      "name": "dep_board_stop_click",
+      "removedIn": "1.22",
+      "replacedBy": "dep_board_toggle",
+      "note": "Unified with nearby_stop_dep_board_click into dep_board_toggle(source)."
+    },
+    {
+      "name": "nearby_stop_dep_board_click",
+      "removedIn": "1.22",
+      "replacedBy": "dep_board_toggle",
+      "note": "Unified into dep_board_toggle(source)."
+    },
+    {
+      "name": "search_stop_map_toggle_click",
+      "removedIn": "1.22",
+      "replacedBy": null,
+      "note": "Map toggle removed; no replacement."
+    }
+  ],
+  "removedParams": [
+    {
+      "event": "stop_selected",
+      "param": "searchQuery",
+      "removedIn": "1.25",
+      "note": "Raw typed text could be a street address (privacy)."
+    },
+    {
+      "event": "stop_label_created",
+      "param": "labelName",
+      "removedIn": "1.25",
+      "note": "Raw label text (privacy)."
+    },
+    {
+      "event": "stop_label_created",
+      "param": "emoji",
+      "removedIn": "1.25",
+      "note": "Replaced by bounded params."
+    },
+    {
+      "event": "stop_label_created",
+      "param": "totalLabelsCountAfter",
+      "removedIn": "1.25",
+      "note": "Replaced by labelCountBucket."
+    },
+    {
+      "event": "stop_label_removed",
+      "param": "labelName",
+      "removedIn": "1.25",
+      "note": "Raw label text (privacy)."
+    },
+    {
+      "event": "stop_label_stop_assigned",
+      "param": "labelName",
+      "removedIn": "1.25",
+      "note": "Raw label text (privacy)."
+    },
+    {
+      "event": "stop_label_stop_assigned",
+      "param": "stopId",
+      "removedIn": "1.25",
+      "note": "Raw stop identity (privacy)."
+    },
+    {
+      "event": "stop_label_stop_assigned",
+      "param": "stopName",
+      "removedIn": "1.25",
+      "note": "Raw stop identity (privacy)."
+    },
+    {
+      "event": "stop_label_stop_assigned",
+      "param": "isProtectedLabel",
+      "removedIn": "1.25",
+      "note": "Replaced by labelKind."
+    },
+    {
+      "event": "stop_label_reordered",
+      "param": "labelName",
+      "removedIn": "1.25",
+      "note": "Raw label text (privacy)."
+    },
+    {
+      "event": "stop_label_reordered",
+      "param": "isProtectedLabel",
+      "removedIn": "1.25",
+      "note": "Replaced by labelKind."
+    },
+    {
+      "event": "stop_label_reordered",
+      "param": "previousIndex",
+      "removedIn": "1.25",
+      "note": "Replaced by moveDistanceBucket."
+    },
+    {
+      "event": "stop_label_reordered",
+      "param": "newIndex",
+      "removedIn": "1.25",
+      "note": "Replaced by moveDistanceBucket."
+    },
+    {
+      "event": "stop_label_reordered",
+      "param": "totalCount",
+      "removedIn": "1.25",
+      "note": "Replaced by setLabelCountBucket."
+    },
+    {
+      "event": "app_start",
+      "param": "batteryLevel",
+      "removedIn": "1.23",
+      "note": "No longer collected."
+    },
+    {
+      "event": "back_click",
+      "param": "isPreviousBackStackEntryNull",
+      "removedIn": "1.23",
+      "note": "Nav debugging aid, no longer needed."
+    }
+  ]
+}

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -1,4 +1,5 @@
 import xyz.ksharma.krail.gradle.AndroidVersion
+import org.gradle.api.tasks.testing.Test as GradleTest
 
 plugins {
     alias(libs.plugins.krail.kotlin.multiplatform)
@@ -16,6 +17,7 @@ kotlin {
         namespace = "xyz.ksharma.krail.core.analytics"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
+        withHostTest {}
     }
 
     iosArm64()
@@ -51,5 +53,27 @@ kotlin {
 
         iosMain.dependencies {
         }
+
+        // AnalyticsContractTest instantiates every AnalyticsEvent subclass to read its
+        // real property map, so it needs full JVM reflection — hence host test, not common.
+        getByName("androidHostTest") {
+            kotlin.srcDir("src/androidHostTest/kotlin")
+            dependencies {
+                implementation(libs.test.kotlin)
+                implementation(libs.kotlinx.serialization.json)
+                implementation(kotlin("reflect"))
+            }
+        }
+    }
+}
+
+// AnalyticsContractTest can rewrite analytics-events.json from the code when this
+// property is set. Gradle applies -D to its own JVM, so it has to be forwarded to the
+// test JVM explicitly:
+//   ./gradlew :core:analytics:testAndroidHostTest -DregenerateAnalyticsContract=1
+tasks.withType<GradleTest>().configureEach {
+    workingDir = projectDir
+    providers.systemProperty("regenerateAnalyticsContract").orNull?.let {
+        systemProperty("regenerateAnalyticsContract", it)
     }
 }

--- a/core/analytics/src/androidHostTest/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsContractTest.kt
+++ b/core/analytics/src/androidHostTest/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsContractTest.kt
@@ -1,0 +1,307 @@
+package xyz.ksharma.krail.core.analytics.event
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import xyz.ksharma.krail.core.analytics.AnalyticsScreen
+import java.io.File
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.isSubclassOf
+import kotlin.reflect.full.primaryConstructor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * `analytics-events.json` is the authoritative contract for KRAIL's analytics events.
+ * KRAIL-Analytics generates its event registry, labels and metric groups from it, so if
+ * this file and the contract disagree, that repo is silently wrong — which is exactly the
+ * failure this contract exists to end.
+ *
+ * This test does not parse Kotlin. It instantiates every [AnalyticsEvent] subclass and
+ * reads the real `properties` map — the same map the Firebase SDK sends. Parsing cannot
+ * do that: `PROP_FROM_STOP_ID to tripFromStopId` emits the key `fromStopId` while the
+ * constructor parameter is called `tripFromStopId`, and a parser records the wrong one.
+ *
+ * Optional params are found by instantiating twice: once with every nullable argument
+ * populated, once with them null. Keys present only in the first pass are optional.
+ */
+class AnalyticsContractTest {
+
+    private companion object {
+        const val REGENERATE = "regenerateAnalyticsContract"
+    }
+
+    private val contract: JsonObject by lazy {
+        val file = contractFile()
+        assertTrue(file.exists(), "Contract not found at ${file.absolutePath}")
+        Json.parseToJsonElement(file.readText()).jsonObject
+    }
+
+    @Test
+    fun `every event in code is declared in the contract with the same params`() {
+        val observed = AnalyticsEvent::class.sealedSubclasses.associate { subclass ->
+            val required = instantiate(subclass, nullablesPopulated = false).properties.orEmpty().keys
+            val full = instantiate(subclass, nullablesPopulated = true)
+            full.name to ObservedEvent(
+                className = subclass.simpleName ?: "?",
+                params = full.properties.orEmpty().keys.associateWith { it !in required },
+            )
+        }
+
+        if (System.getProperty(REGENERATE) != null) {
+            regenerate(observed)
+            return
+        }
+
+        val declared = contract["events"]!!.jsonArray.associate { element ->
+            val obj = element.jsonObject
+            obj["name"]!!.jsonPrimitive.content to obj["params"]!!.jsonArray.associate { p ->
+                p.jsonObject["name"]!!.jsonPrimitive.content to
+                    (p.jsonObject["optional"]!!.jsonPrimitive.content == "true")
+            }
+        }
+
+        val problems = mutableListOf<String>()
+
+        for ((name, event) in observed) {
+            val expected = declared[name]
+            if (expected == null) {
+                problems += "$name (${event.className}) is in AnalyticsEvent.kt but not in analytics-events.json"
+                continue
+            }
+
+            for (param in event.params.keys - expected.keys) {
+                problems += "$name.$param is emitted but the contract does not declare it"
+            }
+            // A param the sample values never triggered is fine only if the contract admits
+            // it is conditional — reflection uses fixed samples and cannot explore every
+            // runtime branch, so `optional` is the honest way to record that.
+            for (param in expected.keys - event.params.keys) {
+                if (expected[param] != true) {
+                    problems += "$name.$param is declared as always-present but the event never emits it"
+                }
+            }
+            for ((param, isOptional) in event.params) {
+                val declaredOptional = expected[param] ?: continue
+                if (!declaredOptional && isOptional) {
+                    problems += "$name.$param is only emitted for some inputs; mark it optional in the contract"
+                }
+                if (declaredOptional && !isOptional) {
+                    problems += "$name.$param is always emitted; the contract marks it optional"
+                }
+            }
+        }
+
+        for (name in declared.keys - observed.keys) {
+            problems += "$name is in analytics-events.json but no AnalyticsEvent subclass emits it"
+        }
+
+        if (problems.isNotEmpty()) {
+            fail(
+                "analytics-events.json is out of date with AnalyticsEvent.kt.\n" +
+                    "Update the contract in this PR — KRAIL-Analytics generates its registry from it.\n" +
+                    "To rewrite it from the code, run:\n" +
+                    "  ./gradlew :core:analytics:testAndroidHostTest -D$REGENERATE=1\n" +
+                    "then review the diff and fill in the label for any new event.\n\n" +
+                    problems.sorted().joinToString("\n") { "  - $it" },
+            )
+        }
+    }
+
+    @Test
+    fun `every event has a label for the dashboard`() {
+        if (System.getProperty(REGENERATE) != null) return
+        val unlabelled = contract["events"]!!.jsonArray
+            .map { it.jsonObject }
+            .filter { it["label"]?.jsonPrimitive?.content.isNullOrBlank() }
+            .map { it["name"]!!.jsonPrimitive.content }
+        assertEquals(
+            emptyList(), unlabelled,
+            "Every event needs a `label` in analytics-events.json — KRAIL-Analytics uses it " +
+                "as the display name, and an unlabelled event shows up as a raw event name.",
+        )
+    }
+
+    @Test
+    fun `contract obeys Firebase naming and budget limits`() {
+        val events = contract["events"]!!.jsonArray.map { it.jsonObject }
+        val removed = contract["removed"]!!.jsonArray.map { it.jsonObject }
+        val budget = contract["firebaseEventNameBudget"]!!.jsonPrimitive.content.toInt()
+
+        val problems = mutableListOf<String>()
+        val nameRule = Regex("^[a-z][a-z0-9_]*$")
+        val reserved = listOf("firebase_", "google_", "ga_")
+
+        for (event in events) {
+            val name = event["name"]!!.jsonPrimitive.content
+            if (!nameRule.matches(name)) problems += "event '$name' is not snake_case starting with a letter"
+            if (name.length > 40) problems += "event '$name' exceeds Firebase's 40-character name limit"
+            reserved.firstOrNull { name.startsWith(it) }
+                ?.let { problems += "event '$name' uses the reserved prefix '$it'" }
+
+            val params = event["params"]!!.jsonArray.map { it.jsonObject["name"]!!.jsonPrimitive.content }
+            if (params.size > 25) problems += "event '$name' declares ${params.size} params; Firebase allows 25"
+            for (param in params) {
+                if (!Regex("^[a-zA-Z][a-zA-Z0-9_]*$").matches(param)) problems += "$name.$param is not a legal parameter name"
+                if (param.length > 40) problems += "$name.$param exceeds the 40-character parameter name limit"
+                reserved.firstOrNull { param.startsWith(it) }
+                    ?.let { problems += "$name.$param uses the reserved prefix '$it'" }
+            }
+        }
+
+        // A name is a permanently spent Firebase slot, even after removal.
+        val spent = events.size + removed.size
+        if (spent > budget) problems += "$spent event names used against a budget of $budget"
+
+        // Every replacement must point at something real, or the union that spans the
+        // rename cannot be generated.
+        val liveNames = events.map { it["name"]!!.jsonPrimitive.content }.toSet()
+        for (entry in removed) {
+            val replacedBy = entry["replacedBy"]?.jsonPrimitive?.contentOrNullSafe() ?: continue
+            if (replacedBy !in liveNames) {
+                problems += "removed event '${entry["name"]!!.jsonPrimitive.content}' claims to be replaced by " +
+                    "'$replacedBy', which is not a live event"
+            }
+        }
+
+        assertEquals(emptyList(), problems, "analytics-events.json violates Firebase constraints")
+    }
+
+    // ── regeneration ───────────────────────────────────────────────────────
+
+    private data class ObservedEvent(val className: String, val params: Map<String, Boolean>)
+
+    /**
+     * Rewrite the contract from the code, preserving everything reflection cannot know:
+     * labels, descriptions, metric membership, and the removed/removedParams history.
+     * Params the sample values never triggered are kept and forced to optional, since
+     * they are real but runtime-conditional.
+     */
+    private fun regenerate(observed: Map<String, ObservedEvent>) {
+        val existing = contract["events"]!!.jsonArray.associate { it.jsonObject["name"]!!.jsonPrimitive.content to it.jsonObject }
+
+        val events = observed.entries.sortedBy { it.key }.map { (name, event) ->
+            val prev = existing[name]
+            val prevParams = prev?.get("params")?.jsonArray
+                ?.associate { it.jsonObject["name"]!!.jsonPrimitive.content to it.jsonObject }
+                .orEmpty()
+
+            val params = buildJsonArray {
+                val names = (event.params.keys + prevParams.keys).sorted()
+                for (param in names) {
+                    val emittedOptional = event.params[param]
+                    add(
+                        buildJsonObject {
+                            put("name", param)
+                            put("optional", emittedOptional ?: true)
+                        },
+                    )
+                }
+            }
+
+            buildJsonObject {
+                put("name", name)
+                put("class", event.className)
+                put("label", prev?.get("label")?.jsonPrimitive?.content ?: "")
+                prev?.get("description")?.let { put("description", it) }
+                prev?.get("metric")?.let { put("metric", it) }
+                put("params", params)
+            }
+        }
+
+        val out = buildJsonObject {
+            for ((key, value) in contract) {
+                if (key == "events") put("events", JsonArray(events)) else put(key, value)
+            }
+        }
+
+        val pretty = Json { prettyPrint = true; prettyPrintIndent = "  " }
+        contractFile().writeText(pretty.encodeToString(JsonObject.serializer(), out) + "\n")
+        println("Regenerated ${contractFile().absolutePath} with ${events.size} events.")
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    private fun kotlinx.serialization.json.JsonPrimitive.contentOrNullSafe(): String? =
+        if (this.toString() == "null") null else content
+
+    /**
+     * Test working directory is the module dir under Gradle, but fall back to walking up
+     * so the test also runs from an IDE run configuration rooted at the repo.
+     */
+    private fun contractFile(): File {
+        val direct = File("analytics-events.json")
+        if (direct.exists()) return direct
+        return File("core/analytics/analytics-events.json")
+    }
+
+    private fun instantiate(subclass: KClass<out AnalyticsEvent>, nullablesPopulated: Boolean): AnalyticsEvent {
+        subclass.objectInstance?.let { return it }
+        val ctor = subclass.primaryConstructor
+            ?: fail("${subclass.simpleName} has no primary constructor and is not an object")
+
+        val args = ctor.parameters.associateWith { param ->
+            if (param.type.isMarkedNullable && !nullablesPopulated) null
+            else sampleFor(param, subclass)
+        }.filterNot { (param, value) ->
+            // Let defaulted params keep their default when we have nothing better.
+            value == null && param.isOptional && !param.type.isMarkedNullable
+        }
+        return ctor.callBy(args)
+    }
+
+    private fun sampleFor(param: KParameter, owner: KClass<*>, depth: Int = 0): Any? {
+        val classifier = param.type.classifier as? KClass<*>
+            ?: fail("${owner.simpleName}.${param.name}: unsupported type ${param.type}")
+
+        return when {
+            classifier == String::class -> "sample"
+            classifier == Boolean::class -> true
+            classifier == Int::class -> 1
+            classifier == Long::class -> 1L
+            classifier == Double::class -> 1.0
+            classifier == Float::class -> 1.0f
+            classifier.java.isEnum -> classifier.java.enumConstants.first()
+            // Collections only affect the emitted VALUE, never the key set, so empty is safe.
+            classifier == Set::class -> emptySet<Any>()
+            classifier == List::class || classifier == Collection::class -> emptyList<Any>()
+            classifier == Map::class -> emptyMap<Any, Any>()
+            classifier.isSubclassOf(AnalyticsScreen::class) ->
+                AnalyticsScreen::class.sealedSubclasses.first().objectInstance
+            classifier.objectInstance != null -> classifier.objectInstance
+            classifier.sealedSubclasses.isNotEmpty() ->
+                classifier.sealedSubclasses.first().objectInstance
+                    ?: buildNested(classifier.sealedSubclasses.first(), owner, param, depth)
+            // A plain data class used as a parameter — build one recursively.
+            classifier.primaryConstructor != null -> buildNested(classifier, owner, param, depth)
+            else -> fail(
+                "${owner.simpleName}.${param.name}: no sample value for ${classifier.simpleName}. " +
+                    "Add a case to sampleFor() — skipping would let the contract drift unnoticed.",
+            )
+        }
+    }
+
+    private fun buildNested(target: KClass<*>, owner: KClass<*>, param: KParameter, depth: Int): Any {
+        if (depth > 4) {
+            fail("${owner.simpleName}.${param.name}: ${target.simpleName} nests more than four levels deep")
+        }
+        val ctor = target.primaryConstructor
+            ?: fail("${owner.simpleName}.${param.name}: ${target.simpleName} has no primary constructor")
+        val args = ctor.parameters
+            .filterNot { it.isOptional }
+            .associateWith { nested ->
+                if (nested.type.isMarkedNullable) null else sampleFor(nested, target, depth + 1)
+            }
+        return ctor.callBy(args)
+    }
+}

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -76,8 +76,41 @@ address results were on screen, the user picked an address" without any query te
 Rows before 2026-07-15 have no `searchSessionId`; treat missing as "pre-join era",
 only app-session-level funnels are possible there.
 
+## The contract — `core/analytics/analytics-events.json`
+
+**This file is the authoritative definition of every analytics event.** It carries each
+event's emitted parameter keys, its human label, the logical metric it belongs to, and
+the full rename history (`removed` / `removedParams`).
+
+`AnalyticsContractTest` asserts `AnalyticsEvent.kt` and the contract agree. It does not
+parse Kotlin — it instantiates every `AnalyticsEvent` subclass and reads the real
+`properties` map, so it sees the keys Firebase actually receives. That matters:
+`PROP_FROM_STOP_ID to tripFromStopId` emits `fromStopId` while the constructor parameter
+is `tripFromStopId`, and a parser records the wrong one.
+
+The test also enforces Firebase's constraints — name and parameter naming rules, the
+40-character limits, 25 params per event, reserved prefixes, the 500-name budget — and
+requires every event to carry a `label`.
+
+**When you add or change an event:**
+
+```bash
+./gradlew :core:analytics:testAndroidHostTest -DregenerateAnalyticsContract=1
+```
+
+That rewrites the contract from the code, preserving labels, descriptions and metric
+membership. Review the diff, fill in the `label` for anything new, and commit it in the
+same PR. `testAndroidHostTest` in CI fails if the contract is stale.
+
+**When you rename or remove an event**, add a `removed` entry declaring `replacedBy`.
+KRAIL-Analytics generates its metric unions from that field, so a rename keeps its
+history automatically instead of collapsing a dashboard metric to zero — which is exactly
+what happened with `journey_card_expand` and `dep_board_stop_click`.
+
 ## Registration gate
 
-Every new event or param must be registered in `docs/EVENT_REGISTRY.md` in the
-**KRAIL-Analytics** repo before the app PR merges: params, trigger description, and
-owner story link.
+KRAIL-Analytics generates its event registry, labels and metric groups from the contract,
+so there is nothing to register by hand — keeping the contract accurate is the whole job.
+
+`docs/ANALYTICS_REGISTRY_HANDOFF.md` remains as the historical audit trail of what was
+registered before the contract existed. New events do not need a row.

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -48,27 +48,36 @@ Registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md`'s "Params registry" table
 
 ## Backfill: events that shipped before this ledger existed
 
-This ledger starts 2026-07-14. Ten event names (plus one new param on an existing event)
-shipped before that date and were never registered on the KRAIL-Analytics side, so they
-arrive in BigQuery with no label and no registry row — invisible to every dashboard that
-keys off the registry. Found by diffing `krail_defined_events` (parsed from
+This ledger starts 2026-07-14. Sixteen event names (plus one new param on an existing
+event) shipped before that date and were never registered on the KRAIL-Analytics side, so
+they arrived in BigQuery with no label and no registry row — invisible to every dashboard
+that keys off the registry. Found by diffing `krail_defined_events` (parsed from
 `AnalyticsEvent.kt` by KRAIL-Analytics `sync-krail.ts`) against `EVENT_REGISTRY.md`.
-Listed here for the audit trail; a `defined-but-unregistered` check now runs daily on the
-analytics side so this class of gap cannot silently reopen.
+
+All rows below were registered in KRAIL-Analytics `docs/EVENT_REGISTRY.md` and
+`dashboard/lib/eventLabels.ts` on 2026-07-22 (KRAIL-Analytics#2). Kept for the audit
+trail. That same change added a `defined-but-unregistered` check which now runs daily and
+fails the analytics build, so this class of gap cannot silently reopen.
 
 | Shipped | Event | Param(s) | Type / values | Trigger | Status |
 |---|---|---|---|---|---|
-| 2026-07-07 | `save_trip_prompt_shown` | `variant` | `plain｜commute` | "Save this trip?" prompt shown on the timetable for an unsaved origin-destination pair | Pending |
-| 2026-07-07 | `save_trip_prompt_action` | `accepted`, `variant`, `dismissCount` | Bool; `plain｜commute`; Int, dismissals for this OD pair including this one, always 0 when `accepted` — prompt stops at 2 | User accepted or dismissed the save prompt (one event for both outcomes) | Pending |
-| 2026-07-07 | `save_trip_click` | `source` (new param) | `star｜prompt`; historical rows carry none — treat null as `star` | Existing event, now distinguishes title-bar star from the prompt | Pending |
-| 2026-06-04 | `retry_api` | `source` | `timetable` | User taps Retry after an API/load failure; unified across surfaces rather than one event per screen | Pending |
-| 2026-05-16 | `no_entries_detected` | `topLevelRoute` | Simple class name of the active top-level route | Nav back stack produced zero entries and the `NoEntriesUI` fallback appeared. **Bug canary — should be silent; it is not.** See "Open items" below | Pending |
-| 2026-05-03 | `saved_trip_card_reordered` | `fromStopId`, `toStopId`, `previousIndex`, `newIndex`, `totalCount` | Stop IDs; Ints | Saved-trip card reordered by drag in edit mode | Pending |
-| 2026-05-03 | `timetable_stop_header_click` | `stopId`, `stopName`, `isOrigin`, `tripFromStopId`, `tripToStopId`, `action` | `action` = `edit_search｜open_departures`; historical rows carry no `action` and were departures opens, so the sheet's full timeline is `action IS NULL OR action = 'open_departures'` | Stop header tapped inside a timetable | Pending |
-| 2026-04-19 | `dep_board_show_previous` | `stopId`, `show`, `source` | Bool `show` (`true` = opened); `DepartureBoardSource` | "Show / hide previous departures" panel toggled | Pending |
-| 2026-02-22 | `search_stop_map_options_opened` | — | — | Options button tapped on the map (SearchStopMap only) | Pending |
-| 2025-09-20 | `clear_recent_search_stops` | `recentSearchCount` | Int | Recent-searches list cleared | Pending |
-| 2025-08-31 | `info_tile_interaction` | `key`, `expand`, `dismiss`, `cta_click` | Tile key; optional bools; CTA URL. Each optional param present only when that interaction happened | Info tile expanded, dismissed, or its CTA tapped | Pending |
+| 2026-07-07 | `save_trip_prompt_shown` | `variant` | `plain｜commute` | "Save this trip?" prompt shown on the timetable for an unsaved origin-destination pair | Registered |
+| 2026-07-07 | `save_trip_prompt_action` | `accepted`, `variant`, `dismissCount` | Bool; `plain｜commute`; Int, dismissals for this OD pair including this one, always 0 when `accepted` — prompt stops at 2 | User accepted or dismissed the save prompt (one event for both outcomes) | Registered |
+| 2026-07-07 | `save_trip_click` | `source` (new param) | `star｜prompt`; historical rows carry none — treat null as `star` | Existing event, now distinguishes title-bar star from the prompt | Registered |
+| 2026-06-04 | `retry_api` | `source` | `timetable` | User taps Retry after an API/load failure; unified across surfaces rather than one event per screen | Registered |
+| 2026-05-16 | `no_entries_detected` | `topLevelRoute` | Simple class name of the active top-level route | Nav back stack produced zero entries and the `NoEntriesUI` fallback appeared. **Bug canary — should be silent; it is not.** See "Open items" below | Registered |
+| 2026-05-03 | `saved_trip_card_reordered` | `fromStopId`, `toStopId`, `previousIndex`, `newIndex`, `totalCount` | Stop IDs; Ints | Saved-trip card reordered by drag in edit mode | Registered |
+| 2026-05-03 | `timetable_stop_header_click` | `stopId`, `stopName`, `isOrigin`, `tripFromStopId`, `tripToStopId`, `action` | `action` = `edit_search｜open_departures`; historical rows carry no `action` and were departures opens, so the sheet's full timeline is `action IS NULL OR action = 'open_departures'` | Stop header tapped inside a timetable | Registered |
+| 2026-04-19 | `dep_board_show_previous` | `stopId`, `show`, `source` | Bool `show` (`true` = opened); `DepartureBoardSource` | "Show / hide previous departures" panel toggled | Registered |
+| 2026-02-22 | `search_stop_map_options_opened` | — | — | Options button tapped on the map (SearchStopMap only) | Registered |
+| 2025-09-20 | `clear_recent_search_stops` | `recentSearchCount` | Int | Recent-searches list cleared | Registered |
+| 2025-08-31 | `info_tile_interaction` | `key`, `expand`, `dismiss`, `cta_click` | Tile key; optional bools; CTA URL. Each optional param present only when that interaction happened | Info tile expanded, dismissed, or its CTA tapped | Registered |
+| 2024-12-24 | `from_field_click` | — | — | From field tapped on the Save Trips screen | Registered |
+| 2024-12-24 | `to_field_click` | — | — | To field tapped on the Save Trips screen | Registered |
+| 2024-12-19 | `delete_saved_trip_card_click` | `fromStopId`, `toStopId` | Stop IDs | Saved trip deleted | Registered |
+| 2024-12-17 | `back_click` | `fromScreen` | `AnalyticsScreen` name | Back navigation from a tracked screen | Registered |
+| 2024-12-17 | `reverse_stop_click` | — | — | From/To stops swapped on the Save Trips screen | Registered |
+| 2024-12-17 | `reverse_time_table_click` | `fromStopId`, `toStopId` | Stop IDs | Trip reversed from the timetable | Registered |
 
 ## Open items for KRAIL-Analytics maintainers
 
@@ -81,7 +90,8 @@ analytics side so this class of gap cannot silently reopen.
   is absent on essentially every firing since the event shipped, and Park & Ride facility
   analysis has no data behind it. Needs an app-side fix (check the param name and value
   against Firebase's naming and length limits at the call site in the P&R card handler).
-  Historical facility data cannot be recovered; it was never recorded.
+  Historical facility data cannot be recovered; it was never recorded. Tracked in
+  [#1762](https://github.com/ksharma-xyz/KRAIL/issues/1762).
 - **`no_entries_detected` is firing.** Its KDoc says the event should stay silent after
   the `resetRoot()` / duplicate `toEntries()` fixes, and that the `NoEntriesUI` fallback
   can be removed if it does. It is arriving in production data, most recently 2026-07-19.


### PR DESCRIPTION
Single PR for all KRAIL-side analytics work from this session. Paired with KRAIL-Analytics `main` (commits `af43a78`, `41e71ad`).

---

## 1. The contract — `core/analytics/analytics-events.json`

**The problem.** KRAIL-Analytics had no reliable way to know what this app emits. It regex-parsed `AnalyticsEvent.kt` and recorded **constructor names**, while Firebase receives **property map keys**:

```
timetable_stop_header_click
  indexed as : stopId, stopName, isOrigin, tripFromStopId, tripToStopId, action
  really is  : stopId, stopName, isOrigin, fromStopId,     toStopId,     action
```

Two of six wrong, because the Kotlin is `PROP_FROM_STOP_ID to tripFromStopId`. Sixteen events had also drifted out of that repo's registry entirely — arriving in BigQuery with no label, invisible to every dashboard.

**The fix.** `analytics-events.json` is now the authoritative definition of every event: emitted parameter keys, human label, the logical metric it feeds, and the rename history. KRAIL-Analytics generates its registry, labels and metric groups from it, so the two repos cannot disagree about what exists.

## 2. `AnalyticsContractTest` keeps it true

It does **not** parse Kotlin. It instantiates every `AnalyticsEvent` subclass and reads the real `properties` map — the same map the SDK sends. Optional params are found by instantiating twice, once with nullable arguments populated and once with them null.

It also enforces Firebase's own constraints (naming rules, 40-char limits, 25 params per event, reserved prefixes, the 500-name budget) and requires every event to carry a `label`, so a new event cannot reach the dashboard as a raw event name.

Writing the contract by hand would be its own drift source, so the test doubles as the generator:

```bash
./gradlew :core:analytics:testAndroidHostTest -DregenerateAnalyticsContract=1
```

It rewrites the file from the code while preserving labels, descriptions and metric membership. **Bootstrapping this way immediately found `reset_time_click`**, which the parser-based pass had missed.

`core:analytics` gains `withHostTest`, so the existing repo-wide `testAndroidHostTest` in `code-quality.yml` runs this — no workflow change needed. Detekt clean.

## 3. Renames become safe

`removed` entries carry `replacedBy`. KRAIL-Analytics generates its metric unions from that field, so a renamed event keeps its history instead of collapsing a dashboard metric to zero — the failure that hit `journey_card_expand` and `dep_board_stop_click`.

Generating those unions immediately fixed two that were wrong by hand: `dep_board_open` was missing `nearby_stop_dep_board_click`, `journey_expand` was missing `journey_card_collapse`.

## 4. Ledger backfill marked registered

Follow-up to #1745. The eleven backfill rows flip `Pending` → `Registered`, and six 2024-12 events that were registered but had no ledger row are added, so the table is a complete audit trail.

`docs/ANALYTICS_EVENTS.md` now documents the contract as the source of truth. The `Pending`/`Registered` flow is retained as history — new events do not need a row, because the contract *is* the registration.

## 5. Open item recorded

`park_ride_card_click.facilityId` — Firebase rejects the param on essentially every firing, so Park & Ride facility data does not exist and never has. Tracked in #1762. Linked from the ledger's open items.

---

## Review notes

- The contract JSON is generated output — review the Kotlin test and the docs; spot-check a couple of entries rather than reading 60 events.
- Worth confirming: the `metric` values (which events feed which logical dashboard metric) are the editorial call I inherited from the analytics side's existing groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMN4pRckETuX4EjHTAw2R9