### PR TITLE
fix(analytics): add park_ride_user_facility to the events contract

### DIFF
--- a/core/analytics/analytics-events.json
+++ b/core/analytics/analytics-events.json
@@ -523,6 +523,29 @@
       ]
     },
     {
+      "name": "park_ride_user_facility",
+      "class": "ParkRideUserFacilityEvent",
+      "label": "Add or Remove Park & Ride",
+      "params": [
+        {
+          "name": "action",
+          "optional": false
+        },
+        {
+          "name": "facilityId",
+          "optional": false
+        },
+        {
+          "name": "source",
+          "optional": false
+        },
+        {
+          "name": "stopId",
+          "optional": false
+        }
+      ]
+    },
+    {
       "name": "plan_trip_click",
       "class": "PlanTripClickEvent",
       "label": "Plan a trip",

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -1,4 +1,5 @@
 import xyz.ksharma.krail.gradle.AndroidVersion
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.testing.Test as GradleTest
 
 plugins {
@@ -76,4 +77,11 @@ tasks.withType<GradleTest>().configureEach {
     providers.systemProperty("regenerateAnalyticsContract").orNull?.let {
         systemProperty("regenerateAnalyticsContract", it)
     }
+    // The test reads analytics-events.json at runtime via File(), so Gradle cannot infer
+    // it as an input. Without this, a JSON-only change is reported UP-TO-DATE / FROM-CACHE
+    // and the contract test does NOT run — the exact case of editing only the contract.
+    // Declaring it forces a re-run whenever the contract changes.
+    inputs.file(layout.projectDirectory.file("analytics-events.json"))
+        .withPropertyName("analyticsContract")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 }


### PR DESCRIPTION
## What

`AnalyticsContractTest` fails on `main`. `ParkRideUserFacilityEvent` is declared in
`AnalyticsEvent.kt` but was never added to `analytics-events.json` when that file became
the shared contract, so the test that compares the two reports the event as missing.

## Changes

- `core/analytics/analytics-events.json`: adds the `park_ride_user_facility` entry, with
  the four params the event already emits (`action`, `facilityId`, `source`, `stopId`),
  all non-optional. Generated with
  `./gradlew :core:analytics:testAndroidHostTest -DregenerateAnalyticsContract=1`, then
  the label filled in to match the wording style of the neighbouring Park & Ride entry.
- No change to `AnalyticsEvent.kt`. Event name, params and their optionality are exactly
  what the code already emits, so this records the existing contract rather than changing
  it.
- `docs/ANALYTICS_REGISTRY_HANDOFF.md` is intentionally untouched: it already carries the
  row for this event (dated 2026-07-22, status `Pending`), so no ledger change is due.

## Testing

- `./gradlew :core:analytics:testAndroidHostTest` green
- `./gradlew testAndroidHostTest --continue` green across all modules (was red on `main`
  before this change)
- `./gradlew detekt --continue` clean, no auto-corrected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJVN8QSe5fNYH5hGo6SEfe
