### PR TITLE
feat(saved-trips): hide Saved Trips section when nothing is saved

### DIFF
--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsListBodyTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsListBodyTest.kt
@@ -1,0 +1,163 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.snapshots.SnapshotStateMap
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import sh.calvin.reorderable.rememberReorderableLazyListState
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import kotlin.test.assertEquals
+
+/**
+ * Compose UI tests for [savedTripsListBody]'s section visibility.
+ *
+ * The rule under test: a rider with nothing saved gets no Saved Trips section at all (no
+ * heading, no placeholder row), while Park & Ride always renders so the feature stays
+ * reachable before a first trip is saved.
+ *
+ * Card contents, reordering and Park & Ride expansion/polling are out of scope here and
+ * covered by [SavedTripViewModelsTest] and the snapshot suite.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [34],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+class SavedTripsListBodyTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    // region Empty saved trips
+
+    @Test
+    fun noSavedTrips_savedTripsHeadingIsNotShown() {
+        composeRule.setContent { ListBody(state = emptyState) }
+
+        composeRule.onNodeWithText(SAVED_TRIPS_TITLE).assertDoesNotExist()
+    }
+
+    @Test
+    fun noSavedTrips_placeholderRowIsNotShown() {
+        composeRule.setContent { ListBody(state = emptyState) }
+
+        composeRule.onNodeWithText(EMPTY_PLACEHOLDER).assertDoesNotExist()
+    }
+
+    @Test
+    fun noSavedTrips_parkRideSectionStillRenders() {
+        composeRule.setContent { ListBody(state = emptyState) }
+
+        composeRule.onNodeWithText(PARK_RIDE_TITLE).assertIsDisplayed()
+        composeRule.onNodeWithText(ADD_FIRST_PARK_RIDE).assertIsDisplayed()
+    }
+
+    @Test
+    fun noSavedTrips_addParkRideClickIsForwarded() {
+        var addClicks = 0
+        composeRule.setContent { ListBody(state = emptyState, onAddParkRideClick = { addClicks++ }) }
+
+        composeRule.onNodeWithText(ADD_FIRST_PARK_RIDE).performClick()
+
+        assertEquals(1, addClicks)
+    }
+
+    // endregion
+
+    // region Populated saved trips
+
+    @Test
+    fun withSavedTrips_savedTripsHeadingIsShown() {
+        composeRule.setContent { ListBody(state = populatedState) }
+
+        composeRule.onNodeWithText(SAVED_TRIPS_TITLE).assertIsDisplayed()
+    }
+
+    @Test
+    fun withSavedTrips_parkRideSectionStillRenders() {
+        composeRule.setContent { ListBody(state = populatedState) }
+
+        composeRule.onNodeWithText(PARK_RIDE_TITLE).assertIsDisplayed()
+    }
+
+    // endregion
+
+    // region Loading
+
+    @Test
+    fun loading_rendersNothing() {
+        composeRule.setContent { ListBody(state = SavedTripsState(isSavedTripsLoading = true)) }
+
+        composeRule.onNodeWithText(SAVED_TRIPS_TITLE).assertDoesNotExist()
+        composeRule.onNodeWithText(PARK_RIDE_TITLE).assertDoesNotExist()
+    }
+
+    // endregion
+
+    @Composable
+    private fun ListBody(
+        state: SavedTripsState,
+        onAddParkRideClick: () -> Unit = {},
+    ) {
+        PreviewTheme {
+            val lazyListState = rememberLazyListState()
+            val reorderState = rememberReorderableLazyListState(lazyListState) { _, _ -> }
+            val expandedMap: SnapshotStateMap<String, Boolean> = remember { mutableStateMapOf() }
+
+            LazyColumn(state = lazyListState) {
+                savedTripsListBody(
+                    savedTripsState = state,
+                    trackedJourney = null,
+                    onEvent = {},
+                    onSavedTripCardClick = { _, _ -> },
+                    onTrackingCardClick = {},
+                    onStopTracking = {},
+                    expandedMap = expandedMap,
+                    editing = false,
+                    reorderState = reorderState,
+                    onEnterEditing = {},
+                    onAddParkRideClick = onAddParkRideClick,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val SAVED_TRIPS_TITLE = "Saved Trips"
+        const val PARK_RIDE_TITLE = "Park & Ride"
+        const val ADD_FIRST_PARK_RIDE = "Add Park & Ride"
+        const val EMPTY_PLACEHOLDER = "Tap ★ on a trip to save it here."
+
+        val emptyState = SavedTripsState(isSavedTripsLoading = false)
+
+        val populatedState = SavedTripsState(
+            isSavedTripsLoading = false,
+            savedTrips = persistentListOf(
+                Trip(
+                    fromStopId = "200060",
+                    fromStopName = "Central Station",
+                    toStopId = "200070",
+                    toStopName = "Town Hall Station",
+                ),
+            ),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideListSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideListSections.kt
@@ -85,8 +85,10 @@ internal fun LazyListScope.stationRows(
 ) {
     item(key = "picker-description") {
         Text(
-            // No em dash in rider-facing copy.
-            text = "Pick any Sydney car park and its live parking shows on your home screen.",
+            // No em dash in rider-facing copy. "Any Sydney car park" overpromised: the list is
+            // only the Park & Ride facilities that report live space counts, not street or
+            // commercial parking, so the copy names what the list actually is.
+            text = "Pick a Park & Ride and its live spaces show on your home screen.",
             style = KrailTheme.typography.bodyMedium,
             color = KrailTheme.colors.softLabel,
             modifier = Modifier

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -106,7 +106,6 @@ fun SavedTripsScreen(
     // entry passes a MapStopSelectionPane (or anything else). Empty slot = blank pane.
     rightPane: @Composable BoxScope.() -> Unit = {},
 ) {
-    val dim = KrailTheme.dimensions
     // Adaptive search-row presentation:
     //   - Phone portrait, tablet, foldable-unfolded: SearchStopRow is ALWAYS expanded —
     //     these form factors have the vertical room, so the full search affordance stays
@@ -188,7 +187,6 @@ fun SavedTripsScreen(
                     savedTripsListBody(
                         savedTripsState = savedTripsState,
                         trackedJourney = trackedJourney,
-                        pageHorizontalPadding = dim.pageHorizontalPadding,
                         onEvent = onEvent,
                         onSavedTripCardClick = onSavedTripCardClick,
                         onTrackingCardClick = onTrackingCardClick,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.unit.Dp
 import kotlinx.collections.immutable.ImmutableList
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_settings
@@ -54,13 +53,12 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
 /**
- * Full LazyColumn body for [SavedTripsScreen] — picks the empty / populated branch and renders the
- * matching content. Pure extraction of the original `when` block; behaviour is identical.
+ * Full LazyColumn body for [SavedTripsScreen]. Info tiles, then the Saved Trips section only
+ * when there is something saved, then Park & Ride which always renders.
  */
 internal fun LazyListScope.savedTripsListBody(
     savedTripsState: SavedTripsState,
     trackedJourney: TrackedJourney?,
-    pageHorizontalPadding: Dp,
     onEvent: (SavedTripUiEvent) -> Unit,
     onSavedTripCardClick: (StopItem?, StopItem?) -> Unit,
     onTrackingCardClick: () -> Unit,
@@ -75,29 +73,10 @@ internal fun LazyListScope.savedTripsListBody(
 
     savedTripsInfoTiles(savedTripsState, onEvent)
 
-    if (savedTripsState.savedTrips.isEmpty()) {
-        // No hero: the bottom search row is already the "plan a trip" affordance, so a
-        // full-page star said nothing the screen was not saying, and pushed the real content
-        // into a corner. Saved Trips and Park & Ride are just two sections, one of which
-        // happens to be empty.
-        stickyHeader(key = "saved_trips_title") {
-            SavedTripsTitle {
-                Text(text = "Saved Trips")
-            }
-        }
-
-        item(key = "saved_trips_empty_row") {
-            Text(
-                text = "Tap ★ on a trip to save it here.",
-                style = KrailTheme.typography.bodyMedium,
-                color = KrailTheme.colors.softLabel,
-                modifier = Modifier
-                    .padding(horizontal = pageHorizontalPadding)
-                    .padding(bottom = KrailTheme.dimensions.spacingXL)
-                    .animateItem(),
-            )
-        }
-    } else {
+    // Nothing saved means no Saved Trips section at all — not a heading over an empty space.
+    // The bottom search row is already the "plan a trip" affordance, so an empty section only
+    // pushed Park & Ride down behind a header that explained nothing.
+    if (savedTripsState.savedTrips.isNotEmpty()) {
         savedTripsContent(
             savedTripsState = savedTripsState,
             trackedJourney = trackedJourney,


### PR DESCRIPTION
## What

With nothing saved, the home screen rendered a "Saved Trips" sticky header over an empty
section and a placeholder row, pushing Park & Ride down the screen. This drops the whole
section when `savedTrips` is empty. Park & Ride is unchanged and still always renders, so
the add card stays reachable before a first trip is saved.

Also retitles the Add Park & Ride picker description, which overstated what the list holds.

## Changes

- `SavedTripsScreenSections.kt`: `savedTripsListBody` now renders `savedTripsContent` only
  when `savedTrips` is not empty. The `"Saved Trips"` sticky header and the
  `"Tap ★ on a trip to save it here."` row are gone.
  - The placeholder row goes with the header rather than staying on its own. Without a
    header above it, it sat directly under the `"Park & Ride"` sticky header and read as
    Park & Ride copy.
  - `parkRideSection` is untouched and still called outside the branch, so the header, any
    cards, the add card and its hint all render in the empty case.
- `AddParkRideListSections.kt`: picker description changes from
  `"Pick any Sydney car park and its live parking shows on your home screen."` to
  `"Pick a Park & Ride and its live spaces show on your home screen."` The list only holds
  Park & Ride facilities that report live space counts, not street or commercial parking.
- `SavedTripsScreen.kt` / `SavedTripsScreenSections.kt`: drops the now-unused
  `pageHorizontalPadding` parameter on `savedTripsListBody`, its call site, the `Dp` import
  and a `val dim` that no longer had a reader.
- New `SavedTripsListBodyTest.kt` (7 tests): section visibility in the empty, populated and
  loading states, plus the add-card click callback.
- `placeholder = "Search"` on the picker's search field is left alone. It is generic and
  does not make a claim about scope.
- The tracking card still lives inside `savedTripsContent`, so a rider tracking a journey
  with zero saved trips does not see it. That behaviour is unchanged by this PR (the old
  empty branch skipped it too) and is left for a separate change.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green, including the 7 new tests
- `./gradlew detekt --rerun-tasks` clean, no auto-corrected files
- `./gradlew compileDebugSources` green
- Installed on a Pixel 10 Pro and checked the empty home screen and the Add Park & Ride
  picker

## Snapshots

Screenshots were reviewed on device during implementation but are not embedded here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJVN8QSe5fNYH5hGo6SEfe
