### PR TITLE
feat(app-review): trigger review on shared delight moments

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/AppReviewDebugProof.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/AppReviewDebugProof.kt
@@ -1,0 +1,79 @@
+package xyz.ksharma.krail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import org.koin.compose.koinInject
+import xyz.ksharma.krail.core.appreview.AppReviewDebugSignal
+import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.ModalBottomSheet
+import xyz.ksharma.krail.taj.components.Text
+import xyz.ksharma.krail.taj.components.TextButton
+import xyz.ksharma.krail.taj.theme.KrailTheme
+
+/**
+ * Debug-only stand-in for the platform review sheet.
+ *
+ * A **sideloaded** debug build can never show the real Play card, and both platforms throttle
+ * and report nothing, so on a device there is otherwise no way to confirm the review trigger
+ * fired. This observes [AppReviewDebugSignal] and shows a sheet naming the [source] moment
+ * whenever a request fires. It is mounted only in debug builds and is **not** the review; the
+ * real platform call still happens alongside it.
+ */
+@Composable
+internal fun AppReviewDebugProof() {
+    val signal: AppReviewDebugSignal = koinInject()
+    var firedSource by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(signal) {
+        signal.requests.collect { firedSource = it }
+    }
+
+    val source = firedSource ?: return
+    val dim = KrailTheme.dimensions
+    ModalBottomSheet(
+        containerColor = KrailTheme.colors.bottomSheetBackground,
+        onDismissRequest = { firedSource = null },
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .systemBarsPadding()
+                .padding(horizontal = dim.spacingXL, vertical = dim.spacingXL),
+            verticalArrangement = Arrangement.spacedBy(dim.spacingM),
+        ) {
+            Text(
+                text = "Review would fire now",
+                style = KrailTheme.typography.headlineMedium,
+                color = KrailTheme.colors.onSurface,
+            )
+            Text(
+                text = "Debug proof only. The real Play or StoreKit sheet is throttled and " +
+                    "never shows on a sideloaded build, so this stands in to confirm the " +
+                    "trigger fired and every gate passed.",
+                style = KrailTheme.typography.bodyLarge,
+                color = KrailTheme.colors.onSurface,
+            )
+            Text(
+                text = "Moment: $source",
+                style = KrailTheme.typography.titleMedium,
+                color = KrailTheme.colors.onSurface,
+            )
+            TextButton(
+                dimensions = ButtonDefaults.largeButtonSize(),
+                onClick = { firedSource = null },
+            ) {
+                Text(text = "Got it")
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -27,6 +27,11 @@ fun KrailApp() {
 
         KrailTheme(themeController = themeController) {
             KrailNavHost()
+
+            // Debug-only proof that the review trigger fired; never composed in release.
+            if (appInfo?.isDebug == true) {
+                AppReviewDebugProof()
+            }
         }
     }
 }

--- a/core/app-review/src/androidHostTest/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManagerTest.kt
+++ b/core/app-review/src/androidHostTest/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManagerTest.kt
@@ -12,7 +12,6 @@ import xyz.ksharma.krail.sandook.LifecycleCounter
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.UserLifecycleStore
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class RealAppReviewManagerTest {
 
@@ -22,6 +21,7 @@ class RealAppReviewManagerTest {
     private lateinit var flag: FakeFlag
     private lateinit var analytics: RecordingAnalytics
     private var now: Long = DAY_ZERO
+    private var savedTrips: Long = 5L
 
     @Before
     fun setup() {
@@ -31,10 +31,11 @@ class RealAppReviewManagerTest {
         flag = FakeFlag()
         analytics = RecordingAnalytics()
 
-        // The default world is an eligible one, so each test changes exactly one thing.
+        // The default world is an eligible one for ask 1, so each test changes one thing.
         flag.setFlagValue(FlagKeys.IN_APP_REVIEW_ENABLED.key, FlagValue.BooleanValue(true))
         preferences.setBoolean(SandookPreferences.KEY_HAS_SEEN_INTRO, true)
         lifecycleStore.installAgeDays = 10L
+        savedTrips = 5L
     }
 
     private fun manager() = RealAppReviewManager(
@@ -43,49 +44,54 @@ class RealAppReviewManagerTest {
         preferences = preferences,
         flag = flag,
         analytics = analytics,
-        nowMillis = { now },
+        savedTripCount = { savedTrips },
     )
 
+    /** Arms a moment and then lands on Saved Trips, which is the pair that can fire a request. */
+    private fun RealAppReviewManager.delightThenLand(
+        moment: DelightMoment = DelightMoment.TIMETABLE_VIEWED,
+    ) {
+        onDelightMoment(moment)
+        onSavedTripsScreenShown()
+    }
+
     @Test
-    fun `requests a review once the open count threshold is reached`() {
-        val manager = manager()
-
-        manager.onSavedTripOpened()
-        manager.onSavedTripOpened()
-        assertEquals(0, requester.requestCount)
-
-        manager.onSavedTripOpened()
+    fun `requests a review on a delight moment when eligible for ask 1`() {
+        manager().delightThenLand()
 
         assertEquals(1, requester.requestCount)
     }
 
     @Test
-    fun `logs review_prompt_requested with the trigger source`() {
-        repeat(THRESHOLD_OPENS) { manager().onSavedTripOpened() }
+    fun `does not request when no delight moment is armed`() {
+        manager().onSavedTripsScreenShown()
 
-        val event = analytics.tracked.filterIsInstance<AnalyticsEvent.ReviewPromptRequestedEvent>()
-        assertEquals(1, event.size)
-        assertEquals("saved_trip_open", event.single().source)
+        assertEquals(0, requester.requestCount)
     }
 
     @Test
-    fun `counts opens even while the feature is switched off`() {
-        flag.setFlagValue(FlagKeys.IN_APP_REVIEW_ENABLED.key, FlagValue.BooleanValue(false))
-        val manager = manager()
+    fun `logs review_prompt_requested with the moment source`() {
+        manager().delightThenLand(DelightMoment.PARK_RIDE_ADDED)
 
-        repeat(THRESHOLD_OPENS) { manager.onSavedTripOpened() }
+        val event = analytics.tracked.filterIsInstance<AnalyticsEvent.ReviewPromptRequestedEvent>()
+        assertEquals(1, event.size)
+        assertEquals("park_ride_added", event.single().source)
+    }
+
+    @Test
+    fun `does not request when the feature is switched off`() {
+        flag.setFlagValue(FlagKeys.IN_APP_REVIEW_ENABLED.key, FlagValue.BooleanValue(false))
+
+        manager().delightThenLand()
 
         assertEquals(0, requester.requestCount)
-        // Switching the flag on later must see the real history, not a reset counter.
-        assertEquals(THRESHOLD_OPENS.toLong(), lifecycleStore.count(LifecycleCounter.SAVED_TRIP_OPEN))
     }
 
     @Test
     fun `does not request during onboarding`() {
         preferences.setBoolean(SandookPreferences.KEY_HAS_SEEN_INTRO, false)
-        val manager = manager()
 
-        repeat(THRESHOLD_OPENS) { manager.onSavedTripOpened() }
+        manager().delightThenLand()
 
         assertEquals(0, requester.requestCount)
     }
@@ -93,9 +99,8 @@ class RealAppReviewManagerTest {
     @Test
     fun `does not request before the account is old enough`() {
         lifecycleStore.installAgeDays = 1L
-        val manager = manager()
 
-        repeat(THRESHOLD_OPENS) { manager.onSavedTripOpened() }
+        manager().delightThenLand()
 
         assertEquals(0, requester.requestCount)
     }
@@ -103,82 +108,101 @@ class RealAppReviewManagerTest {
     @Test
     fun `does not request when the install date was never recorded`() {
         lifecycleStore.installAgeDays = null
-        val manager = manager()
 
-        repeat(THRESHOLD_OPENS) { manager.onSavedTripOpened() }
-
-        assertEquals(0, requester.requestCount)
-    }
-
-    @Test
-    fun `does not request right after a zero result search`() {
-        val manager = manager()
-        repeat(THRESHOLD_OPENS - 1) { manager.onSavedTripOpened() }
-
-        manager.onZeroResultSearch()
-        manager.onSavedTripOpened()
+        manager().delightThenLand()
 
         assertEquals(0, requester.requestCount)
     }
 
     @Test
-    fun `requests again once the zero result suppression window has passed`() {
-        val manager = manager()
-        repeat(THRESHOLD_OPENS - 1) { manager.onSavedTripOpened() }
-        manager.onZeroResultSearch()
+    fun `does not request with fewer than the minimum saved trips`() {
+        savedTrips = 1L
 
-        now = DAY_ZERO + MILLIS_PER_DAY
-        manager.onSavedTripOpened()
+        manager().delightThenLand()
+
+        assertEquals(0, requester.requestCount)
+    }
+
+    @Test
+    fun `consumes the armed moment even when the gates fail`() {
+        val manager = manager()
+        savedTrips = 1L // not yet eligible
+        manager.delightThenLand()
+        assertEquals(0, requester.requestCount)
+
+        // Now eligible, but the earlier moment was already consumed on landing, so a bare
+        // landing with nothing armed must not fire.
+        savedTrips = 5L
+        manager.onSavedTripsScreenShown()
+
+        assertEquals(0, requester.requestCount)
+    }
+
+    @Test
+    fun `does not ask a second time inside the spacing window`() {
+        val manager = manager()
+        manager.delightThenLand() // ask 1
+        assertEquals(1, requester.requestCount)
+
+        now = DAY_ZERO + MILLIS_PER_DAY * 30 // well under the 150-day gap
+        manager.delightThenLand()
 
         assertEquals(1, requester.requestCount)
     }
 
     @Test
-    fun `does not request again inside the cooldown`() {
+    fun `asks a second time once the spacing window has passed`() {
         val manager = manager()
-        repeat(THRESHOLD_OPENS) { manager.onSavedTripOpened() }
-        assertEquals(1, requester.requestCount)
+        manager.delightThenLand() // ask 1
 
-        now = DAY_ZERO + MILLIS_PER_DAY * 30
-        manager.onSavedTripOpened()
-
-        assertEquals(1, requester.requestCount)
-    }
-
-    @Test
-    fun `requests again once the cooldown has elapsed`() {
-        val manager = manager()
-        repeat(THRESHOLD_OPENS) { manager.onSavedTripOpened() }
-
-        now = DAY_ZERO + MILLIS_PER_DAY * (DEFAULT_COOLDOWN_DAYS + 1)
-        manager.onSavedTripOpened()
+        now = DAY_ZERO + MILLIS_PER_DAY * (MIN_DAYS_BETWEEN_ASKS + 1)
+        manager.delightThenLand()
 
         assertEquals(2, requester.requestCount)
     }
 
     @Test
-    fun `remote config thresholds override the defaults`() {
-        flag.setFlagValue(FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS.key, FlagValue.NumberValue(1L))
+    fun `never asks a third time`() {
         val manager = manager()
+        manager.delightThenLand() // ask 1
 
-        manager.onSavedTripOpened()
+        now = DAY_ZERO + MILLIS_PER_DAY * (MIN_DAYS_BETWEEN_ASKS + 1)
+        manager.delightThenLand() // ask 2
+        assertEquals(2, requester.requestCount)
 
-        assertTrue(requester.requestCount == 1)
+        now += MILLIS_PER_DAY * (MIN_DAYS_BETWEEN_ASKS + 1)
+        manager.delightThenLand()
+
+        assertEquals(2, requester.requestCount)
+        assertEquals(2, lifecycleStore.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+    }
+
+    @Test
+    fun `remote config thresholds override the defaults`() {
+        flag.setFlagValue(FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIPS.key, FlagValue.NumberValue(1L))
+        savedTrips = 1L
+
+        manager().delightThenLand()
+
+        assertEquals(1, requester.requestCount)
     }
 
     private companion object {
         const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
         const val DAY_ZERO = 1_700_000_000_000L
-        const val THRESHOLD_OPENS = 3
+        const val MIN_DAYS_BETWEEN_ASKS = 150L
     }
 }
 
 private class FakeAppReviewRequester : AppReviewRequester {
     var requestCount = 0
         private set
+    var lastSource: String? = null
+        private set
 
-    override fun requestReview() {
+    override fun requestReview(source: String) {
         requestCount++
+        lastSource = source
     }
 }
 
@@ -212,4 +236,14 @@ private class FakeUserLifecycleStore(private val nowMillis: () -> Long) : UserLi
 
     override fun count(counter: LifecycleCounter): Long = counts.getOrElse(counter) { 0L }
     override fun lastAtMillis(counter: LifecycleCounter): Long? = lastAt[counter]
+
+    override fun millisSinceLast(counter: LifecycleCounter): Long? {
+        val last = lastAt[counter] ?: return null
+        return nowMillis() - last
+    }
+
+    override fun reset(counter: LifecycleCounter) {
+        counts.remove(counter)
+        lastAt.remove(counter)
+    }
 }

--- a/core/app-review/src/androidHostTest/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManagerTest.kt
+++ b/core/app-review/src/androidHostTest/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManagerTest.kt
@@ -177,16 +177,6 @@ class RealAppReviewManagerTest {
         assertEquals(2, lifecycleStore.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
     }
 
-    @Test
-    fun `remote config thresholds override the defaults`() {
-        flag.setFlagValue(FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIPS.key, FlagValue.NumberValue(1L))
-        savedTrips = 1L
-
-        manager().delightThenLand()
-
-        assertEquals(1, requester.requestCount)
-    }
-
     private companion object {
         const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
         const val DAY_ZERO = 1_700_000_000_000L

--- a/core/app-review/src/androidMain/kotlin/xyz/ksharma/krail/core/appreview/AndroidAppReviewRequester.kt
+++ b/core/app-review/src/androidMain/kotlin/xyz/ksharma/krail/core/appreview/AndroidAppReviewRequester.kt
@@ -16,9 +16,14 @@ import xyz.ksharma.krail.platform.ops.CurrentActivityHolder
 class AndroidAppReviewRequester(
     private val context: Context,
     private val activityHolder: CurrentActivityHolder,
+    private val debugSignal: AppReviewDebugSignal,
 ) : AppReviewRequester {
 
-    override fun requestReview() {
+    override fun requestReview(source: String) {
+        // Proof for on-device testing: a sideloaded debug build can never show the real card,
+        // so a debug composable observes this. Inert in release (nothing subscribes).
+        debugSignal.signalRequested(source)
+
         val activity = activityHolder.current
         if (activity == null) {
             // Backgrounded between the trigger and here. Nothing to attach a card to.

--- a/core/app-review/src/androidMain/kotlin/xyz/ksharma/krail/core/appreview/di/AppReviewModule.android.kt
+++ b/core/app-review/src/androidMain/kotlin/xyz/ksharma/krail/core/appreview/di/AppReviewModule.android.kt
@@ -2,24 +2,31 @@ package xyz.ksharma.krail.core.appreview.di
 
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.appreview.AndroidAppReviewRequester
+import xyz.ksharma.krail.core.appreview.AppReviewDebugSignal
 import xyz.ksharma.krail.core.appreview.AppReviewManager
 import xyz.ksharma.krail.core.appreview.AppReviewRequester
+import xyz.ksharma.krail.core.appreview.RealAppReviewDebugSignal
 import xyz.ksharma.krail.core.appreview.RealAppReviewManager
+import xyz.ksharma.krail.sandook.Sandook
 
 actual val appReviewModule = module {
+    single<AppReviewDebugSignal> { RealAppReviewDebugSignal() }
+
     single<AppReviewRequester> {
-        AndroidAppReviewRequester(context = get(), activityHolder = get())
+        AndroidAppReviewRequester(context = get(), activityHolder = get(), debugSignal = get())
     }
 
-    // Single, not factory: the zero-result-search suppression is in-memory state that has to
-    // be shared between the screen that sets it and the screen that reads it.
+    // Single, not factory: the armed delight moment is in-memory state that must be shared
+    // between the screen that arms it and the Saved Trips screen that fires it.
     single<AppReviewManager> {
+        val sandook = get<Sandook>()
         RealAppReviewManager(
             requester = get(),
             lifecycleStore = get(),
             preferences = get(),
             flag = get(),
             analytics = get(),
+            savedTripCount = { sandook.selectAllTrips().size.toLong() },
         )
     }
 }

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewDebugSignal.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewDebugSignal.kt
@@ -1,0 +1,42 @@
+package xyz.ksharma.krail.core.appreview
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Debug-only proof channel for the review trigger.
+ *
+ * The real review sheet is unobservable: Play throttles it and a **sideloaded** debug build
+ * cannot show it at all, so on a device there is no way to confirm the trigger fired at the
+ * right moment. The requester emits the firing [DelightMoment] source here on every real
+ * request. In debug builds a composable observes this and shows a stand-in sheet as proof; in
+ * release builds nothing subscribes, so it is inert.
+ *
+ * This is a diagnostic, not the review itself. It never replaces the real platform call.
+ */
+interface AppReviewDebugSignal {
+
+    /** Emits the analytics `source` of each fired review request. */
+    val requests: SharedFlow<String>
+
+    /** Records that a review request just fired for [source]. Never throws, never suspends. */
+    fun signalRequested(source: String)
+}
+
+internal class RealAppReviewDebugSignal : AppReviewDebugSignal {
+
+    // Buffered and drop-oldest so an emit with no active subscriber (every release build, and
+    // debug before the observer mounts) never suspends or fails.
+    private val _requests = MutableSharedFlow<String>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    override val requests: SharedFlow<String> = _requests.asSharedFlow()
+
+    override fun signalRequested(source: String) {
+        _requests.tryEmit(source)
+    }
+}

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewManager.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewManager.kt
@@ -1,8 +1,7 @@
 package xyz.ksharma.krail.core.appreview
 
 /**
- * Decides when to ask the platform for a review sheet, and counts the engagement that
- * feeds that decision.
+ * Decides when to ask the platform for a review sheet.
  *
  * ## Why there is no dialog here
  *
@@ -22,23 +21,62 @@ package xyz.ksharma.krail.core.appreview
  * A user-initiated "Rate KRAIL" row in Settings is a different thing and is allowed, because
  * it deep-links to the store listing rather than driving this API.
  *
- * ## What gates a request
+ * ## How the two-ask model works
  *
- * State comes from the user-lifecycle store, policy comes from Remote Config, so thresholds
- * move without a release. See `docs/USER_LIFECYCLE_STORE.md`.
+ * A user is asked **at most twice, ever**. Both asks fire on the same shared set of
+ * [DelightMoment]s and differ only by their gates: ask 1 needs a tenured, invested user; ask
+ * 2 needs a long gap after ask 1. After the second ask, never again. See
+ * `docs/investigations/IN_APP_REVIEW_TIMING.md` for the reasoning.
+ *
+ * The platform never reports whether a sheet was shown or what was rated, so there is no
+ * outcome to react to. Every ask is treated identically and we simply stop after two
+ * well-timed ones.
+ *
+ * ## Arm-then-fire
+ *
+ * A delight moment usually happens on a screen the review sheet should **not** cover (a
+ * timetable, the add-park-ride picker). So [onDelightMoment] only *arms* a pending request;
+ * [onSavedTripsScreenShown] is what actually evaluates the gates and fires, once the user has
+ * landed back on the calm Saved Trips screen. State comes from the user-lifecycle store,
+ * policy comes from Remote Config, so thresholds move without a release.
  */
 interface AppReviewManager {
 
     /**
-     * Records that the user opened a saved trip, and requests a review sheet if that open
-     * made them eligible. Safe to call on every open; it does its own gating.
+     * Records that a positive, completed action just happened, arming a review request to be
+     * evaluated the next time the user lands on the Saved Trips screen. Safe to call on every
+     * such moment; it overwrites any moment still armed, since only the source label differs.
      */
-    fun onSavedTripOpened()
+    fun onDelightMoment(moment: DelightMoment)
 
     /**
-     * Notes that a search just came back empty, which suppresses review requests for a
-     * short window. A rating ask that lands seconds after the app failed to find anything
-     * is asking at the worst possible moment.
+     * The Saved Trips screen became visible. If a [DelightMoment] is armed and every gate
+     * passes, requests the platform review sheet now and consumes the armed moment. A no-op
+     * when nothing is armed, so it is safe to call on every appearance of the screen.
      */
-    fun onZeroResultSearch()
+    fun onSavedTripsScreenShown()
+}
+
+/**
+ * The completed, positive actions that can arm a review request. Each carries the analytics
+ * `source` label recorded on `review_prompt_requested`, so a new moment extends that event
+ * rather than minting a new Firebase event name.
+ *
+ * All four land the user on a calm screen and none is a "rate" button or a mid-task
+ * interruption. That is the whole compliance argument; do not add a moment that fires during
+ * an incomplete task.
+ */
+enum class DelightMoment(val source: String) {
+
+    /** Opened a saved trip, saw its timetable load, and navigated back to Saved Trips. */
+    TIMETABLE_VIEWED("timetable_viewed"),
+
+    /** Saved a trip. */
+    TRIP_SAVED("trip_saved"),
+
+    /** Added a Park and Ride facility. */
+    PARK_RIDE_ADDED("park_ride_added"),
+
+    /** Tapped a Park and Ride card on the Saved Trips screen (armed after a short delay). */
+    PARK_RIDE_CARD_TAPPED("park_ride_card_tapped"),
 }

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewManager.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewManager.kt
@@ -37,8 +37,10 @@ package xyz.ksharma.krail.core.appreview
  * A delight moment usually happens on a screen the review sheet should **not** cover (a
  * timetable, the add-park-ride picker). So [onDelightMoment] only *arms* a pending request;
  * [onSavedTripsScreenShown] is what actually evaluates the gates and fires, once the user has
- * landed back on the calm Saved Trips screen. State comes from the user-lifecycle store,
- * policy comes from Remote Config, so thresholds move without a release.
+ * landed back on the calm Saved Trips screen. State comes from the user-lifecycle store;
+ * the engagement thresholds are app-side constants and only the master on/off gate
+ * (`IN_APP_REVIEW_ENABLED`) comes from Remote Config, so the feature can be armed without a
+ * release.
  */
 interface AppReviewManager {
 

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewRequester.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewRequester.kt
@@ -20,6 +20,9 @@ interface AppReviewRequester {
     /**
      * Requests the platform review sheet. Silent no-op when the platform cannot show one.
      * Never throws: a failed review request must not affect anything the user was doing.
+     *
+     * @param source the [DelightMoment] that prompted this request, used only for logging and
+     *   the debug proof surface. The platform sheet itself carries no KRAIL-authored context.
      */
-    fun requestReview()
+    fun requestReview(source: String)
 }

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewThresholds.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewThresholds.kt
@@ -3,27 +3,28 @@ package xyz.ksharma.krail.core.appreview
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.asBoolean
-import xyz.ksharma.krail.core.remoteconfig.flag.asNumber
 
 /**
- * The policy half of the review trigger: every tunable it reads comes from Remote Config, so
- * thresholds move without a release. The state half lives in the user-lifecycle store.
+ * The policy half of the review trigger. Only the master on/off switch is tunable from Remote
+ * Config so the feature can be armed without a release; the engagement thresholds are fixed
+ * app-side constants, changed by editing them here when needed. The state half lives in the
+ * user-lifecycle store.
  *
  * These sit in their own file rather than on [RealAppReviewManager] so the manager stays under
  * its function limit and the tunables are readable in one place.
  */
 
 /** Saved trips the user must have before ask 1 (`>= this`). */
-internal const val DEFAULT_MIN_SAVED_TRIPS = 2L
+internal const val MIN_SAVED_TRIPS = 2L
 
 /** Minimum install age in days before ask 1. */
-internal const val DEFAULT_MIN_ACCOUNT_AGE_DAYS = 3L
+internal const val MIN_ACCOUNT_AGE_DAYS = 3L
 
 /**
  * Minimum days between ask 1 and ask 2. 150 days is about five months, which keeps both asks
  * comfortably inside the platform's silent per-year quota so neither is wasted against it.
  */
-internal const val DEFAULT_MIN_DAYS_BETWEEN_ASKS = 150L
+internal const val MIN_DAYS_BETWEEN_ASKS = 150L
 
 /**
  * Off unless Remote Config says otherwise, so the trigger stays dormant until it is
@@ -31,15 +32,3 @@ internal const val DEFAULT_MIN_DAYS_BETWEEN_ASKS = 150L
  */
 internal fun Flag.isInAppReviewEnabled(): Boolean =
     getFlagValue(FlagKeys.IN_APP_REVIEW_ENABLED.key).asBoolean(fallback = false)
-
-internal fun Flag.minSavedTrips(): Long =
-    getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIPS.key)
-        .asNumber(fallback = DEFAULT_MIN_SAVED_TRIPS)
-
-internal fun Flag.minAccountAgeDays(): Long =
-    getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS.key)
-        .asNumber(fallback = DEFAULT_MIN_ACCOUNT_AGE_DAYS)
-
-internal fun Flag.minDaysBetweenAsks(): Long =
-    getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS.key)
-        .asNumber(fallback = DEFAULT_MIN_DAYS_BETWEEN_ASKS)

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewThresholds.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/AppReviewThresholds.kt
@@ -13,14 +13,17 @@ import xyz.ksharma.krail.core.remoteconfig.flag.asNumber
  * its function limit and the tunables are readable in one place.
  */
 
-/** Saved-trip opens required before a review sheet is requested. */
-internal const val DEFAULT_MIN_SAVED_TRIP_OPENS = 3L
+/** Saved trips the user must have before ask 1 (`>= this`). */
+internal const val DEFAULT_MIN_SAVED_TRIPS = 2L
 
-/** Minimum install age in days before a review sheet is requested. */
+/** Minimum install age in days before ask 1. */
 internal const val DEFAULT_MIN_ACCOUNT_AGE_DAYS = 3L
 
-/** Days between review requests. */
-internal const val DEFAULT_COOLDOWN_DAYS = 60L
+/**
+ * Minimum days between ask 1 and ask 2. 150 days is about five months, which keeps both asks
+ * comfortably inside the platform's silent per-year quota so neither is wasted against it.
+ */
+internal const val DEFAULT_MIN_DAYS_BETWEEN_ASKS = 150L
 
 /**
  * Off unless Remote Config says otherwise, so the trigger stays dormant until it is
@@ -29,14 +32,14 @@ internal const val DEFAULT_COOLDOWN_DAYS = 60L
 internal fun Flag.isInAppReviewEnabled(): Boolean =
     getFlagValue(FlagKeys.IN_APP_REVIEW_ENABLED.key).asBoolean(fallback = false)
 
-internal fun Flag.minSavedTripOpens(): Long =
-    getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS.key)
-        .asNumber(fallback = DEFAULT_MIN_SAVED_TRIP_OPENS)
+internal fun Flag.minSavedTrips(): Long =
+    getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIPS.key)
+        .asNumber(fallback = DEFAULT_MIN_SAVED_TRIPS)
 
 internal fun Flag.minAccountAgeDays(): Long =
     getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS.key)
         .asNumber(fallback = DEFAULT_MIN_ACCOUNT_AGE_DAYS)
 
-internal fun Flag.reviewCooldownDays(): Long =
-    getFlagValue(FlagKeys.IN_APP_REVIEW_COOLDOWN_DAYS.key)
-        .asNumber(fallback = DEFAULT_COOLDOWN_DAYS)
+internal fun Flag.minDaysBetweenAsks(): Long =
+    getFlagValue(FlagKeys.IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS.key)
+        .asNumber(fallback = DEFAULT_MIN_DAYS_BETWEEN_ASKS)

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManager.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManager.kt
@@ -61,13 +61,13 @@ class RealAppReviewManager(
 
     /** Ask 1: a tenured, invested user. */
     private fun isFirstAskDue(): Boolean =
-        isAccountOldEnough() && savedTripCount() >= flag.minSavedTrips()
+        isAccountOldEnough() && savedTripCount() >= MIN_SAVED_TRIPS
 
     /** Ask 2: a long, deliberate gap after ask 1, keeping both inside the OS quota. */
     private fun isSecondAskDue(): Boolean {
         val millisSinceAsk1 =
             lifecycleStore.millisSinceLast(LifecycleCounter.REVIEW_PROMPT_REQUESTED) ?: return false
-        return millisSinceAsk1 >= flag.minDaysBetweenAsks() * MILLIS_PER_DAY
+        return millisSinceAsk1 >= MIN_DAYS_BETWEEN_ASKS * MILLIS_PER_DAY
     }
 
     /**
@@ -79,7 +79,7 @@ class RealAppReviewManager(
 
     private fun isAccountOldEnough(): Boolean {
         val ageDays = lifecycleStore.daysSinceFirstInstall() ?: return false
-        return ageDays >= flag.minAccountAgeDays()
+        return ageDays >= MIN_ACCOUNT_AGE_DAYS
     }
 
     private companion object {

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManager.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManager.kt
@@ -7,11 +7,10 @@ import xyz.ksharma.krail.core.remoteconfig.flag.Flag
 import xyz.ksharma.krail.sandook.LifecycleCounter
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.UserLifecycleStore
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
 
 /**
- * @param nowMillis injectable clock; production uses the system clock, tests drive it.
+ * @param savedTripCount reads how many trips the user has saved right now. A live count query,
+ *   not a stored counter, so ask 1 gates on what the user actually has.
  */
 class RealAppReviewManager(
     private val requester: AppReviewRequester,
@@ -19,38 +18,57 @@ class RealAppReviewManager(
     private val preferences: SandookPreferences,
     private val flag: Flag,
     private val analytics: Analytics,
-    private val nowMillis: () -> Long = { systemNowMillis() },
+    private val savedTripCount: () -> Long,
 ) : AppReviewManager {
 
-    private var zeroResultSearchAtMillis: Long? = null
+    // In memory on purpose: a delight moment and the landing on Saved Trips that consumes it
+    // are a within-session pair, so process death between them means the landing being guarded
+    // never happened.
+    private var pendingDelightMoment: DelightMoment? = null
 
-    override fun onZeroResultSearch() {
-        zeroResultSearchAtMillis = nowMillis()
+    override fun onDelightMoment(moment: DelightMoment) {
+        pendingDelightMoment = moment
     }
 
-    override fun onSavedTripOpened() {
-        // Counted before the gates so the engagement is recorded even while the feature is
-        // switched off; flipping the flag on later then sees the user's real history.
-        val openCount = lifecycleStore.increment(LifecycleCounter.SAVED_TRIP_OPEN)
+    override fun onSavedTripsScreenShown() {
+        // Consume on arrival whether or not it fires: a landing is a one-time event, and
+        // delight moments recur often enough that spending one on a not-yet-eligible user
+        // costs nothing.
+        val moment = pendingDelightMoment ?: return
+        pendingDelightMoment = null
 
-        if (!isReviewRequestDue(openCount)) return
+        if (!isReviewRequestDue()) return
 
         // Recorded before the call, not after: the platform never reports an outcome, so
-        // "we asked" is the only fact there is, and it is also what drives the cooldown.
+        // "we asked" is the only fact there is. Its count is the lifetime cap and its
+        // last-seen time is the spacing between the two asks.
         lifecycleStore.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
-        analytics.track(AnalyticsEvent.ReviewPromptRequestedEvent(source = SOURCE_SAVED_TRIP_OPEN))
-        log("AppReview: requesting platform review sheet (savedTripOpens=$openCount)")
+        analytics.track(AnalyticsEvent.ReviewPromptRequestedEvent(source = moment.source))
+        log("AppReview: requesting platform review sheet (source=${moment.source})")
 
-        requester.requestReview()
+        requester.requestReview(source = moment.source)
     }
 
-    private fun isReviewRequestDue(openCount: Long): Boolean =
-        flag.isInAppReviewEnabled() &&
-            hasFinishedOnboarding() &&
-            openCount >= flag.minSavedTripOpens() &&
-            isAccountOldEnough() &&
-            isPastCooldown() &&
-            !isAfterZeroResultSearch()
+    private fun isReviewRequestDue(): Boolean {
+        if (!flag.isInAppReviewEnabled()) return false
+        if (!hasFinishedOnboarding()) return false
+        return when (lifecycleStore.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED)) {
+            0L -> isFirstAskDue()
+            1L -> isSecondAskDue()
+            else -> false // Lifetime cap of two asks; never prompt again.
+        }
+    }
+
+    /** Ask 1: a tenured, invested user. */
+    private fun isFirstAskDue(): Boolean =
+        isAccountOldEnough() && savedTripCount() >= flag.minSavedTrips()
+
+    /** Ask 2: a long, deliberate gap after ask 1, keeping both inside the OS quota. */
+    private fun isSecondAskDue(): Boolean {
+        val millisSinceAsk1 =
+            lifecycleStore.millisSinceLast(LifecycleCounter.REVIEW_PROMPT_REQUESTED) ?: return false
+        return millisSinceAsk1 >= flag.minDaysBetweenAsks() * MILLIS_PER_DAY
+    }
 
     /**
      * Apple's guideline is explicit that a review must not be requested during onboarding.
@@ -64,38 +82,8 @@ class RealAppReviewManager(
         return ageDays >= flag.minAccountAgeDays()
     }
 
-    /**
-     * Spaces attempts out rather than firing on every eligible open. The OS throttles too,
-     * but it throttles silently, so without this we would burn the platform quota on
-     * back-to-back requests and never know.
-     */
-    private fun isPastCooldown(): Boolean {
-        val lastRequestedAt =
-            lifecycleStore.lastAtMillis(LifecycleCounter.REVIEW_PROMPT_REQUESTED) ?: return true
-        return nowMillis() - lastRequestedAt >= flag.reviewCooldownDays() * MILLIS_PER_DAY
-    }
-
-    /**
-     * [zeroResultSearchAtMillis] is in memory on purpose: this guards against a request
-     * landing seconds after a failed search, which is a within-session concern. Process
-     * death clearing it is fine, because a search and a saved-trip open separated by a
-     * process death were never the adjacent pair being guarded against.
-     */
-    private fun isAfterZeroResultSearch(): Boolean {
-        val searchedAt = zeroResultSearchAtMillis ?: return false
-        return nowMillis() - searchedAt < ZERO_RESULT_SUPPRESSION_MILLIS
-    }
-
-    companion object {
-
-        private const val SOURCE_SAVED_TRIP_OPEN = "saved_trip_open"
+    private companion object {
 
         private const val MILLIS_PER_DAY = 24L * 60L * 60L * 1000L
-
-        // How long a zero-result search keeps blocking a request.
-        private const val ZERO_RESULT_SUPPRESSION_MILLIS = 5L * 60L * 1000L
-
-        @OptIn(ExperimentalTime::class)
-        private fun systemNowMillis(): Long = Clock.System.now().toEpochMilliseconds()
     }
 }

--- a/core/app-review/src/iosMain/kotlin/xyz/ksharma/krail/core/appreview/IosAppReviewRequester.kt
+++ b/core/app-review/src/iosMain/kotlin/xyz/ksharma/krail/core/appreview/IosAppReviewRequester.kt
@@ -11,9 +11,14 @@ import xyz.ksharma.krail.core.log.log
  * iOS shows the rating alert at most a few times per year per user and reports nothing back,
  * so a call here is a request, never a guarantee.
  */
-class IosAppReviewRequester : AppReviewRequester {
+class IosAppReviewRequester(
+    private val debugSignal: AppReviewDebugSignal,
+) : AppReviewRequester {
 
-    override fun requestReview() {
+    override fun requestReview(source: String) {
+        // Proof for on-device testing; inert in release (nothing subscribes).
+        debugSignal.signalRequested(source)
+
         // StoreKit presents UI, so it has to be asked on the main thread.
         NSOperationQueue.mainQueue.addOperationWithBlock {
             val windowScene = UIApplication.sharedApplication.keyWindow?.windowScene

--- a/core/app-review/src/iosMain/kotlin/xyz/ksharma/krail/core/appreview/di/AppReviewModule.ios.kt
+++ b/core/app-review/src/iosMain/kotlin/xyz/ksharma/krail/core/appreview/di/AppReviewModule.ios.kt
@@ -1,23 +1,30 @@
 package xyz.ksharma.krail.core.appreview.di
 
 import org.koin.dsl.module
+import xyz.ksharma.krail.core.appreview.AppReviewDebugSignal
 import xyz.ksharma.krail.core.appreview.AppReviewManager
 import xyz.ksharma.krail.core.appreview.AppReviewRequester
 import xyz.ksharma.krail.core.appreview.IosAppReviewRequester
+import xyz.ksharma.krail.core.appreview.RealAppReviewDebugSignal
 import xyz.ksharma.krail.core.appreview.RealAppReviewManager
+import xyz.ksharma.krail.sandook.Sandook
 
 actual val appReviewModule = module {
-    single<AppReviewRequester> { IosAppReviewRequester() }
+    single<AppReviewDebugSignal> { RealAppReviewDebugSignal() }
 
-    // Single, not factory: the zero-result-search suppression is in-memory state that has to
-    // be shared between the screen that sets it and the screen that reads it.
+    single<AppReviewRequester> { IosAppReviewRequester(debugSignal = get()) }
+
+    // Single, not factory: the armed delight moment is in-memory state that must be shared
+    // between the screen that arms it and the Saved Trips screen that fires it.
     single<AppReviewManager> {
+        val sandook = get<Sandook>()
         RealAppReviewManager(
             requester = get(),
             lifecycleStore = get(),
             preferences = get(),
             flag = get(),
             analytics = get(),
+            savedTripCount = { sandook.selectAllTrips().size.toLong() },
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -172,18 +172,6 @@ object RemoteConfigDefaults {
                 first = FlagKeys.IN_APP_REVIEW_ENABLED.key,
                 second = false,
             ),
-            Pair(
-                first = FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIPS.key,
-                second = 2,
-            ),
-            Pair(
-                first = FlagKeys.IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS.key,
-                second = 3,
-            ),
-            Pair(
-                first = FlagKeys.IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS.key,
-                second = 150,
-            ),
         )
     }
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -173,16 +173,16 @@ object RemoteConfigDefaults {
                 second = false,
             ),
             Pair(
-                first = FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS.key,
-                second = 3,
+                first = FlagKeys.IN_APP_REVIEW_MIN_SAVED_TRIPS.key,
+                second = 2,
             ),
             Pair(
                 first = FlagKeys.IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS.key,
                 second = 3,
             ),
             Pair(
-                first = FlagKeys.IN_APP_REVIEW_COOLDOWN_DAYS.key,
-                second = 60,
+                first = FlagKeys.IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS.key,
+                second = 150,
             ),
         )
     }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -89,10 +89,11 @@ enum class FlagKeys(val key: String) {
     IN_APP_REVIEW_ENABLED("in_app_review_enabled"),
 
     /**
-     * Saved-trip opens required before a review sheet is requested. Defaults to
-     * `DEFAULT_MIN_SAVED_TRIP_OPENS` in `:core:app-review` when missing or malformed.
+     * Saved trips the user must have before the first review ask (`>= this`). A live count of
+     * the saved-trip table, not a stored counter. Defaults to `DEFAULT_MIN_SAVED_TRIPS` in
+     * `:core:app-review` when missing or malformed.
      */
-    IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS("in_app_review_min_saved_trip_opens"),
+    IN_APP_REVIEW_MIN_SAVED_TRIPS("in_app_review_min_saved_trips"),
 
     /**
      * Minimum install age in days before a review sheet is requested, read from the
@@ -102,9 +103,9 @@ enum class FlagKeys(val key: String) {
     IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS("in_app_review_min_account_age_days"),
 
     /**
-     * Days between review requests. Both platforms throttle silently, so without a
-     * client-side cooldown the platform quota gets spent on back-to-back requests with no
-     * way to observe it. Defaults to `DEFAULT_COOLDOWN_DAYS` in `:core:app-review`.
+     * Minimum days between the first review ask and the second (and final) one. About five
+     * months by default, which keeps both asks inside the platform's silent per-year quota.
+     * Defaults to `DEFAULT_MIN_DAYS_BETWEEN_ASKS` in `:core:app-review`.
      */
-    IN_APP_REVIEW_COOLDOWN_DAYS("in_app_review_cooldown_days"),
+    IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS("in_app_review_min_days_between_asks"),
 }

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -87,25 +87,4 @@ enum class FlagKeys(val key: String) {
      * deep-links to the store listing and is unaffected.
      */
     IN_APP_REVIEW_ENABLED("in_app_review_enabled"),
-
-    /**
-     * Saved trips the user must have before the first review ask (`>= this`). A live count of
-     * the saved-trip table, not a stored counter. Defaults to `DEFAULT_MIN_SAVED_TRIPS` in
-     * `:core:app-review` when missing or malformed.
-     */
-    IN_APP_REVIEW_MIN_SAVED_TRIPS("in_app_review_min_saved_trips"),
-
-    /**
-     * Minimum install age in days before a review sheet is requested, read from the
-     * user-lifecycle store (`docs/USER_LIFECYCLE_STORE.md`). Defaults to
-     * `DEFAULT_MIN_ACCOUNT_AGE_DAYS` in `:core:app-review` when missing or malformed.
-     */
-    IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS("in_app_review_min_account_age_days"),
-
-    /**
-     * Minimum days between the first review ask and the second (and final) one. About five
-     * months by default, which keeps both asks inside the platform's silent per-year quota.
-     * Defaults to `DEFAULT_MIN_DAYS_BETWEEN_ASKS` in `:core:app-review`.
-     */
-    IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS("in_app_review_min_days_between_asks"),
 }

--- a/docs/investigations/IN_APP_REVIEW_TIMING.md
+++ b/docs/investigations/IN_APP_REVIEW_TIMING.md
@@ -1,0 +1,302 @@
+# In-app review: trigger placement and timing
+
+Working notes for the in-app review request (issue #1739, built on the user-lifecycle
+store from #1742). The plumbing is built and the trigger described in **FINAL DESIGN**
+below is now implemented. Read this before enabling the feature or changing the trigger.
+
+## Status
+
+Four branches, stacked, not yet raised as PRs:
+
+| Branch | Contains |
+|---|---|
+| `user-lifecycle-store` | `:sandook` `UserLifecycleStore`: install date, named counters, migration `12.sqm` |
+| `app-review-wrapper` | `:core:app-review` module, `AppReviewRequester`, Android and iOS implementations, `CurrentActivityHolder` |
+| `app-review-eligibility` | `RealAppReviewManager` two-ask gates, Remote Config keys, `review_prompt_requested` event |
+| `app-review-trigger` | The shared delight-moment trigger wired into `SavedTripsViewModel`, `TimeTableViewModel`, and `AddParkRideViewModel` |
+
+All four compile on Android and iOS, pass detekt, and have green tests. The feature is
+inert: `in_app_review_enabled` defaults to `false`.
+
+## FINAL DESIGN (decided 2026-07-24, supersedes the analysis below)
+
+The trigger is settled. The analysis further down records how it was reached; this section
+is the spec to build. The next session codes this fresh, reusing the store, the wrapper,
+and the gate infrastructure, and deleting the logic listed under "To delete".
+
+**Ask at most twice per user, ever. Then never again.**
+
+Both asks fire on the **same shared set of delight moments**. They differ only by their
+gates. This is deliberate: one moment-set and two gate-sets is less code than two separate
+triggers, and it means no user is stranded waiting for a specific moment they never reach.
+
+### Delight moments (any one of these)
+
+- **A**: user opened a saved trip, viewed the timetable, and navigated **back** to the
+  Saved Trips screen. Prompt fires on arrival at Saved Trips, not on the timetable.
+- **B**: user saved a trip and arrived on the Saved Trips screen.
+- **C**: user added a Park and Ride facility (the park-ride picker feature, now on `main`)
+  and arrived on the Saved Trips screen.
+- **D**: user tapped a Park and Ride card, and 3 seconds elapsed (delay so the prompt is
+  not in the same frame as the tap).
+
+All four are completed positive actions landing on a calm screen. None is a "rate" button,
+none interrupts a pending task.
+
+### Ask 1 (first prompt)
+
+Any delight moment above, when all of these hold:
+
+- `in_app_review_enabled` is on
+- onboarding finished (`KEY_HAS_SEEN_INTRO`)
+- install age greater than 3 days
+- user has 2 or more saved trips
+- lifetime asks so far is 0
+
+### Ask 2 (second and final prompt)
+
+Any delight moment above, when both hold:
+
+- at least 5 months since ask 1
+- lifetime asks so far is 1
+
+After ask 2, never prompt again. Lifetime cap is 2.
+
+Note the earlier "first save is a bad moment" caveat does **not** apply to moment B here:
+by the time B can fire, the user already has 2+ saved trips and (for ask 2) 5+ months of
+tenure, so a save is an engaged user's action, not a day-one visitor's.
+
+### Why these numbers
+
+- **Two asks, lifetime**: we cannot detect whether a prompt was shown, dismissed, or
+  rated, so we treat every ask identically and simply stop after two well-timed ones. A
+  user who has not rated after two good moments will not.
+- **5 months**: spaces the two asks to well within Apple's roughly 3-per-year ceiling, so
+  we never waste a request against the silent OS throttle.
+- **2 saved trips + day 3**: investment plus tenure, so the asker is an engaged user, not
+  a day-one visitor who cannot judge the app yet.
+- **Completed moments only (moments A to D above)**: never mid-task. A transit user is
+  often walking to a platform; interrupting that is how you earn a one-star.
+- **Shared moment-set for both asks**: closes the gap where a user who never taps a Park
+  and Ride card would otherwise never reach ask 2. Whatever positive moment they hit first
+  after the 5-month gate fires it.
+
+### Deleted in the rework (done)
+
+- `SavedTripsViewModel.onSavedTripCardClick` no longer calls the review manager (the tap
+  trigger was the wrong moment).
+- `SearchStopViewModel`'s `onZeroResultSearch()` call and the whole zero-result suppression
+  gate are gone. Search has nothing to do with this feature.
+- The `SAVED_TRIP_OPEN` lifecycle counter is removed; ask 1 gates on saved-trip *count*, a
+  `SavedTrip` table query (`savedTripCount` provider), not an open counter.
+- `IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS` and `IN_APP_REVIEW_COOLDOWN_DAYS` Remote Config keys
+  are replaced by `IN_APP_REVIEW_MIN_SAVED_TRIPS` (default 2) and
+  `IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS` (default 150, about five months).
+
+### Reused as-is
+
+- `UserLifecycleStore` install date and the `REVIEW_PROMPT_REQUESTED` counter: its count is
+  the lifetime cap of 2, its last-seen time is the 5-month spacing.
+- `AppReviewRequester`, both platform implementations, `CurrentActivityHolder`.
+- `RealAppReviewManager` structure and `review_prompt_requested` (new `source` values, one
+  per [`DelightMoment`], extend the event rather than minting new names).
+
+## Architecture
+
+All decision logic lives in `:core:app-review`. Feature code calls two methods and knows
+no rules, so the ruleset can be replaced without touching any screen.
+
+```
+:core:app-review
+  AppReviewManager.kt       interface + why-no-dialog rationale
+  RealAppReviewManager.kt   the gates
+  AppReviewThresholds.kt    Remote Config readers and default values
+  AppReviewRequester.kt     platform contract, no logic
+  androidMain/iosMain       Play In-App Review, StoreKit
+```
+
+Supporting split: `:sandook` owns **state** (what happened), `:core:remote-config` owns
+**policy** (the numbers), `:core:app-review` owns **the decision**. Do not add threshold
+constants to the store; that is the boundary violation to reject in review.
+
+## Compliance constraints (not negotiable)
+
+Both stores forbid the custom pre-prompt plus sentiment gate pattern:
+
+- **Google Play In-App Review policy**: no custom prompt or question before the API, no
+  gating by sentiment, no triggering from a button.
+- **Apple HIG (Ratings and reviews) and Guideline 1.1.7**: not in response to a button
+  tap, no custom prompt that mimics or precedes the system alert, only after demonstrated
+  engagement, never during onboarding.
+
+Consequence: there is no KRAIL-authored dialog anywhere in this feature. The rationale is
+duplicated in `AppReviewManager`'s KDoc so a later change has to read it before removing
+it.
+
+## Implemented gates
+
+A [`DelightMoment`] arms a request; landing on Saved Trips (`onSavedTripsScreenShown`)
+evaluates the gates and, if they pass, fires. The armed moment is consumed on every landing
+whether or not it fires, so a not-yet-eligible user simply spends that moment and re-arms on
+the next one.
+
+Common gates (both asks):
+
+| Gate | Default | Source |
+|---|---|---|
+| Feature enabled | `false` | `IN_APP_REVIEW_ENABLED` |
+| Onboarding finished | n/a | `KEY_HAS_SEEN_INTRO` |
+
+Then, by how many times the user has been asked (`REVIEW_PROMPT_REQUESTED` count):
+
+| Prior asks | Fires when | Tunable |
+|---|---|---|
+| 0 (ask 1) | install age ≥ N days **and** saved-trip count ≥ M | `IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS` (3), `IN_APP_REVIEW_MIN_SAVED_TRIPS` (2) |
+| 1 (ask 2) | ≥ D days since ask 1 | `IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS` (150) |
+| 2 or more | never | lifetime cap, hardcoded |
+
+The lifetime cap of two is deliberately not a Remote Config dial: it is the premise of the
+design (the platform reports no outcome, so we stop after two well-timed asks), not a knob.
+
+## Timing analysis
+
+### Reframe: do not try to detect delight
+
+Delight is not observable. Dwell time is ambiguous: thirty seconds on a timetable means
+"reading calmly" or "cannot find my train", and those are indistinguishable from
+instrumentation. Guessing wrong produces exactly the low rating the feature is meant to
+avoid.
+
+Frustration, by contrast, is precisely observable. So invert the design: **fire on a calm,
+neutral moment and suppress hard on any recent friction.**
+
+Friction signals available:
+
+| Signal | Wired up? |
+|---|---|
+| Zero-result search | yes, gate 6 |
+| API error or retry tapped | no |
+| Departures failed to load | no |
+| Rapid re-search (several queries in a minute) | no |
+| Tracking dropped out | no |
+| Empty trip results | no |
+
+There is also a domain-specific pressure most apps do not have: transit users are
+frequently walking to a platform. Being in a hurry is the default state, not the
+exception.
+
+### Candidate moments
+
+| Moment | Intent pending | Likely rushed | Verdict |
+|---|---|---|---|
+| Saved-trip card tap (current) | yes | yes | worst case |
+| 30s dwell on timetable | no | yes | dwell is not delight, likely mid-commute |
+| Back from timetable | no | yes | better, but the user is now moving |
+| Park and Ride card expand plus 5 to 10s | partly | no | discretionary so unhurried, but rare and mid-decision |
+| Return to Saved Trips after a clean timetable view | no | lower | best candidate |
+| Cold start, lands on home, idles, does not drill in | no | no | calmest, weakest engagement evidence |
+| Just saved a new trip | no | no | investment signal, but often a first-ever action |
+
+### Leading proposal
+
+User opens a saved trip, the timetable loads without error, they dwell past a floor
+(around 10s), they navigate back, and the request fires roughly 2s later while they are on
+the Saved Trips screen.
+
+Rationale: intent is satisfied, there is evidence the app worked, and the sheet lands on a
+calm screen rather than on top of live departure data. The post-navigation delay matters as
+much as the placement; never fire in the same frame as a navigation.
+
+Park and Ride expand is a sound secondary trigger later. It is a discretionary action, so
+the user is not under time pressure. It is too infrequent to be primary. If added, reuse
+`review_prompt_requested` with a different `source` value rather than minting a new event
+name (Firebase caps the app at 500 event names, forever).
+
+### This cannot be A/B tested
+
+Neither platform reports whether the sheet appeared or what was submitted. There is no
+outcome signal to optimise against. What is actually available:
+
+- Aggregate store rating volume and average from Play Console and App Store Connect, which
+  is laggy, noisy, and confounded by releases.
+- A proxy: whether the session continued normally after `review_prompt_requested` fired.
+
+Practical consequence: choose placement by principle, roll out slowly behind the flag, and
+read aggregate store data over weeks rather than days. Treat it as a design decision, not
+an experiment.
+
+## Where the trigger lives
+
+The module boundary keeps each caller to one or two lines:
+
+- `AppReviewManager.onDelightMoment(moment)` arms a request; each [`DelightMoment`] carries
+  its own analytics `source`.
+- `AppReviewManager.onSavedTripsScreenShown()` evaluates the gates and fires.
+
+Callers:
+
+- `TimeTableViewModel` arms `TIMETABLE_VIEWED` on a clean load and `TRIP_SAVED` on either
+  save path (star toggle and the save-trip prompt).
+- `AddParkRideViewModel` arms `PARK_RIDE_ADDED` when a facility is added.
+- `SavedTripsViewModel` fires on every arrival at the screen (`onSavedTripsScreenShown`), and
+  arms + fires `PARK_RIDE_CARD_TAPPED` after a 3-second delay on a Park and Ride card tap.
+
+## Testing on device
+
+The feature is gated, so first relax the gates in Remote Config:
+
+```
+in_app_review_enabled                true
+in_app_review_min_saved_trips        1
+in_app_review_min_account_age_days   0
+in_app_review_min_days_between_asks  0
+```
+
+A fresh install cannot otherwise trigger it, because the default minimum install age is
+three days and the default minimum saved trips is two. Also finish the intro, then hit one
+of the delight moments (save a trip, view a timetable and return, add a Park and Ride
+facility, or tap a Park and Ride card).
+
+| Build | Behaviour |
+|---|---|
+| iOS run from Xcode (debug) | StoreKit alert shows every time, no throttle. This is the real visual test. |
+| iOS TestFlight | Never shows. Apple disables it there. |
+| iOS App Store | Throttled, roughly three times a year. |
+| Android sideloaded (`installDebug`) | `requestReviewFlow()` fails because the install did not come from Play. Logs and returns. No card. |
+| Android internal testing or internal app sharing | Real card, subject to Play quota. |
+
+Android:
+
+```sh
+./gradlew :androidApp:installDebug
+adb logcat -c && adb logcat | grep -i AppReview
+```
+
+Expect `AppReview: requesting platform review sheet`, which proves every gate passed,
+followed by a `requestReviewFlow failed` line, which is normal for a sideloaded build and
+is not a defect.
+
+iOS: open `iosApp/iosApp.xcodeproj` and run from Xcode.
+
+An unbuilt convenience: adding review overrides to the existing debug-only
+`DebugConfigScreen` would replace the Remote Config round trip with an on-device toggle,
+including a bypass-all-gates action.
+
+## Migration numbering
+
+`12.sqm` is used rather than `11.sqm` because a parallel park-ride branch already claims
+`11`. The two migrations create different tables, so they are independent and safe in
+either order, and `UserLifecycleStoreTest` covers the upgrade path explicitly. If merge
+order changes so that this lands first, renumber to `11` rather than leaving a permanent
+gap in the sequence.
+
+## Open decisions
+
+1. **Trigger placement is resolved** (FINAL DESIGN above) and implemented. What remains is a
+   judgement call on *enabling* it: turn the flag on for a slice, then read aggregate store
+   ratings over weeks, since neither platform reports whether a sheet showed.
+2. **Settings rows are not built.** Issue #1739 also asks for a user-initiated "Rate KRAIL"
+   store deep link and an optional "Send feedback" mailto row. These are allowed because they
+   are user-initiated and open the store rather than driving the API.
+3. **Debug Config overrides are not built.** On-device toggles to bypass the gates would
+   replace the Remote Config round trip during QA.

--- a/docs/investigations/IN_APP_REVIEW_TIMING.md
+++ b/docs/investigations/IN_APP_REVIEW_TIMING.md
@@ -90,8 +90,9 @@ tenure, so a save is an engaged user's action, not a day-one visitor's.
 - The `SAVED_TRIP_OPEN` lifecycle counter is removed; ask 1 gates on saved-trip *count*, a
   `SavedTrip` table query (`savedTripCount` provider), not an open counter.
 - `IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS` and `IN_APP_REVIEW_COOLDOWN_DAYS` Remote Config keys
-  are replaced by `IN_APP_REVIEW_MIN_SAVED_TRIPS` (default 2) and
-  `IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS` (default 150, about five months).
+  are replaced by the app-side constants `MIN_SAVED_TRIPS` (2) and `MIN_DAYS_BETWEEN_ASKS`
+  (150, about five months) in `AppReviewThresholds.kt`. These are no longer Remote Config
+  tunables: only `IN_APP_REVIEW_ENABLED` remains on Remote Config, as the master on/off gate.
 
 ### Reused as-is
 
@@ -149,11 +150,14 @@ Common gates (both asks):
 
 Then, by how many times the user has been asked (`REVIEW_PROMPT_REQUESTED` count):
 
-| Prior asks | Fires when | Tunable |
+| Prior asks | Fires when | Threshold (app-side constant) |
 |---|---|---|
-| 0 (ask 1) | install age ≥ N days **and** saved-trip count ≥ M | `IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS` (3), `IN_APP_REVIEW_MIN_SAVED_TRIPS` (2) |
-| 1 (ask 2) | ≥ D days since ask 1 | `IN_APP_REVIEW_MIN_DAYS_BETWEEN_ASKS` (150) |
+| 0 (ask 1) | install age ≥ N days **and** saved-trip count ≥ M | `MIN_ACCOUNT_AGE_DAYS` (3), `MIN_SAVED_TRIPS` (2) |
+| 1 (ask 2) | ≥ D days since ask 1 | `MIN_DAYS_BETWEEN_ASKS` (150) |
 | 2 or more | never | lifetime cap, hardcoded |
+
+The engagement thresholds are fixed constants in `AppReviewThresholds.kt`, not Remote Config
+dials. Only `IN_APP_REVIEW_ENABLED` is tunable from Remote Config.
 
 The lifetime cap of two is deliberately not a Remote Config dial: it is the premise of the
 design (the platform reports no outcome, so we stop after two well-timed asks), not a knob.

--- a/feature/debug-settings/ui/build.gradle.kts
+++ b/feature/debug-settings/ui/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
                 implementation(projects.core.remoteConfig)
                 implementation(projects.feature.debugSettings.state)
                 implementation(projects.feature.debugSettings.store)
+                implementation(projects.sandook)
                 implementation(projects.taj)
 
                 implementation(libs.compose.foundation)

--- a/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugConfigScreen.kt
+++ b/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugConfigScreen.kt
@@ -39,6 +39,7 @@ fun DebugConfigScreen(
     onAddressSearchToggle: (Boolean) -> Unit = {},
     onBackClick: () -> Unit = {},
     onNetworkClick: () -> Unit = {},
+    onResetReviewClick: () -> Unit = {},
 ) {
     Box(
         modifier = modifier
@@ -77,6 +78,13 @@ fun DebugConfigScreen(
                         subtitle = "Override SEARCH_STOP_ADDRESS_SEARCH_ENABLED RC flag.",
                         checked = addressSearchEnabled,
                         onCheckedChange = onAddressSearchToggle,
+                    )
+                }
+                item(key = "tile-reset-review") {
+                    DebugConfigTile(
+                        title = "Reset in-app review",
+                        subtitle = "Clear the 'already asked' count so it can fire again. Keeps the install date.",
+                        onClick = onResetReviewClick,
                     )
                 }
             }

--- a/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsViewModel.kt
+++ b/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsViewModel.kt
@@ -15,6 +15,8 @@ import xyz.ksharma.krail.feature.debug.settings.state.DebugSettingsEvent
 import xyz.ksharma.krail.feature.debug.settings.state.DebugSettingsState
 import xyz.ksharma.krail.feature.debug.settings.state.NetworkSource
 import xyz.ksharma.krail.feature.debug.settings.store.DebugNetworkConfigStore
+import xyz.ksharma.krail.sandook.LifecycleCounter
+import xyz.ksharma.krail.sandook.UserLifecycleStore
 
 /**
  * Shared ViewModel for the Debug Config screens.
@@ -27,6 +29,7 @@ import xyz.ksharma.krail.feature.debug.settings.store.DebugNetworkConfigStore
 class DebugSettingsViewModel(
     private val store: DebugNetworkConfigStore,
     private val flag: Flag,
+    private val userLifecycleStore: UserLifecycleStore,
 ) : ViewModel() {
 
     private val _bffEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
@@ -61,6 +64,16 @@ class DebugSettingsViewModel(
 
     fun reset() {
         onEvent(DebugSettingsEvent.Reset)
+    }
+
+    /**
+     * Clears the "already asked for review" count so the in-app review can fire again while
+     * testing. Deliberately keeps the install date, so age-based gates stay realistic.
+     */
+    fun resetInAppReviewAsks() {
+        viewModelScope.launch {
+            userLifecycleStore.reset(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
+        }
     }
 
     private fun refreshLiveFlag() {

--- a/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/navigation/DebugConfigEntries.kt
+++ b/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/navigation/DebugConfigEntries.kt
@@ -40,6 +40,7 @@ fun EntryProviderScope<NavKey>.DebugConfigEntries(
             onAddressSearchToggle = viewModel::setAddressSearchEnabled,
             onBackClick = onBack,
             onNetworkClick = onNavigateToNetwork,
+            onResetReviewClick = viewModel::resetInAppReviewAsks,
         )
     }
 

--- a/feature/debug-settings/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsViewModelTest.kt
+++ b/feature/debug-settings/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsViewModelTest.kt
@@ -17,6 +17,8 @@ import xyz.ksharma.krail.feature.debug.settings.state.DebugSettingsEvent
 import xyz.ksharma.krail.feature.debug.settings.state.DebugSettingsState
 import xyz.ksharma.krail.feature.debug.settings.state.NetworkSource
 import xyz.ksharma.krail.feature.debug.settings.store.DebugNetworkConfigStore
+import xyz.ksharma.krail.sandook.LifecycleCounter
+import xyz.ksharma.krail.sandook.UserLifecycleStore
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -45,7 +47,11 @@ class DebugSettingsViewModelTest {
     @Test
     fun `Given default state When selectSource BFF_PROD Then store receives event`() = runTest {
         val store = FakeDebugStore()
-        val viewModel = DebugSettingsViewModel(store = store, flag = FakeFlag(false))
+        val viewModel = DebugSettingsViewModel(
+            store = store,
+            flag = FakeFlag(false),
+            userLifecycleStore = FakeUserLifecycleStore(),
+        )
 
         viewModel.selectSource(NetworkSource.BFF_PROD)
 
@@ -58,7 +64,11 @@ class DebugSettingsViewModelTest {
     @Test
     fun `Given default state When selectSource NSW_DIRECT Then store receives event`() = runTest {
         val store = FakeDebugStore()
-        val viewModel = DebugSettingsViewModel(store = store, flag = FakeFlag(false))
+        val viewModel = DebugSettingsViewModel(
+            store = store,
+            flag = FakeFlag(false),
+            userLifecycleStore = FakeUserLifecycleStore(),
+        )
 
         viewModel.selectSource(NetworkSource.NSW_DIRECT)
 
@@ -71,7 +81,11 @@ class DebugSettingsViewModelTest {
     @Test
     fun `Given live RC value true When state collected Then bffEnabled emits true`() = runTest {
         val store = FakeDebugStore()
-        val viewModel = DebugSettingsViewModel(store = store, flag = FakeFlag(true))
+        val viewModel = DebugSettingsViewModel(
+            store = store,
+            flag = FakeFlag(true),
+            userLifecycleStore = FakeUserLifecycleStore(),
+        )
 
         // Subscribe to state to trigger onStart, which refreshes bffEnabled.
         viewModel.state.test {
@@ -85,7 +99,11 @@ class DebugSettingsViewModelTest {
     @Test
     fun `Given live RC value false When state collected Then bffEnabled emits false`() = runTest {
         val store = FakeDebugStore()
-        val viewModel = DebugSettingsViewModel(store = store, flag = FakeFlag(false))
+        val viewModel = DebugSettingsViewModel(
+            store = store,
+            flag = FakeFlag(false),
+            userLifecycleStore = FakeUserLifecycleStore(),
+        )
 
         viewModel.state.test {
             awaitItem()
@@ -98,11 +116,58 @@ class DebugSettingsViewModelTest {
     @Test
     fun `Given default state When reset called Then store receives Reset event`() = runTest {
         val store = FakeDebugStore()
-        val viewModel = DebugSettingsViewModel(store = store, flag = FakeFlag(false))
+        val viewModel = DebugSettingsViewModel(
+            store = store,
+            flag = FakeFlag(false),
+            userLifecycleStore = FakeUserLifecycleStore(),
+        )
 
         viewModel.reset()
 
         assertEquals(DebugSettingsEvent.Reset, store.lastEvent)
+    }
+
+    @Test
+    fun `resetInAppReviewAsks clears the review counter but keeps the install date`() = runTest {
+        val lifecycleStore = FakeUserLifecycleStore()
+        lifecycleStore.recordFirstInstallIfAbsent()
+        lifecycleStore.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
+        val viewModel = DebugSettingsViewModel(
+            store = FakeDebugStore(),
+            flag = FakeFlag(false),
+            userLifecycleStore = lifecycleStore,
+        )
+
+        viewModel.resetInAppReviewAsks()
+
+        assertEquals(0L, lifecycleStore.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        assertEquals(true, lifecycleStore.firstInstallAtMillis() != null)
+    }
+}
+
+private class FakeUserLifecycleStore : UserLifecycleStore {
+    private var installAtMillis: Long? = null
+    private val counts = mutableMapOf<LifecycleCounter, Long>()
+
+    override fun recordFirstInstallIfAbsent() {
+        if (installAtMillis == null) installAtMillis = 0L
+    }
+
+    override fun firstInstallAtMillis(): Long? = installAtMillis
+    override fun daysSinceFirstInstall(): Long? = installAtMillis?.let { 0L }
+
+    override fun increment(counter: LifecycleCounter): Long {
+        val next = counts.getOrElse(counter) { 0L } + 1
+        counts[counter] = next
+        return next
+    }
+
+    override fun count(counter: LifecycleCounter): Long = counts.getOrElse(counter) { 0L }
+    override fun lastAtMillis(counter: LifecycleCounter): Long? = null
+    override fun millisSinceLast(counter: LifecycleCounter): Long? = null
+
+    override fun reset(counter: LifecycleCounter) {
+        counts.remove(counter)
     }
 }
 

--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
                 implementation(projects.core.snapshotTestingAnnotations)
                 implementation(projects.core.adaptiveUi)
                 implementation(projects.core.appInfo)
+                implementation(projects.core.appReview)
                 implementation(projects.core.appVersion)
                 implementation(projects.core.analytics)
                 implementation(projects.core.coroutinesExt)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -80,6 +80,7 @@ val viewModelsModule = module {
             infoTileManager = get(),
             inviteFriendsTileManager = get(),
             trackingManager = get<TrackingManager>(),
+            appReviewManager = get(),
         )
     }
 
@@ -100,6 +101,7 @@ val viewModelsModule = module {
             platformOps = get(),
             analytics = get(),
             ioDispatcher = get(named(IODispatcher)),
+            appReviewManager = get(),
         )
     }
 
@@ -119,6 +121,7 @@ val viewModelsModule = module {
             festivalManager = get(),
             flag = get(),
             shareManager = get(),
+            appReviewManager = get(),
             tripTrackingDebugOverride = tripTrackingDebugOverride,
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideViewModel.kt
@@ -21,6 +21,8 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.core.appreview.AppReviewManager
+import xyz.ksharma.krail.core.appreview.DelightMoment
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.coroutines.ext.launchWithExceptionHandler
 import xyz.ksharma.krail.platform.ops.PlatformOps
@@ -49,6 +51,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideUiEvent
  * that stays owned by the home cards' expand-and-visible lifecycle
  * (see `docs/POLLING_LIFECYCLE.md`).
  */
+@Suppress("LongParameterList")
 class AddParkRideViewModel(
     private val catalogue: ParkRideCatalogue,
     private val parkRideSandook: NswParkRideSandook,
@@ -56,6 +59,7 @@ class AddParkRideViewModel(
     private val platformOps: PlatformOps,
     private val analytics: Analytics,
     private val ioDispatcher: CoroutineDispatcher,
+    private val appReviewManager: AppReviewManager,
 ) : ViewModel() {
 
     private var observeUserAddedJob: Job? = null
@@ -215,6 +219,9 @@ class AddParkRideViewModel(
                     }.toSet(),
                     source = UserAdded,
                 )
+                // Adding a facility is a delight moment; it fires once the user returns to
+                // the Saved Trips screen. Removing one is not, so this stays in the add branch.
+                appReviewManager.onDelightMoment(DelightMoment.PARK_RIDE_ADDED)
             }
 
             trackToggle(station)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -26,6 +26,8 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
+import xyz.ksharma.krail.core.appreview.AppReviewManager
+import xyz.ksharma.krail.core.appreview.DelightMoment
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 import xyz.ksharma.krail.core.remoteconfig.flag.Flag
@@ -79,6 +81,7 @@ class SavedTripsViewModel(
     private val platformOps: PlatformOps,
     private val inviteFriendsTileManager: InviteFriendsTileManager,
     private val trackingManager: TrackingManager,
+    private val appReviewManager: AppReviewManager,
 ) : ViewModel() {
 
     init {
@@ -125,6 +128,7 @@ class SavedTripsViewModel(
             updateSelectedStops()
             updateInviteFriendsTileSeenState()
             loadReorderTipSeenState()
+            maybeRequestReview()
         }
         .onCompletion {
             cleanupJobs()
@@ -150,8 +154,7 @@ class SavedTripsViewModel(
     fun onEvent(event: SavedTripUiEvent) {
         when (event) {
             is SavedTripUiEvent.DeleteSavedTrip -> onDeleteSavedTrip(event.trip)
-            is SavedTripUiEvent.AnalyticsSavedTripCardClick ->
-                analytics.trackSavedTripCardClick(event.fromStopId, event.toStopId)
+            is SavedTripUiEvent.AnalyticsSavedTripCardClick -> onSavedTripCardClick(event)
             SavedTripUiEvent.ReverseStopClick -> {
                 stopResultsManager.reverseSelectedStops()
                 updateUiState {
@@ -187,6 +190,35 @@ class SavedTripsViewModel(
             SavedTripUiEvent.StopTracking -> trackingManager.stop()
             is SavedTripUiEvent.MoveSavedTripToIndex -> onMoveSavedTrip(event.tripId, event.targetIndex)
             SavedTripUiEvent.MarkReorderTipSeen -> onMarkReorderTipSeen()
+        }
+    }
+
+    private fun onSavedTripCardClick(event: SavedTripUiEvent.AnalyticsSavedTripCardClick) {
+        analytics.trackSavedTripCardClick(event.fromStopId, event.toStopId)
+    }
+
+    /**
+     * Saved Trips is the one calm screen the review sheet is allowed to land on. If a delight
+     * moment (a clean timetable view, a save, a park-and-ride add) was armed elsewhere, this
+     * is where it fires; the manager owns every gate and no-ops when nothing is armed. On the
+     * IO dispatcher because the eligibility check reads the saved-trip count from the database.
+     */
+    private fun maybeRequestReview() {
+        viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+            appReviewManager.onSavedTripsScreenShown()
+        }
+    }
+
+    /**
+     * Expanding a Park and Ride card is a delight moment, but it happens on the Saved Trips
+     * screen itself rather than on a screen we navigate away from. So we arm and fire in one
+     * place, after a short delay so the sheet is not requested in the same frame as the tap.
+     */
+    private fun armParkRideCardReviewMoment() {
+        viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
+            delay(PARK_RIDE_CARD_REVIEW_DELAY_MS)
+            appReviewManager.onDelightMoment(DelightMoment.PARK_RIDE_CARD_TAPPED)
+            appReviewManager.onSavedTripsScreenShown()
         }
     }
 
@@ -249,6 +281,7 @@ class SavedTripsViewModel(
                 log("Fetching Park Ride facility for stopId: ${parkRideState.stopId}")
                 fetchAndSaveParkRideFacilityIfNeeded(stopId = parkRideState.stopId)
             }
+            armParkRideCardReviewMoment()
             log("Park Ride card expanded done")
         } else {
             log(
@@ -739,6 +772,10 @@ class SavedTripsViewModel(
         log("Cleanup jobs in SavedTripsViewModel completed.")
     }
 }
+
+// Delay before requesting review after a Park and Ride card tap, so it never fires in the
+// same frame as the tap.
+private const val PARK_RIDE_CARD_REVIEW_DELAY_MS = 3_000L
 
 private fun SavedTrip.toTrip(): Trip = Trip(
     fromStopId = fromStopId,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -27,6 +27,8 @@ import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.analytics.event.trackScreenViewEvent
 import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
+import xyz.ksharma.krail.core.appreview.AppReviewManager
+import xyz.ksharma.krail.core.appreview.DelightMoment
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isBefore
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
 import xyz.ksharma.krail.core.datetime.DateTimeHelper.toApiDateString
@@ -77,6 +79,7 @@ class TimeTableViewModel(
     private val ioDispatcher: CoroutineDispatcher,
     private val festivalManager: FestivalManager,
     val flag: Flag,
+    private val appReviewManager: AppReviewManager,
     private val tripTrackingDebugOverride: Boolean = true,
 ) : ViewModel() {
 
@@ -484,6 +487,10 @@ class TimeTableViewModel(
         result.onSuccess { response ->
             updateTripsCache(response)
             updateUiStateWithFilteredTrips()
+            // The timetable loaded without error: arm a review ask to fire once the user
+            // navigates back to the calm Saved Trips screen. Idempotent, so a background
+            // auto-refresh re-arming the same moment is harmless.
+            appReviewManager.onDelightMoment(DelightMoment.TIMETABLE_VIEWED)
         }.onFailure {
             // fetchTrip() runs on every screen-visible (onStart) and every auto-refresh.
             // A failure on one of those silent/background refreshes must NOT blow away
@@ -709,6 +716,7 @@ class TimeTableViewModel(
             )
             log("Saved Trip (Prompt): $trip")
             updateUiState { copy(isTripSaved = true, showSaveTripPrompt = false) }
+            appReviewManager.onDelightMoment(DelightMoment.TRIP_SAVED)
         }
     }
 
@@ -944,6 +952,7 @@ class TimeTableViewModel(
                     log("Saved Trip (Pref): $trip")
                     // Saving via the star makes the prompt redundant — drop it.
                     updateUiState { copy(isTripSaved = true, showSaveTripPrompt = false) }
+                    appReviewManager.onDelightMoment(DelightMoment.TRIP_SAVED)
                 }
             }
         }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideSelectionTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideSelectionTest.kt
@@ -26,6 +26,7 @@ import xyz.ksharma.krail.sandook.NswParkRideSandook.Companion.SavedParkRideSourc
 import xyz.ksharma.krail.sandook.SavedParkRide
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ErrorKind
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideUiEvent
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
 import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -71,6 +72,7 @@ class AddParkRideSelectionTest {
             platformOps = platformOps,
             analytics = analytics,
             ioDispatcher = testDispatcher,
+            appReviewManager = FakeAppReviewManager(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/AddParkRideViewModelTest.kt
@@ -26,6 +26,7 @@ import xyz.ksharma.krail.sandook.NswParkRideSandook.Companion.SavedParkRideSourc
 import xyz.ksharma.krail.sandook.SavedParkRide
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideState.ErrorKind
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.AddParkRideUiEvent
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
 import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -66,6 +67,7 @@ class AddParkRideViewModelTest {
             platformOps = platformOps,
             analytics = analytics,
             ioDispatcher = testDispatcher,
+            appReviewManager = FakeAppReviewManager(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
@@ -14,6 +14,7 @@ import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
 import xyz.ksharma.krail.core.testing.fakes.FakeAppVersionManager
 import xyz.ksharma.krail.core.testing.fakes.FakeFlag
 import xyz.ksharma.krail.core.testing.fakes.FakeInfoTileManager
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
 import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeInviteFriendsTileManager
 import xyz.ksharma.krail.core.testing.fakes.FakeNswParkRideSandook
 import xyz.ksharma.krail.core.testing.fakes.FakeParkRideFacilityManager
@@ -92,6 +93,7 @@ class SavedTripsViewModelTest {
             infoTileManager = fakeInfoTileManager,
             inviteFriendsTileManager = fakeInviteFriendsTileManager,
             trackingManager = TrackingManager(),
+            appReviewManager = FakeAppReviewManager(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeAppReviewManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeAppReviewManager.kt
@@ -1,0 +1,25 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import xyz.ksharma.krail.core.appreview.AppReviewManager
+import xyz.ksharma.krail.core.appreview.DelightMoment
+
+/**
+ * Records calls instead of touching the platform review APIs. Eligibility itself is
+ * covered by `RealAppReviewManagerTest` in `:core:app-review`; ViewModel tests only care
+ * that the right moments are armed and that the screen fires the check.
+ */
+class FakeAppReviewManager : AppReviewManager {
+
+    val armedMoments = mutableListOf<DelightMoment>()
+
+    var savedTripsScreenShownCount = 0
+        private set
+
+    override fun onDelightMoment(moment: DelightMoment) {
+        armedMoments += moment
+    }
+
+    override fun onSavedTripsScreenShown() {
+        savedTripsScreenShownCount++
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelCacheTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelCacheTest.kt
@@ -42,6 +42,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel.Companion.MAX_LOAD_MORE_COUNT
 import kotlinx.datetime.TimeZone.Companion.currentSystemDefault
 import kotlinx.datetime.toLocalDateTime
@@ -86,6 +87,7 @@ class TimeTableViewModelCacheTest {
             ioDispatcher = testDispatcher,
             festivalManager = FakeFestivalManager(),
             flag = FakeFlag(),
+            appReviewManager = FakeAppReviewManager(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -42,6 +42,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState.JourneyC
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel.Companion.JOURNEY_ENDED_CACHE_THRESHOLD_TIME
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel.Companion.MAX_LOAD_MORE_COUNT
 import xyz.ksharma.krail.trip.planner.ui.timetable.TimeTableViewModel.Companion.REFRESH_TIME_TEXT_DURATION
@@ -89,6 +90,7 @@ class TimeTableViewModelTest {
             ioDispatcher = testDispatcher,
             festivalManager = festivalManager,
             flag = fakeFlag,
+            appReviewManager = FakeAppReviewManager(),
         )
     }
 

--- a/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/UserLifecycleStoreTest.kt
+++ b/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/UserLifecycleStoreTest.kt
@@ -76,28 +76,42 @@ class UserLifecycleStoreTest {
 
     @Test
     fun `counter starts at zero with no last seen time`() {
-        assertEquals(0L, store.count(LifecycleCounter.SAVED_TRIP_OPEN))
-        assertNull(store.lastAtMillis(LifecycleCounter.SAVED_TRIP_OPEN))
+        assertEquals(0L, store.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        assertNull(store.lastAtMillis(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
     }
 
     @Test
     fun `increment returns the running total and stamps the last seen time`() {
-        assertEquals(1L, store.increment(LifecycleCounter.SAVED_TRIP_OPEN))
-        assertEquals(DAY_ZERO, store.lastAtMillis(LifecycleCounter.SAVED_TRIP_OPEN))
+        assertEquals(1L, store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        assertEquals(DAY_ZERO, store.lastAtMillis(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
 
         now = DAY_ZERO + MILLIS_PER_DAY
-        assertEquals(2L, store.increment(LifecycleCounter.SAVED_TRIP_OPEN))
-        assertEquals(3L, store.increment(LifecycleCounter.SAVED_TRIP_OPEN))
+        assertEquals(2L, store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        assertEquals(3L, store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
 
-        assertEquals(3L, store.count(LifecycleCounter.SAVED_TRIP_OPEN))
-        assertEquals(DAY_ZERO + MILLIS_PER_DAY, store.lastAtMillis(LifecycleCounter.SAVED_TRIP_OPEN))
+        assertEquals(3L, store.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        assertEquals(DAY_ZERO + MILLIS_PER_DAY, store.lastAtMillis(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+    }
+
+    @Test
+    fun `reset clears the counter but leaves the install date intact`() {
+        store.recordFirstInstallIfAbsent()
+        store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
+        store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
+
+        store.reset(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
+
+        assertEquals(0L, store.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        assertNull(store.lastAtMillis(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
+        // The install date lives in a separate preferences row, so reset must not touch it.
+        assertEquals(DAY_ZERO, store.firstInstallAtMillis())
     }
 
     @Test
     fun `counters and install date survive reopening the database`() {
         store.recordFirstInstallIfAbsent()
-        store.increment(LifecycleCounter.SAVED_TRIP_OPEN)
-        store.increment(LifecycleCounter.SAVED_TRIP_OPEN)
+        store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
+        store.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED)
 
         // A second store over the same driver stands in for a relaunch after an app update:
         // nothing is held in memory, every value is read back from the database.
@@ -108,7 +122,7 @@ class UserLifecycleStoreTest {
         )
 
         assertEquals(DAY_ZERO, reopened.firstInstallAtMillis())
-        assertEquals(2L, reopened.count(LifecycleCounter.SAVED_TRIP_OPEN))
+        assertEquals(2L, reopened.count(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
     }
 
     @Test
@@ -130,7 +144,7 @@ class UserLifecycleStoreTest {
             nowMillis = { now },
         )
 
-        assertEquals(1L, upgraded.increment(LifecycleCounter.SAVED_TRIP_OPEN))
+        assertEquals(1L, upgraded.increment(LifecycleCounter.REVIEW_PROMPT_REQUESTED))
 
         upgradeDriver.close()
     }

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealUserLifecycleStore.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealUserLifecycleStore.kt
@@ -42,6 +42,15 @@ internal class RealUserLifecycleStore(
     override fun lastAtMillis(counter: LifecycleCounter): Long? =
         queries.selectCounter(counter.key).executeAsOneOrNull()?.last_at_millis
 
+    override fun millisSinceLast(counter: LifecycleCounter): Long? {
+        val lastAt = lastAtMillis(counter) ?: return null
+        return nowMillis() - lastAt
+    }
+
+    override fun reset(counter: LifecycleCounter) {
+        queries.deleteCounter(counter.key)
+    }
+
     companion object {
 
         /**

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/UserLifecycleStore.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/UserLifecycleStore.kt
@@ -47,6 +47,20 @@ interface UserLifecycleStore {
 
     /** Epoch millis of the most recent [increment] of [counter], or `null` if never. */
     fun lastAtMillis(counter: LifecycleCounter): Long?
+
+    /**
+     * Milliseconds elapsed since the most recent [increment] of [counter], or `null` if it has
+     * never been incremented. Uses this store's own clock, so callers that only need "how long
+     * ago" do not have to inject a second clock of their own.
+     */
+    fun millisSinceLast(counter: LifecycleCounter): Long?
+
+    /**
+     * Clears [counter]'s total and last-seen time, so [count] reads `0` again. Only touches this
+     * one counter: the install date lives in a separate preferences row and is untouched. Used
+     * by debug tooling to re-arm one-shot flows without a full data wipe.
+     */
+    fun reset(counter: LifecycleCounter)
 }
 
 /**
@@ -57,9 +71,6 @@ interface UserLifecycleStore {
  * inventing per-feature persistence.
  */
 enum class LifecycleCounter(val key: String) {
-
-    /** Incremented each time the user opens one of their saved trips. */
-    SAVED_TRIP_OPEN("saved_trip_open_count"),
 
     /**
      * Incremented each time the platform review sheet is *requested*. The platform never


### PR DESCRIPTION
## What

Replaces the saved-trip-open counter and zero-result-search suppression gate in `RealAppReviewManager` with a shared delight-moment trigger: a completed positive action arms a request, and it fires (subject to gating) the next time the user lands on the Saved Trips screen. Adds a lifetime cap of two asks.

## Changes

- `AppReviewManager`: `onSavedTripOpened()`/`onZeroResultSearch()` replaced by `onDelightMoment(moment: DelightMoment)` (arms) and `onSavedTripsScreenShown()` (evaluates gates and fires). `DelightMoment` enum: `TIMETABLE_VIEWED`, `TRIP_SAVED`, `PARK_RIDE_ADDED`, `PARK_RIDE_CARD_TAPPED`, each carrying the analytics `source` label.
- `RealAppReviewManager`: gates on `LifecycleCounter.REVIEW_PROMPT_REQUESTED`'s count: ask 1 needs account age and saved-trip count thresholds, ask 2 needs a minimum gap since ask 1, and a third ask never fires. `savedTripCount` is now a live query callback (`Sandook.selectAllTrips().size`) rather than a stored open-counter.
- `AppReviewThresholds.kt`: `MIN_SAVED_TRIPS`, `MIN_ACCOUNT_AGE_DAYS`, `MIN_DAYS_BETWEEN_ASKS` are now fixed app-side constants instead of Remote Config-tunable values; only `IN_APP_REVIEW_ENABLED` remains in Remote Config. Removed the now-unused `IN_APP_REVIEW_MIN_SAVED_TRIP_OPENS` / `IN_APP_REVIEW_MIN_ACCOUNT_AGE_DAYS` / `IN_APP_REVIEW_COOLDOWN_DAYS` flag keys and defaults.
- `AppReviewRequester.requestReview()` takes a `source: String` (the firing moment), threaded through to a new debug-only `AppReviewDebugSignal`/`AppReviewDebugProof` sheet that mirrors the request on-device (a sideloaded debug build can never show the real Play card, so there was otherwise no way to confirm the trigger fired).
- `UserLifecycleStore`: removed the now-unused `SAVED_TRIP_OPEN` counter; added `millisSinceLast(counter)` and `reset(counter)` (used by the ask-1/ask-2 gap check and by a new debug-settings "Reset in-app review" tile that clears the ask count while keeping the install date).
- Wired `onDelightMoment` calls into `TimeTableViewModel` (clean timetable load, star-toggle save, save-trip-prompt save) and `AddParkRideViewModel` (facility added), and `onSavedTripsScreenShown`/`PARK_RIDE_CARD_TAPPED` arming into `SavedTripsViewModel` (screen shown, park-ride card tap after a 3s delay).
- `docs/investigations/IN_APP_REVIEW_TIMING.md`: added as the working-notes doc for the trigger design and rollout/testing steps.

## Testing

- `./gradlew :core:app-review:testAndroidHostTest :sandook:testAndroidHostTest :feature:debug-settings:ui:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest` green
- `./gradlew detekt --continue` clean
- `./gradlew compileDebugSources` (Android) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
