### PR TITLE
refactor: make DI-bound implementation classes internal

### DIFF
--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/theme/AndroidThemeManagerImpl.kt
@@ -12,7 +12,7 @@ import xyz.ksharma.krail.taj.theme.ThemeMode
  * when theme mode changes to ensure status bar and navigation bar
  * colors are updated correctly.
  */
-class AndroidThemeManagerImpl(
+internal class AndroidThemeManagerImpl(
     val context: Context,
 ) : ThemeManager {
 

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/theme/IOSThemeManagerImpl.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/theme/IOSThemeManagerImpl.kt
@@ -6,7 +6,7 @@ import xyz.ksharma.krail.taj.theme.ThemeMode
  * iOS implementation of ThemeManager
  * iOS handles theme changes automatically, so this is a no-op
  */
-class IOSThemeManagerImpl : ThemeManager {
+internal class IOSThemeManagerImpl : ThemeManager {
     override fun applyThemeMode(themeMode: ThemeMode) {
         // iOS handles theme changes automatically through the system
         // No action needed here

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/RealAnalytics.kt
@@ -7,7 +7,7 @@ import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.core.appinfo.AppInfoProvider
 import xyz.ksharma.krail.core.log.log
 
-class RealAnalytics(
+internal class RealAnalytics(
     private val firebaseAnalytics: FirebaseAnalytics,
     private val appInfoProvider: AppInfoProvider,
     private val coroutineScope: CoroutineScope,

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -70,7 +70,7 @@ class AndroidAppInfo(private val context: Context) : AppInfo {
             "deviceManufacturer=$deviceManufacturer, locale=$locale, timeZone=$timeZone)"
 }
 
-class AndroidAppInfoProvider(
+internal class AndroidAppInfoProvider(
     private val context: Context,
 ) : AppInfoProvider {
     override fun getAppInfo(): AppInfo = AndroidAppInfo(context)

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -65,7 +65,7 @@ class IOSAppInfo : AppInfo {
             "deviceManufacturer=$deviceManufacturer, locale=$locale, timeZone=$timeZone)"
 }
 
-class IosAppInfoProvider : AppInfoProvider {
+internal class IosAppInfoProvider : AppInfoProvider {
     override fun getAppInfo(): AppInfo {
         return IOSAppInfo()
     }

--- a/core/app-review/src/androidMain/kotlin/xyz/ksharma/krail/core/appreview/AndroidAppReviewRequester.kt
+++ b/core/app-review/src/androidMain/kotlin/xyz/ksharma/krail/core/appreview/AndroidAppReviewRequester.kt
@@ -13,7 +13,7 @@ import xyz.ksharma.krail.platform.ops.CurrentActivityHolder
  * The flow needs a real Activity, which is why it goes through [CurrentActivityHolder]
  * rather than the application Context.
  */
-class AndroidAppReviewRequester(
+internal class AndroidAppReviewRequester(
     private val context: Context,
     private val activityHolder: CurrentActivityHolder,
 ) : AppReviewRequester {

--- a/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManager.kt
+++ b/core/app-review/src/commonMain/kotlin/xyz/ksharma/krail/core/appreview/RealAppReviewManager.kt
@@ -12,7 +12,7 @@ import xyz.ksharma.krail.sandook.UserLifecycleStore
  * @param savedTripCount reads how many trips the user has saved right now. A live count query,
  *   not a stored counter, so ask 1 gates on what the user actually has.
  */
-class RealAppReviewManager(
+internal class RealAppReviewManager(
     private val requester: AppReviewRequester,
     private val lifecycleStore: UserLifecycleStore,
     private val preferences: SandookPreferences,

--- a/core/app-review/src/iosMain/kotlin/xyz/ksharma/krail/core/appreview/IosAppReviewRequester.kt
+++ b/core/app-review/src/iosMain/kotlin/xyz/ksharma/krail/core/appreview/IosAppReviewRequester.kt
@@ -11,7 +11,7 @@ import xyz.ksharma.krail.core.log.log
  * iOS shows the rating alert at most a few times per year per user and reports nothing back,
  * so a call here is a request, never a guarantee.
  */
-class IosAppReviewRequester : AppReviewRequester {
+internal class IosAppReviewRequester : AppReviewRequester {
 
     override fun requestReview() {
         // StoreKit presents UI, so it has to be asked on the main thread.

--- a/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
+++ b/core/app-start/src/commonMain/kotlin/xyz/ksharma/krail/core/appstart/RealAppstart.kt
@@ -6,7 +6,7 @@ import xyz.ksharma.krail.core.remoteconfig.RemoteConfig
 import xyz.ksharma.krail.io.gtfs.nswstops.StopsManager
 import xyz.ksharma.krail.sandook.UserLifecycleStore
 
-class RealAppStart(
+internal class RealAppStart(
     private val coroutineScope: CoroutineScope,
     private val remoteConfig: RemoteConfig,
     private val nswStopsManager: StopsManager,

--- a/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManager.kt
+++ b/core/app-version/src/commonMain/kotlin/xyz/ksharma/krail/core/appversion/AppVersionManager.kt
@@ -52,7 +52,7 @@ interface AppVersionManager {
     )
 }
 
-class RealAppVersionManager(
+internal class RealAppVersionManager(
     private val appInfoProvider: AppInfoProvider,
     private val flag: Flag,
 ) : AppVersionManager {

--- a/core/share/src/androidMain/kotlin/xyz/ksharma/krail/core/share/AndroidShareManager.kt
+++ b/core/share/src/androidMain/kotlin/xyz/ksharma/krail/core/share/AndroidShareManager.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 
-class AndroidShareManager(private val context: Context) : ShareManager {
+internal class AndroidShareManager(private val context: Context) : ShareManager {
 
     override suspend fun shareImage(bitmap: ImageBitmap, title: String, text: String?): Result<Unit> =
         runCatching {

--- a/core/share/src/iosMain/kotlin/xyz/ksharma/krail/core/share/IosShareManager.kt
+++ b/core/share/src/iosMain/kotlin/xyz/ksharma/krail/core/share/IosShareManager.kt
@@ -22,7 +22,7 @@ import platform.UIKit.UIWindowScene
 import platform.UIKit.popoverPresentationController
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-class IosShareManager : ShareManager {
+internal class IosShareManager : ShareManager {
 
     override suspend fun shareImage(bitmap: ImageBitmap, title: String, text: String?): Result<Unit> =
         runCatching {

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/RealDiscoverSydneyManager.kt
@@ -20,7 +20,7 @@ import xyz.ksharma.krail.discover.network.api.db.DiscoverCardOrderingEngine
 import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
 
 @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-class RealDiscoverSydneyManager(
+internal class RealDiscoverSydneyManager(
     private val flag: Flag,
     private val defaultDispatcher: CoroutineDispatcher = DispatchersComponent().defaultDispatcher,
     private val discoverCardOrderingEngine: DiscoverCardOrderingEngine,

--- a/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
+++ b/discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt
@@ -11,7 +11,7 @@ import xyz.ksharma.krail.sandook.DiscoverCardSeenPreferences
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-class RealDiscoverCardOrderingEngine(
+internal class RealDiscoverCardOrderingEngine(
     private val discoverCardPreferences: DiscoverCardSeenPreferences,
 ) : DiscoverCardOrderingEngine {
 

--- a/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
+++ b/feature/park-ride/network/src/commonMain/kotlin/xyz/ksharma/krail/park/ride/network/RealNswParkRideFacilityManager.kt
@@ -9,7 +9,7 @@ import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
 import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
 import xyz.ksharma.krail.park.ride.network.model.NswParkRideFacility
 
-class RealNswParkRideFacilityManager(
+internal class RealNswParkRideFacilityManager(
     private val flag: Flag,
 ) : NswParkRideFacilityManager {
 

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/NetworkRateLimiter.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/NetworkRateLimiter.kt
@@ -18,7 +18,7 @@ import kotlin.time.Duration.Companion.seconds
  *
  * Note: This class should not be Singleton. It should be created per use-case.
  */
-class NetworkRateLimiter : RateLimiter {
+internal class NetworkRateLimiter : RateLimiter {
 
     private val triggerFlow = MutableSharedFlow<Unit>(replay = 1)
     private val isFirstTime = MutableStateFlow(false)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideAvailabilityLoader.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideAvailabilityLoader.kt
@@ -39,7 +39,7 @@ interface ParkRideAvailabilityLoader {
     suspend fun refreshIfNeeded(mappings: List<ParkRideMapping>)
 }
 
-class RealParkRideAvailabilityLoader(
+internal class RealParkRideAvailabilityLoader(
     private val parkRideSandook: NswParkRideSandook,
     private val parkRideService: ParkRideService,
     private val flag: Flag,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideCatalogue.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideCatalogue.kt
@@ -32,7 +32,7 @@ interface ParkRideCatalogue {
     fun loadingEmoji(): LoadingEmoji
 }
 
-class RealParkRideCatalogue(
+internal class RealParkRideCatalogue(
     private val nswParkRideFacilityManager: NswParkRideFacilityManager,
     private val stopResultsManager: StopResultsManager,
     private val sandook: Sandook,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealRemoteAddressResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealRemoteAddressResultsManager.kt
@@ -17,7 +17,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
  * (`SearchStopViewModel`) is the single place that turns a failure into an empty list
  * for the UI - see feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md.
  */
-class RealRemoteAddressResultsManager(
+internal class RealRemoteAddressResultsManager(
     private val tripPlanningService: TripPlanningService,
     private val ioDispatcher: CoroutineDispatcher,
 ) : RemoteAddressResultsManager {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/RealStopResultsManager.kt
@@ -26,7 +26,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.LocationKind
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
-class RealStopResultsManager(
+internal class RealStopResultsManager(
     private val sandook: Sandook,
     private val nswBusRoutesSandook: NswBusRoutesSandook,
     private val flag: Flag,

--- a/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.android.kt
+++ b/gtfs-static/src/androidMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.android.kt
@@ -3,7 +3,7 @@ package xyz.ksharma.krail.gtfs_static
 import android.content.Context
 import java.io.File
 
-class AndroidFileStorage(private val context: Context) : FileStorage {
+internal class AndroidFileStorage(private val context: Context) : FileStorage {
     override suspend fun saveFile(fileName: String, data: ByteArray) {
         val file = File(context.filesDir, fileName)
         file.writeBytes(data)

--- a/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
+++ b/gtfs-static/src/commonMain/kotlin/xyz/ksharma/krail/gtfs_static/RealNswGtfsService.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.withContext
 import xyz.ksharma.krail.core.di.DispatchersComponent
 import xyz.ksharma.krail.core.log.log
 
-class RealNswGtfsService(
+internal class RealNswGtfsService(
     private val httpClient: HttpClient,
     private val fileStorage: FileStorage,
     private val ioDispatcher: CoroutineDispatcher = DispatchersComponent().ioDispatcher,

--- a/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
+++ b/gtfs-static/src/iosMain/kotlin/xyz/ksharma/krail/gtfs_static/FileStorage.ios.kt
@@ -11,7 +11,7 @@ import platform.Foundation.dataWithBytes
 import platform.Foundation.writeToFile
 import xyz.ksharma.krail.core.log.log
 
-class IosFileStorage : FileStorage {
+internal class IosFileStorage : FileStorage {
     @OptIn(ExperimentalForeignApi::class)
     override suspend fun saveFile(fileName: String, data: ByteArray) {
         log("Saving file: $fileName")

--- a/info-tile/network/real/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/real/RealInfoTileManager.kt
+++ b/info-tile/network/real/src/commonMain/kotlin/xyz/ksharma/krail/info/tile/network/real/RealInfoTileManager.kt
@@ -22,7 +22,7 @@ import xyz.ksharma.krail.info.tile.state.InfoTileCta
 import xyz.ksharma.krail.info.tile.state.InfoTileData
 import xyz.ksharma.krail.sandook.SandookPreferences
 
-class RealInfoTileManager(
+internal class RealInfoTileManager(
     private val appVersionManager: AppVersionManager,
     private val appInfoProvider: AppInfoProvider,
     private val preferences: SandookPreferences,

--- a/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswbusroutes/NswBusRoutesManager.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswbusroutes/NswBusRoutesManager.kt
@@ -17,7 +17,7 @@ import xyz.ksharma.krail.sandook.SandookPreferences.Companion.NSW_BUS_ROUTES_VER
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-class NswBusRoutesManager(
+internal class NswBusRoutesManager(
     private val ioDispatcher: CoroutineDispatcher,
     private val nswBusRoutesSandook: NswBusRoutesSandook,
     private val preferences: SandookPreferences,

--- a/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswstops/NswStopsManager.kt
+++ b/io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswstops/NswStopsManager.kt
@@ -15,7 +15,7 @@ import xyz.ksharma.krail.sandook.SandookPreferences.Companion.NSW_STOPS_VERSION
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-class NswStopsManager(
+internal class NswStopsManager(
     private val ioDispatcher: CoroutineDispatcher,
     private val sandook: Sandook,
     private val preferences: SandookPreferences,

--- a/platform/ops/src/androidMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.android.kt
+++ b/platform/ops/src/androidMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.android.kt
@@ -6,7 +6,7 @@ import androidx.core.net.toUri
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 
-class AndroidPlatformOps(private val context: Context) : PlatformOps {
+internal class AndroidPlatformOps(private val context: Context) : PlatformOps {
 
     // "Tell your mates about KRAIL"
     override fun sharePlainText(text: String, title: String) {

--- a/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
+++ b/platform/ops/src/iosMain/kotlin/xyz/ksharma/krail/platform/ops/PlatformOps.ios.kt
@@ -17,7 +17,7 @@ import platform.UIKit.popoverPresentationController
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.log.logError
 
-class IosPlatformOps : PlatformOps {
+internal class IosPlatformOps : PlatformOps {
     override fun sharePlainText(text: String, title: String) {
         handleShareClick(text = text, title = title)
     }

--- a/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/AndroidSandookDriverFactory.kt
+++ b/sandook/src/androidMain/kotlin/xyz/ksharma/krail/sandook/AndroidSandookDriverFactory.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 
-class AndroidSandookDriverFactory(private val context: Context) : SandookDriverFactory {
+internal class AndroidSandookDriverFactory(private val context: Context) : SandookDriverFactory {
     override fun createDriver(): SqlDriver {
         return AndroidSqliteDriver(
             schema = KrailSandook.Schema,

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealNswBusRoutesSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealNswBusRoutesSandook.kt
@@ -5,7 +5,7 @@ package xyz.ksharma.krail.sandook
  * Delegates to the SQLDelight generated queries.
  */
 @Suppress("TooManyFunctions")
-class RealNswBusRoutesSandook(
+internal class RealNswBusRoutesSandook(
     sandook: KrailSandook,
 ) : NswBusRoutesSandook {
 

--- a/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
+++ b/sandook/src/iosMain/kotlin/xyz/ksharma/krail/sandook/IosSandookDriverFactory.kt
@@ -13,7 +13,7 @@ import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter6
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter7
 import xyz.ksharma.krail.sandook.migrations.SandookMigrationAfter8
 
-class IosSandookDriverFactory : SandookDriverFactory {
+internal class IosSandookDriverFactory : SandookDriverFactory {
     override fun createDriver(): SqlDriver {
         return NativeSqliteDriver(
             schema = KrailSandook.Schema,


### PR DESCRIPTION
## What

Tightens visibility on implementation classes that are bound behind an interface via Koin (`single<Interface>{}`/`factory<Interface>{}`) within their own module, from `public` (the Kotlin default) to `internal`. First half of #1772.

## Changes

- 31 classes across `core/app-review`, `core/analytics`, `core/app-start`, `core/app-version`, `core/share`, `core/app-info`, `platform/ops`, `gtfs-static`, `io/gtfs`, `discover/network/real`, `feature/park-ride/network`, `feature/trip-planner/network`, `feature/trip-planner/ui`, `sandook`, and `composeApp` changed from `class Foo` to `internal class Foo`.
- Each candidate was found by locating its Koin DI binding, then verified by grepping the exact class name across the whole repo to confirm every reference lives inside its own module (Koin wiring plus same-module tests, both of which resolve `internal` symbols fine). No production or test code outside a class's own module referenced it by concrete type.
- Left untouched: classes already `internal` (`RealSandook`, `RealUserLifecycleStore`, `RealAppReviewDebugSignal`, etc.), classes without an interface indirection (ViewModels, Composables, state/event classes), and `BffEndpointResolver` (public and deliberately referenced by concrete type from several modules' constructors, not the impl-behind-interface pattern this sweep targets).

## Testing

- `./gradlew compileDebugSources` (Android) and `compileKotlinIosSimulatorArm64` (iOS) both green
- `./gradlew detekt testAndroidHostTest --continue` green across the whole repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
