### PR TITLE
feat(detekt): add PublicImplementationClass custom rule

### DIFF
--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/Navigator.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/Navigator.kt
@@ -75,7 +75,7 @@ import xyz.ksharma.krail.taj.theme.KrailThemeStyle
  * @return Navigator instance with theme loaded from database
  */
 @Composable
-fun rememberNavigator(state: NavigationState): Navigator {
+internal fun rememberNavigator(state: NavigationState): Navigator {
     val sandook: Sandook = koinInject()
     val navigator = remember(state) { Navigator(state) }
 
@@ -100,7 +100,7 @@ fun rememberNavigator(state: NavigationState): Navigator {
  * Implements NavigatorBase so feature modules can depend on the interface
  * without circular dependencies.
  */
-class Navigator(val state: NavigationState) : NavigatorBase {
+internal class Navigator(val state: NavigationState) : NavigatorBase {
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // THEME MANAGEMENT (Temporary Coupling - See Migration Plan Below)
@@ -388,5 +388,5 @@ private fun Navigator.stackSummary(): String =
 
 // To be used for Previews
 @Composable
-fun rememberPreviewNavigator(navigationState: NavigationState): Navigator =
+internal fun rememberPreviewNavigator(navigationState: NavigationState): Navigator =
     remember { Navigator(navigationState) }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/di/EntryProviderCollector.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/di/EntryProviderCollector.kt
@@ -30,7 +30,7 @@ import xyz.ksharma.krail.navigation.Navigator
  * ```
  */
 @Composable
-fun collectEntryProviders(
+internal fun collectEntryProviders(
     navigator: Navigator,
 ): (NavKey) -> NavEntry<NavKey> {
     // Inject all entry builders from Koin using centralized qualifiers

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -74,6 +74,16 @@ exceptions:
   ThrowingNewInstanceOfSameException:
     active: true
 
+krail:
+  PublicImplementationClass:
+    active: true
+    # Interfaces backed by external/library contracts (not this repo's own module
+    # interfaces) that a class may legitimately implement while staying public.
+    excludeSuperTypes: []
+    # :core:testing's Fake* classes are the repo's canonical shared test doubles, deliberately
+    # public so other modules' test source sets can construct them directly.
+    excludes: ['**/core/testing/**']
+
 naming:
   ClassNaming:
     ignoreAnnotated: ['org.junit.jupiter.api.Nested']

--- a/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
+++ b/core/app-info/src/androidMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.android.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 
-class AndroidAppInfo(private val context: Context) : AppInfo {
+internal class AndroidAppInfo(private val context: Context) : AppInfo {
 
     override val devicePlatformType: DevicePlatformType = DevicePlatformType.ANDROID
 

--- a/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
+++ b/core/app-info/src/iosMain/kotlin/xyz/ksharma/krail/core/appinfo/AppInfo.ios.kt
@@ -12,7 +12,7 @@ import platform.UIKit.UIScreen
 import platform.UIKit.UIUserInterfaceStyle
 import kotlin.experimental.ExperimentalNativeApi
 
-class IOSAppInfo : AppInfo {
+internal class IOSAppInfo : AppInfo {
 
     override val devicePlatformType: DevicePlatformType = DevicePlatformType.IOS
     private val info = NSBundle.mainBundle.infoDictionary

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/fuzzy/FuzzyStopRanker.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/fuzzy/FuzzyStopRanker.kt
@@ -21,7 +21,7 @@ interface FuzzyStopRanker {
     ): List<SearchStopState.SearchResult.Stop>
 }
 
-class DefaultFuzzyStopRanker : FuzzyStopRanker {
+internal class DefaultFuzzyStopRanker : FuzzyStopRanker {
     override fun rank(
         query: String,
         candidates: List<SearchStopState.SearchResult.Stop>,

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Detekt.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Detekt.kt
@@ -14,6 +14,12 @@ fun Project.configureDetekt() {
     // Compose specific rules
     dependencies.add("detektPlugins", libs.findLibrary("detekt-compose").get())  //  }
 
+    // KRAIL's own custom rules (see gradle/build-logic/detekt-rules), e.g. PublicImplementationClass.
+    // A GAV string, not project(":detekt-rules") — that project lives in the separate
+    // includeBuild("gradle/build-logic") composite build, not in this (the root) build's project
+    // graph, so it has to be requested by coordinate and resolved via composite substitution.
+    dependencies.add("detektPlugins", "xyz.ksharma.krail.gradle:detekt-rules:unspecified")
+
     extensions.configure<DetektExtension>("detekt") {
         autoCorrect = true
         buildUponDefaultConfig = true

--- a/gradle/build-logic/detekt-rules/build.gradle.kts
+++ b/gradle/build-logic/detekt-rules/build.gradle.kts
@@ -1,0 +1,34 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+// Consumed by the root build's :convention module across the includeBuild("gradle/build-logic")
+// composite boundary via dependency substitution (project(":detekt-rules") only resolves within
+// this composite build itself, not the root build that calls configureDetekt()) — see Detekt.kt.
+group = "xyz.ksharma.krail.gradle"
+version = "unspecified"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+kotlin {
+    jvmToolchain(21)
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_21)
+    }
+}
+
+dependencies {
+    compileOnly(libs.detekt.api)
+
+    testImplementation(libs.detekt.test)
+    testImplementation(kotlin("test-junit"))
+}
+
+tasks.test {
+    useJUnit()
+}

--- a/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/KrailRuleSetProvider.kt
+++ b/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/KrailRuleSetProvider.kt
@@ -1,0 +1,17 @@
+package xyz.ksharma.krail.detekt
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.RuleSet
+import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+
+class KrailRuleSetProvider : RuleSetProvider {
+
+    override val ruleSetId: String = "krail"
+
+    override fun instance(config: Config): RuleSet = RuleSet(
+        ruleSetId,
+        listOf(
+            PublicImplementationClass(config),
+        ),
+    )
+}

--- a/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/PublicImplementationClass.kt
+++ b/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/PublicImplementationClass.kt
@@ -1,0 +1,145 @@
+package xyz.ksharma.krail.detekt
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
+
+/**
+ * Flags a top-level `class` that is public (the Kotlin default), implements at least one
+ * supertype, and isn't otherwise excluded — the shape of a DI implementation class that
+ * should be `internal` instead.
+ *
+ * The intended pattern in this codebase: interfaces are the public surface a module exposes;
+ * their implementations are wired to the interface via Koin (`single<Interface> { Impl() }`)
+ * within the same module and are never meant to be depended on by concrete type from outside
+ * it, so they should be `internal` (or `private`).
+ *
+ * ## Why this is a name-based heuristic, not a resolved one
+ *
+ * Detekt's Gradle plugin runs one task per module and only sees that module's own files, so a
+ * rule can never confirm "this class is referenced only within its own module" — the compiler
+ * already does that job better than a lint ever could: once a flagged class is made `internal`,
+ * any other module that was (incorrectly) depending on it by concrete type simply fails to
+ * compile.
+ *
+ * Ideally this rule would also confirm the implemented supertype is an `interface` declared in
+ * this codebase (as opposed to a binary/library contract like `Parcelable`) using detekt's type
+ * resolution (`bindingContext`). In practice, detekt's Kotlin Multiplatform support does not
+ * populate a usable binding context for this project's module structure — verified directly:
+ * the equivalent `@RequiresTypeResolution` implementation produced zero findings against a
+ * deliberately broken sample class, on both the experimental `detektAndroidMain` task and the
+ * `detektMetadataCommonMain` task, while the same rule logic correctly flagged the identical
+ * code in a unit test harness with type resolution set up explicitly. So instead: match by raw
+ * supertype name.
+ *
+ * One purely syntactic check needs no resolution at all and is applied unconditionally: a
+ * supertype written as `Foo(args)` is always a superclass constructor call (extending an
+ * abstract/open class, e.g. `ViewModel()`), never interface implementation, so it's excluded
+ * before the name ever reaches [EXCLUDE_SUPER_TYPES_KEY]. What's left after that — plain `Foo`
+ * or delegated `Foo by x` — is genuinely ambiguous without resolution (could be this codebase's
+ * own interface, or an external one like `Parcelable`/`KoinComponent`/Compose's `Shape`), which
+ * is what [EXCLUDE_SUPER_TYPES_KEY] and [DEFAULT_EXCLUDED_SUPER_TYPES] are for.
+ */
+class PublicImplementationClass(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        id = "PublicImplementationClass",
+        severity = Severity.Style,
+        description = "Implementation classes bound to an interface via DI should be " +
+            "'internal' (or 'private'); only the interface is meant to be the public surface.",
+        debt = Debt.FIVE_MINS,
+    )
+
+    private val excludeSuperTypes: List<String> by lazy {
+        DEFAULT_EXCLUDED_SUPER_TYPES + valueOrDefault(EXCLUDE_SUPER_TYPES_KEY, emptyList())
+    }
+
+    override fun visitClass(klass: KtClass) {
+        super.visitClass(klass)
+        if (!isCandidate(klass)) return
+
+        val superTypeNames = rawSuperTypeSimpleNames(klass).filterNot { it in excludeSuperTypes }
+        if (superTypeNames.isEmpty()) return
+
+        report(
+            CodeSmell(
+                issue = issue,
+                entity = Entity.atName(klass),
+                message = "'${klass.name}' implements ${superTypeNames.joinToString()} but is " +
+                    "declared public. Make it 'internal' (or 'private') and depend on the " +
+                    "interface everywhere else, or add it to '$EXCLUDE_SUPER_TYPES_KEY' in " +
+                    "detekt.yml if it genuinely needs to stay public.",
+            ),
+        )
+    }
+
+    /** Top-level, concrete (non-abstract/sealed), not already narrowed, has a supertype list. */
+    private fun isCandidate(klass: KtClass): Boolean {
+        if (!klass.isTopLevel()) return false
+        if (klass.isInterface()) return false
+        if (klass.isEnum()) return false
+        if (klass.isAnnotation()) return false
+        if (klass.isData()) return false
+        if (klass.isSealed()) return false
+        if (klass.hasModifier(KtTokens.ABSTRACT_KEYWORD)) return false
+        if (klass.hasModifier(KtTokens.PRIVATE_KEYWORD)) return false
+        if (klass.hasModifier(KtTokens.INTERNAL_KEYWORD)) return false
+        if (klass.hasModifier(KtTokens.PROTECTED_KEYWORD)) return false
+        return klass.getSuperTypeList() != null
+    }
+
+    /**
+     * Simple (unqualified, un-generic'd) names of the supertypes that look like interface
+     * implementation, i.e. `: Foo` or `: Foo by delegate` — not `: Foo(args)`, which is always a
+     * superclass constructor call (extending an abstract/open class, e.g. `ViewModel()`,
+     * `AndroidSqliteDriver.Callback(schema)`), never interface implementation. This syntactic
+     * split needs no type resolution and reliably tells the two apart.
+     */
+    private fun rawSuperTypeSimpleNames(klass: KtClass): List<String> =
+        klass.getSuperTypeList()?.entries.orEmpty()
+            .filterNot { it is KtSuperTypeCallEntry }
+            .mapNotNull { entry -> entry.typeAsUserType?.referencedName }
+
+    companion object {
+        const val EXCLUDE_SUPER_TYPES_KEY = "excludeSuperTypes"
+
+        /**
+         * Common external/library contracts a class can implement while staying legitimately
+         * public — none of these are "this codebase's own module interface" the rule targets.
+         * Extend per-module via [EXCLUDE_SUPER_TYPES_KEY] in detekt.yml rather than editing this.
+         */
+        val DEFAULT_EXCLUDED_SUPER_TYPES = listOf(
+            "Parcelable",
+            "Serializable",
+            "Comparable",
+            "Comparator",
+            "Iterable",
+            "Iterator",
+            "Closeable",
+            "AutoCloseable",
+            "Runnable",
+            "CharSequence",
+            "Throwable",
+            "Exception",
+            "RuntimeException",
+            "IllegalStateException",
+            "IllegalArgumentException",
+            "CoroutineScope",
+            "NavKey",
+            "KoinComponent",
+            "Shape",
+            "Node",
+            "DrawModifierNode",
+            "LayoutModifierNode",
+            "PointerInputModifierNode",
+            "SemanticsModifierNode",
+        )
+    }
+}

--- a/gradle/build-logic/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
+++ b/gradle/build-logic/detekt-rules/src/main/resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider
@@ -1,0 +1,1 @@
+xyz.ksharma.krail.detekt.KrailRuleSetProvider

--- a/gradle/build-logic/detekt-rules/src/test/kotlin/xyz/ksharma/krail/detekt/PublicImplementationClassTest.kt
+++ b/gradle/build-logic/detekt-rules/src/test/kotlin/xyz/ksharma/krail/detekt/PublicImplementationClassTest.kt
@@ -1,0 +1,165 @@
+package xyz.ksharma.krail.detekt
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PublicImplementationClassTest {
+
+    @Test
+    fun `flags a public class implementing an interface`() {
+        val code = """
+            interface Greeter {
+                fun greet(): String
+            }
+
+            class RealGreeter : Greeter {
+                override fun greet(): String = "hi"
+            }
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(1, findings.size)
+    }
+
+    @Test
+    fun `flags a public class even when its interface is declared elsewhere`() {
+        // No local interface declaration at all here — this is the realistic shape in this
+        // codebase: impl and interface live in different files (or different modules), so the
+        // rule can't and doesn't try to verify the supertype resolves to a local interface.
+        val code = """
+            class RealGreeter : Greeter {
+                override fun greet(): String = "hi"
+            }
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(1, findings.size)
+    }
+
+    @Test
+    fun `does not flag an internal implementation`() {
+        val code = """
+            internal class RealGreeter : Greeter {
+                override fun greet(): String = "hi"
+            }
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not flag a class with no supertype`() {
+        val code = """
+            class PlainValue(val value: Int)
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not flag a data class`() {
+        val code = """
+            data class RealGreeter(val name: String) : Greeter
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not flag a sealed class`() {
+        val code = """
+            sealed class Result : Greeter
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not flag a class implementing a default-excluded super type`() {
+        val code = """
+            class MyException : Throwable()
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `respects the excludeSuperTypes config`() {
+        val code = """
+            class RealGreeter : Greeter {
+                override fun greet(): String = "hi"
+            }
+        """.trimIndent()
+
+        val config = TestConfig(PublicImplementationClass.EXCLUDE_SUPER_TYPES_KEY to listOf("Greeter"))
+        val findings = PublicImplementationClass(config).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `does not flag a class extending an abstract class via constructor call`() {
+        // `: ViewModel()` is a superclass constructor call, never interface implementation —
+        // the parens are the tell, and need no type resolution to read.
+        val code = """
+            class MyViewModel : ViewModel()
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+
+    @Test
+    fun `flags only the interface half of a mixed supertype list`() {
+        val code = """
+            class RealGreeter : BaseClass(), Greeter {
+                override fun greet(): String = "hi"
+            }
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(1, findings.size)
+        assertEquals(true, findings.single().message.contains("Greeter"))
+        assertEquals(false, findings.single().message.contains("BaseClass"))
+    }
+
+    @Test
+    fun `flags delegated interface implementation`() {
+        val code = """
+            class RealGreeter(delegate: Greeter) : Greeter by delegate
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(1, findings.size)
+    }
+
+    @Test
+    fun `does not flag a nested class`() {
+        val code = """
+            class Outer {
+                class Inner : Greeter
+            }
+        """.trimIndent()
+
+        val findings = PublicImplementationClass(TestConfig()).compileAndLint(code)
+
+        assertEquals(0, findings.size)
+    }
+}

--- a/gradle/build-logic/settings.gradle.kts
+++ b/gradle/build-logic/settings.gradle.kts
@@ -20,3 +20,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "build-logic"
 include(":convention")
+include(":detekt-rules")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,6 +180,9 @@ test-robolectric = { module = "org.robolectric:robolectric", version.ref = "robo
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 detekt-compose = { group = "io.nlopez.compose.rules", name = "detekt", version.ref = "detektCompose" }
+### detekt-api/detekt-test back the custom :detekt-rules ruleset in build-logic
+detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
+detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detekt" }
 
 ## Maps
 maplibre-compose = { module = "org.maplibre.compose:maplibre-compose", version.ref = "maplibre" }
@@ -188,6 +191,7 @@ maplibre-compose = { module = "org.maplibre.compose:maplibre-compose", version.r
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidKotlinMultiplatformLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 #kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfigGradlePlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,11 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+// pluginManagement's includeBuild (above) only registers build-logic's *plugins*. Registering it
+// again here makes its regular library projects (:detekt-rules) substitutable for normal GAV
+// dependencies too — needed so Detekt.kt can add :detekt-rules to detektPlugins by coordinate.
+includeBuild("gradle/build-logic")
+
 // Read local.properties for dev credentials (git-ignored, never committed).
 val localProps = Properties().apply {
     rootProject.projectDir.resolve("local.properties").takeIf { it.exists() }?.inputStream()?.use(::load)


### PR DESCRIPTION
## What

Adds a custom detekt rule, `PublicImplementationClass`, that flags a public class implementing an interface when it should be `internal` per this repo's DI pattern (interfaces are the public surface; Koin-bound implementations are module-internal). Closes the remaining scope of #1772 (the manual sweep shipped separately in #1775).

## Changes

- New module `gradle/build-logic/detekt-rules` (plain Kotlin JVM library, sibling to `:convention` inside the `gradle/build-logic` composite build) containing `PublicImplementationClass` (the rule) and `KrailRuleSetProvider` (registers it under a `krail` ruleset via `META-INF/services`).
- `Detekt.kt`: wires `xyz.ksharma.krail.gradle:detekt-rules` into every module's `detektPlugins` configuration. Since `Detekt.kt` runs in the *root* build's project context but `:detekt-rules` lives in the *build-logic* composite build, it's requested by GAV coordinate (not `project(":detekt-rules")`, which only resolves within build-logic's own build) and resolved via Gradle's composite-build dependency substitution — `settings.gradle.kts` now also `includeBuild`s `gradle/build-logic` at the top level (previously only inside `pluginManagement`, which registers plugins but not regular library substitution).
- `config/detekt.yml`: activates `krail: PublicImplementationClass`, with an `excludeSuperTypes` denylist for external contracts (`Parcelable`, `KoinComponent`, Compose's `Shape`/`Node`/`DrawModifierNode`, etc.) and a path exclude for `:core:testing`'s `Fake*` classes, which are the repo's intentionally-public shared test doubles.
- Fixed 4 more genuine instances of the pattern that the rule caught beyond the prior manual sweep: `Navigator` (`composeApp`), `AndroidAppInfo`/`IOSAppInfo` (`core/app-info`), `DefaultFuzzyStopRanker` (`feature/trip-planner/ui`) — all now `internal`. Narrowing `Navigator` cascaded into `rememberNavigator()`, `rememberPreviewNavigator()`, and `collectEntryProviders()`, which the compiler required to also become `internal` since they exposed `Navigator` in a public signature.
- No changes needed to `scripts/fullQualityChecks.sh` or CI: both already run `./gradlew detekt`, and the rule is wired into that same task for every module.

## Why the rule matches by raw supertype name, not by resolving the interface

Ideally the rule would confirm the implemented supertype is an `interface` declared in this codebase (as opposed to a binary/library contract) using detekt's type resolution (`bindingContext`). In practice, detekt's Kotlin Multiplatform support does not populate a usable binding context for this project's module structure — verified directly: an `@RequiresTypeResolution` implementation of the same rule produced zero findings against a deliberately broken sample class, on both the experimental `detektAndroidMain` task and the `detektMetadataCommonMain` task, while the identical rule logic correctly flagged the same code in a unit test harness with type resolution set up explicitly.

The rule instead matches by raw supertype name, with one purely syntactic distinction that needs no resolution: a supertype written as `Foo(args)` is always a superclass constructor call (extending an abstract/open class, e.g. `ViewModel()`), never interface implementation, so it's excluded outright. What's left after that (`: Foo` or `: Foo by x`) is genuinely ambiguous without resolution, which is what the `excludeSuperTypes` denylist is for.

## Testing

- `gradlew :detekt-rules:test` (12 unit tests) green
- `./gradlew detekt --continue --no-build-cache --rerun` across the whole repo: zero `PublicImplementationClass` findings (confirmed with a fresh Gradle daemon each time — a long-lived daemon caches `detektPlugins` jars by URL and silently serves stale rule bytecode across runs otherwise, which cost significant time to track down during development)
- `./gradlew compileDebugSources` (Android) and `compileKotlinIosSimulatorArm64` (iOS) both green
- `./gradlew detekt testAndroidHostTest --continue --no-build-cache --rerun` across the whole repo green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
