### PR TITLE
fix(analytics): sanitize location ids and names in event params

### DIFF
--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         namespace = "xyz.ksharma.krail.core.analytics"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
+        withHostTest {}
     }
 
     iosArm64()
@@ -28,6 +29,12 @@ kotlin {
     }
 
     sourceSets {
+        commonTest {
+            dependencies {
+                implementation(libs.test.kotlin)
+            }
+        }
+
         androidMain {
             dependencies {
                 // Firebase BOM needed for GitLive Firebase Android platform dependencies

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -21,11 +21,19 @@ private const val PROP_TOTAL_COUNT = "totalCount"
 private const val PROP_LEG_COUNT = "legCount"
 private const val PROP_TRANSPORT_MODES = "transportModes"
 
-sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? = null) {
+/**
+ * Every event's [properties] pass through [AnalyticsParamSanitizer] before they are
+ * exposed, so no subclass can leak an address as text or hand Firebase a parameter value
+ * it will silently drop. Subclasses therefore build their maps from the raw values they
+ * are given - do not truncate or hash at the call site.
+ */
+sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? = null) {
+
+    val properties: Map<String, Any>? = rawProperties?.let(AnalyticsParamSanitizer::sanitize)
 
     data class ScreenViewEvent(val screen: AnalyticsScreen) : AnalyticsEvent(
         name = "view_screen",
-        properties = mapOf("name" to screen.name),
+        rawProperties = mapOf("name" to screen.name),
     )
 
     // region SavedTrips
@@ -33,13 +41,13 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class SavedTripCardClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "saved_trip_card_click",
-            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+            rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     data class DeleteSavedTripClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "delete_saved_trip_card_click",
-            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+            rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     data object ReverseStopClickEvent : AnalyticsEvent(name = "reverse_stop_click")
@@ -47,7 +55,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class LoadTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "load_timetable_click",
-            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+            rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     /**
@@ -58,7 +66,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class RetryApiEvent(val source: Source) :
         AnalyticsEvent(
             name = "retry_api",
-            properties = mapOf(PROP_SOURCE to source.value),
+            rawProperties = mapOf(PROP_SOURCE to source.value),
         ) {
         enum class Source(val value: String) {
             TIMETABLE("timetable"),
@@ -98,7 +106,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val totalCount: Int,
     ) : AnalyticsEvent(
         name = "saved_trip_card_reordered",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_FROM_STOP_ID to fromStopId,
             PROP_TO_STOP_ID to toStopId,
             PROP_PREVIOUS_INDEX to previousIndex,
@@ -112,6 +120,12 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     // region SearchStop
 
     /**
+     * @param stopId               Transit stop ids are sent as-is. An address/POI id is
+     *                             replaced by a short stable hash by
+     *                             [AnalyticsParamSanitizer]: the raw EFA id embeds the
+     *                             street and suburb as text, and at 120+ characters
+     *                             Firebase dropped the parameter outright, which made
+     *                             every address selection look like it carried no stop.
      * @param searchSessionId      Joins the selection to its [SearchStopQuery] firings.
      *                             Null when the selection had no live query (recents,
      *                             empty-state stops, map picks).
@@ -131,7 +145,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val displayedAddressCount: CountBucket? = null,
     ) : AnalyticsEvent(
         name = "stop_selected",
-        properties = buildMap {
+        rawProperties = buildMap {
             put(PROP_STOP_ID, stopId)
             put("isRecentSearch", isRecentSearch)
             put("locationKind", locationKind.value)
@@ -219,7 +233,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val resultSource: ResultSource = ResultSource.LOCAL,
     ) : AnalyticsEvent(
         name = "search_stop_query",
-        properties = buildMap {
+        rawProperties = buildMap {
             put("queryLength", queryLength)
             put("searchSessionId", searchSessionId)
             put("resultSource", resultSource.value)
@@ -241,7 +255,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val recentSearchCount: Int,
     ) : AnalyticsEvent(
         name = "clear_recent_search_stops",
-        properties = mapOf(
+        rawProperties = mapOf(
             "recentSearchCount" to recentSearchCount,
         ),
     )
@@ -308,7 +322,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val labelCountBucket: StopLabelCountBucket,
     ) : AnalyticsEvent(
         name = "stop_label_created",
-        properties = mapOf(
+        rawProperties = mapOf(
             "creationSurface" to creationSurface.value,
             "labelCountBucket" to labelCountBucket.value,
         ),
@@ -347,7 +361,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val isReassignment: Boolean,
     ) : AnalyticsEvent(
         name = "stop_label_stop_assigned",
-        properties = mapOf(
+        rawProperties = mapOf(
             "assignmentSurface" to assignmentSurface.value,
             "assignmentMode" to assignmentMode.value,
             "locationKind" to locationKind.value,
@@ -386,7 +400,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val labelKind: StopLabelKind,
     ) : AnalyticsEvent(
         name = "stop_label_removed",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_ACTION to action.value,
             "hadStop" to hadStop,
             PROP_LABEL_KIND to labelKind.value,
@@ -423,7 +437,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val setLabelCountBucket: StopLabelCountBucket,
     ) : AnalyticsEvent(
         name = "stop_label_reordered",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_LABEL_KIND to labelKind.value,
             "moveDistanceBucket" to moveDistanceBucket.value,
             "setLabelCountBucket" to setLabelCountBucket.value,
@@ -454,7 +468,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     data class ThemeSelectedEvent(val themeId: String) : AnalyticsEvent(
         name = "theme_selected",
-        properties = mapOf("themeId" to themeId),
+        rawProperties = mapOf("themeId" to themeId),
     )
 
     // endregion
@@ -470,7 +484,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class ReverseTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "reverse_time_table_click",
-            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+            rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     /**
@@ -484,7 +498,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: String = SOURCE_STAR,
     ) : AnalyticsEvent(
         name = "save_trip_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_FROM_STOP_ID to fromStopId,
             PROP_TO_STOP_ID to toStopId,
             PROP_SOURCE to source,
@@ -505,7 +519,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      */
     data class SaveTripPromptShownEvent(val variant: String) : AnalyticsEvent(
         name = "save_trip_prompt_shown",
-        properties = mapOf(PROP_VARIANT to variant),
+        rawProperties = mapOf(PROP_VARIANT to variant),
     ) {
         companion object {
             const val VARIANT_PLAIN = "plain"
@@ -527,7 +541,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val dismissCount: Int = 0,
     ) : AnalyticsEvent(
         name = "save_trip_prompt_action",
-        properties = mapOf(
+        rawProperties = mapOf(
             "accepted" to accepted,
             PROP_VARIANT to variant,
             "dismissCount" to dismissCount,
@@ -536,7 +550,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
 
     data class PlanTripClickEvent(val fromStopId: String, val toStopId: String) : AnalyticsEvent(
         name = "plan_trip_click",
-        properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+        rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
     )
 
     data class ModeClickEvent(
@@ -545,7 +559,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val displayModeSelectionRow: Boolean,
     ) : AnalyticsEvent(
         name = "mode_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_FROM_STOP_ID to fromStopId,
             PROP_TO_STOP_ID to toStopId,
             "displayModeSelectionRow" to displayModeSelectionRow,
@@ -558,7 +572,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val unselectedProductClasses: Set<Int>,
     ) : AnalyticsEvent(
         name = "mode_selection_done",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_FROM_STOP_ID to fromStopId,
             PROP_TO_STOP_ID to toStopId,
             "unselected" to unselectedProductClasses.toString(),
@@ -573,7 +587,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val isReset: Boolean = false,
     ) : AnalyticsEvent(
         name = "date_time_select",
-        properties = mapOf(
+        rawProperties = mapOf(
             "dayOfWeek" to dayOfWeek,
             "time" to time,
             "journeyOption" to journeyOption,
@@ -605,7 +619,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val isPastDeparture: Boolean,
     ) : AnalyticsEvent(
         name = "share_journey_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_TRANSPORT_MODES to transportModes,
             "lines" to lines,
             PROP_LEG_COUNT to legCount,
@@ -626,7 +640,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val transportModes: String,
     ) : AnalyticsEvent(
         name = "journey_card_toggle",
-        properties = mapOf(
+        rawProperties = mapOf(
             "expanded" to expanded,
             "hasStarted" to hasStarted,
             PROP_LEG_COUNT to legCount,
@@ -647,7 +661,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val lineName: String,
     ) : AnalyticsEvent(
         name = "journey_leg_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             "expanded" to expanded,
             "transportMode" to transportMode,
             "lineName" to lineName,
@@ -657,7 +671,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
     data class JourneyAlertClickEvent(val fromStopId: String, val toStopId: String) :
         AnalyticsEvent(
             name = "journey_alert_click",
-            properties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
+            rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
         )
 
     /**
@@ -699,7 +713,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val action: String,
     ) : AnalyticsEvent(
         name = "timetable_stop_header_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             PROP_STOP_NAME to stopName,
             "isOrigin" to isOrigin,
@@ -742,7 +756,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val visibleJourneyCount: Int,
     ) : AnalyticsEvent(
         name = "timetable_load_more_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_FROM_STOP_ID to fromStopId,
             PROP_TO_STOP_ID to toStopId,
             "loadMoreCount" to loadMoreCount,
@@ -774,7 +788,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val visibleJourneyCount: Int,
     ) : AnalyticsEvent(
         name = "timetable_load_previous_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_FROM_STOP_ID to fromStopId,
             PROP_TO_STOP_ID to toStopId,
             "isCustomDateTime" to isCustomDateTime,
@@ -800,14 +814,14 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val topLevelRoute: String,
     ) : AnalyticsEvent(
         name = "no_entries_detected",
-        properties = mapOf("topLevelRoute" to topLevelRoute),
+        rawProperties = mapOf("topLevelRoute" to topLevelRoute),
     )
 
     data class BackClickEvent(
         val fromScreen: AnalyticsScreen,
     ) : AnalyticsEvent(
         name = "back_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             "fromScreen" to fromScreen.name,
         ),
     )
@@ -825,7 +839,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val timeZone: String,
     ) : AnalyticsEvent(
         name = "app_start",
-        properties = mapOf(
+        rawProperties = mapOf(
             "platformType" to platformType.trim(),
             "appVersion" to appVersion.trim(),
             "osVersion" to osVersion.trim(),
@@ -850,7 +864,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      */
     data class ReferFriend(val entryPoint: EntryPoint) : AnalyticsEvent(
         name = "refer_friend",
-        properties = mapOf(
+        rawProperties = mapOf(
             "entryPoint" to entryPoint.from,
         ),
     ) {
@@ -874,7 +888,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val pageNumber: Int,
     ) : AnalyticsEvent(
         name = "intro_lets_krail",
-        properties = mapOf(
+        rawProperties = mapOf(
             "completedOnPage" to pageType.name,
             "completedOnPageNumber" to pageNumber,
         ),
@@ -897,7 +911,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: SocialConnectionSource,
     ) : AnalyticsEvent(
         name = "social_connection_link_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             "socialPlatform" to socialPlatformType.platformName,
             PROP_SOURCE to source.source,
         ),
@@ -931,7 +945,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val time: Long = Clock.System.now().epochSeconds,
     ) : AnalyticsEvent(
         name = "park_ride_card_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId.trim(),
             "facilityId" to facilityId.trim(),
             PROP_EXPAND to expand.toString().trim(),
@@ -956,7 +970,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: Source,
     ) : AnalyticsEvent(
         name = "park_ride_user_facility",
-        properties = mapOf(
+        rawProperties = mapOf(
             "facilityId" to facilityId.trim(),
             PROP_STOP_ID to stopId.trim(),
             PROP_ACTION to action.value,
@@ -993,7 +1007,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val partnerSocialLink: PartnerSocialLink? = null,
     ) : AnalyticsEvent(
         name = "discover_card_click",
-        properties = mutableMapOf(
+        rawProperties = mutableMapOf(
             // "location" to location,
             PROP_SOURCE to source.actionName,
             "cardId" to cardId,
@@ -1030,7 +1044,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val location: String = "SYD",
     ) : AnalyticsEvent(
         name = "discover_session_complete",
-        properties = mapOf(
+        rawProperties = mapOf(
             "cardSeenCount" to cardSeenCount,
             "location" to location,
         ),
@@ -1040,7 +1054,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val cardType: DiscoverCardClick.CardType,
     ) : AnalyticsEvent(
         name = "discover_filter_chip_selected",
-        properties = mapOf(
+        rawProperties = mapOf(
             "cardType" to cardType.displayName,
         ),
     )
@@ -1082,7 +1096,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val modesChanged: Boolean,
     ) : AnalyticsEvent(
         name = "search_stop_map_options_saved",
-        properties = mapOf(
+        rawProperties = mapOf(
             "radiusKm" to radiusKm,
             PROP_TRANSPORT_MODES to transportModes,
             "showDistanceScale" to showDistanceScale,
@@ -1122,7 +1136,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val hadUserLocation: Boolean,
     ) : AnalyticsEvent(
         name = "stop_selected_from_map",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             "searchRadiusKm" to searchRadiusKm,
             "enabledModesCount" to enabledModesCount,
@@ -1149,7 +1163,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val transportModesCount: Int,
     ) : AnalyticsEvent(
         name = "nearby_stop_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             "transportModesCount" to transportModesCount,
         ),
@@ -1175,7 +1189,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: Source,
     ) : AnalyticsEvent(
         name = "location_permission_settings_click",
-        properties = mapOf(PROP_SOURCE to source.value),
+        rawProperties = mapOf(PROP_SOURCE to source.value),
     ) {
         enum class Source(val value: String) {
             SEARCH_STOP_MAP("search_stop_map"),
@@ -1201,7 +1215,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: Source,
     ) : AnalyticsEvent(
         name = "user_location_button_click",
-        properties = mapOf(
+        rawProperties = mapOf(
             "isLocationActive" to isLocationActive,
             PROP_SOURCE to source.value,
         ),
@@ -1245,7 +1259,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: DepartureBoardSource,
     ) : AnalyticsEvent(
         name = "dep_board_screen_view",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             PROP_STOP_NAME to stopName,
             PROP_SOURCE to source.value,
@@ -1273,7 +1287,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: DepartureBoardSource,
     ) : AnalyticsEvent(
         name = "dep_board_line_filter_click",
-        properties = buildMap {
+        rawProperties = buildMap {
             put(PROP_STOP_ID, stopId)
             put("selected", selected)
             put(PROP_SOURCE, source.value)
@@ -1296,7 +1310,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: DepartureBoardSource,
     ) : AnalyticsEvent(
         name = "dep_board_show_previous",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             "show" to show,
             PROP_SOURCE to source.value,
@@ -1319,7 +1333,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: DepartureBoardSource,
     ) : AnalyticsEvent(
         name = "dep_board_toggle",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             PROP_STOP_NAME to stopName,
             PROP_EXPAND to expand,
@@ -1345,7 +1359,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val source: DepartureBoardSource,
     ) : AnalyticsEvent(
         name = "dep_board_status",
-        properties = mapOf(
+        rawProperties = mapOf(
             PROP_STOP_ID to stopId,
             PROP_ACTION to action.value,
             PROP_SOURCE to source.value,
@@ -1368,7 +1382,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
         val ctaUrl: String? = null,
     ) : AnalyticsEvent(
         name = "info_tile_interaction",
-        properties = mutableMapOf<String, Any>(
+        rawProperties = mutableMapOf<String, Any>(
             "key" to key,
         ).apply {
             dismiss?.let { put("dismiss", dismiss) }
@@ -1393,7 +1407,7 @@ sealed class AnalyticsEvent(val name: String, val properties: Map<String, Any>? 
      */
     data class ReviewPromptRequestedEvent(val source: String) : AnalyticsEvent(
         name = "review_prompt_requested",
-        properties = mapOf(PROP_SOURCE to source),
+        rawProperties = mapOf(PROP_SOURCE to source),
     )
 
     // endregion

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizer.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizer.kt
@@ -1,0 +1,85 @@
+package xyz.ksharma.krail.core.analytics.event
+
+/**
+ * Last line of defence applied to every [AnalyticsEvent]'s properties before they leave
+ * the app. Two failure modes it exists to stop:
+ *
+ * 1. **Firebase silently drops any String parameter longer than 100 characters.** The
+ *    event still lands, the parameter simply is not there, so a dashboard reads
+ *    "this feature is unused" instead of "this parameter was rejected". Address/POI
+ *    selections hit exactly this: an EFA `streetID:...` id is 120+ characters, so
+ *    `stop_selected` rows for addresses arrived with no `stopId` at all.
+ * 2. **Address ids and address display names are personal data.** An EFA address id
+ *    embeds the street, suburb and postcode as plain text
+ *    (`streetID:1500000015:123:...:Example St:Parramatta:...:2150:...`), and the matching
+ *    display name is the address itself. Sending either would undo the search-query
+ *    redaction the app already does - a home address is exactly what must never reach
+ *    analytics.
+ *
+ * Transit stop ids are unaffected: they are short and non-identifying, so they pass
+ * through verbatim and every existing stop dashboard keeps working. An id is treated as
+ * identifying when it is namespaced with a colon (`streetID:`, `poiID:`, `coord:`) or
+ * exceeds the parameter limit - structural rather than prefix matching, so an unknown
+ * future EFA namespace is redacted too rather than leaking until someone notices.
+ */
+internal object AnalyticsParamSanitizer {
+
+    /** Firebase's hard limit for a String parameter value; longer values are dropped. */
+    const val MAX_PARAM_VALUE_LENGTH = 100
+
+    /**
+     * Substituted for a stop name that belongs to an address/POI, so the row stays
+     * countable without carrying the address text.
+     */
+    const val REDACTED_LOCATION_NAME = "address"
+
+    /** Prefix marking a value as a hashed location id rather than a real stop id. */
+    const val HASHED_ID_PREFIX = "addr_"
+
+    private const val NAMESPACE_SEPARATOR = ':'
+
+    private val LOCATION_ID_KEYS = setOf("stopId", "fromStopId", "toStopId")
+
+    private val LOCATION_NAME_KEYS = setOf("stopName")
+
+    private const val FNV_OFFSET_BASIS = -3_750_763_034_362_895_579L // 0xcbf29ce484222325
+    private const val FNV_PRIME = 1_099_511_628_211L
+    private const val HEX_RADIX = 16
+    private const val HASH_HEX_LENGTH = 16
+
+    fun sanitize(properties: Map<String, Any>): Map<String, Any> {
+        val hasAddressId = properties.any { (key, value) ->
+            key in LOCATION_ID_KEYS && value is String && value.isAddressId()
+        }
+        return properties.mapValues { (key, value) ->
+            when {
+                value !is String -> value
+                key in LOCATION_ID_KEYS -> locationId(value)
+                key in LOCATION_NAME_KEYS && hasAddressId -> REDACTED_LOCATION_NAME
+                value.length > MAX_PARAM_VALUE_LENGTH -> value.take(MAX_PARAM_VALUE_LENGTH)
+                else -> value
+            }
+        }
+    }
+
+    /**
+     * Returns [rawId] unchanged for transit stops, or a stable short hash for an
+     * address/POI id. The hash is deterministic across platforms and app launches, so
+     * "which addresses are picked most" stays answerable while the address text does not.
+     */
+    fun locationId(rawId: String): String =
+        if (rawId.isAddressId()) HASHED_ID_PREFIX + hash(rawId) else rawId
+
+    private fun String.isAddressId(): Boolean =
+        contains(NAMESPACE_SEPARATOR) || length > MAX_PARAM_VALUE_LENGTH
+
+    /** FNV-1a 64-bit - no crypto dependency needed, and identical on Android and iOS. */
+    private fun hash(value: String): String {
+        var hash = FNV_OFFSET_BASIS
+        for (char in value) {
+            hash = hash xor char.code.toLong()
+            hash *= FNV_PRIME
+        }
+        return hash.toULong().toString(HEX_RADIX).padStart(HASH_HEX_LENGTH, '0')
+    }
+}

--- a/core/analytics/src/commonTest/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizerTest.kt
+++ b/core/analytics/src/commonTest/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizerTest.kt
@@ -1,0 +1,132 @@
+package xyz.ksharma.krail.core.analytics.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AnalyticsParamSanitizerTest {
+
+    @Test
+    fun `transit stop id passes through unchanged`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(mapOf("stopId" to "200060"))
+
+        assertEquals("200060", sanitized["stopId"])
+    }
+
+    @Test
+    fun `address id is hashed`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(mapOf("stopId" to ADDRESS_ID))
+
+        val stopId = sanitized["stopId"] as String
+        assertTrue(stopId.startsWith(AnalyticsParamSanitizer.HASHED_ID_PREFIX))
+        assertTrue(stopId.length <= AnalyticsParamSanitizer.MAX_PARAM_VALUE_LENGTH)
+    }
+
+    @Test
+    fun `hashed address id carries none of the address text`() {
+        val stopId = AnalyticsParamSanitizer.locationId(ADDRESS_ID)
+
+        assertTrue("Example" !in stopId)
+        assertTrue("Parramatta" !in stopId)
+        assertTrue("2150" !in stopId)
+    }
+
+    @Test
+    fun `same address id always hashes to the same value`() {
+        assertEquals(
+            AnalyticsParamSanitizer.locationId(ADDRESS_ID),
+            AnalyticsParamSanitizer.locationId(ADDRESS_ID),
+        )
+    }
+
+    @Test
+    fun `different address ids hash to different values`() {
+        val other = ADDRESS_ID.replace("Example St", "Other St")
+
+        assertTrue(
+            AnalyticsParamSanitizer.locationId(ADDRESS_ID) !=
+                AnalyticsParamSanitizer.locationId(other),
+        )
+    }
+
+    @Test
+    fun `poi and coord ids are hashed too`() {
+        listOf("poiID:987654:Museum", "coord:151.2:-33.8:EPSG:4326").forEach { rawId ->
+            assertTrue(
+                AnalyticsParamSanitizer.locationId(rawId)
+                    .startsWith(AnalyticsParamSanitizer.HASHED_ID_PREFIX),
+                "expected $rawId to be hashed",
+            )
+        }
+    }
+
+    @Test
+    fun `trip endpoint ids are sanitized as well`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(
+            mapOf("fromStopId" to ADDRESS_ID, "toStopId" to "200060"),
+        )
+
+        assertTrue(
+            (sanitized["fromStopId"] as String)
+                .startsWith(AnalyticsParamSanitizer.HASHED_ID_PREFIX),
+        )
+        assertEquals("200060", sanitized["toStopId"])
+    }
+
+    @Test
+    fun `stop name is redacted when the id is an address`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(
+            mapOf("stopId" to ADDRESS_ID, "stopName" to "35 Example St, Parramatta"),
+        )
+
+        assertEquals(AnalyticsParamSanitizer.REDACTED_LOCATION_NAME, sanitized["stopName"])
+    }
+
+    @Test
+    fun `stop name is kept for a transit stop`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(
+            mapOf("stopId" to "200060", "stopName" to "Central Station"),
+        )
+
+        assertEquals("Central Station", sanitized["stopName"])
+    }
+
+    @Test
+    fun `any over-long string value is truncated rather than dropped by Firebase`() {
+        val long = "a".repeat(250)
+
+        val sanitized = AnalyticsParamSanitizer.sanitize(mapOf("query" to long))
+
+        assertEquals(AnalyticsParamSanitizer.MAX_PARAM_VALUE_LENGTH, (sanitized["query"] as String).length)
+    }
+
+    @Test
+    fun `non string values are untouched`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(
+            mapOf("isRecentSearch" to true, "totalCount" to 7),
+        )
+
+        assertEquals(true, sanitized["isRecentSearch"])
+        assertEquals(7, sanitized["totalCount"])
+    }
+
+    @Test
+    fun `event properties are sanitized through the base class`() {
+        val event = AnalyticsEvent.StopSelectedEvent(
+            stopId = ADDRESS_ID,
+            locationKind = AnalyticsEvent.StopSelectedEvent.LocationKind.ADDRESS,
+        )
+
+        val stopId = event.properties?.get("stopId") as String
+        assertTrue(stopId.length <= AnalyticsParamSanitizer.MAX_PARAM_VALUE_LENGTH)
+        assertTrue("Example" !in stopId)
+    }
+
+    private companion object {
+        // Shape of a real EFA address id: the street, suburb and postcode are plain text
+        // and the whole thing is well over Firebase's 100-char parameter limit.
+        const val ADDRESS_ID =
+            "streetID:1500000015:123:95346013:-1:Example St:Parramatta:Example St::" +
+                "Example St:2150:ANY:DIVA_SINGLEHOUSE:4871080:3749205:GDAV:nsw:0"
+    }
+}

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -76,6 +76,37 @@ address results were on screen, the user picked an address" without any query te
 Rows before 2026-07-15 have no `searchSessionId`; treat missing as "pre-join era",
 only app-session-level funnels are possible there.
 
+## Param sanitizing: location ids and the 100-char limit
+
+Every event's properties pass through `AnalyticsParamSanitizer` in the `AnalyticsEvent`
+base class, so no call site needs to hash or truncate. It exists because of two traps:
+
+- **Firebase silently drops any String param value over 100 characters.** The event still
+  lands, the param is just missing, so a dashboard reads "unused feature" rather than
+  "rejected param". This is exactly what happened to address selections in v1.25: an EFA
+  `streetID:...` id is 120+ chars, so `stop_selected` rows for addresses arrived with no
+  `stopId`, address search looked unused, and stop rankings quietly omitted those
+  selections.
+- **Address ids and address display names are personal data.** An EFA address id embeds
+  the street, suburb and postcode as plain text, and the display name is the address
+  itself. Sending either would undo the query redaction described above.
+
+Rules applied:
+
+| Param | Value | Result |
+|---|---|---|
+| `stopId`, `fromStopId`, `toStopId` | transit stop id (no colon, ≤ 100 chars) | unchanged |
+| `stopId`, `fromStopId`, `toStopId` | namespaced id (`streetID:`, `poiID:`, `coord:`) or over the limit | `addr_` + stable 64-bit hash |
+| `stopName` | event also carries an address id | `address` |
+| any String | over 100 chars | truncated to 100 |
+
+The hash is stable across launches and devices, so "which addresses get picked" stays
+rankable while the address text never leaves the device. Address rows before this shipped
+have **no** `stopId` at all — do not read their absence as "no address selections".
+
+When adding a param that can carry a location id or a user-visible place name, add its key
+to the relevant set in `AnalyticsParamSanitizer` rather than sanitizing at the call site.
+
 ## How analytics reaches the dashboard
 
 `AnalyticsEvent.kt` is the only thing this repo owns for analytics — it defines the event


### PR DESCRIPTION
## What

Firebase silently drops any String event parameter longer than 100 characters: the event
still lands, the parameter is simply missing. EFA address and POI ids
(`streetID:...`, `poiID:...`, `coord:...`) run well past that limit, so `stop_selected`
rows for address selections arrived with no `stopId` and address selections could not be
counted.

Those ids are also not safe to send verbatim. An EFA address id embeds the street, suburb
and postcode as plain text, and the matching `stopName` is the address itself, so sending
either would undo the query redaction the app already does. The same ids reach
`fromStopId` / `toStopId` whenever a trip origin or destination is an address, so the fix
is applied centrally rather than per event.

## Changes

- New `AnalyticsParamSanitizer` in `:core:analytics`:
  - `stopId`, `fromStopId`, `toStopId` keep transit stop ids verbatim; a namespaced or
    over-long id is replaced with a stable FNV-1a 64-bit hash prefixed `addr_`
  - `stopName` becomes `address` when the same event carries an address id
  - any other String value over 100 characters is truncated rather than dropped
  - an id counts as identifying when it contains a colon or exceeds the limit, which is
    structural rather than a prefix list, so an unknown future namespace is redacted by
    default
- `AnalyticsEvent` base class routes every properties map through the sanitizer. The
  constructor parameter is renamed to `rawProperties`; `properties` now exposes the
  sanitized map, so no call site hashes or truncates.
- `:core:analytics` gains `withHostTest {}` and a `commonTest` source set; the module had
  no tests before.
- `docs/ANALYTICS_EVENTS.md` documents the sanitizing rules and the fact that address rows
  predating this change carry no `stopId` at all.
- The hash is deterministic across platforms and launches, so grouping by an address id
  still works while the address text never leaves the device.

## Testing

- `./gradlew :core:analytics:testAndroidHostTest` green (12 new tests: transit ids pass
  through, address/POI/coord ids hash, hash is stable and collision-free across two
  addresses, no address text survives, `stopName` redaction, truncation, non-String values
  untouched, sanitizing applied through the event base class)
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest
  :feature:track:ui:testAndroidHostTest :feature:track:state:testAndroidHostTest
  :composeApp:testAndroidHostTest --continue` green
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS simulator compile, detekt)

No UI change, so no device QA and no snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
