### PR TITLE
fix(analytics): send park and ride facility ids, mark truncated values

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizer.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizer.kt
@@ -36,6 +36,16 @@ internal object AnalyticsParamSanitizer {
     /** Prefix marking a value as a hashed location id rather than a real stop id. */
     const val HASHED_ID_PREFIX = "addr_"
 
+    /**
+     * Appended to a value that was too long to send whole. Truncation keeps the row
+     * instead of letting Firebase drop the param, but a silently shortened value is
+     * indistinguishable from a real one - a param that starts arriving as clean-looking
+     * garbage is worse than one that is visibly rejected. The marker keeps the defect
+     * visible in the dashboard: any value ending in it is a call site sending the wrong
+     * thing, not data.
+     */
+    const val TRUNCATION_MARKER = "~trunc"
+
     private const val NAMESPACE_SEPARATOR = ':'
 
     private val LOCATION_ID_KEYS = setOf("stopId", "fromStopId", "toStopId")
@@ -56,7 +66,7 @@ internal object AnalyticsParamSanitizer {
                 value !is String -> value
                 key in LOCATION_ID_KEYS -> locationId(value)
                 key in LOCATION_NAME_KEYS && hasAddressId -> REDACTED_LOCATION_NAME
-                value.length > MAX_PARAM_VALUE_LENGTH -> value.take(MAX_PARAM_VALUE_LENGTH)
+                value.length > MAX_PARAM_VALUE_LENGTH -> truncate(value)
                 else -> value
             }
         }
@@ -69,6 +79,9 @@ internal object AnalyticsParamSanitizer {
      */
     fun locationId(rawId: String): String =
         if (rawId.isAddressId()) HASHED_ID_PREFIX + hash(rawId) else rawId
+
+    private fun truncate(value: String): String =
+        value.take(MAX_PARAM_VALUE_LENGTH - TRUNCATION_MARKER.length) + TRUNCATION_MARKER
 
     private fun String.isAddressId(): Boolean =
         contains(NAMESPACE_SEPARATOR) || length > MAX_PARAM_VALUE_LENGTH

--- a/core/analytics/src/commonTest/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizerTest.kt
+++ b/core/analytics/src/commonTest/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsParamSanitizerTest.kt
@@ -101,6 +101,22 @@ class AnalyticsParamSanitizerTest {
     }
 
     @Test
+    fun `truncated value is marked so it cannot be mistaken for real data`() {
+        val sanitized = AnalyticsParamSanitizer.sanitize(mapOf("facilityId" to "b".repeat(150)))
+
+        assertTrue((sanitized["facilityId"] as String).endsWith(AnalyticsParamSanitizer.TRUNCATION_MARKER))
+    }
+
+    @Test
+    fun `a value at the limit is left alone`() {
+        val exact = "c".repeat(AnalyticsParamSanitizer.MAX_PARAM_VALUE_LENGTH)
+
+        val sanitized = AnalyticsParamSanitizer.sanitize(mapOf("query" to exact))
+
+        assertEquals(exact, sanitized["query"])
+    }
+
+    @Test
     fun `non string values are untouched`() {
         val sanitized = AnalyticsParamSanitizer.sanitize(
             mapOf("isRecentSearch" to true, "totalCount" to 7),

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -98,11 +98,18 @@ Rules applied:
 | `stopId`, `fromStopId`, `toStopId` | transit stop id (no colon, ≤ 100 chars) | unchanged |
 | `stopId`, `fromStopId`, `toStopId` | namespaced id (`streetID:`, `poiID:`, `coord:`) or over the limit | `addr_` + stable 64-bit hash |
 | `stopName` | event also carries an address id | `address` |
-| any String | over 100 chars | truncated to 100 |
+| any String | over 100 chars | truncated to 100, ending in `~trunc` |
 
 The hash is stable across launches and devices, so "which addresses get picked" stays
 rankable while the address text never leaves the device. Address rows before this shipped
 have **no** `stopId` at all — do not read their absence as "no address selections".
+
+The `~trunc` suffix is deliberate. Truncation keeps the row instead of letting Firebase
+drop the param, but a silently shortened value looks exactly like a real one, so a broken
+call site would read as working data and the rejection signal that flags it would vanish.
+Any value ending in `~trunc` is a call site sending the wrong thing, not data. Fix the
+call site rather than widening the limit: `park_ride_card_click.facilityId` was joining
+whole facility objects instead of their ids, which is a call-site bug, not a length one.
 
 When adding a param that can carry a location id or a user-visible place name, add its key
 to the relevant set in `AnalyticsParamSanitizer` rather than sanitizing at the call site.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -250,7 +250,14 @@ class SavedTripsViewModel(
             event = AnalyticsEvent.ParkRideCardClickEvent(
                 stopId = parkRideState.stopId,
                 expand = isExpanded,
-                facilityId = parkRideState.facilities.joinToString(),
+                // Ids only: joining the facility objects themselves stringified the whole
+                // data class, which is both unreadable and long enough that Firebase
+                // rejected the param outright. Sorted and comma-joined matches how
+                // multi-value params are encoded elsewhere (e.g. transportModes).
+                facilityId = parkRideState.facilities
+                    .map { it.facilityId }
+                    .sorted()
+                    .joinToString(separator = ","),
             ),
         )
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
@@ -597,6 +597,26 @@ class SavedTripsViewModelTest {
         )
     }
 
+    @Test
+    fun `GIVEN ParkRideCardClick event WHEN tracked THEN facilityId carries ids only`() = runTest {
+        val parkRideState = createParkRideUiState(
+            facilities = persistentSetOf(
+                createParkRideFacilityDetail(facilityId = "28", facilityName = "North car park"),
+                createParkRideFacilityDetail(facilityId = "26", facilityName = "South car park"),
+            ),
+        )
+
+        viewModel.onEvent(SavedTripUiEvent.ParkRideCardClick(parkRideState, isExpanded = true))
+
+        val event = assertIs<AnalyticsEvent.ParkRideCardClickEvent>(
+            (fakeAnalytics as FakeAnalytics).getTrackedEvent("park_ride_card_click"),
+        )
+        // Sorted so the same pair of car parks is always one value, and ids only: joining
+        // the facility objects stringified the whole data class and blew the param limit.
+        assertEquals("26,28", event.facilityId)
+        assertEquals("26,28", event.properties?.get("facilityId"))
+    }
+
     // endregion Park and Ride Tests
 
     // region Selected Stop Events Tests


### PR DESCRIPTION
## What

`park_ride_card_click` sent `facilityId` as `facilities.joinToString()`, which stringified
the whole `ParkRideFacilityDetail` data class. The result ran past Firebase's 100-character
parameter limit and was rejected outright, so the param carried nothing.

## Changes

- `SavedTripsViewModel` joins the facility **ids**, sorted and comma-separated, matching how
  other multi-value params are encoded
- `AnalyticsParamSanitizer` now appends `~trunc` to any value it shortens. Truncation on its
  own turned a visibly rejected param into clean-looking garbage and removed the signal that
  flags the broken call site
- Ledger row added for the marker

## Testing

- `./gradlew :core:analytics:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest` green
- `./scripts/fullQualityChecks.sh` green
- Device (Pixel Tablet emulator): `ParkRideCardClickEvent(stopId=2155384, facilityId=26,27,28, expand=true)`

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
