### PR TITLE
feat(analytics): carry searchSessionId through to load_timetable_click

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -20,6 +20,7 @@ private const val PROP_NEW_INDEX = "newIndex"
 private const val PROP_TOTAL_COUNT = "totalCount"
 private const val PROP_LEG_COUNT = "legCount"
 private const val PROP_TRANSPORT_MODES = "transportModes"
+private const val PROP_SEARCH_SESSION_ID = "searchSessionId"
 
 /**
  * Every event's [properties] pass through [AnalyticsParamSanitizer] before they are
@@ -52,11 +53,26 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
 
     data object ReverseStopClickEvent : AnalyticsEvent(name = "reverse_stop_click")
 
-    data class LoadTimeTableClickEvent(val fromStopId: String, val toStopId: String) :
-        AnalyticsEvent(
-            name = "load_timetable_click",
-            rawProperties = mapOf(PROP_FROM_STOP_ID to fromStopId, PROP_TO_STOP_ID to toStopId),
-        )
+    /**
+     * @param searchSessionId Set when this trip was loaded off the back of a stop the
+     *                        rider had just searched for, which is what closes the search
+     *                        funnel: [StopSelectedEvent] only proves a stop was picked,
+     *                        this proves the rider reached departure times. Null when the
+     *                        trip was loaded from a saved card, a recent, or a map pick -
+     *                        no search preceded it, so attributing one would be wrong.
+     */
+    data class LoadTimeTableClickEvent(
+        val fromStopId: String,
+        val toStopId: String,
+        val searchSessionId: String? = null,
+    ) : AnalyticsEvent(
+        name = "load_timetable_click",
+        rawProperties = buildMap {
+            put(PROP_FROM_STOP_ID, fromStopId)
+            put(PROP_TO_STOP_ID, toStopId)
+            searchSessionId?.let { put(PROP_SEARCH_SESSION_ID, it) }
+        },
+    )
 
     /**
      * User taps Retry after an API/load failure. Unified across surfaces to stay within the
@@ -150,7 +166,7 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
             put("isRecentSearch", isRecentSearch)
             put("locationKind", locationKind.value)
             addressType?.let { put("addressType", it.value) }
-            searchSessionId?.let { put("searchSessionId", it) }
+            searchSessionId?.let { put(PROP_SEARCH_SESSION_ID, it) }
             displayedLocalCount?.let { put("displayedLocalCount", it.value) }
             displayedAddressCount?.let { put("displayedAddressCount", it.value) }
         },
@@ -235,7 +251,7 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
         name = "search_stop_query",
         rawProperties = buildMap {
             put("queryLength", queryLength)
-            put("searchSessionId", searchSessionId)
+            put(PROP_SEARCH_SESSION_ID, searchSessionId)
             put("resultSource", resultSource.value)
             if (isError) {
                 put("isError", isError)

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -62,7 +62,15 @@ Semantics:
 - **One ID per settled query.** Typing "cen" then "central" mints two IDs. Every
   event describing the same query instance carries the same ID.
 - **Carried by** `search_stop_query` (both the `resultSource = local` and
-  `resultSource = address` firings) and `stop_selected`.
+  `resultSource = address` firings), `stop_selected`, and `load_timetable_click`.
+- **Closes at the timetable, not the selection.** `stop_selected` only proves a stop was
+  picked; `load_timetable_click` is where the rider actually reaches departure times, so
+  the id is carried across via `SearchSessionStore` (`:feature:trip-planner:ui`). Two
+  rules keep that attribution honest: the pending id is **consumed once** (loading the
+  same trip again is a repeat view, not a second conversion), and it is only attached when
+  the loaded trip still contains **the stop that was selected in that session** (searching
+  and then tapping an unrelated saved trip attributes nothing). A selection with no live
+  query records a null id, which also clears any earlier pending one.
 - **Null when there is no live query.** Selections from recents, empty-state stops,
   and map picks attach no ID; joining them to a search would be wrong.
 - **Meaningless by design.** Not stored on device, not derived from anything, adds

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -28,8 +28,10 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.InviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.RealInviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealRemoteAddressResultsManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.RealSearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RemoteAddressResultsManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.resolveAddressSearchMinQueryLength
@@ -74,6 +76,7 @@ val viewModelsModule = module {
             parkRideService = get(),
             parkRideSandook = get(),
             stopResultsManager = get(),
+            searchSessionStore = get(),
             flag = get(),
             preferences = get(),
             platformOps = get(),
@@ -157,6 +160,8 @@ val viewModelsModule = module {
         )
     }
 
+    single<SearchSessionStore> { RealSearchSessionStore() }
+
     single<RemoteAddressResultsManager> {
         RealRemoteAddressResultsManager(
             tripPlanningService = get(),
@@ -206,6 +211,7 @@ val viewModelsModule = module {
             ioDispatcher = get(named(IODispatcher)),
             preferences = get(),
             sandook = get(),
+            searchSessionStore = get(),
             isAddressSearchEnabled = isAddressSearchEnabled,
             addressSearchMinQueryLength = addressSearchMinQueryLength,
         )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripAnalytics.kt
@@ -16,6 +16,16 @@ internal fun Analytics.trackSavedTripCardClick(fromStopId: String, toStopId: Str
     track(AnalyticsEvent.SavedTripCardClickEvent(fromStopId = fromStopId, toStopId = toStopId))
 }
 
-internal fun Analytics.trackLoadTimeTableClick(fromStopId: String, toStopId: String) {
-    track(AnalyticsEvent.LoadTimeTableClickEvent(fromStopId = fromStopId, toStopId = toStopId))
+internal fun Analytics.trackLoadTimeTableClick(
+    fromStopId: String,
+    toStopId: String,
+    searchSessionId: String?,
+) {
+    track(
+        AnalyticsEvent.LoadTimeTableClickEvent(
+            fromStopId = fromStopId,
+            toStopId = toStopId,
+            searchSessionId = searchSessionId,
+        ),
+    )
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -51,6 +51,7 @@ import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences
 import xyz.ksharma.krail.sandook.SavedParkRide
 import xyz.ksharma.krail.sandook.SavedTrip
+import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
@@ -75,6 +76,7 @@ class SavedTripsViewModel(
     private val parkRideService: ParkRideService,
     private val parkRideSandook: NswParkRideSandook,
     private val stopResultsManager: StopResultsManager,
+    private val searchSessionStore: SearchSessionStore,
     private val flag: Flag,
     private val preferences: SandookPreferences,
     private val infoTileManager: InfoTileManager,
@@ -166,7 +168,14 @@ class SavedTripsViewModel(
                 analytics.track(AnalyticsEvent.ReverseStopClickEvent)
             }
             is SavedTripUiEvent.AnalyticsLoadTimeTableClick ->
-                analytics.trackLoadTimeTableClick(event.fromStopId, event.toStopId)
+                analytics.trackLoadTimeTableClick(
+                    fromStopId = event.fromStopId,
+                    toStopId = event.toStopId,
+                    searchSessionId = searchSessionStore.consumeFor(
+                        fromStopId = event.fromStopId,
+                        toStopId = event.toStopId,
+                    ),
+                )
             SavedTripUiEvent.AnalyticsSettingsButtonClick ->
                 analytics.track(AnalyticsEvent.SettingsClickEvent)
             SavedTripUiEvent.AnalyticsFromButtonClick ->

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchSessionStore.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchSessionStore.kt
@@ -1,0 +1,61 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+/**
+ * Carries a `searchSessionId` from the stop selection that produced it to the
+ * `load_timetable_click` that follows, so the search funnel can be measured all the way
+ * to "the rider actually saw departure times" rather than stopping at "a stop was picked".
+ *
+ * The two events fire from different ViewModels on different screens (SearchStop and
+ * SavedTrips) and the search ViewModel is gone by the time the trip is loaded, so the id
+ * has to live somewhere both can reach. This is that somewhere: a process-scoped single,
+ * deliberately tiny, holding at most one pending selection.
+ *
+ * Attribution rules, both chosen so a session id is never attached to a trip the search
+ * did not actually lead to:
+ *  - **Consume-once.** The id is cleared when read. Loading the same trip a second time
+ *    is a repeat view, not a second search converting.
+ *  - **Stop must match.** The id is only returned when the loaded trip still contains the
+ *    stop that was selected in that session. Searching and then tapping an unrelated
+ *    saved trip card attributes nothing.
+ *
+ * Selections with no live query (recents, map picks) record a null id, which also clears
+ * any earlier pending one - those selections are genuinely unattributable and must not
+ * inherit the previous search's id.
+ */
+interface SearchSessionStore {
+
+    /**
+     * Records the session that produced a stop selection.
+     *
+     * @param searchSessionId id of the settled query behind the selection, or null when
+     *                        the selection came from recents, an empty-state stop or the
+     *                        map.
+     * @param stopId          stop the rider selected; used to verify the trip that gets
+     *                        loaded is the one this search led to.
+     */
+    fun recordSelection(searchSessionId: String?, stopId: String)
+
+    /**
+     * Returns the pending session id when either endpoint of the loaded trip is the stop
+     * it was recorded against, else null. Always clears the pending selection.
+     */
+    fun consumeFor(fromStopId: String, toStopId: String): String?
+}
+
+internal class RealSearchSessionStore : SearchSessionStore {
+
+    private var pending: Selection? = null
+
+    override fun recordSelection(searchSessionId: String?, stopId: String) {
+        pending = searchSessionId?.let { Selection(searchSessionId = it, stopId = stopId) }
+    }
+
+    override fun consumeFor(fromStopId: String, toStopId: String): String? {
+        val selection = pending
+        pending = null
+        return selection?.searchSessionId
+            ?.takeIf { selection.stopId == fromStopId || selection.stopId == toStopId }
+    }
+
+    private data class Selection(val searchSessionId: String, val stopId: String)
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -68,6 +68,7 @@ class SearchStopViewModel(
     private val ioDispatcher: CoroutineDispatcher,
     private val preferences: SandookPreferences,
     private val sandook: Sandook,
+    private val searchSessionStore: SearchSessionStore,
     private val isAddressSearchEnabled: () -> Boolean = { false },
     private val addressSearchMinQueryLength: () -> Int = { DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH },
 ) : ViewModel() {
@@ -121,6 +122,14 @@ class SearchStopViewModel(
                 // belong to a previous (or no) query, so send nothing.
                 val state = _uiState.value
                 val fromLiveQuery = state.searchQuery.isNotBlank()
+                // Hand the session to whatever loads a trip next, so the funnel can run
+                // past selection to "departure times were actually seen". Recents and
+                // empty-state stops record null, which also clears any earlier pending
+                // session rather than letting it attach to an unrelated trip.
+                searchSessionStore.recordSelection(
+                    searchSessionId = currentSearchSessionId.takeIf { fromLiveQuery },
+                    stopId = event.stopItem.stopId,
+                )
                 analytics.track(
                     StopSelectedEvent(
                         stopId = event.stopItem.stopId,
@@ -255,6 +264,10 @@ class SearchStopViewModel(
             }
 
             is SearchStopUiEvent.TrackStopSelectedFromMap -> {
+                // A map pick belongs to no query. Recording null clears any session left
+                // pending by an earlier search so the trip that follows is not credited
+                // to a search the rider abandoned.
+                searchSessionStore.recordSelection(searchSessionId = null, stopId = event.stopId)
                 analytics.track(
                     AnalyticsEvent.StopSelectedFromMapEvent(
                         stopId = event.stopId,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
@@ -37,6 +37,7 @@ import xyz.ksharma.krail.sandook.Sandook
 import xyz.ksharma.krail.sandook.SandookPreferences.Companion.KEY_DISMISSED_INFO_TILES
 import xyz.ksharma.krail.feature.track.TrackingManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
+import xyz.ksharma.krail.trip.planner.ui.searchstop.RealSearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
@@ -69,6 +70,7 @@ class SavedTripsViewModelTest {
     private val fakeFlag = FakeFlag()
 
     private val fakeSandookPreferences = FakeSandookPreferences()
+    private val searchSessionStore = RealSearchSessionStore()
 
     private val fakeAppVersionManager = FakeAppVersionManager()
 
@@ -87,6 +89,7 @@ class SavedTripsViewModelTest {
             parkRideService = fakeParkRideService,
             parkRideSandook = fakeNswParkRideSandook,
             stopResultsManager = fakeStopResultsManager,
+            searchSessionStore = searchSessionStore,
             flag = fakeFlag,
             preferences = fakeSandookPreferences,
             platformOps = fakePlatformOps,
@@ -618,6 +621,52 @@ class SavedTripsViewModelTest {
     }
 
     // endregion Park and Ride Tests
+
+    // region Search funnel Tests
+
+    @Test
+    fun `GIVEN a searched stop WHEN the trip is loaded THEN searchSessionId is attached`() = runTest {
+        searchSessionStore.recordSelection(searchSessionId = "session-1", stopId = "200060")
+
+        viewModel.onEvent(
+            SavedTripUiEvent.AnalyticsLoadTimeTableClick(fromStopId = "200060", toStopId = "200070"),
+        )
+
+        val event = assertIs<AnalyticsEvent.LoadTimeTableClickEvent>(
+            (fakeAnalytics as FakeAnalytics).getTrackedEvent("load_timetable_click"),
+        )
+        assertEquals("session-1", event.searchSessionId)
+        assertEquals("session-1", event.properties?.get("searchSessionId"))
+    }
+
+    @Test
+    fun `GIVEN no preceding search WHEN a trip is loaded THEN no searchSessionId is sent`() = runTest {
+        viewModel.onEvent(
+            SavedTripUiEvent.AnalyticsLoadTimeTableClick(fromStopId = "200060", toStopId = "200070"),
+        )
+
+        val event = assertIs<AnalyticsEvent.LoadTimeTableClickEvent>(
+            (fakeAnalytics as FakeAnalytics).getTrackedEvent("load_timetable_click"),
+        )
+        assertNull(event.searchSessionId)
+        assertFalse(event.properties.orEmpty().containsKey("searchSessionId"))
+    }
+
+    @Test
+    fun `GIVEN a search WHEN an unrelated saved trip is loaded THEN no searchSessionId is sent`() = runTest {
+        searchSessionStore.recordSelection(searchSessionId = "session-1", stopId = "200060")
+
+        viewModel.onEvent(
+            SavedTripUiEvent.AnalyticsLoadTimeTableClick(fromStopId = "200080", toStopId = "200090"),
+        )
+
+        val event = assertIs<AnalyticsEvent.LoadTimeTableClickEvent>(
+            (fakeAnalytics as FakeAnalytics).getTrackedEvent("load_timetable_click"),
+        )
+        assertNull(event.searchSessionId)
+    }
+
+    // endregion Search funnel Tests
 
     // region Selected Stop Events Tests
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchSessionStoreTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchSessionStoreTest.kt
@@ -1,0 +1,82 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SearchSessionStoreTest {
+
+    private val store = RealSearchSessionStore()
+
+    @Test
+    fun `GIVEN a searched stop WHEN that trip is loaded THEN the session id is attached`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = CENTRAL)
+
+        assertEquals(SESSION, store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN the searched stop is the destination THEN the session id is still attached`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = TOWN_HALL)
+
+        assertEquals(SESSION, store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN a consumed session WHEN the same trip is loaded again THEN nothing is attached`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = CENTRAL)
+        store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL)
+
+        assertNull(store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN a search WHEN an unrelated trip is loaded THEN nothing is attached`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = CENTRAL)
+
+        assertNull(store.consumeFor(fromStopId = "200080", toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN an unrelated trip consumed the pending selection THEN it does not resurface`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = CENTRAL)
+        store.consumeFor(fromStopId = "200080", toStopId = TOWN_HALL)
+
+        assertNull(store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN a recent or map selection THEN no session is attached`() {
+        store.recordSelection(searchSessionId = null, stopId = CENTRAL)
+
+        assertNull(store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN a search followed by a recent tap THEN the earlier session is cleared`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = CENTRAL)
+        store.recordSelection(searchSessionId = null, stopId = TOWN_HALL)
+
+        assertNull(store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN two searched stops THEN the later selection wins`() {
+        store.recordSelection(searchSessionId = SESSION, stopId = CENTRAL)
+        store.recordSelection(searchSessionId = LATER_SESSION, stopId = TOWN_HALL)
+
+        assertEquals(LATER_SESSION, store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    @Test
+    fun `GIVEN nothing recorded THEN nothing is attached`() {
+        assertNull(store.consumeFor(fromStopId = CENTRAL, toStopId = TOWN_HALL))
+    }
+
+    private companion object {
+        const val SESSION = "a1b2c3d4e5f60718"
+        const val LATER_SESSION = "f0e1d2c3b4a59687"
+        const val CENTRAL = "200060"
+        const val TOWN_HALL = "200070"
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelLabelHandlersTest.kt
@@ -66,6 +66,7 @@ class SearchStopViewModelLabelHandlersTest {
     private val fakeNearbyStopsManager = FakeNearbyStopsManagerForMap()
     private val fakePreferences = FakeSandookPreferences()
     private val fakeSandook = FakeSandook()
+    private val searchSessionStore = RealSearchSessionStore()
 
     private lateinit var viewModel: SearchStopViewModel
 
@@ -87,6 +88,7 @@ class SearchStopViewModelLabelHandlersTest {
             ioDispatcher = testDispatcher,
             preferences = fakePreferences,
             sandook = fakeSandook,
+            searchSessionStore = searchSessionStore,
         )
     }
 
@@ -529,6 +531,7 @@ class SearchStopViewModelLabelHandlersTest {
             ioDispatcher = testDispatcher,
             preferences = FakeSandookPreferences(),
             sandook = freshSandook,
+            searchSessionStore = RealSearchSessionStore(),
         )
         // Subscribe so the VM scope's observer collects.
         freshVm.uiState.test {

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -34,6 +34,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -48,6 +49,7 @@ class SearchStopViewModelTest {
     private val fakeNearbyStopsManager = FakeNearbyStopsManagerForMap()
     private val fakePreferences = FakeSandookPreferences()
     private val fakeSandook = FakeSandook()
+    private val searchSessionStore = RealSearchSessionStore()
 
     private val testDispatcher = StandardTestDispatcher()
 
@@ -63,6 +65,7 @@ class SearchStopViewModelTest {
             ioDispatcher = testDispatcher,
             preferences = fakePreferences,
             sandook = fakeSandook,
+            searchSessionStore = searchSessionStore,
         )
     }
 
@@ -343,6 +346,7 @@ class SearchStopViewModelTest {
                 ioDispatcher = testDispatcher,
                 preferences = fakePreferences,
                 sandook = fakeSandook,
+                searchSessionStore = searchSessionStore,
             )
 
             // THEN - Initial state should not include recents (screen triggers refresh)
@@ -621,6 +625,74 @@ class SearchStopViewModelTest {
         }
 
     @Test
+    fun `GIVEN a live query WHEN a stop is selected THEN the session is handed to the trip that follows`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Central"))
+                advanceUntilIdle()
+                viewModel.onEvent(
+                    SearchStopUiEvent.TrackStopSelected(
+                        StopItem(stopName = "Central Station", stopId = "10101"),
+                    ),
+                )
+                advanceUntilIdle()
+
+                assertTrue(fakeAnalytics is FakeAnalytics)
+                val selected = fakeAnalytics.getTrackedEvent("stop_selected")
+                assertIs<AnalyticsEvent.StopSelectedEvent>(selected)
+                assertEquals(
+                    selected.searchSessionId,
+                    searchSessionStore.consumeFor(fromStopId = "10101", toStopId = "20202"),
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a recent tap WHEN a stop is selected THEN no session is handed on`() = runTest {
+        viewModel.onEvent(
+            SearchStopUiEvent.TrackStopSelected(
+                StopItem(stopName = "Central Station", stopId = "10101"),
+                isRecentSearch = true,
+            ),
+        )
+        advanceUntilIdle()
+
+        assertNull(searchSessionStore.consumeFor(fromStopId = "10101", toStopId = "20202"))
+    }
+
+    @Test
+    fun `GIVEN a search WHEN the rider then picks from the map THEN the stale session is cleared`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Central"))
+                advanceUntilIdle()
+                viewModel.onEvent(
+                    SearchStopUiEvent.TrackStopSelected(
+                        StopItem(stopName = "Central Station", stopId = "10101"),
+                    ),
+                )
+                viewModel.onEvent(
+                    SearchStopUiEvent.TrackStopSelectedFromMap(
+                        stopId = "30303",
+                        searchRadiusKm = 2.0,
+                        enabledModesCount = 3,
+                        nearbyStopsCount = 5,
+                        hadUserLocation = true,
+                    ),
+                )
+                advanceUntilIdle()
+
+                assertNull(searchSessionStore.consumeFor(fromStopId = "10101", toStopId = "30303"))
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `CountBucket boundaries`() {
         val bucket = AnalyticsEvent.StopSelectedEvent.CountBucket.Companion::from
         assertEquals(AnalyticsEvent.StopSelectedEvent.CountBucket.ZERO, bucket(0))
@@ -769,6 +841,7 @@ class SearchStopViewModelTest {
         ioDispatcher = testDispatcher,
         preferences = fakePreferences,
         sandook = fakeSandook,
+        searchSessionStore = searchSessionStore,
         isAddressSearchEnabled = { true },
         addressSearchMinQueryLength = { minQueryLength },
     )


### PR DESCRIPTION
## What

The search funnel stopped at selection. `stop_selected` carries a `searchSessionId`,
`load_timetable_click` did not, so "the rider searched and picked a stop" was measurable but
"the rider reached departure times" was not.

## Changes

- New `SearchSessionStore` (`:feature:trip-planner:ui`) carries the id from the selection
  that produced it to the trip load that follows; the two events fire from different
  ViewModels on different screens and the search ViewModel is gone by then
- `LoadTimeTableClickEvent` gains `searchSessionId`, omitted when null
- Two rules keep attribution honest, because `load_timetable_click` also fires for saved
  cards: the pending id is consumed once, and it only attaches when the loaded trip still
  contains the stop selected in that session
- Recents, empty-state stops and map picks record a null id, which also clears any earlier
  pending one rather than letting an abandoned search attach to the next trip

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green — 9 store tests plus
  ViewModel tests on both call sites
- `./scripts/fullQualityChecks.sh` green
- Device: search then load reports the id; re-opening the same trip reports null

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
