### PR TITLE
feat(analytics): record why the save-trip prompt ended

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -546,23 +546,52 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
      * User acted on the "Save this trip?" prompt. One event for both outcomes
      * (accept and dismiss) to stay within the Firebase 500-event budget.
      *
-     * @param accepted true when the user tapped Save, false when dismissed.
-     * @param dismissCount Total dismissals for this origin-destination pair
-     * including this one — the prompt stops appearing for the pair at 2.
-     * Always 0 when [accepted] is true.
+     * Every way the prompt can end now fires this event with a [reason], so
+     * "ignored" stops being inferred from a missing row. The four endings need
+     * different fixes and used to be one bucket: a rider who consciously moved on,
+     * one who saved with the star instead, one who left the screen, and one whose
+     * prompt was replaced by a different trip.
+     *
+     * Rows before this shipped carry no `reason` and are all explicit dismissals
+     * (the only ending that fired an event then) - do not read a missing `reason`
+     * as "unknown".
+     *
+     * @param accepted true when the user tapped Save, false for every other ending.
+     * @param reason Which ending this was. Null only on historic rows and on
+     * accepts.
+     * @param dismissCount Total explicit dismissals for this origin-destination
+     * pair including this one - the prompt stops appearing for the pair at 2.
+     * Always 0 when [accepted] is true, and 0 for non-explicit endings: they are
+     * not refusals and deliberately do not count towards that limit.
      */
     data class SaveTripPromptActionEvent(
         val accepted: Boolean,
         val variant: String,
         val dismissCount: Int = 0,
+        val reason: DismissReason? = null,
     ) : AnalyticsEvent(
         name = "save_trip_prompt_action",
-        rawProperties = mapOf(
-            "accepted" to accepted,
-            PROP_VARIANT to variant,
-            "dismissCount" to dismissCount,
-        ),
-    )
+        rawProperties = buildMap {
+            put("accepted", accepted)
+            put(PROP_VARIANT, variant)
+            put("dismissCount", dismissCount)
+            reason?.let { put("reason", it.value) }
+        },
+    ) {
+        enum class DismissReason(val value: String) {
+            /** Rider tapped "Not now" - the only ending that is a real refusal. */
+            EXPLICIT("explicit"),
+
+            /** Rider saved with the star instead, which makes the prompt redundant. */
+            SUPERSEDED("superseded"),
+
+            /** Rider left the timetable with the prompt still on screen. */
+            NAVIGATED_AWAY("navigated_away"),
+
+            /** A different trip loaded underneath the prompt and took it away. */
+            REPLACED("replaced"),
+        }
+    }
 
     data class PlanTripClickEvent(val fromStopId: String, val toStopId: String) : AnalyticsEvent(
         name = "plan_trip_click",

--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -530,6 +530,12 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
      * "Save this trip?" prompt shown on the timetable after loading an unsaved
      * origin-destination pair (the aha-moment save nudge).
      *
+     * Fires when the prompt actually composes, not when it becomes eligible. The
+     * prompt is an item in the timetable list, so it can sit in state without ever
+     * being scrolled to; earlier rows counted eligibility and therefore over-count
+     * what riders saw. Rates measured across that boundary are not comparable -
+     * the denominator changes meaning from "eligible" to "seen".
+     *
      * @param variant `plain` for the simple save prompt; `commute` for the
      * Home/Work label-assigning variant.
      */

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableUiEvent.kt
@@ -92,4 +92,11 @@ sealed interface TimeTableUiEvent {
 
     /** User dismissed the "Save this trip?" prompt. */
     data object SaveTripPromptDismissed : TimeTableUiEvent
+
+    /**
+     * The "Save this trip?" prompt composed, meaning it actually reached the
+     * screen. Sent from the list item rather than derived from state, because a
+     * prompt held in state may never be scrolled to.
+     */
+    data object SaveTripPromptDisplayed : TimeTableUiEvent
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/SaveTripPromptCard.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.timetable
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -43,6 +44,11 @@ internal fun LazyListScope.saveTripPromptItem(
     if (!showSaveTripPrompt) return
     item(key = "save-trip-prompt") {
         val haptic = LocalHapticFeedback.current
+        // A lazy item only composes once it is in (or near) the viewport, so this
+        // is the first moment the prompt can be said to have reached the rider.
+        // Eligibility was previously reported as "shown", which counted prompts
+        // that were never scrolled to. The ViewModel de-dupes recompositions.
+        LaunchedEffect(Unit) { onEvent(TimeTableUiEvent.SaveTripPromptDisplayed) }
         InfoTile(
             infoTileData = saveTripPromptTileData,
             initialState = InfoTileState.EXPANDED,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAnalytics.kt
@@ -14,6 +14,27 @@ import kotlin.time.Instant
 
 private const val AEST_TIMEZONE = "Australia/Sydney"
 
+/**
+ * Records an ending of the save-trip prompt that is not an explicit refusal, so the
+ * silent cases (star save, leaving the screen, a different trip loading) announce
+ * themselves instead of being inferred from a missing row.
+ *
+ * [AnalyticsEvent.SaveTripPromptActionEvent.dismissCount] stays 0 here on purpose:
+ * these endings are not refusals and must not count towards the two-dismissal limit
+ * that stops the prompt for a pair.
+ */
+internal fun Analytics.trackSaveTripPromptEnded(
+    reason: AnalyticsEvent.SaveTripPromptActionEvent.DismissReason,
+) {
+    track(
+        AnalyticsEvent.SaveTripPromptActionEvent(
+            accepted = false,
+            variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
+            reason = reason,
+        ),
+    )
+}
+
 internal fun Analytics.trackJourneyCardToggleEvent(
     expanded: Boolean,
     hasStarted: Boolean,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -163,6 +164,10 @@ class TimeTableViewModel(
 
     private var lastInitializedRouteFromTo: Pair<String, String>? = null
 
+    // One ending per prompt: onCleared and the screen-left watcher can both reach
+    // the abandonment report.
+    private var savePromptAbandonReported = false
+
     /**
      * Cache of trips. Key is [TimeTableState.JourneyCardInfo.journeyId] and value is
      * [TimeTableState.JourneyCardInfo].
@@ -197,6 +202,7 @@ class TimeTableViewModel(
         // SearchStopViewModel's pattern; we deliberately skip the seed-on-empty
         // branch since SearchStopViewModel owns label seeding.
         observeStopLabels()
+        observeSavePromptAbandonment()
     }
 
     /**
@@ -320,6 +326,8 @@ class TimeTableViewModel(
             TimeTableUiEvent.SaveTripPromptAccepted -> onSaveTripPromptAccepted()
 
             TimeTableUiEvent.SaveTripPromptDismissed -> onSaveTripPromptDismissed()
+
+            TimeTableUiEvent.SaveTripPromptDisplayed -> onSavePromptDisplayed()
         }
     }
 
@@ -663,9 +671,13 @@ class TimeTableViewModel(
 
     /**
      * Resolves whether the one-tap "Save this trip?" prompt should be visible
-     * for the trip being loaded. Returns the value for the load's own state
-     * update; also fires the shown event and burns the per-session allowance
-     * the first time it resolves true.
+     * for the trip being loaded, and burns the per-session allowance the first
+     * time it resolves true.
+     *
+     * Deliberately does **not** fire the shown event: eligibility is not display.
+     * The prompt is an item in the timetable list, so resolving it true only means
+     * it was put into state, not that it ever reached the screen. The event fires
+     * from [onSavePromptDisplayed] when the item actually composes.
      *
      * Only users with ZERO saved trips ever see the prompt — once any trip is
      * saved the user has discovered the feature and the nudge is pointless.
@@ -680,12 +692,25 @@ class TimeTableViewModel(
             promptDismissCount(tripId) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
         if (!eligible) return false
         savePromptShownInSession = true
+        return true
+    }
+
+    /**
+     * The prompt reached the screen. Fired from composition rather than from
+     * eligibility so `save_trip_prompt_shown` counts prompts riders could actually
+     * see; a prompt resolved into state but never scrolled to used to count as
+     * shown and inflated every rate measured against it.
+     *
+     * Guarded because a list item recomposes freely: one shown event per prompt.
+     */
+    private fun onSavePromptDisplayed() {
+        if (savePromptDisplayTracked) return
+        savePromptDisplayTracked = true
         analytics.track(
             AnalyticsEvent.SaveTripPromptShownEvent(
                 variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
             ),
         )
-        return true
     }
 
     private fun promptDismissCount(tripId: String): Long =
@@ -1271,25 +1296,53 @@ class TimeTableViewModel(
     override fun onCleared() {
         super.onCleared()
         log("TimeTableViewModel cleared")
-        trackSavePromptAbandonedOnLeave()
+        trackSavePromptAbandoned()
         cleanupJobs()
     }
 
     /**
-     * Leaving the screen with the prompt still up is the largest silent ending, so
-     * it gets recorded rather than inferred from a missing row.
+     * Reports a prompt the rider left without answering.
      *
-     * Safe from [onCleared]: `analytics.track()` runs on its own scope, not
-     * `viewModelScope`, which is already cancelled by then. A configuration change
-     * does not reach here either - the ViewModel survives it - so this really is a
-     * departure and not a recreation.
+     * Once per prompt: [onCleared] and the screen-left watcher can both reach this,
+     * and a prompt has exactly one ending. Safe from [onCleared] because
+     * `analytics.track()` runs on its own scope rather than `viewModelScope`, which
+     * is cancelled by then.
      */
     @VisibleForTesting
-    fun trackSavePromptAbandonedOnLeave() {
-        if (!_uiState.value.showSaveTripPrompt) return
+    fun trackSavePromptAbandoned() {
+        // A prompt that never composed was never abandoned - it was never seen.
+        // That case belongs to the gap between eligibility and display, not here.
+        if (!savePromptDisplayTracked) return
+        if (!_uiState.value.showSaveTripPrompt || savePromptAbandonReported) return
+        savePromptAbandonReported = true
         analytics.trackSaveTripPromptEnded(
             AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.NAVIGATED_AWAY,
         )
+    }
+
+    /**
+     * Watches for the rider leaving the timetable with the prompt still up.
+     *
+     * [onCleared] cannot carry this: the ViewModel is resolved from the activity's
+     * store (JourneyMap deliberately reuses this same instance), so it only clears
+     * when the app goes, not when the screen does. Losing every uiState subscriber
+     * is the real "screen is gone" signal.
+     *
+     * The grace period is what keeps a configuration change from being counted as
+     * a departure: rotation drops the subscriber and re-adds it immediately, and
+     * `collectLatest` cancels the pending report when that happens.
+     */
+    private fun observeSavePromptAbandonment() {
+        viewModelScope.launch {
+            _uiState.subscriptionCount
+                .map { count -> count > 0 }
+                .distinctUntilChanged()
+                .collectLatest { hasSubscribers ->
+                    if (hasSubscribers) return@collectLatest
+                    delay(SAVE_PROMPT_ABANDON_GRACE)
+                    trackSavePromptAbandoned()
+                }
+        }
     }
 
     /**
@@ -1314,6 +1367,10 @@ class TimeTableViewModel(
 
     companion object {
         private const val ANR_TIMEOUT = 5000L
+
+// Long enough that a configuration change re-subscribes well inside it, short
+// enough that a real departure is reported while the session is still live.
+        private val SAVE_PROMPT_ABANDON_GRACE = 5.seconds
 
         @VisibleForTesting
         val REFRESH_TIME_TEXT_DURATION = 10.seconds
@@ -1357,9 +1414,16 @@ class TimeTableViewModel(
         // (process lifetime), across all TimeTableViewModel instances.
         private var savePromptShownInSession = false
 
+        // Separate from the eligibility flag above: that one is burned when the
+        // prompt enters state, this one when it actually composes. Also process
+        // scoped, so a rotation recomposing the item does not fire a second
+        // shown event for the same prompt.
+        private var savePromptDisplayTracked = false
+
         @VisibleForTesting
         fun resetSavePromptSessionFlagForTest() {
             savePromptShownInSession = false
+            savePromptDisplayTracked = false
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -734,6 +734,7 @@ class TimeTableViewModel(
                     accepted = false,
                     variant = AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN,
                     dismissCount = newCount.toInt(),
+                    reason = AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.EXPLICIT,
                 ),
             )
         }
@@ -951,6 +952,13 @@ class TimeTableViewModel(
                     )
                     log("Saved Trip (Pref): $trip")
                     // Saving via the star makes the prompt redundant — drop it.
+                    // Riders doing this looked identical to riders ignoring the
+                    // prompt, because dropping it fired nothing; say so instead.
+                    if (_uiState.value.showSaveTripPrompt) {
+                        analytics.trackSaveTripPromptEnded(
+                            AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.SUPERSEDED,
+                        )
+                    }
                     updateUiState { copy(isTripSaved = true, showSaveTripPrompt = false) }
                     appReviewManager.onDelightMoment(DelightMoment.TRIP_SAVED)
                 }
@@ -1109,6 +1117,15 @@ class TimeTableViewModel(
         sandook.clearAlerts() // Alerts cache is keyed to the old trip pair too.
 
         val savedTrip = sandook.selectTripById(tripId = newTrip.tripId)
+        // Editing a stop takes a live prompt off screen, and the once-per-session
+        // gate means the reload will not bring it back. The rider never answered
+        // it and never chose to lose it, so record that rather than leaving it to
+        // look like an ignore.
+        if (_uiState.value.showSaveTripPrompt) {
+            analytics.trackSaveTripPromptEnded(
+                AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.REPLACED,
+            )
+        }
         updateUiState {
             copy(
                 trip = newTrip,
@@ -1254,7 +1271,25 @@ class TimeTableViewModel(
     override fun onCleared() {
         super.onCleared()
         log("TimeTableViewModel cleared")
+        trackSavePromptAbandonedOnLeave()
         cleanupJobs()
+    }
+
+    /**
+     * Leaving the screen with the prompt still up is the largest silent ending, so
+     * it gets recorded rather than inferred from a missing row.
+     *
+     * Safe from [onCleared]: `analytics.track()` runs on its own scope, not
+     * `viewModelScope`, which is already cancelled by then. A configuration change
+     * does not reach here either - the ViewModel survives it - so this really is a
+     * departure and not a recreation.
+     */
+    @VisibleForTesting
+    fun trackSavePromptAbandonedOnLeave() {
+        if (!_uiState.value.showSaveTripPrompt) return
+        analytics.trackSaveTripPromptEnded(
+            AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.NAVIGATED_AWAY,
+        )
     }
 
     /**

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.TimeZone.Companion.currentSystemDefault
@@ -2161,7 +2162,7 @@ class TimeTableViewModelTest {
     }
 
     @Test
-    fun `GIVEN unsaved pair WHEN timetable loads THEN save prompt is shown and shown event fires once`() =
+    fun `GIVEN unsaved pair WHEN timetable loads THEN prompt enters state but nothing is reported as shown`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics
 
@@ -2178,11 +2179,30 @@ class TimeTableViewModelTest {
             advanceUntilIdle()
 
             assertTrue(viewModel.uiState.value.showSaveTripPrompt)
-            val tracked = analytics.getTrackedEvent("save_trip_prompt_shown")
-            assertNotNull(tracked)
-            val event = assertIs<AnalyticsEvent.SaveTripPromptShownEvent>(tracked)
-            assertEquals(AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN, event.variant)
+            // Eligibility is not display: the item may never be scrolled to.
+            assertFalse(analytics.isEventTracked("save_trip_prompt_shown"))
         }
+
+    @Test
+    fun `GIVEN prompt in state WHEN the item composes THEN the shown event fires once`() = runTest {
+        val analytics = fakeAnalytics as FakeAnalytics
+        loadPromptTrip()
+        advanceUntilIdle()
+
+        viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDisplayed)
+        advanceUntilIdle()
+
+        val event = assertIs<AnalyticsEvent.SaveTripPromptShownEvent>(
+            assertNotNull(analytics.getTrackedEvent("save_trip_prompt_shown")),
+        )
+        assertEquals(AnalyticsEvent.SaveTripPromptShownEvent.VARIANT_PLAIN, event.variant)
+
+        // Recomposition (scrolling away and back, rotation) must not re-report it.
+        viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDisplayed)
+        advanceUntilIdle()
+
+        assertEquals(1, analytics.getTrackedEvents("save_trip_prompt_shown").size)
+    }
 
     @Test
     fun `GIVEN already-saved pair WHEN timetable loads THEN no prompt is shown`() =
@@ -2346,14 +2366,18 @@ class TimeTableViewModelTest {
         }
 
     @Test
-    fun `GIVEN prompt visible WHEN the rider leaves the timetable THEN the ending is navigated away`() =
+    fun `GIVEN prompt visible WHEN the screen loses its last subscriber THEN the ending is navigated away`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics
             loadPromptTrip()
             advanceUntilIdle()
-            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
-
-            viewModel.trackSavePromptAbandonedOnLeave()
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDisplayed)
+            advanceUntilIdle()
+            // Subscribe like the screen does, then go away and stay away.
+            val collectJob = launch { viewModel.uiState.collect {} }
+            advanceUntilIdle()
+            collectJob.cancel()
+            advanceUntilIdle()
 
             val event = assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(
                 assertNotNull(analytics.getTrackedEvent("save_trip_prompt_action")),
@@ -2362,6 +2386,46 @@ class TimeTableViewModelTest {
                 AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.NAVIGATED_AWAY,
                 event.reason,
             )
+        }
+
+    @Test
+    fun `GIVEN prompt visible WHEN a configuration change re-subscribes inside the grace THEN nothing is reported`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDisplayed)
+            advanceUntilIdle()
+            analytics.clear()
+            val first = launch { viewModel.uiState.collect {} }
+            advanceUntilIdle()
+
+            // Rotation: the old collector goes and a new one arrives immediately.
+            first.cancel()
+            val second = launch { viewModel.uiState.collect {} }
+            advanceUntilIdle()
+
+            assertFalse(analytics.isEventTracked("save_trip_prompt_action"))
+            second.cancel()
+        }
+
+    @Test
+    fun `GIVEN prompt visible WHEN abandonment is reported twice THEN only one ending is recorded`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDisplayed)
+            advanceUntilIdle()
+            analytics.clear()
+
+            // Leaving the screen and the app going away can both reach this; a
+            // prompt still has exactly one ending.
+            viewModel.trackSavePromptAbandoned()
+            viewModel.trackSavePromptAbandoned()
+
+            assertEquals(1, analytics.getTrackedEvents("save_trip_prompt_action").size)
         }
 
     @Test
@@ -2374,7 +2438,7 @@ class TimeTableViewModelTest {
             advanceUntilIdle()
             analytics.clear()
 
-            viewModel.trackSavePromptAbandonedOnLeave()
+            viewModel.trackSavePromptAbandoned()
 
             assertFalse(analytics.isEventTracked("save_trip_prompt_action"))
         }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -2277,6 +2277,141 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN prompt visible WHEN dismissed THEN the ending is recorded as explicit`() = runTest {
+        val analytics = fakeAnalytics as FakeAnalytics
+        loadPromptTrip()
+        advanceUntilIdle()
+
+        viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDismissed)
+        advanceUntilIdle()
+
+        val event = assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(
+            assertNotNull(analytics.getTrackedEvent("save_trip_prompt_action")),
+        )
+        assertEquals(
+            AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.EXPLICIT,
+            event.reason,
+        )
+        assertEquals("explicit", event.properties?.get("reason"))
+    }
+
+    @Test
+    fun `GIVEN prompt visible WHEN the trip is saved with the star THEN the ending is superseded`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+
+            viewModel.onEvent(TimeTableUiEvent.SaveTripButtonClicked)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            val event = assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(
+                assertNotNull(analytics.getTrackedEvent("save_trip_prompt_action")),
+            )
+            assertFalse(event.accepted)
+            assertEquals(
+                AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.SUPERSEDED,
+                event.reason,
+            )
+            // Not a refusal, so it must not count towards the two-dismissal limit.
+            assertEquals(0, event.dismissCount)
+            assertNull(
+                fakePreferences.getLong(
+                    SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + promptTrip.tripId,
+                ),
+            )
+        }
+
+    @Test
+    fun `GIVEN no prompt on screen WHEN the trip is saved with the star THEN no prompt ending is recorded`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            sandook.insertOrReplaceTrip(
+                tripId = "OTHER_TRIP_ID",
+                fromStopId = "OTHER_FROM",
+                fromStopName = "Other From",
+                toStopId = "OTHER_TO",
+                toStopName = "Other To",
+            )
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+
+            viewModel.onEvent(TimeTableUiEvent.SaveTripButtonClicked)
+            advanceUntilIdle()
+
+            assertFalse(analytics.isEventTracked("save_trip_prompt_action"))
+        }
+
+    @Test
+    fun `GIVEN prompt visible WHEN the rider leaves the timetable THEN the ending is navigated away`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+
+            viewModel.trackSavePromptAbandonedOnLeave()
+
+            val event = assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(
+                assertNotNull(analytics.getTrackedEvent("save_trip_prompt_action")),
+            )
+            assertEquals(
+                AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.NAVIGATED_AWAY,
+                event.reason,
+            )
+        }
+
+    @Test
+    fun `GIVEN prompt already resolved WHEN the rider leaves the timetable THEN nothing extra is recorded`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            viewModel.onEvent(TimeTableUiEvent.SaveTripPromptDismissed)
+            advanceUntilIdle()
+            analytics.clear()
+
+            viewModel.trackSavePromptAbandonedOnLeave()
+
+            assertFalse(analytics.isEventTracked("save_trip_prompt_action"))
+        }
+
+    @Test
+    fun `GIVEN prompt visible WHEN a different trip loads under it THEN the ending is replaced`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            loadPromptTrip()
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.showSaveTripPrompt)
+            analytics.clear()
+
+            // Same session, so the once-per-session gate refuses a second prompt and
+            // the live one disappears without the rider touching it.
+            viewModel.onEvent(
+                TimeTableUiEvent.TripStopChanged(
+                    stopId = "OTHER_STOP_ID",
+                    stopName = "OTHER_STOP_NAME",
+                    isOrigin = false,
+                ),
+            )
+            viewModel.fetchTrip()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            val event = assertIs<AnalyticsEvent.SaveTripPromptActionEvent>(
+                assertNotNull(analytics.getTrackedEvent("save_trip_prompt_action")),
+            )
+            assertEquals(
+                AnalyticsEvent.SaveTripPromptActionEvent.DismissReason.REPLACED,
+                event.reason,
+            )
+            assertEquals(0, event.dismissCount)
+        }
+
+    @Test
     fun `GIVEN pair dismissed twice before WHEN timetable loads in a new session THEN prompt never returns for that pair`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics


### PR DESCRIPTION
## What

Only an explicit "Not now" tap fired an event for the save-trip prompt, so every other
ending was inferred from the absence of one. And `save_trip_prompt_shown` fired from
eligibility rather than display, counting prompts that were never scrolled to.

## Changes

- `save_trip_prompt_action` carries a `reason`: `explicit`, `superseded` (saved with the
  star, which already dropped the prompt silently), `navigated_away`, `replaced` (a stop
  edit takes the prompt away and the once-per-session gate stops it returning)
- Non-explicit endings keep `dismissCount = 0` and do not touch the stored count — they are
  not refusals and must not push a pair towards the two-dismissal cut-off
- `save_trip_prompt_shown` now fires when the list item composes, de-duped so recomposition
  and rotation cannot report the same prompt twice
- The abandonment signal moved off `onCleared`: the ViewModel resolves from the activity's
  store (JourneyMap relies on that to reuse the instance), so `onCleared` means app exit,
  not screen exit. Losing the last `uiState` subscriber is the real signal, with a grace
  period so a configuration change is not counted as a departure

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green — one test per reason, plus
  de-dupe and configuration-change cases
- `./scripts/fullQualityChecks.sh` green
- Device: rotation with the prompt up adds no extra `shown` row and no false abandon;
  leaving the screen reports `navigated_away`

No UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
