### PR TITLE
docs(analytics): record the param caps and how to read window reporting

### DIFF
--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -7,9 +7,34 @@ Read this before adding or modifying any event in
 
 Firebase Analytics hard-caps the app at **500 unique event names, forever**. GA never
 lets a name be reclaimed from history — a shipped event name is a permanently spent
-slot, even if the code stops sending it. Budget as of 2026-07-22: 60 events defined in
-code plus ~10 historical names, roughly 430 slots left. Update this count when adding
+slot, even if the code stops sending it. Budget as of 2026-08-05: 52 events defined in
+code plus ~10 historical names, roughly 438 slots left. Update this count when adding
 or removing events.
+
+### The other three caps, and which one actually bites
+
+The 500 event names are the famous limit. Three more exist, and the one that constrains
+this app is not the one people reach for. Measured on `main`, 2026-08-05:
+
+| Cap | Limit | Where we are |
+|---|---|---|
+| Params per event | 25 custom | **11** on the widest (`device_window`, `app_start` at 10 each, plus `pane`). Everything else is 7 or below |
+| Event-scoped custom dimensions | 50 per GA4 property | **118 distinct param names** across 52 events |
+| User-scoped custom dimensions | 25 per property | **3** used (`device_form_factor`, `window_width_class`, `pane_mode`) |
+
+Params-per-event has plenty of room, including for `pane`, which rides every event. The
+binding constraint is the **event-scoped dimension cap**: the app emits more than twice
+what a standard GA4 property can surface, and has done for a while.
+
+What that means in practice:
+
+- **BigQuery is unaffected.** Every param lands on the row whether or not it is registered,
+  so BigQuery analysis never hits this cap. Most KRAIL-Analytics queries live there.
+- **The GA4 UI only shows registered dimensions.** An unregistered param is invisible, and
+  invisible looks exactly like absent - the same failure mode as a dropped param. If a param
+  seems missing in the UI, check registration before assuming the app stopped sending it.
+- Adding a param is cheap for the app and not free for analytics. That is another reason
+  the checklist below prefers reusing an existing param over minting one.
 
 ## Decision checklist: new event name vs param
 
@@ -19,8 +44,9 @@ or removing events.
 2. It shares no surface AND no param set with an existing event.
 3. It would be charted standalone on a dashboard.
 
-**Otherwise extend an existing event with a param.** Params are effectively free: the
-limit is 25 per event and nothing in the app is near it.
+**Otherwise extend an existing event with a param.** Params are cheap for the app - the
+limit is 25 per event and the widest event sits at 11 - but not free downstream: each new
+param name competes for a registerable dimension slot, see the caps section above.
 
 | Situation | Pattern | Example |
 |---|---|---|
@@ -121,6 +147,31 @@ whole facility objects instead of their ids, which is a call-site bug, not a len
 
 When adding a param that can carry a location id or a user-visible place name, add its key
 to the relevant set in `AnalyticsParamSanitizer` rather than sanitizing at the call site.
+
+## Window, fold and pane reporting: how to read it
+
+`device_window`, `device_window_changed` and the `pane` param answer "is anyone on a large
+screen, and what do they do there". Five things about them are counter-intuitive enough
+that they have been misread once already, so they are written down rather than re-derived.
+These match the addendum in KRAIL-Analytics' `docs/TRACKING_REQUEST_SCREEN_SIZE.md`.
+
+- **An unfold emits two `device_window_changed` rows, not one.** The resize lands first;
+  `androidx.window` delivers the `FoldingFeature` a second or two later. Both are true.
+  **Count unfolds by `toFoldState = FLAT`, never by row totals.**
+- **A wide window that stays `SINGLE` is a finding, not noise.** `widthSizeClass` is the
+  input, `paneMode` is what the layout did with it. The gap between them is the whole point
+  of tracking both.
+- **`formFactor = PHONE` on a device whose model is a Fold is the used-closed segment.**
+  A folded foldable reports no hinge inside the window, so the app cannot see it and does
+  not guess. Crossed with `deviceModel`, that combination is the answer, not a defect.
+- **`pane` is last-touch attribution.** For an event with a tap behind it, that is where the
+  tap happened. For a passive event (screen view, polling, a window change) it is where the
+  rider was last working - **never read it as "where the tap happened" for those**.
+  `SINGLE` means a one-pane window or no touch yet, not "unknown".
+- **Five width classes, not Material's three.** The app branches on `LARGE` and
+  `EXTRA_LARGE` too, and reporting on a different axis than the layout uses would be
+  pointless. Raw `widthDp` ships alongside, so any bucketing can be redone against history
+  without an app change.
 
 ## How analytics reaches the dashboard
 


### PR DESCRIPTION
## What

Docs only. Records two things that were worked out by hand this week so they are not
re-derived: the analytics param caps, and how to read the new window/fold/pane reporting.

## Changes

- `docs/ANALYTICS_EVENTS.md`, new caps section: params-per-event has room (11 on the widest
  event against a limit of 25, even with `pane` on every event), but the **event-scoped
  custom dimension cap is the binding one** — 118 distinct param names against 50
  registerable dimensions. BigQuery is unaffected since every param lands on the row; in the
  GA4 UI an unregistered param is invisible, which looks identical to absent
- New section on window, fold and pane reporting: an unfold emits two rows not one (count by
  `toFoldState = FLAT`), a wide window that stays `SINGLE` is a finding, `formFactor = PHONE`
  on a Fold model is the used-closed segment, `pane` is last-touch and must not be read as
  "where the tap happened" for passive events, and the width class has five values because
  that is what the layout branches on
- Refreshes the event count in the budget section to the measured 52
- Rewords "params are effectively free" in the checklist, which contradicted the new caps
  section

Mirrors the addendum on the KRAIL-Analytics side so the two do not drift.

## Testing

Docs only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
