### PR TITLE
fix(scripts): read the version portably in cut-release.sh

### DIFF
--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -32,8 +32,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Read current version from the base branch (local checkout must be up-to-date)
-CURRENT_VERSION=$(grep -oP '(?<=versionName = ")[^"]+' "$ROOT/androidApp/build.gradle.kts")
+# Read current version from the base branch (local checkout must be up-to-date).
+# sed, not `grep -oP`: BSD grep on macOS has no -P, so the Perl-regex form aborted this
+# script on the maintainer's own machine while working fine in CI on ubuntu.
+CURRENT_VERSION=$(sed -n 's/.*versionName = "\([^"]*\)".*/\1/p' "$ROOT/androidApp/build.gradle.kts" | head -1)
 if [[ -z "$CURRENT_VERSION" ]]; then
   echo "error: could not read versionName from androidApp/build.gradle.kts" >&2
   exit 1


### PR DESCRIPTION
## What

`scripts/cut-release.sh` read `versionName` with `grep -oP`. BSD grep on macOS has no `-P`,
so the script exited immediately:

```
grep: invalid option -- P
```

The documented way to cut a release failed on the machine releases are cut from, while
working fine in CI on ubuntu. Cutting 1.26.0 needed the underlying `gh workflow run` call
by hand instead.

## Changes

- `scripts/cut-release.sh` reads the version with a `sed` expression that behaves the same
  on BSD and GNU
- The workflow files keep `grep -oP` on purpose: they only ever run on `ubuntu-latest`, and
  changing a release path that works is not worth the risk

## Testing

On macOS, with the fix:

```
  Release branch : prod/1.26.0  (from main)
  Next on main   : 1.27.0
Aborted.
```

Reads the version, computes the next one, prints the plan, and aborts cleanly when the
prompt is declined. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
