### PR TITLE
fix(park-ride): stop car parks reading above 100% full (1.26 pick)

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt
@@ -12,6 +12,20 @@ import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState.ParkRid
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
+private const val FULL_PERCENT = 100
+
+/**
+ * Caps a real occupancy reading at [max] while leaving the negative loading sentinel alone.
+ *
+ * [FULL_PERCENT] is the cap everywhere: a full car park is 100%, the feed can report more
+ * than that, and the UI must never repeat it.
+ *
+ * A card that has never had data carries -1 for every number, which the UI reads as
+ * "still loading". Clamping into a 0..100 range would turn that sentinel into a real
+ * looking 0% and show an empty car park where there is simply no reading yet.
+ */
+private fun Int.coerceAtMostIfReal(max: Int): Int = if (this < 0) this else minOf(this, max)
+
 /**
  * Converts a [CarParkFacilityDetailResponse] to a [NSWParkRideFacilityDetail] for database storage.
  *
@@ -39,7 +53,16 @@ fun CarParkFacilityDetailResponse.toNSWParkRideFacilityDetail(
         it.occupancy.total?.toIntOrNull() ?: it.occupancy.transients?.toIntOrNull() ?: 0
     }
     val spotsAvailable = totalSpots - occupiedSpots
-    val percentageFull = if (totalSpots > 0) (occupiedSpots * 100) / totalSpots else 0
+    // Clamped for the same reason spotsAvailable is: the feed reports occupancy above
+    // capacity often enough to matter (overflow parking, a stale `spots` total, bays
+    // counted in occupancy but not in capacity), and a car park cannot be more than full.
+    // Leaving this unbounded while clamping spotsAvailable produced "0 spots available,
+    // 135% full" on the same card - two numbers from the same inputs disagreeing.
+    val percentageFull = if (totalSpots > 0) {
+        ((occupiedSpots * FULL_PERCENT) / totalSpots).coerceIn(0, FULL_PERCENT)
+    } else {
+        0
+    }
     val timeText = messageDate.toSimple12HourTime().replace(" ", "\u00A0")
 
     log(
@@ -70,7 +93,11 @@ internal fun NSWParkRideFacilityDetail.toParkRideState(): ParkRideFacilityDetail
         spotsAvailable = spotsAvailable.toInt(),
         totalSpots = totalSpots.toInt(),
         facilityName = facilityName,
-        percentageFull = percentageFull.toInt(),
+        // Clamped on the way out as well as on the way in: rows written before the write
+        // path was fixed are already on disk with values above 100, and they would keep
+        // rendering that way until the next successful poll replaced them.
+        // The -1 loading sentinel is preserved - it is not an occupancy value.
+        percentageFull = percentageFull.toInt().coerceAtMostIfReal(FULL_PERCENT),
         timeText = timeText,
         stopId = stopId,
         facilityId = facilityId,
@@ -93,17 +120,10 @@ fun List<NSWParkRideFacilityDetail>.toParkRideUiState(): List<ParkRideUiState> {
 
             val uniqueFacilities = facilitiesForStop
                 .filter { seenFacilityIds.add(it.facilityId) }
-                .map {
-                    ParkRideFacilityDetail(
-                        spotsAvailable = it.spotsAvailable.toInt(),
-                        totalSpots = it.totalSpots.toInt(),
-                        facilityName = it.facilityName,
-                        percentageFull = it.percentageFull.toInt(),
-                        stopId = it.stopId,
-                        timeText = it.timeText,
-                        facilityId = it.facilityId,
-                    )
-                }
+                // Was an inline copy of toParkRideState(), which is the path the home
+                // cards actually render from - so a fix applied only to that function
+                // would have missed the screen showing the wrong number.
+                .map { it.toParkRideState() }
                 .toImmutableSet()
 
             if (uniqueFacilities.isNotEmpty()) {

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapperTest.kt
@@ -1,5 +1,9 @@
 package xyz.ksharma.krail.trip.planner.ui.savedtrips
 
+import xyz.ksharma.krail.park.ride.network.model.CarParkFacilityDetailResponse
+import xyz.ksharma.krail.park.ride.network.model.Location
+import xyz.ksharma.krail.park.ride.network.model.Occupancy
+import xyz.ksharma.krail.park.ride.network.model.Zone
 import xyz.ksharma.krail.sandook.NSWParkRideFacilityDetail
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -60,16 +64,174 @@ class ParkRideMapperTest {
         assertEquals(1, uiState.first().facilities.size)
     }
 
+    // region occupancy above capacity
+
+    @Test
+    fun `a car park reported beyond capacity is shown as full, not over full`() {
+        // Gosford, seen in production: the feed reported occupancy above the recorded
+        // capacity and the card read "0 spots available, 135% full".
+        val details = listOf(
+            facilityDetail(facilityId = "26", stopId = "2155384", percentageFull = 135),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(100, uiState.first().facilities.first().percentageFull)
+    }
+
+    @Test
+    fun `a reading just over capacity is capped too`() {
+        // Ashfield, same day: 101%.
+        val details = listOf(
+            facilityDetail(facilityId = "5", stopId = "205710", percentageFull = 101),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(100, uiState.first().facilities.first().percentageFull)
+    }
+
+    @Test
+    fun `an ordinary reading passes through untouched`() {
+        val details = listOf(
+            facilityDetail(facilityId = "26", stopId = "2155384", percentageFull = 60),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(60, uiState.first().facilities.first().percentageFull)
+    }
+
+    @Test
+    fun `a genuinely full car park still reads 100`() {
+        val details = listOf(
+            facilityDetail(facilityId = "26", stopId = "2155384", percentageFull = 100),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(100, uiState.first().facilities.first().percentageFull)
+    }
+
+    @Test
+    fun `the loading sentinel survives the cap`() {
+        // -1 across every number means "no reading yet". Clamping it into 0..100 would
+        // render an empty car park where there is simply no data.
+        val details = listOf(
+            facilityDetail(facilityId = "26", stopId = "2155384", percentageFull = -1),
+        )
+
+        val uiState = details.toParkRideUiState()
+
+        assertEquals(-1, uiState.first().facilities.first().percentageFull)
+    }
+
+    // endregion
+
+    // region occupancy above capacity, at the point it is calculated
+
+    @Test
+    fun `occupancy above capacity is stored as 100, never more`() {
+        // 135 cars recorded against 100 spots, which is what produced the 135% card.
+        val response = facilityResponse(totalSpots = "100", occupied = "135")
+
+        val stored = response.toNSWParkRideFacilityDetail(stopName = "Gosford", stopId = "2250")
+
+        assertEquals(100L, stored.percentageFull)
+    }
+
+    @Test
+    fun `spots available and percentage full agree once capacity is exceeded`() {
+        // The pair has to be consistent: clamping one and not the other is what put
+        // "0 spots available" next to "135% full" on the same card.
+        val response = facilityResponse(totalSpots = "100", occupied = "135")
+
+        val stored = response.toNSWParkRideFacilityDetail(stopName = "Gosford", stopId = "2250")
+
+        assertEquals(0L, stored.spotsAvailable)
+        assertEquals(100L, stored.percentageFull)
+    }
+
+    @Test
+    fun `a normal car park is unaffected`() {
+        val response = facilityResponse(totalSpots = "100", occupied = "60")
+
+        val stored = response.toNSWParkRideFacilityDetail(stopName = "Gosford", stopId = "2250")
+
+        assertEquals(60L, stored.percentageFull)
+        assertEquals(40L, stored.spotsAvailable)
+    }
+
+    @Test
+    fun `an empty car park reads zero, not clamped upwards`() {
+        val response = facilityResponse(totalSpots = "100", occupied = "0")
+
+        val stored = response.toNSWParkRideFacilityDetail(stopName = "Gosford", stopId = "2250")
+
+        assertEquals(0L, stored.percentageFull)
+        assertEquals(100L, stored.spotsAvailable)
+    }
+
+    @Test
+    fun `a facility reporting no capacity does not divide by zero`() {
+        val response = facilityResponse(totalSpots = "0", occupied = "12")
+
+        val stored = response.toNSWParkRideFacilityDetail(stopName = "Gosford", stopId = "2250")
+
+        assertEquals(0L, stored.percentageFull)
+        assertEquals(0L, stored.spotsAvailable)
+    }
+
+    // endregion
+
+    private fun facilityResponse(
+        totalSpots: String,
+        occupied: String,
+    ) = CarParkFacilityDetailResponse(
+        tsn = "2250",
+        time = "0",
+        spots = totalSpots,
+        zones = listOf(
+            Zone(
+                spots = totalSpots,
+                zoneId = "1",
+                occupancy = Occupancy(
+                    loop = null,
+                    total = occupied,
+                    monthlies = null,
+                    openGate = null,
+                    transients = null,
+                ),
+                zoneName = "Zone 1",
+                parentZoneId = "0",
+            ),
+        ),
+        parkID = 1,
+        location = Location(suburb = "Gosford", address = "", latitude = "0.0", longitude = "0.0"),
+        occupancy = Occupancy(
+            loop = null,
+            total = occupied,
+            monthlies = null,
+            openGate = null,
+            transients = null,
+        ),
+        messageDate = "2026-08-06T08:16:00",
+        facilityId = "26",
+        facilityName = "Park&Ride - Gosford",
+        tfnswFacilityId = "2250TPR001",
+    )
+
     private fun facilityDetail(
         facilityId: String,
         stopId: String,
         facilityName: String = "Car park $facilityId",
+        percentageFull: Long = 60,
     ) = NSWParkRideFacilityDetail(
         facilityId = facilityId,
         spotsAvailable = 40,
         totalSpots = 100,
         facilityName = facilityName,
-        percentageFull = 60,
+        percentageFull = percentageFull,
         stopId = stopId,
         stopName = "Station $stopId",
         timeText = "8:00 AM",


### PR DESCRIPTION
Cherry-pick of #1791 into `prod/1.26.0`.

## Why this is picked rather than left for 1.27

RC1 is already on TestFlight and Play Internal with the defect visible on the home Park &
Ride card, which is the main story of this release. Riders see "0 spots available, 135%
full" on the same card, two numbers from the same inputs disagreeing.

## What changed

`percentageFull` is clamped to 0..100, the same way `spotsAvailable` already was. The feed
reports occupancy above capacity often enough to matter: Gosford returns 1466 cars against
1059 spots, which is 138% raw.

Clamped on both sides of the database so rows already stored above 100 stop rendering that
way, with the `-1` loading sentinel preserved. `toParkRideUiState()` now calls the shared
`toParkRideState()` mapper rather than an inline copy, which is the path the home cards
actually render from.

Full reasoning in #1791.

## Testing on this branch

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green, `ParkRideMapperTest` at 13
  tests
- Cherry-pick applied cleanly, no conflicts
- Verified on device from the same change on `main`: Gosford now reads "0 spots available,
  100% full" against the live feed data that produced 135%

Merging this fires RC2 and redistributes to Play Internal and TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4