### PR TITLE
feat(search): gate address search on local stop match count

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -169,6 +169,10 @@ object RemoteConfigDefaults {
                 second = 6,
             ),
             Pair(
+                first = FlagKeys.SEARCH_STOP_ADDRESS_MAX_LOCAL_STOPS.key,
+                second = 10,
+            ),
+            Pair(
                 first = FlagKeys.IN_APP_REVIEW_ENABLED.key,
                 second = false,
             ),

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/flag/FlagKeys.kt
@@ -78,6 +78,17 @@ enum class FlagKeys(val key: String) {
     SEARCH_STOP_ADDRESS_MIN_QUERY_LENGTH("search_stop_address_min_query_length"),
 
     /**
+     * Above this many on-device stop matches for the settled query, an address/POI
+     * request is suppressed — a rider already looking at a long, correct stop list is
+     * not stuck, and those calls almost never end in an address being picked. Queries of
+     * 12 characters or more bypass this: a string that long is usually an address.
+     * Bounded integer `0..50`; a missing, malformed, or out-of-range value falls back to
+     * `10` client-side rather than being clamped. See
+     * feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md.
+     */
+    SEARCH_STOP_ADDRESS_MAX_LOCAL_STOPS("search_stop_address_max_local_stops"),
+
+    /**
      * Kill switch for requesting the platform review sheet (Play In-App Review / StoreKit).
      * `false` by default so the trigger stays dormant until it is deliberately switched on.
      * When off, saved-trip opens are still counted, so flipping it on later sees each user's

--- a/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
+++ b/feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md
@@ -10,10 +10,11 @@ All in `searchstop/address/` (`:feature:trip-planner:ui`):
 
 | Class | Kind | Responsibility |
 |---|---|---|
-| `AddressSearchGate` | enum | The four possible eligibility outcomes. |
-| `AddressSearchEligibility` | pure object | `evaluate(normalizedQuery, isAddressSearchEnabled, minQueryLength) -> AddressSearchGate`. No I/O, no state. |
+| `AddressSearchGate` | enum | The five possible eligibility outcomes. |
+| `AddressSearchEligibility` | pure object | `evaluate(normalizedQuery, isAddressSearchEnabled, minQueryLength, localStopResultCount, maxLocalStopsForAddressSearch) -> AddressSearchGate`. No I/O, no state. |
 | `AddressSearchQueryNormalizer.kt` | pure functions | `normalizeAddressQuery` (trim) and `addressSearchCacheKey` (trim + lowercase). |
 | `AddressSearchMinQueryLength.kt` | pure function | `resolveAddressSearchMinQueryLength(flag)` — reads and validates the Remote Config integer. |
+| `AddressSearchMaxLocalStops.kt` | pure function | `resolveAddressSearchMaxLocalStops(flag)` — same, for the stop-count gate. |
 | `AddressSearchCache` | stateful class | Per-`SearchStopViewModel` bounded LRU with per-entry TTL. |
 
 Each is independently unit-testable without a ViewModel, Koin, or a fake network layer —
@@ -23,9 +24,39 @@ that was the point of splitting them out rather than growing
 ## Gate order
 
 `AddressSearchEligibility.evaluate` checks, in order: kill switch off -> blank -> below
-threshold -> eligible. `SearchStopViewModel.onAddressSearchTextChanged` calls this
-**before** creating a loading state or a coroutine, and again after the 350ms debounce
-(a flag flip or further edit mid-debounce must not fire a now-stale request).
+threshold -> stops already sufficient -> eligible.
+`SearchStopViewModel.onAddressSearchTextChanged` calls this **before** creating a loading
+state or a coroutine, and again after the 350ms debounce (a flag flip or further edit
+mid-debounce must not fire a now-stale request). The post-debounce check clears the
+address section on its way out, so a previous query's addresses can't linger under a
+newly-suppressed one.
+
+### Stop-count gate
+
+Query length is a weak predictor of whether a rider wants an address; the number of
+on-device stop matches already on screen is a much stronger one. Above
+`search_stop_address_max_local_stops` local matches the call is suppressed with
+`STOPS_ALREADY_SUFFICIENT` — a rider looking at a long, correct stop list is
+demonstrably not stuck. Queries of `ADDRESS_SEARCH_LONG_QUERY_LENGTH` (12) characters or
+more bypass it: a string that long is usually an address, and should still get one even
+if the stop list happens to be busy.
+
+`localStopResultCount` is **nullable, and null means "not known yet"** — it is not a
+stand-in for zero. On the keystroke the local pipeline is still inside its own 100ms
+debounce, so the only count available is the previous query's, which for incremental
+typing is a broader (larger) result set and would suppress calls that should fire. The
+stop-count check therefore runs only at the post-debounce site (350ms), by which time the
+local results have settled. The local pipeline's analytics firing recomputes the gate with
+the same settled count, so the reported gate is the decision that actually gets made.
+
+`STOPS_ALREADY_SUFFICIENT` must stay distinct from `BELOW_THRESHOLD`: two different
+reasons for not calling collapsed into one value would make the `addressSearchGate` param
+unable to tell them apart, which is the entire point of reporting it.
+
+Because the gate now returns a non-`ELIGIBLE` value for queries the local site previously
+handed to the address pipeline, `resolveLocalZeroResultQuery` owns the zero-result
+carve-out for those queries. That **increases** captured zero-result query text (still
+under the same redaction rules) — expected, not a regression.
 
 ## Cache
 
@@ -90,6 +121,8 @@ address-eligible queries because only it knows both pipelines' counts. See
 |---|---|---|---|
 | `search_stop_address_search_enabled` | Boolean | `false` | - |
 | `search_stop_address_min_query_length` | Integer | `6` | `2..12`, else fallback |
+| `search_stop_address_max_local_stops` | Integer | `10` | `0..50`, else fallback |
 
-`resolveAddressSearchMinQueryLength` range-checks in `Long` space before narrowing to
-`Int`, so an oversized remote value can't wrap around into a false in-range result.
+Both resolvers range-check in `Long` space before narrowing to `Int`, so an oversized
+remote value can't wrap around into a false in-range result, and both **fall back rather
+than clamp** — a typo must not quietly become a valid-looking setting.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -34,6 +34,7 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.RemoteAddressResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.resolveAddressSearchMaxLocalStops
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.resolveAddressSearchMinQueryLength
 import xyz.ksharma.krail.trip.planner.ui.searchstop.fuzzy.DefaultFuzzyStopRanker
 import xyz.ksharma.krail.trip.planner.ui.searchstop.fuzzy.FuzzyStopRanker
@@ -202,6 +203,7 @@ val viewModelsModule = module {
         // Read live, not once, same reasoning as isAddressSearchEnabled above - Remote
         // Config can push a new threshold while this ViewModel is already alive.
         val addressSearchMinQueryLength = { resolveAddressSearchMinQueryLength(flag) }
+        val addressSearchMaxLocalStops = { resolveAddressSearchMaxLocalStops(flag) }
         SearchStopViewModel(
             analytics = get(),
             stopResultsManager = get(),
@@ -214,6 +216,7 @@ val viewModelsModule = module {
             searchSessionStore = get(),
             isAddressSearchEnabled = isAddressSearchEnabled,
             addressSearchMinQueryLength = addressSearchMinQueryLength,
+            addressSearchMaxLocalStops = addressSearchMaxLocalStops,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalytics.kt
@@ -36,6 +36,41 @@ internal fun Analytics.trackAddressSearchResolved(
 }
 
 /**
+ * One firing per settled local stop search. [addressSearchGate] is passed in rather than
+ * recomputed here: the caller holds the settled local stop count the gate needs.
+ */
+internal fun Analytics.trackLocalSearchResolved(
+    query: String,
+    searchSessionId: String,
+    localResultsCount: Int,
+    addressSearchGate: AddressSearchGate,
+) {
+    track(
+        AnalyticsEvent.SearchStopQuery(
+            queryLength = query.length,
+            searchSessionId = searchSessionId,
+            resultsCount = localResultsCount,
+            zeroResultQuery = resolveLocalZeroResultQuery(
+                query = query,
+                localResultsCount = localResultsCount,
+                addressSearchGate = addressSearchGate,
+            ),
+        ),
+    )
+}
+
+/** Local pipeline threw. No gate is reported: the query never reached that decision. */
+internal fun Analytics.trackLocalSearchFailed(query: String, searchSessionId: String) {
+    track(
+        AnalyticsEvent.SearchStopQuery(
+            queryLength = query.length,
+            searchSessionId = searchSessionId,
+            isError = true,
+        ),
+    )
+}
+
+/**
  * Local-pipeline carve-out site. When the address pipeline is eligible for the query,
  * it resolves later and owns the carve-out decision (the query may be a real address
  * the NSW API recognises), so this returns null.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -42,6 +42,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.normaliseLabelName
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchCache
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchEligibility
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchGate
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.addressSearchCacheKey
 import xyz.ksharma.krail.trip.planner.ui.searchstop.address.normalizeAddressQuery
@@ -71,6 +72,7 @@ class SearchStopViewModel(
     private val searchSessionStore: SearchSessionStore,
     private val isAddressSearchEnabled: () -> Boolean = { false },
     private val addressSearchMinQueryLength: () -> Int = { DEFAULT_ADDRESS_SEARCH_MIN_QUERY_LENGTH },
+    private val addressSearchMaxLocalStops: () -> Int = { DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS },
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<SearchStopState> = MutableStateFlow(SearchStopState())
@@ -537,26 +539,23 @@ class SearchStopViewModel(
             runCatching {
                 val stopResults = stopResultsManager.fetchStopResults(query)
                 updateUiState { displayData(stopResults) }
-                analytics.track(
-                    AnalyticsEvent.SearchStopQuery(
-                        queryLength = query.length,
-                        searchSessionId = searchSessionId,
-                        resultsCount = stopResults.size,
-                        zeroResultQuery = resolveLocalZeroResultQuery(
-                            query = query,
-                            localResultsCount = stopResults.size,
-                            addressSearchGate = currentAddressSearchGate(normalizeAddressQuery(query)),
-                        ),
+                analytics.trackLocalSearchResolved(
+                    query = query,
+                    searchSessionId = searchSessionId,
+                    localResultsCount = stopResults.size,
+                    // Same inputs the address job's post-debounce check will see (its
+                    // 350ms debounce outlasts this pipeline's 100ms), so this is the
+                    // decision that actually gets made, not a guess at it.
+                    addressSearchGate = currentAddressSearchGate(
+                        normalizedQuery = normalizeAddressQuery(query),
+                        localStopResultCount = stopResults.size,
                     ),
                 )
             }.getOrElse {
                 updateUiState { displayError() }
-                analytics.track(
-                    AnalyticsEvent.SearchStopQuery(
-                        queryLength = query.length,
-                        searchSessionId = searchSessionId,
-                        isError = true,
-                    ),
+                analytics.trackLocalSearchFailed(
+                    query = query,
+                    searchSessionId = searchSessionId,
                 )
             }
         }
@@ -572,7 +571,15 @@ class SearchStopViewModel(
         val normalizedQuery = normalizeAddressQuery(query)
         val searchSessionId = currentSearchSessionId
 
-        if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) {
+        // The local pipeline for THIS query has not settled yet - it is still inside its
+        // own debounce - so the stop-count check is deliberately skipped here rather than
+        // run against the previous query's count, which for an incremental keystroke is a
+        // broader (larger) result set and would suppress calls that should fire. Null
+        // means "not known yet"; the check runs after the debounce below, on the settled
+        // count.
+        if (currentAddressSearchGate(normalizedQuery, localStopResultCount = null) !=
+            AddressSearchGate.ELIGIBLE
+        ) {
             updateUiState { copy(addressResults = persistentListOf(), isAddressSearchLoading = false) }
             return
         }
@@ -591,8 +598,20 @@ class SearchStopViewModel(
             delay(ADDRESS_SEARCH_DEBOUNCE_MS)
 
             // A flag flip or further edit during the debounce must not fire a now-stale
-            // request - re-check the same gate the caller already passed.
-            if (currentAddressSearchGate(normalizedQuery) != AddressSearchGate.ELIGIBLE) return@launch
+            // request - re-check the gate the caller already passed, now with the settled
+            // local stop count, which is the check that could not run on the keystroke.
+            // Clears the section on the way out: a previous query's addresses left on
+            // screen under a newly-suppressed query would be worse than showing none.
+            if (currentAddressSearchGate(
+                    normalizedQuery = normalizedQuery,
+                    localStopResultCount = _uiState.value.searchResults.size,
+                ) != AddressSearchGate.ELIGIBLE
+            ) {
+                updateUiState {
+                    copy(addressResults = persistentListOf(), isAddressSearchLoading = false)
+                }
+                return@launch
+            }
 
             updateUiState { copy(isAddressSearchLoading = true) }
             // suspendSafeResult, not runCatching: a cancelled coroutine (e.g. this job
@@ -628,11 +647,16 @@ class SearchStopViewModel(
         }
     }
 
-    private fun currentAddressSearchGate(normalizedQuery: String): AddressSearchGate =
+    private fun currentAddressSearchGate(
+        normalizedQuery: String,
+        localStopResultCount: Int?,
+    ): AddressSearchGate =
         AddressSearchEligibility.evaluate(
             normalizedQuery = normalizedQuery,
             isAddressSearchEnabled = isAddressSearchEnabled(),
             minQueryLength = addressSearchMinQueryLength(),
+            localStopResultCount = localStopResultCount,
+            maxLocalStopsForAddressSearch = addressSearchMaxLocalStops(),
         )
 
     private fun StopItem.productClasses(): String =

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibility.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibility.kt
@@ -1,6 +1,13 @@
 package xyz.ksharma.krail.trip.planner.ui.searchstop.address
 
 /**
+ * A query this long is treated as address-shaped regardless of how busy the local stop
+ * list is: someone typing a string this long is usually typing an address and should
+ * still get one. This is the escape hatch on the stop-count gate below.
+ */
+const val ADDRESS_SEARCH_LONG_QUERY_LENGTH = 12
+
+/**
  * Pure eligibility gate for the address/POI search API call. Evaluated at the
  * ViewModel boundary before any loading state or network job is created — see
  * feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md.
@@ -10,14 +17,42 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop.address
  */
 object AddressSearchEligibility {
 
+    /**
+     * @param localStopResultCount On-device stop matches already on screen for this
+     * query, or `null` when they have not settled yet. Query length is a weak predictor
+     * of whether anyone wants an address; how many stops the rider is already looking at
+     * is a much stronger one — a rider staring at a long, correct stop list is
+     * demonstrably not stuck. `null` skips that check rather than guessing with a
+     * previous query's count.
+     * @param maxLocalStopsForAddressSearch Above this many local matches the address call
+     * is suppressed, unless the query is at least [ADDRESS_SEARCH_LONG_QUERY_LENGTH]
+     * characters. Remote-config tunable.
+     */
     fun evaluate(
         normalizedQuery: String,
         isAddressSearchEnabled: Boolean,
         minQueryLength: Int,
+        localStopResultCount: Int?,
+        maxLocalStopsForAddressSearch: Int,
     ): AddressSearchGate = when {
         !isAddressSearchEnabled -> AddressSearchGate.DISABLED
         normalizedQuery.isBlank() -> AddressSearchGate.BLANK
         normalizedQuery.length < minQueryLength -> AddressSearchGate.BELOW_THRESHOLD
+
+        isStopListAlreadySufficient(
+            normalizedQuery = normalizedQuery,
+            localStopResultCount = localStopResultCount,
+            maxLocalStopsForAddressSearch = maxLocalStopsForAddressSearch,
+        ) -> AddressSearchGate.STOPS_ALREADY_SUFFICIENT
+
         else -> AddressSearchGate.ELIGIBLE
     }
+
+    private fun isStopListAlreadySufficient(
+        normalizedQuery: String,
+        localStopResultCount: Int?,
+        maxLocalStopsForAddressSearch: Int,
+    ): Boolean = localStopResultCount != null &&
+        localStopResultCount > maxLocalStopsForAddressSearch &&
+        normalizedQuery.length < ADDRESS_SEARCH_LONG_QUERY_LENGTH
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchGate.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchGate.kt
@@ -4,10 +4,15 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop.address
  * Outcome of [AddressSearchEligibility.evaluate]. Only [ELIGIBLE] may schedule a
  * debounced address/POI request; every other value clears the address section
  * without a loading state or a network call.
+ *
+ * [STOPS_ALREADY_SUFFICIENT] is deliberately distinct from [BELOW_THRESHOLD]: they are
+ * two different reasons for not calling, and `search_stop_query`'s `addressSearchGate`
+ * param has to be able to tell them apart - that is the whole point of reporting it.
  */
 enum class AddressSearchGate {
     DISABLED,
     BLANK,
     BELOW_THRESHOLD,
+    STOPS_ALREADY_SUFFICIENT,
     ELIGIBLE,
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMaxLocalStops.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMaxLocalStops.kt
@@ -1,0 +1,27 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import xyz.ksharma.krail.core.remoteconfig.flag.Flag
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.asNumber
+
+const val DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS = 10
+private val VALID_ADDRESS_SEARCH_MAX_LOCAL_STOPS_RANGE = 0L..50L
+
+/**
+ * Resolves `search_stop_address_max_local_stops` with the same bounds contract as
+ * [resolveAddressSearchMinQueryLength]: a missing, malformed, or out-of-range remote
+ * value falls back to [DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS] rather than being
+ * silently clamped into range, so a typo cannot quietly turn the address search off
+ * (`0`) or on for everyone (a huge value). The range check happens in `Long` space
+ * before narrowing to `Int`, so an oversized remote value can't wrap around into a
+ * false in-range result.
+ */
+fun resolveAddressSearchMaxLocalStops(flag: Flag): Int {
+    val raw = flag.getFlagValue(FlagKeys.SEARCH_STOP_ADDRESS_MAX_LOCAL_STOPS.key)
+        .asNumber(DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS.toLong())
+    return if (raw in VALID_ADDRESS_SEARCH_MAX_LOCAL_STOPS_RANGE) {
+        raw.toInt()
+    } else {
+        DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -22,6 +22,7 @@ import xyz.ksharma.krail.core.analytics.Analytics
 import xyz.ksharma.krail.core.analytics.AnalyticsScreen
 import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS
 import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
@@ -832,7 +833,10 @@ class SearchStopViewModelTest {
 
     // region Address search eligibility
 
-    private fun addressAwareViewModel(minQueryLength: Int = 6) = SearchStopViewModel(
+    private fun addressAwareViewModel(
+        minQueryLength: Int = 6,
+        maxLocalStops: Int = DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS,
+    ) = SearchStopViewModel(
         analytics = fakeAnalytics,
         stopResultsManager = fakeStopResultsManager,
         remoteAddressResultsManager = fakeRemoteAddressResultsManager,
@@ -844,6 +848,7 @@ class SearchStopViewModelTest {
         searchSessionStore = searchSessionStore,
         isAddressSearchEnabled = { true },
         addressSearchMinQueryLength = { minQueryLength },
+        addressSearchMaxLocalStops = { maxLocalStops },
     )
 
     @Test
@@ -865,6 +870,87 @@ class SearchStopViewModelTest {
 
                 assertEquals(0, fakeRemoteAddressResultsManager.callCount)
                 assertTrue(addressViewModel.uiState.value.addressResults.isEmpty())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN the stop list already answers the query WHEN it settles THEN no address request is made`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Opera House",
+                    addressType = "poi",
+                ),
+            )
+            // "Sydney" matches one local stop; a max of 0 makes that "already sufficient".
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6, maxLocalStops = 0)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                assertEquals(0, fakeRemoteAddressResultsManager.callCount)
+                assertTrue(addressViewModel.uiState.value.addressResults.isEmpty())
+                assertFalse(addressViewModel.uiState.value.isAddressSearchLoading)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN the stop list is busy WHEN the query is long THEN the escape hatch still fires the request`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Airport",
+                    addressType = "poi",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6, maxLocalStops = 0)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                // 12 characters - at the long-query escape hatch, and still matches a stop.
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney Airpo"))
+                advanceUntilIdle()
+
+                assertEquals(1, fakeRemoteAddressResultsManager.callCount)
+                assertEquals(1, addressViewModel.uiState.value.addressResults.size)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN addresses on screen WHEN the next query is suppressed THEN the stale addresses are cleared`() =
+        runTest {
+            fakeRemoteAddressResultsManager.results = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Sydney Airport",
+                    addressType = "poi",
+                ),
+            )
+            val addressViewModel = addressAwareViewModel(minQueryLength = 6, maxLocalStops = 0)
+
+            addressViewModel.uiState.test {
+                skipItems(1)
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney Airpo"))
+                advanceUntilIdle()
+                assertEquals(1, addressViewModel.uiState.value.addressResults.size)
+
+                // Shorter query, still above the length threshold, but now suppressed by
+                // the stop-count gate - the previous query's addresses must not linger.
+                addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Sydney"))
+                advanceUntilIdle()
+
+                assertTrue(addressViewModel.uiState.value.addressResults.isEmpty())
+                assertFalse(addressViewModel.uiState.value.isAddressSearchLoading)
 
                 cancelAndIgnoreRemainingEvents()
             }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibilityTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchEligibilityTest.kt
@@ -5,75 +5,172 @@ import kotlin.test.assertEquals
 
 class AddressSearchEligibilityTest {
 
+    private fun evaluate(
+        normalizedQuery: String,
+        isAddressSearchEnabled: Boolean = true,
+        minQueryLength: Int = 6,
+        localStopResultCount: Int? = null,
+        maxLocalStopsForAddressSearch: Int = DEFAULT_ADDRESS_SEARCH_MAX_LOCAL_STOPS,
+    ) = AddressSearchEligibility.evaluate(
+        normalizedQuery = normalizedQuery,
+        isAddressSearchEnabled = isAddressSearchEnabled,
+        minQueryLength = minQueryLength,
+        localStopResultCount = localStopResultCount,
+        maxLocalStopsForAddressSearch = maxLocalStopsForAddressSearch,
+    )
+
     @Test
     fun `GIVEN kill switch disabled WHEN evaluate THEN DISABLED regardless of query`() {
         assertEquals(
             AddressSearchGate.DISABLED,
-            AddressSearchEligibility.evaluate(
-                normalizedQuery = "Sydney Opera House",
-                isAddressSearchEnabled = false,
-                minQueryLength = 6,
-            ),
+            evaluate(normalizedQuery = "Sydney Opera House", isAddressSearchEnabled = false),
         )
     }
 
     @Test
     fun `GIVEN blank normalized query WHEN evaluate THEN BLANK`() {
-        assertEquals(
-            AddressSearchGate.BLANK,
-            AddressSearchEligibility.evaluate(
-                normalizedQuery = "",
-                isAddressSearchEnabled = true,
-                minQueryLength = 6,
-            ),
-        )
+        assertEquals(AddressSearchGate.BLANK, evaluate(normalizedQuery = ""))
     }
 
     @Test
     fun `GIVEN query shorter than threshold WHEN evaluate THEN BELOW_THRESHOLD`() {
-        assertEquals(
-            AddressSearchGate.BELOW_THRESHOLD,
-            AddressSearchEligibility.evaluate(
-                normalizedQuery = "Syd",
-                isAddressSearchEnabled = true,
-                minQueryLength = 6,
-            ),
-        )
+        assertEquals(AddressSearchGate.BELOW_THRESHOLD, evaluate(normalizedQuery = "Syd"))
     }
 
     @Test
     fun `GIVEN query exactly at threshold WHEN evaluate THEN ELIGIBLE`() {
-        assertEquals(
-            AddressSearchGate.ELIGIBLE,
-            AddressSearchEligibility.evaluate(
-                normalizedQuery = "Sydney",
-                isAddressSearchEnabled = true,
-                minQueryLength = 6,
-            ),
-        )
+        assertEquals(AddressSearchGate.ELIGIBLE, evaluate(normalizedQuery = "Sydney"))
     }
 
     @Test
     fun `GIVEN query longer than threshold WHEN evaluate THEN ELIGIBLE`() {
-        assertEquals(
-            AddressSearchGate.ELIGIBLE,
-            AddressSearchEligibility.evaluate(
-                normalizedQuery = "Sydney Opera House",
-                isAddressSearchEnabled = true,
-                minQueryLength = 6,
-            ),
-        )
+        assertEquals(AddressSearchGate.ELIGIBLE, evaluate(normalizedQuery = "Sydney Op"))
     }
 
     @Test
     fun `GIVEN disabled AND blank AND below threshold WHEN evaluate THEN disabled wins`() {
         assertEquals(
             AddressSearchGate.DISABLED,
-            AddressSearchEligibility.evaluate(
-                normalizedQuery = "",
-                isAddressSearchEnabled = false,
-                minQueryLength = 6,
+            evaluate(normalizedQuery = "", isAddressSearchEnabled = false),
+        )
+    }
+
+    // region Local stop count gate
+
+    @Test
+    fun `GIVEN local count is unknown WHEN evaluate THEN the stop count gate is not applied`() {
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            evaluate(normalizedQuery = "Sydney", localStopResultCount = null),
+        )
+    }
+
+    @Test
+    fun `GIVEN more local stops than the max WHEN evaluate THEN STOPS_ALREADY_SUFFICIENT`() {
+        assertEquals(
+            AddressSearchGate.STOPS_ALREADY_SUFFICIENT,
+            evaluate(
+                normalizedQuery = "Sydney",
+                localStopResultCount = 11,
+                maxLocalStopsForAddressSearch = 10,
             ),
         )
     }
+
+    @Test
+    fun `GIVEN exactly the max local stops WHEN evaluate THEN ELIGIBLE`() {
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            evaluate(
+                normalizedQuery = "Sydney",
+                localStopResultCount = 10,
+                maxLocalStopsForAddressSearch = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN zero local stops WHEN evaluate THEN ELIGIBLE`() {
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            evaluate(normalizedQuery = "Sydney", localStopResultCount = 0),
+        )
+    }
+
+    @Test
+    fun `GIVEN a busy stop list WHEN the query is long enough THEN the escape hatch keeps it ELIGIBLE`() {
+        val longQuery = "1 Fulton Place"
+        assertEquals(12, ADDRESS_SEARCH_LONG_QUERY_LENGTH)
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            evaluate(
+                normalizedQuery = longQuery,
+                localStopResultCount = 50,
+                maxLocalStopsForAddressSearch = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN a busy stop list WHEN the query is one char short of the hatch THEN suppressed`() {
+        assertEquals(
+            AddressSearchGate.STOPS_ALREADY_SUFFICIENT,
+            evaluate(
+                normalizedQuery = "abcdefghijk", // 11 chars
+                localStopResultCount = 50,
+                maxLocalStopsForAddressSearch = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN a busy stop list WHEN the query is exactly the hatch length THEN ELIGIBLE`() {
+        assertEquals(
+            AddressSearchGate.ELIGIBLE,
+            evaluate(
+                normalizedQuery = "abcdefghijkl", // 12 chars
+                localStopResultCount = 50,
+                maxLocalStopsForAddressSearch = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN a busy stop list AND a below-threshold query WHEN evaluate THEN BELOW_THRESHOLD wins`() {
+        assertEquals(
+            AddressSearchGate.BELOW_THRESHOLD,
+            evaluate(
+                normalizedQuery = "Syd",
+                localStopResultCount = 50,
+                maxLocalStopsForAddressSearch = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN a busy stop list AND the kill switch off WHEN evaluate THEN DISABLED wins`() {
+        assertEquals(
+            AddressSearchGate.DISABLED,
+            evaluate(
+                normalizedQuery = "Sydney",
+                isAddressSearchEnabled = false,
+                localStopResultCount = 50,
+                maxLocalStopsForAddressSearch = 10,
+            ),
+        )
+    }
+
+    @Test
+    fun `GIVEN max local stops of zero WHEN any stop matched THEN STOPS_ALREADY_SUFFICIENT`() {
+        assertEquals(
+            AddressSearchGate.STOPS_ALREADY_SUFFICIENT,
+            evaluate(
+                normalizedQuery = "Sydney",
+                localStopResultCount = 1,
+                maxLocalStopsForAddressSearch = 0,
+            ),
+        )
+    }
+
+    // endregion Local stop count gate
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMaxLocalStopsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/address/AddressSearchMaxLocalStopsTest.kt
@@ -1,0 +1,63 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.address
+
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagValue
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AddressSearchMaxLocalStopsTest {
+
+    private val fakeFlag = FakeFlag()
+
+    private fun setRemote(value: FlagValue) {
+        fakeFlag.setFlagValue(FlagKeys.SEARCH_STOP_ADDRESS_MAX_LOCAL_STOPS.key, value)
+    }
+
+    @Test
+    fun `GIVEN no remote value WHEN resolve THEN default ten`() {
+        assertEquals(10, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN in-range remote value WHEN resolve THEN that value`() {
+        setRemote(FlagValue.NumberValue(3))
+        assertEquals(3, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN lower bound remote value WHEN resolve THEN that value`() {
+        setRemote(FlagValue.NumberValue(0))
+        assertEquals(0, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN upper bound remote value WHEN resolve THEN that value`() {
+        setRemote(FlagValue.NumberValue(50))
+        assertEquals(50, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN below-range remote value WHEN resolve THEN fallback to default`() {
+        setRemote(FlagValue.NumberValue(-1))
+        assertEquals(10, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN above-range remote value WHEN resolve THEN fallback to default`() {
+        setRemote(FlagValue.NumberValue(51))
+        assertEquals(10, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN wildly oversized remote value WHEN resolve THEN fallback to default not a wrapped Int`() {
+        setRemote(FlagValue.NumberValue(Long.MAX_VALUE))
+        assertEquals(10, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+
+    @Test
+    fun `GIVEN malformed non-numeric remote value WHEN resolve THEN fallback to default`() {
+        setRemote(FlagValue.StringValue("ten"))
+        assertEquals(10, resolveAddressSearchMaxLocalStops(fakeFlag))
+    }
+}


### PR DESCRIPTION
## What

Address/POI eligibility decided on query length alone. This adds a second input the app already has at the decision point: how many on-device stops already match the query.

## Changes

- `AddressSearchEligibility.evaluate` takes `localStopResultCount` and `maxLocalStopsForAddressSearch`, and returns a new `STOPS_ALREADY_SUFFICIENT` gate value when more stops than the max already match.
- Queries of `ADDRESS_SEARCH_LONG_QUERY_LENGTH` (12) characters or more bypass the check. A string that long is usually an address and should still get one even if the stop list is busy.
- `localStopResultCount` is **nullable, and null means "not settled yet"**, not zero. On the keystroke the local pipeline is still inside its own debounce, so the only count available belongs to the previous query, which for incremental typing is a broader result set and would suppress calls that should fire. The check runs at the post-debounce site, on the settled count.
- The post-debounce site now clears the address section when it declines to call. Previously a `return@launch` there left the previous query's addresses on screen; that also applied to a flag flip mid-debounce.
- New remote config key `search_stop_address_max_local_stops`, default `10`, validated `0..50`, falling back rather than clamping, same contract as the length key.
- `STOPS_ALREADY_SUFFICIENT` is deliberately a separate enum value from `BELOW_THRESHOLD`: they are different reasons for not calling, and the follow-up PR reports them separately.
- The local search analytics firing moves into `SearchQueryAnalytics.kt` (`trackLocalSearchResolved` / `trackLocalSearchFailed`). Without it the gate wiring pushes `SearchStopViewModel` past its `LargeClass` limit; no suppressions added.
- `ADDRESS_SEARCH_ELIGIBILITY.md` updated with the gate order, the null semantics, and the remote config table.

Left untouched: the cache lookup still happens before the settled count exists, so a cache hit can serve a query the stop-count gate would later decline. That costs no network call, which is the point of the gate.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest :composeApp:testAndroidHostTest --continue` green. New cases cover the boundary (`count == max` stays eligible), the 12-character escape hatch either side of the boundary, precedence over `BELOW_THRESHOLD` and `DISABLED`, `max = 0`, and the null "not settled yet" path; plus the resolver's in-range, out-of-range, oversized, and malformed cases.
- `./gradlew detekt --continue` green.
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS simulator compile, detekt).
- Device QA on an Android emulator, debug build, with the remote threshold at 9:

| Query | chars | local matches | gate | address call |
|---|---|---|---|---|
| `fulton p` | 8 | 50 | `BELOW_THRESHOLD` | no |
| `fulton pl` | 9 | 10 | `ELIGIBLE` | yes |
| `central st` | 10 | 13 | `STOPS_ALREADY_SUFFICIENT` | no |
| `central stre` | 12 | 50 | `ELIGIBLE` (escape hatch) | yes |

  Going from an eligible query to a suppressed one clears the address section (checked against a UI dump). Rotated portrait and landscape with results loaded: query text, local results and address section all survive, no `FATAL EXCEPTION`, crash buffer clean. iOS build installs and launches on the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
