### PR TITLE
fix(ios): distribute TestFlight builds to tester groups from CI

### DIFF
--- a/.github/workflows/distribute-testflight.yml
+++ b/.github/workflows/distribute-testflight.yml
@@ -6,17 +6,11 @@ on:
       artifact-name:
         required: false
         type: string
-      notify-testers:
-        required: false
-        type: boolean
-        default: false
+  # No inputs: the Fastfile owns distribution (internal groups only, no external
+  # testers), so there was nothing for a notify-testers input to control. It was
+  # declared here but never forwarded to fastlane by any step, and no caller ever
+  # passed it.
   workflow_dispatch:
-    inputs:
-      notify-testers:
-        description: 'Notify external testers after upload'
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   distribute:

--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -95,10 +95,21 @@ platform :ios do
     app_store_connect_api_key
     upload_to_testflight(
       ipa: "./build/iosApp.ipa",
-      skip_waiting_for_build_processing: true,
+      # Must be false: with skip_waiting_for_build_processing fastlane returns as soon
+      # as the binary is accepted, before the build exists as something distributable,
+      # so it cannot assign groups and the build lands in TestFlight belonging to
+      # nobody. That is the whole reason uploads were invisible to testers.
+      skip_waiting_for_build_processing: false,
+      # Processing is usually a few minutes but Apple gives no guarantee. Bound the
+      # wait so a slow processing queue fails the job loudly instead of burning the
+      # runner's full 6h budget.
+      wait_processing_timeout_duration: 1800,
       skip_submission: true,
+      # Internal groups only. External distribution needs a Beta App Review, which is
+      # not something an RC push should trigger unattended.
       distribute_external: false,
-      notify_external_testers: false
+      notify_external_testers: false,
+      groups: ["Internal", "Friends"]
     )
   end
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -20,6 +20,12 @@
         <string>$(MARKETING_VERSION)</string>
         <key>CFBundleVersion</key>
         <string>$(CURRENT_PROJECT_VERSION)</string>
+	<!-- KRAIL only uses HTTPS and the OS keychain, both exempt under the encryption
+	     export rules. Declaring this here answers the export-compliance question at
+	     upload time; without it every single build sits in TestFlight as "Missing
+	     Compliance" and is withheld from testers until someone answers by hand. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## What

TestFlight uploads reached App Store Connect but did not reach testers. Two independent causes, both fixed here.

**No group assignment.** `upload_to_testflight` ran with `skip_waiting_for_build_processing: true`, so fastlane returned as soon as Apple accepted the binary, before the build existed as something distributable. Group assignment cannot happen in that window, and no `groups:` were requested either, so a build landed in TestFlight belonging to nobody. Waiting for processing is a precondition for assigning groups, not an optional extra.

**Missing export compliance.** `Info.plist` declared no `ITSAppUsesNonExemptEncryption`, so every build sat as "Missing Compliance" and was withheld from testers until someone answered the export question by hand. KRAIL only uses HTTPS and the OS keychain, both exempt under the encryption export rules, so the answer is a constant and belongs in the plist.

## Changes

- `iosApp/fastlane/Fastfile`: `skip_waiting_for_build_processing: false`, bounded by `wait_processing_timeout_duration: 1800` so a stalled processing queue fails the job loudly instead of holding the runner for its full budget
- `iosApp/fastlane/Fastfile`: `groups: ["Internal", "Friends"]`. `distribute_external` stays `false`, since external distribution requires a Beta App Review that an RC push must not trigger unattended
- `iosApp/iosApp/Info.plist`: add `ITSAppUsesNonExemptEncryption` = `false`
- `.github/workflows/distribute-testflight.yml`: drop the `notify-testers` input. It was declared on both `workflow_call` and `workflow_dispatch`, never forwarded to fastlane by any step, and never passed by any caller, so it controlled nothing
- Left untouched: `skip_submission: true` and `distribute_external: false`, both of which should stay off for an automated RC pipeline

## Trade-off

The job now blocks on Apple's processing queue instead of returning immediately, so the `distribute-testflight` step gets longer by however long processing takes (typically a few minutes). That wait is what buys group assignment; there is no way to have both.

## Testing

- `ruby -c iosApp/fastlane/Fastfile` syntax OK
- `plutil -lint iosApp/iosApp/Info.plist` OK; `plutil -extract ITSAppUsesNonExemptEncryption raw` returns `false`
- Both edited workflow files parse as YAML, and `release-2-deploy-rc.yml` still resolves its `push` trigger
- No caller passes `notify-testers`, verified by grep across `.github/workflows/`
- End to end verification needs a real upload, so this is confirmed on the next RC push to a `prod/**` branch, not in this PR

## Follow-up not in this PR

If build 45's group assignment came from "Automatic distribution" being enabled on the Friends group in App Store Connect rather than from CI, that setting stays as-is and is now redundant for these two groups. Worth confirming on the next RC that both `IN` and `FR` appear on the build, and turning the console setting off if CI is doing the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYfQGMHrgq9LW7xCVw4gC4
