### PR TITLE
fix(saved-trips): prevent duplicate trip identities

### DIFF
--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeSandook.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeSandook.kt
@@ -99,9 +99,16 @@ class FakeSandook : Sandook {
         toStopId: String,
         toStopName: String,
     ) {
-        val existingSortOrder = tripsFlow.value.find { it.tripId == tripId }?.sort_order ?: 0L
+        val canonicalTripId = "$fromStopId->$toStopId"
+        val existingSortOrder = tripsFlow.value
+            .find {
+                it.tripId == canonicalTripId ||
+                    (it.fromStopId == fromStopId && it.toStopId == toStopId)
+            }
+            ?.sort_order
+            ?: 0L
         val trip = SavedTrip(
-            tripId,
+            canonicalTripId,
             fromStopId,
             fromStopName,
             toStopId,
@@ -110,7 +117,10 @@ class FakeSandook : Sandook {
             sort_order = existingSortOrder,
         )
         val current = tripsFlow.value.toMutableList()
-        current.removeAll { it.tripId == tripId }
+        current.removeAll {
+            it.tripId == canonicalTripId ||
+                (it.fromStopId == fromStopId && it.toStopId == toStopId)
+        }
         current.add(trip)
         tripsFlow.value = current
     }

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/Trip.kt
@@ -12,8 +12,14 @@ data class Trip(
     val toStopId: String,
     val toStopName: String,
 ) {
+    /**
+     * Stable storage and Compose identity for this ordered stop pair.
+     *
+     * Keep this format aligned with the Sandook `SavedTrip` constraints and migrations.
+     * A separator is required; concatenating opaque stop IDs can create duplicate list keys.
+     */
     val tripId: String
-        get() = "$fromStopId$toStopId"
+        get() = "$fromStopId->$toStopId"
 
     fun toJsonString() = Json.encodeToString(serializer(), this)
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -684,12 +684,12 @@ class TimeTableViewModel(
      * Frequency rules (story A2): at most once per app session, and stop after
      * [MAX_SAVE_TRIP_PROMPT_DISMISSALS] dismissals for the same pair.
      */
-    private fun resolveSavePromptOnLoad(tripId: String): Boolean {
+    private fun resolveSavePromptOnLoad(trip: Trip): Boolean {
         // Already on screen (e.g. same-trip re-init) — keep it there.
         if (_uiState.value.showSaveTripPrompt) return true
         val eligible = !savePromptShownInSession &&
             sandook.selectAllTrips().isEmpty() &&
-            promptDismissCount(tripId) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
+            promptDismissCount(trip) < MAX_SAVE_TRIP_PROMPT_DISMISSALS
         if (!eligible) return false
         savePromptShownInSession = true
         return true
@@ -713,8 +713,14 @@ class TimeTableViewModel(
         )
     }
 
-    private fun promptDismissCount(tripId: String): Long =
-        preferences.getLong(SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + tripId) ?: 0L
+    private fun promptDismissCount(trip: Trip): Long {
+        val prefix = SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX
+        val canonicalCount = preferences.getLong(prefix + trip.tripId) ?: 0L
+        // tripId used to be the two stop IDs concatenated without a separator. Keep honouring
+        // those persisted counters after moving saved trips to the canonical pair identity.
+        val legacyCount = preferences.getLong(prefix + trip.fromStopId + trip.toStopId) ?: 0L
+        return maxOf(canonicalCount, legacyCount)
+    }
 
     private fun onSaveTripPromptAccepted() {
         val trip = tripInfo ?: return
@@ -749,7 +755,7 @@ class TimeTableViewModel(
         val trip = tripInfo ?: return
         updateUiState { copy(showSaveTripPrompt = false) }
         viewModelScope.launch(ioDispatcher) {
-            val newCount = promptDismissCount(trip.tripId) + 1
+            val newCount = promptDismissCount(trip) + 1
             preferences.setLong(
                 key = SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + trip.tripId,
                 value = newCount,
@@ -1051,7 +1057,7 @@ class TimeTableViewModel(
         // Resolved at load time so the prompt shows while journeys are still
         // loading; results simply render below it when they arrive. Folded into
         // the same state update as the load itself (single emission).
-        val showSavePrompt = resolveSavePromptOnLoad(currentTripId)
+        val showSavePrompt = resolveSavePromptOnLoad(trip)
 
         if (!isSameTrip) {
             // Different trip - clear state and fetch new data

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripViewModelsTest.kt
@@ -945,7 +945,7 @@ class SavedTripsViewModelTest {
                 // Wait for savedTrips to land in state before issuing the move.
                 awaitItem()
 
-                viewModel.onEvent(SavedTripUiEvent.MoveSavedTripToIndex("AB", 2))
+                viewModel.onEvent(SavedTripUiEvent.MoveSavedTripToIndex("A->B", 2))
 
                 // Drain emissions until we have the reorder event tracked. The
                 // optimistic state update can emit before analytics fires, so we
@@ -979,7 +979,7 @@ class SavedTripsViewModelTest {
 
                 // Source == target is a no-op in the handler. Analytics must mirror
                 // that, otherwise drop-in-place gestures inflate reorder counts.
-                viewModel.onEvent(SavedTripUiEvent.MoveSavedTripToIndex("AB", 0))
+                viewModel.onEvent(SavedTripUiEvent.MoveSavedTripToIndex("A->B", 0))
                 advanceUntilIdle()
 
                 assertFalse(analytics.isEventTracked("saved_trip_card_reordered"))

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -2492,6 +2492,23 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN pair dismissed under legacy ID WHEN timetable loads THEN prompt stays dismissed`() =
+        runTest {
+            val analytics = fakeAnalytics as FakeAnalytics
+            val legacyTripId = promptTrip.fromStopId + promptTrip.toStopId
+            fakePreferences.setLong(
+                SandookPreferences.KEY_SAVE_TRIP_PROMPT_DISMISSALS_PREFIX + legacyTripId,
+                TimeTableViewModel.MAX_SAVE_TRIP_PROMPT_DISMISSALS,
+            )
+
+            loadPromptTrip()
+            advanceUntilIdle()
+
+            assertFalse(viewModel.uiState.value.showSaveTripPrompt)
+            assertFalse(analytics.isEventTracked("save_trip_prompt_shown"))
+        }
+
+    @Test
     fun `GIVEN prompt already shown this session WHEN another unsaved pair loads THEN prompt is not shown again`() =
         runTest {
             val analytics = fakeAnalytics as FakeAnalytics

--- a/sandook/Migrations.md
+++ b/sandook/Migrations.md
@@ -30,3 +30,29 @@ version `X`, so it may depend on the migrated schema.
 If the work can be represented in SQL, keep it in the `.sqm` file instead. No Android
 callback change is needed for a standard SQLDelight migration: `SandookCallback` delegates
 to SQLDelight's schema migration via `super.onUpgrade(...)`.
+
+## Saved-trip identity invariant
+
+A saved trip is identified by its ordered `(fromStopId, toStopId)` pair. The reverse
+direction is a different trip. Its internal `tripId` is the canonical string
+`fromStopId->toStopId`; it is a storage and UI key, not user-facing text and not a value
+that callers should parse.
+
+This contract crosses SQL and Kotlin, so keep all of these layers aligned:
+
+- `Trip.tripId` supplies the Compose list key and the IDs used by select, delete, and reorder.
+- `RealSandook.insertOrReplaceTrip` derives the ID from the two stop IDs instead of trusting
+  a caller-provided serialization. `FakeSandook` must behave the same way.
+- `SavedTrip` enforces both `CHECK (tripId = fromStopId || '->' || toStopId)` and
+  `UNIQUE (fromStopId, toStopId)`. Do not remove either constraint: the check keeps the ID
+  canonical, while the unique constraint prevents two IDs from representing the same pair.
+
+Never construct a saved-trip ID by concatenating stop IDs without a separator. That made
+legacy and current database rows resolve to the same Compose key, and delete operations
+could target a different ID from the stored row.
+
+If this identity format changes, update the current `.sq` schema, `Trip`, both Sandook
+implementations, and persisted preference keys together. Add a numbered migration that
+canonicalizes existing rows and deterministically resolves duplicates, plus an executable
+`KrailSandook.Schema.migrate(...)` regression test containing the legacy row shapes. Preserve
+stop names, timestamps, and sort order unless the product requirement explicitly says otherwise.

--- a/sandook/Migrations.md
+++ b/sandook/Migrations.md
@@ -14,6 +14,10 @@ SQLDelight generates `KrailSandook.Schema.migrate(...)` from the `.sqm` files an
 platform drivers invoke it. Existing installations run each missing `.sqm` migration in
 order; fresh installations create the current schema directly.
 
+When rebuilding a table through a named staging table, start with
+`DROP TABLE IF EXISTS staging_table`. This makes a retry recover safely if an interrupted or
+externally replayed migration left the staging table behind while the schema version stayed old.
+
 Do **not** add a matching iOS `SandookMigrationAfterX` class or `AfterVersion(X)` entry
 solely because a new `.sqm` file exists. The callbacks are not migration registration:
 they are optional hooks that run only *after* SQLDelight has completed the migration to

--- a/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/SavedTripIdentityMigrationTest.kt
+++ b/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/SavedTripIdentityMigrationTest.kt
@@ -1,0 +1,151 @@
+package xyz.ksharma.krail.sandook
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.Dispatchers
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@RunWith(RobolectricTestRunner::class)
+class SavedTripIdentityMigrationTest {
+
+    @Test
+    fun `migration merges duplicate stop pairs and canonicalizes their IDs`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        createVersionThirteenTable(driver)
+        driver.insertLegacyTrip(
+            tripId = "200060-200080",
+            fromStopId = "200060",
+            fromStopName = "Old Central",
+            toStopId = "200080",
+            toStopName = "Wynyard Station",
+            timestamp = "2026-08-06 09:07:19",
+            sortOrder = 4,
+        )
+        driver.insertLegacyTrip(
+            tripId = "200060200080",
+            fromStopId = "200060",
+            fromStopName = "Central Station",
+            toStopId = "200080",
+            toStopName = "Wynyard Station",
+            timestamp = "2026-08-08 11:28:46",
+            sortOrder = 0,
+        )
+        driver.insertLegacyTrip(
+            tripId = "200070-200060",
+            fromStopId = "200070",
+            fromStopName = "Town Hall Station",
+            toStopId = "200060",
+            toStopName = "Central Station",
+            timestamp = "2026-08-06 09:07:19",
+            sortOrder = 1,
+        )
+
+        KrailSandook.Schema.migrate(
+            driver = driver,
+            oldVersion = VERSION_THIRTEEN,
+            newVersion = KrailSandook.Schema.version,
+        )
+
+        val trips = KrailSandook(driver).krailSandookQueries.selectAllTrips().executeAsList()
+        assertEquals(2, trips.size)
+        val centralToWynyard = trips.single {
+            it.fromStopId == "200060" && it.toStopId == "200080"
+        }
+        assertEquals("200060->200080", centralToWynyard.tripId)
+        assertEquals("Central Station", centralToWynyard.fromStopName)
+        assertEquals(0L, centralToWynyard.sort_order)
+        assertEquals(
+            setOf("200060->200080", "200070->200060"),
+            trips.map { it.tripId }.toSet(),
+        )
+        assertNonCanonicalTripIdRejected(driver)
+
+        driver.close()
+    }
+
+    @Test
+    fun `store normalizes a mismatched caller ID before writing`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        KrailSandook.Schema.create(driver)
+        val store = RealSandook(KrailSandook(driver), Dispatchers.Unconfined)
+
+        store.insertOrReplaceTrip(
+            tripId = "200060-200080",
+            fromStopId = "200060",
+            fromStopName = "Central Station",
+            toStopId = "200080",
+            toStopName = "Wynyard Station",
+        )
+
+        assertNotNull(store.selectTripById("200060->200080"))
+        assertNull(store.selectTripById("200060-200080"))
+        assertNonCanonicalTripIdRejected(driver)
+
+        driver.close()
+    }
+
+    private fun assertNonCanonicalTripIdRejected(driver: JdbcSqliteDriver) {
+        assertFails {
+            driver.insertLegacyTrip(
+                tripId = "300000-400000",
+                fromStopId = "300000",
+                fromStopName = "From Station",
+                toStopId = "400000",
+                toStopName = "To Station",
+                timestamp = "2026-08-08 12:00:00",
+                sortOrder = 0,
+            )
+        }
+    }
+
+    private fun createVersionThirteenTable(driver: JdbcSqliteDriver) {
+        driver.execute(
+            identifier = null,
+            sql = """
+                CREATE TABLE SavedTrip (
+                    tripId TEXT PRIMARY KEY,
+                    fromStopId TEXT NOT NULL,
+                    fromStopName TEXT NOT NULL,
+                    toStopId TEXT NOT NULL,
+                    toStopName TEXT NOT NULL,
+                    timestamp TEXT DEFAULT (datetime('now')),
+                    sort_order INTEGER NOT NULL DEFAULT 0
+                )
+            """.trimIndent(),
+            parameters = 0,
+        )
+    }
+
+    private fun JdbcSqliteDriver.insertLegacyTrip(
+        tripId: String,
+        fromStopId: String,
+        fromStopName: String,
+        toStopId: String,
+        toStopName: String,
+        timestamp: String,
+        sortOrder: Long,
+    ) {
+        execute(
+            identifier = null,
+            sql = "INSERT INTO SavedTrip VALUES (?, ?, ?, ?, ?, ?, ?)",
+            parameters = 7,
+        ) {
+            bindString(0, tripId)
+            bindString(1, fromStopId)
+            bindString(2, fromStopName)
+            bindString(3, toStopId)
+            bindString(4, toStopName)
+            bindString(5, timestamp)
+            bindLong(6, sortOrder)
+        }
+    }
+
+    private companion object {
+        const val VERSION_THIRTEEN = 13L
+    }
+}

--- a/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/SavedTripIdentityMigrationTest.kt
+++ b/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/SavedTripIdentityMigrationTest.kt
@@ -69,6 +69,40 @@ class SavedTripIdentityMigrationTest {
     }
 
     @Test
+    fun `migration discards a leftover staging table before retrying`() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        createVersionThirteenTable(driver)
+        driver.insertLegacyTrip(
+            tripId = "200060200080",
+            fromStopId = "200060",
+            fromStopName = "Central Station",
+            toStopId = "200080",
+            toStopName = "Wynyard Station",
+            timestamp = "2026-08-08 11:28:46",
+            sortOrder = 2,
+        )
+        driver.execute(
+            identifier = null,
+            sql = "CREATE TABLE SavedTripByStops (stale TEXT NOT NULL)",
+            parameters = 0,
+        )
+
+        KrailSandook.Schema.migrate(
+            driver = driver,
+            oldVersion = VERSION_THIRTEEN,
+            newVersion = KrailSandook.Schema.version,
+        )
+
+        val trip = KrailSandook(driver).krailSandookQueries.selectAllTrips().executeAsOne()
+        assertEquals("200060->200080", trip.tripId)
+        assertEquals("Central Station", trip.fromStopName)
+        assertEquals(2L, trip.sort_order)
+        assertNonCanonicalTripIdRejected(driver)
+
+        driver.close()
+    }
+
+    @Test
     fun `store normalizes a mismatched caller ID before writing`() {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         KrailSandook.Schema.create(driver)

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -42,8 +42,14 @@ internal class RealSandook(
         toStopId: String,
         toStopName: String,
     ) {
+        // This boundary owns saved-trip identity. Keep it aligned with Trip.tripId and the
+        // SavedTrip CHECK constraint instead of trusting a caller-provided serialization.
+        val canonicalTripId = "$fromStopId->$toStopId"
+        if (tripId != canonicalTripId) {
+            log("Normalizing saved trip ID from $tripId to $canonicalTripId")
+        }
         query.insertOrReplaceTrip(
-            tripId,
+            canonicalTripId,
             fromStopId,
             fromStopName,
             toStopId,

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -46,6 +46,8 @@ internal class RealSandook(
         // SavedTrip CHECK constraint instead of trusting a caller-provided serialization.
         val canonicalTripId = "$fromStopId->$toStopId"
         if (tripId != canonicalTripId) {
+            // Temporary migration diagnostic; safe to remove after legacy-ID callers have
+            // aged out. Keep the canonicalization above as a permanent storage boundary.
             log("Normalizing saved trip ID from $tripId to $canonicalTripId")
         }
         query.insertOrReplaceTrip(

--- a/sandook/src/commonMain/sqldelight/migrations/13.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/13.sqm
@@ -17,6 +17,11 @@ CREATE TABLE IF NOT EXISTS SavedTrip (
     sort_order INTEGER NOT NULL DEFAULT 0
 );
 
+-- A previous interrupted or externally replayed migration may have left the staging table
+-- behind while the database version still reports 13. Always rebuild it from SavedTrip so a
+-- retry is deterministic and cannot preserve a partial copy.
+DROP TABLE IF EXISTS SavedTripByStops;
+
 CREATE TABLE SavedTripByStops (
     tripId TEXT PRIMARY KEY,
     fromStopId TEXT NOT NULL,

--- a/sandook/src/commonMain/sqldelight/migrations/13.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/13.sqm
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS SavedTrip (
 -- retry is deterministic and cannot preserve a partial copy.
 DROP TABLE IF EXISTS SavedTripByStops;
 
-CREATE TABLE SavedTripByStops (
+CREATE TABLE IF NOT EXISTS SavedTripByStops (
     tripId TEXT PRIMARY KEY,
     fromStopId TEXT NOT NULL,
     fromStopName TEXT NOT NULL,

--- a/sandook/src/commonMain/sqldelight/migrations/13.sqm
+++ b/sandook/src/commonMain/sqldelight/migrations/13.sqm
@@ -1,0 +1,61 @@
+-- Migration 13: Saved trips are identified by their origin/destination pair.
+--
+-- Older or externally seeded databases can contain a legacy hyphenated tripId alongside
+-- the current concatenated tripId for the same pair. The UI derives its LazyColumn key from
+-- the stop pair, so those two rows become the same key and crash Compose on every launch.
+-- Rebuild the table to keep only the newest row per pair, move every surviving row to the
+-- unambiguous canonical ID, and enforce pair uniqueness for future writes.
+-- SavedTrip has existed since schema version 1. Recreating the legacy shape defensively is
+-- a no-op for real upgrades and keeps partial migration fixtures safe.
+CREATE TABLE IF NOT EXISTS SavedTrip (
+    tripId TEXT PRIMARY KEY,
+    fromStopId TEXT NOT NULL,
+    fromStopName TEXT NOT NULL,
+    toStopId TEXT NOT NULL,
+    toStopName TEXT NOT NULL,
+    timestamp TEXT DEFAULT (datetime('now')),
+    sort_order INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE SavedTripByStops (
+    tripId TEXT PRIMARY KEY,
+    fromStopId TEXT NOT NULL,
+    fromStopName TEXT NOT NULL,
+    toStopId TEXT NOT NULL,
+    toStopName TEXT NOT NULL,
+    timestamp TEXT DEFAULT (datetime('now')),
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    CHECK (tripId = fromStopId || '->' || toStopId),
+    UNIQUE (fromStopId, toStopId)
+);
+
+INSERT INTO SavedTripByStops(
+    tripId,
+    fromStopId,
+    fromStopName,
+    toStopId,
+    toStopName,
+    timestamp,
+    sort_order
+)
+SELECT
+    current.fromStopId || '->' || current.toStopId,
+    current.fromStopId,
+    current.fromStopName,
+    current.toStopId,
+    current.toStopName,
+    current.timestamp,
+    current.sort_order
+FROM SavedTrip AS current
+WHERE current.rowid = (
+    SELECT candidate.rowid
+    FROM SavedTrip AS candidate
+    WHERE candidate.fromStopId = current.fromStopId
+        AND candidate.toStopId = current.toStopId
+    ORDER BY candidate.timestamp DESC, candidate.rowid DESC
+    LIMIT 1
+);
+
+DROP TABLE SavedTrip;
+
+ALTER TABLE SavedTripByStops RENAME TO SavedTrip;

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/KrailSandook.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/KrailSandook.sq
@@ -21,7 +21,9 @@ CREATE TABLE SavedTrip (
     toStopId TEXT NOT NULL,
     toStopName TEXT NOT NULL,
     timestamp TEXT DEFAULT (datetime('now')),
-    sort_order INTEGER NOT NULL DEFAULT 0
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    CHECK (tripId = fromStopId || '->' || toStopId),
+    UNIQUE (fromStopId, toStopId)
 );
 
 insertOrReplaceTrip:


### PR DESCRIPTION
## What

Fixes a persistent Saved Trips crash caused by two database rows resolving to the same Compose `LazyColumn` key. The change repairs already-affected databases, enforces the identity invariant in SQLite, and documents the cross-layer contract so it is not accidentally broken again.

## Root cause

The affected schema-13 database contained both of these rows for the same Central → Wynyard stop pair:

- legacy ID: `200060-200080`
- current ID: `200060200080`

`SavedTrip.tripId` was not used directly by the UI. Both rows were mapped to a `Trip` whose computed ID concatenated the two stop IDs, so both became `200060200080`. Compose then received the same key twice and threw `IllegalArgumentException: Key "200060200080" was already used` while rendering Saved Trips.

This also explains why deleting and re-saving could make the crash persistent: deletion used the UI's concatenated ID, which did not match the legacy hyphenated database row. The legacy row remained, and saving inserted the concatenated row beside it.

## Fix

- Define saved-trip identity as the ordered `(fromStopId, toStopId)` pair and represent its internal ID as `fromStopId->toStopId`.
- Normalize IDs at the `RealSandook` write boundary so older or mismatched callers cannot reintroduce legacy IDs. The mismatch log is explicitly documented as temporary migration telemetry that can be removed after legacy callers age out; the normalization remains permanent.
- Enforce the identity in the current SQLDelight schema and migrated schema with both:
  - `CHECK (tripId = fromStopId || '->' || toStopId)`, which rejects noncanonical IDs even from external/direct writes;
  - `UNIQUE(fromStopId, toStopId)`, which prevents multiple rows representing the same direction-specific pair.
- Add migration `13.sqm`, which:
  - removes any stale `SavedTripByStops` staging table before rebuilding, so a retry is deterministic after an interrupted or externally replayed migration;
  - rebuilds `SavedTrip` with both identity constraints;
  - keeps the newest row for each duplicate pair (`timestamp DESC`, then `rowid DESC` for a deterministic tie-break);
  - rewrites retained IDs to the canonical pair ID;
  - preserves the retained row's stop IDs, names, timestamp, and sort order;
  - leaves unrelated and reverse-direction trips distinct.
- Keep `FakeSandook` behavior aligned with production storage.
- Continue honoring save-prompt dismissal counters stored under the old concatenated trip ID, avoiding an unrelated prompt-frequency reset for existing users.
- Document the invariant and future-change checklist in `sandook/Migrations.md`, with focused KDoc/comments at the UI identity and Sandook write boundary.

## Existing-user and migration impact

- Existing saved trips remain visible with the same names and ordering; only the internal identifier changes.
- If a database has multiple rows for the exact same origin/destination pair, they are intentionally collapsed to the newest row because they represent the invalid state that triggers the crash.
- Fresh installs create the constrained schema directly.
- Existing installs run the shared SQLDelight migration before Saved Trips are read.
- `sandook/Migrations.md` explicitly says pure SQL `.sqm` migrations are invoked by both platform drivers. Android delegates through `SandookCallback.super.onUpgrade`; iOS uses `NativeSqliteDriver(KrailSandook.Schema, ...)`. No new iOS `AfterVersion` callback is needed because this repair is entirely SQL.

## Prevention contract

The documented invariant requires future identity-format changes to update `Trip.tripId`, `RealSandook`, `FakeSandook`, the current `.sq` schema, persisted preference compatibility, and a numbered migration together. It also requires an executable `KrailSandook.Schema.migrate(...)` test with the historical row shapes and preservation assertions. Stop IDs must never be concatenated without a separator or parsed back out of `tripId`.

## Validation

- `./scripts/fullQualityChecks.sh` — passed after the final documentation/constraint amendment, including Android compilation, iOS simulator compilation, and Detekt.
- `./gradlew testAndroidHostTest --continue` — passed (620 tasks) for the crash fix.
- Focused final regression runs passed:
  - `SavedTripIdentityMigrationTest`, including stale staging-table recovery and direct noncanonical-write rejection against both fresh and migrated schemas;
  - `TimeTableViewModelTest`, including legacy prompt-key compatibility.
- Migration regression reproduces the exact legacy/current duplicate pattern, calls generated `KrailSandook.Schema.migrate(13, 14)`, and verifies deduplication, canonical IDs, retained newest data, unaffected rows, write normalization, and database enforcement.
- Physical Android: Pixel 10 Pro on Android 16, debug app updated in place without clearing data. Its retained database was confirmed at schema 13 before launch; logs showed `Upgrading database from version 13 to 14`; the database header then reported 14; the process remained alive; and four pre-existing Saved Trips rendered without a duplicate-key or SQLite exception.
- iOS: iPhone 17 simulator on iOS 26.4, installed over the affected schema-13 database. Migration reduced the three corrupt rows to two canonical pairs. The full Saved Trips → Timetable → unstar → re-save → back → long-press → delete flow completed without the crash.

## Repository migration-tooling note

`verifyMigrations.set(true)` is configured, but the repository does not check in a SQLDelight baseline `.db` and does not configure `schemaOutputDirectory`, so `:sandook:verifyCommonMainKrailSandookMigration` exits before evaluating any migration and no schema-generation task is registered. This is pre-existing on `main`. The executable generated-schema migration test plus real Android and iOS schema-13 upgrades provide the migration verification for this change.

## Screenshots

Not applicable. There is no visual UI change.
