### PR TITLE
chore(store-listing): add device captures and capture flows

### DIFF
--- a/store-listing/krail/.gitignore
+++ b/store-listing/krail/.gitignore
@@ -1,0 +1,5 @@
+# Contains store-performance figures. KRAIL is a public repo, so this stays local.
+krail-store-listing-marketing-report.html
+
+# Scratch output from render-store-images.py
+.render-work/

--- a/store-listing/krail/capture-flows/android-plan-from-timetable.yaml
+++ b/store-listing/krail/capture-flows/android-plan-from-timetable.yaml
@@ -1,0 +1,5 @@
+appId: xyz.ksharma.krail.debug
+---
+- tapOn: "Plan your trip"
+- waitForAnimationToEnd
+- assertVisible: "Select Date"

--- a/store-listing/krail/capture-flows/android-tablet-expand-333.yaml
+++ b/store-listing/krail/capture-flows/android-tablet-expand-333.yaml
@@ -1,0 +1,5 @@
+appId: xyz.ksharma.krail.debug
+---
+- tapOn: "333"
+- waitForAnimationToEnd
+- assertVisible: "15 stops"

--- a/store-listing/krail/capture-flows/android-tablet-expand-plan-sheet.yaml
+++ b/store-listing/krail/capture-flows/android-tablet-expand-plan-sheet.yaml
@@ -1,0 +1,8 @@
+appId: xyz.ksharma.krail.debug
+---
+- swipe:
+    start: "50%,52%"
+    end: "50%,12%"
+    duration: 500
+- waitForAnimationToEnd
+- assertVisible: "Leave Now"

--- a/store-listing/krail/capture-flows/android-tablet-home-to-work.yaml
+++ b/store-listing/krail/capture-flows/android-tablet-home-to-work.yaml
@@ -1,0 +1,8 @@
+appId: xyz.ksharma.krail.debug
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn:
+    point: "18%,19%"
+- waitForAnimationToEnd

--- a/store-listing/krail/capture-flows/android-tablet-parking.yaml
+++ b/store-listing/krail/capture-flows/android-tablet-parking.yaml
@@ -1,0 +1,8 @@
+appId: xyz.ksharma.krail.debug
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Tallawong Station"
+- waitForAnimationToEnd
+- assertVisible: "Tallawong P1"

--- a/store-listing/krail/capture-flows/android-tablet-saved-trips.yaml
+++ b/store-listing/krail/capture-flows/android-tablet-saved-trips.yaml
@@ -1,0 +1,6 @@
+appId: xyz.ksharma.krail.debug
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- assertVisible: "Saved Trips"

--- a/store-listing/krail/capture-flows/android-tablet-select-light-theme.yaml
+++ b/store-listing/krail/capture-flows/android-tablet-select-light-theme.yaml
@@ -1,0 +1,10 @@
+appId: xyz.ksharma.krail.debug
+---
+- tapOn:
+    point: "34%,6%"
+- waitForAnimationToEnd
+- assertVisible: "Settings"
+- tapOn: "Change Theme"
+- waitForAnimationToEnd
+- tapOn: "Light"
+- waitForAnimationToEnd

--- a/store-listing/krail/capture-flows/ios-expand-333.yaml
+++ b/store-listing/krail/capture-flows/ios-expand-333.yaml
@@ -1,0 +1,5 @@
+appId: xyz.ksharma.krail
+---
+- tapOn: "333"
+- waitForAnimationToEnd
+- assertVisible: "15 stops"

--- a/store-listing/krail/capture-flows/ios-expand-plan-sheet.yaml
+++ b/store-listing/krail/capture-flows/ios-expand-plan-sheet.yaml
@@ -1,0 +1,8 @@
+appId: xyz.ksharma.krail
+---
+- swipe:
+    start: "50%,52%"
+    end: "50%,12%"
+    duration: 500
+- waitForAnimationToEnd
+- assertVisible: "Leave Now"

--- a/store-listing/krail/capture-flows/ios-home-to-work.yaml
+++ b/store-listing/krail/capture-flows/ios-home-to-work.yaml
@@ -1,0 +1,9 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Krail App"
+- waitForAnimationToEnd
+- tapOn: "Home to Work"
+- waitForAnimationToEnd

--- a/store-listing/krail/capture-flows/ios-parking.yaml
+++ b/store-listing/krail/capture-flows/ios-parking.yaml
@@ -1,0 +1,10 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Krail App"
+- waitForAnimationToEnd
+- tapOn: "Tallawong Station"
+- waitForAnimationToEnd
+- assertVisible: "Tallawong P1"

--- a/store-listing/krail/capture-flows/ios-plan-from-timetable.yaml
+++ b/store-listing/krail/capture-flows/ios-plan-from-timetable.yaml
@@ -1,0 +1,5 @@
+appId: xyz.ksharma.krail
+---
+- tapOn: "Plan your trip"
+- waitForAnimationToEnd
+- assertVisible: "Select Date"

--- a/store-listing/krail/capture-flows/ios-saved-trips.yaml
+++ b/store-listing/krail/capture-flows/ios-saved-trips.yaml
@@ -1,0 +1,8 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Krail App"
+- waitForAnimationToEnd
+- assertVisible: "Saved Trips"

--- a/store-listing/krail/capture-flows/ios-select-light-theme.yaml
+++ b/store-listing/krail/capture-flows/ios-select-light-theme.yaml
@@ -1,0 +1,10 @@
+appId: xyz.ksharma.krail
+---
+- tapOn:
+    point: "42%,4%"
+- waitForAnimationToEnd
+- assertVisible: "Settings"
+- tapOn: "Change Theme"
+- waitForAnimationToEnd
+- tapOn: "Light"
+- waitForAnimationToEnd

--- a/store-listing/krail/capture-flows/ipad13-home-to-work-from-saved.yaml
+++ b/store-listing/krail/capture-flows/ipad13-home-to-work-from-saved.yaml
@@ -1,0 +1,5 @@
+appId: xyz.ksharma.krail
+---
+- tapOn:
+    point: "20%,12%"
+- waitForAnimationToEnd

--- a/store-listing/krail/capture-flows/iphone65-capture-expanded-333.yaml
+++ b/store-listing/krail/capture-flows/iphone65-capture-expanded-333.yaml
@@ -1,0 +1,15 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Krail App"
+- waitForAnimationToEnd
+- tapOn:
+    point: "50%,20%"
+- waitForAnimationToEnd
+- assertVisible: "333"
+- tapOn: "333"
+- waitForAnimationToEnd
+- assertVisible: "15 stops"
+- takeScreenshot: store-listing/krail/screenshots/iphone65/03_home_to_work_timetable

--- a/store-listing/krail/capture-flows/iphone65-capture-parking.yaml
+++ b/store-listing/krail/capture-flows/iphone65-capture-parking.yaml
@@ -1,0 +1,17 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Krail App"
+- waitForAnimationToEnd
+- tapOn: "Tallawong Station"
+- waitForAnimationToEnd
+- assertVisible: "Tallawong P1"
+- swipe:
+    start: "50%,32%"
+    end: "50%,78%"
+    duration: 500
+- waitForAnimationToEnd
+- assertVisible: "Tallawong P1"
+- takeScreenshot: store-listing/krail/screenshots/iphone65/02_parking_tallawong

--- a/store-listing/krail/capture-flows/iphone65-capture-plan-trip.yaml
+++ b/store-listing/krail/capture-flows/iphone65-capture-plan-trip.yaml
@@ -1,0 +1,24 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "Krail App"
+- waitForAnimationToEnd
+- tapOn:
+    point: "50%,20%"
+- waitForAnimationToEnd
+- assertVisible: "333"
+- tapOn: "333"
+- waitForAnimationToEnd
+- assertVisible: "15 stops"
+- tapOn: "Plan your trip"
+- waitForAnimationToEnd
+- assertVisible: "Select Date"
+- swipe:
+    start: "50%,52%"
+    end: "50%,12%"
+    duration: 500
+- waitForAnimationToEnd
+- assertVisible: "Leave Now"
+- takeScreenshot: store-listing/krail/screenshots/iphone65/04_plan_trip_sheet

--- a/store-listing/krail/capture-flows/iphone65-home-to-work-from-saved.yaml
+++ b/store-listing/krail/capture-flows/iphone65-home-to-work-from-saved.yaml
@@ -1,0 +1,5 @@
+appId: xyz.ksharma.krail
+---
+- tapOn:
+    point: "50%,20%"
+- waitForAnimationToEnd

--- a/store-listing/krail/capture-flows/iphone65-select-light-theme.yaml
+++ b/store-listing/krail/capture-flows/iphone65-select-light-theme.yaml
@@ -1,0 +1,13 @@
+appId: xyz.ksharma.krail
+---
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn:
+    point: "90%,8%"
+- waitForAnimationToEnd
+- assertVisible: "Settings"
+- tapOn: "Change Theme"
+- waitForAnimationToEnd
+- tapOn: "Light"
+- waitForAnimationToEnd

--- a/store-listing/krail/screenshots/android_mobile/ALERTS_1.png
+++ b/store-listing/krail/screenshots/android_mobile/ALERTS_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df783edefa9810ee5853f84baa41997f2e80ba09935c51707ddbe34fedb64c56
+size 213732

--- a/store-listing/krail/screenshots/android_mobile/LIGHT_RAIL_TIMETABLE.png
+++ b/store-listing/krail/screenshots/android_mobile/LIGHT_RAIL_TIMETABLE.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f75e8274eadd313dee88a036124700a78ac9a51ab930b4a03fe23e54acc9387e
+size 236983

--- a/store-listing/krail/screenshots/android_mobile/MAP_TIMETABLE_JPURNEY.png
+++ b/store-listing/krail/screenshots/android_mobile/MAP_TIMETABLE_JPURNEY.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0ad72e8da082ac7205f4c07013f3def5c6bae948bb8668a6fd993ad030b1657
+size 1745072

--- a/store-listing/krail/screenshots/android_mobile/PLAN_TRIP_SHEET.png
+++ b/store-listing/krail/screenshots/android_mobile/PLAN_TRIP_SHEET.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9a2bcb73aaaaa5eb670852b16733c1005f3eeb6a0f1286cd77f0b26ff207c3b
+size 137847

--- a/store-listing/krail/screenshots/android_mobile/Tallawong_Parking_Card.png
+++ b/store-listing/krail/screenshots/android_mobile/Tallawong_Parking_Card.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:880c48901161718037225971a8830837e2113340e83947fff9b768616e48bfb1
+size 204325

--- a/store-listing/krail/screenshots/android_mobile/dark_mode.png
+++ b/store-listing/krail/screenshots/android_mobile/dark_mode.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:212c9c358b2604acd0a67703ccd9b8dde8e5a773cfe06df1dfe35bfdcf232d55
+size 152117

--- a/store-listing/krail/screenshots/android_mobile/saved_trip.png
+++ b/store-listing/krail/screenshots/android_mobile/saved_trip.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5028e8cfd15d91fd26fe0afd125c1e46f19aa535d1093b60b1a5483ffb2e5eec
+size 138683

--- a/store-listing/krail/screenshots/android_mobile/time_table_bus.png
+++ b/store-listing/krail/screenshots/android_mobile/time_table_bus.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef199f1c5352120831615781b498ae6adbfd7d78c8dd053beca35552ed541715
+size 238949

--- a/store-listing/krail/screenshots/android_tablet/01_saved_trips.png
+++ b/store-listing/krail/screenshots/android_tablet/01_saved_trips.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5589a2f931e1e2fc68f186e1bd2aba4fc639e0665e524130d4020bdd37b7c08
+size 2315339

--- a/store-listing/krail/screenshots/android_tablet/02_parking_tallawong.png
+++ b/store-listing/krail/screenshots/android_tablet/02_parking_tallawong.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82038fc083f590309c94eb1e60fe9b21f308049ca494a8572be2672238099e66
+size 2357301

--- a/store-listing/krail/screenshots/android_tablet/03_work_to_uni_delays.png
+++ b/store-listing/krail/screenshots/android_tablet/03_work_to_uni_delays.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ce7297bb793ff270c5422d0149c525169f47c64c546671b7c174e49123036b1
+size 2253724

--- a/store-listing/krail/screenshots/android_tablet/04_plan_trip_sheet.png
+++ b/store-listing/krail/screenshots/android_tablet/04_plan_trip_sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f9f0b1ef229a072bb7405d14930316ad9931b62fa5c07cdf9d3e22cc32ed1fb
+size 1050475

--- a/store-listing/krail/screenshots/ipad13/01_saved_trips.png
+++ b/store-listing/krail/screenshots/ipad13/01_saved_trips.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76859e8b9580fd616659463d7877f92c1255fab3badfb16c0064f28975e6e2a5
+size 3096665

--- a/store-listing/krail/screenshots/ipad13/02_parking_tallawong.png
+++ b/store-listing/krail/screenshots/ipad13/02_parking_tallawong.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9655131482454c537b25298c3efa3b230b147d09d2fffb1f90bf77d422561208
+size 3167063

--- a/store-listing/krail/screenshots/ipad13/03_home_to_work_timetable_map.png
+++ b/store-listing/krail/screenshots/ipad13/03_home_to_work_timetable_map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fb0cc65b4a103d42a7dfb54c034bcb845de9265fd2cd831d5165cbc9a09fe8f
+size 2835709

--- a/store-listing/krail/screenshots/ipad13/04_plan_trip_sheet.png
+++ b/store-listing/krail/screenshots/ipad13/04_plan_trip_sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6d4b8f4938670c59fa6e924047316fabbde7b47fb8820b67ff40a9a9f97ec95
+size 1863818

--- a/store-listing/krail/screenshots/iphone65/01_saved_trips.png
+++ b/store-listing/krail/screenshots/iphone65/01_saved_trips.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:659208fb0ea499f97729897cd1b1d5909acb53eb7a3847c3aebb1c37efc47288
+size 205682

--- a/store-listing/krail/screenshots/iphone65/02_parking_tallawong.png
+++ b/store-listing/krail/screenshots/iphone65/02_parking_tallawong.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5732a3aede797bc150349132070fe399a76c5d7a72f0a4c0e62094e056f2b2e8
+size 233599

--- a/store-listing/krail/screenshots/iphone65/03_home_to_work_timetable.png
+++ b/store-listing/krail/screenshots/iphone65/03_home_to_work_timetable.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5104b509682e476e1924f40be2bf3b2c7a7133e7864a8c724b29614bb9644132
+size 274832

--- a/store-listing/krail/screenshots/iphone65/04_plan_trip_sheet.png
+++ b/store-listing/krail/screenshots/iphone65/04_plan_trip_sheet.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cf75bcea00cd34b1bd8f3c7da0f044d84782c6c75cef0bb1375b439728da35e
+size 146400


### PR DESCRIPTION
## What

Adds the source device captures and the Maestro flows that produce them.

## Changes

- `screenshots/android_mobile/` : 8 captures at 1080x2400
- `screenshots/android_tablet/` : 4 captures at 2560x1600
- `screenshots/iphone65/` : 4 captures at 1242x2688
- `screenshots/ipad13/` : 4 captures at 2064x2752
- `capture-flows/` : Maestro flows per platform for saved trips, parking, the expanded
  333 journey and the plan trip sheet
- `store-listing/krail/.gitignore` : ignores the local marketing report, which holds
  store performance figures and does not belong in a public repo, and the renderer's
  scratch directory

## Testing

- No Kotlin, Gradle or resource files changed, so detekt and the unit test tasks are
  unaffected and were not run
- Every PNG opens and reports its expected dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
