### PR TITLE
docs-gardener: fifth audit (report-only)

### DIFF
--- a/.github/docs-gardener/AUDIT.md
+++ b/.github/docs-gardener/AUDIT.md
@@ -1,60 +1,110 @@
-# Docs Gardener Audit — 2026-08-01
+# Docs Gardener Audit — 2026-08-08
 
 Run mode: **report-only** (per Part B of `CHARTER.md`). No documentation was
 modified, moved, or deleted by this run. Everything below is a proposal for a
 human (or a future `active`-mode run) to act on.
 
-This is the fourth run. It builds on the
+This is the fifth run. It builds on the
 [first run](#carried-forward-findings-from-the-2026-07-17-run) (PR
 [#1727](https://github.com/ksharma-xyz/KRAIL/pull/1727), merged), the
 [second run](#carried-forward-findings-from-the-2026-07-17-run) (PR
-[#1732](https://github.com/ksharma-xyz/KRAIL/pull/1732), merged), and the
+[#1732](https://github.com/ksharma-xyz/KRAIL/pull/1732), merged), the
 [third run](#carried-forward-findings-from-the-2026-07-17-run) (PR
-[#1777](https://github.com/ksharma-xyz/KRAIL/pull/1777), merged), and adds a
-delta review of everything that changed since (`aa3b25f..HEAD`, 4 commits over
-7 days: three automated NSW GTFS data bumps, #1778/#1780/#1781, and one
-dependency bump, #1779).
+[#1777](https://github.com/ksharma-xyz/KRAIL/pull/1777), merged), and the
+[fourth run](#carried-forward-findings-from-the-2026-07-17-run) (PR
+[#1782](https://github.com/ksharma-xyz/KRAIL/pull/1782), merged), and adds a
+delta review of everything that changed since (`6ed9290..HEAD`, 16 commits
+over 7 days).
 
 ## Feedback ingestion
 
 Searched `is:pr label:docs-gardener` (any state) against `ksharma-xyz/krail`:
-three results, PR #1727 (first run), #1732 (second run), and #1777 (third
-run), all merged. All three report `"comments":0`; no issue comments, review
-comments, or `charter:`-prefixed review threads on any of them. Nothing to
-fold into the Steering Log this run; no prior rejection to avoid re-proposing.
+four results, PR #1727 (first run), #1732 (second run), #1777 (third run),
+and #1782 (fourth run), all merged. All four report zero issue comments, zero
+review comments, and zero review threads — no `charter:`-prefixed feedback on
+any of them. Nothing to fold into the Steering Log this run; no prior
+rejection to avoid re-proposing.
 
 ## Charter Part A drift
 
-**Performed this run** (unlike the second and third runs, which skipped it —
-sibling-repo access was available this time via `add_repo` +
-`get_file_contents`, no full clone needed). Fetched
-`ksharma-xyz/krail-bff`'s `.github/docs-gardener/CHARTER.md` at its default
-branch HEAD and diffed its Part A section against this repo's Part A
-byte-for-byte (Mission through PR conventions, both sections delimited by the
-`## Part A: Core Policy` / `## Part B: Repo Overrides` headings). **No drift**
-— the two Part A sections are identical.
+Performed this run via `add_repo` (read access) + a shallow clone of
+`ksharma-xyz/krail-bff`, then diffed its
+`.github/docs-gardener/CHARTER.md` Part A section (everything between the
+`## Part A: Core Policy` and `## Part B: Repo Overrides` headings) against
+this repo's Part A byte-for-byte. **No drift** — the two Part A sections are
+identical.
 
 ## Delta review this run
 
-`aa3b25f` (the third run's merge commit) to `origin/main` (`6ed9290`) is 4
-commits over 7 days:
+`6ed9290` (the fourth run's own delta endpoint, i.e. the state audited by
+PR #1782) to `origin/main` (`0cb2c07`) is 16 commits over 7 days
+(2026-08-01 to 2026-08-08):
 
 ```
-$ git log --format="%ai %h %s" aa3b25f..origin/main
-2026-08-01 13:53:13 +0000 6ed9290 Update NSW GTFS data (stops + routes) (#1781)
-2026-07-31 14:01:51 +0000 2054f5f Update NSW GTFS data (stops + routes) (#1780)
-2026-07-27 05:55:48 +0000 9948380 build(deps): bump json from 2.19.8 to 2.19.9 (#1779)
-2026-07-26 13:51:48 +0000 8f57039 Update NSW GTFS data (stops + routes) (#1778)
+$ git log --format="%ai %h %s" 6ed9290..origin/main
+2026-08-08 23:50:35 +1000 0cb2c07 fix(saved-trips): prevent duplicate trip identities (#1802)
+2026-08-08 08:40:29 +1000 2d69977 fix(ios): distribute TestFlight builds to tester groups from CI (#1800)
+2026-08-07 22:17:29 +1000 aaaa226 fix(search): remove the address search stop-count gate and result cache (#1798)
+2026-08-07 19:25:17 +1000 63105ea feat(analytics): report the address search gate on search_stop_query (#1794)
+2026-08-07 19:02:58 +1000 5dbaa7c feat(search): gate address search on local stop match count (#1793)
+2026-08-06 13:55:32 +0000 1dbe6d8 Update NSW GTFS data (stops + routes) (#1797)
+2026-08-06 18:20:26 +1000 ab2ecb8 fix(park-ride): stop car parks reading above 100% full (#1791)
+2026-08-06 00:16:49 +1000 d347793 docs-gardener: fourth audit (report-only) (#1782)
+2026-08-05 23:26:06 +1000 bd2496f chore: bump version to 1.27.0 (#1789)
+2026-08-05 23:03:27 +1000 2348b1e fix(scripts): read the version portably in cut-release.sh (#1790)
+2026-08-05 22:40:06 +1000 1848bda docs(analytics): record the param caps and how to read window reporting (#1788)
+2026-08-05 20:23:11 +1000 76f7a4f feat(analytics): report the window KRAIL runs in, and when it changes (#1787)
+2026-08-05 19:56:02 +1000 285fb0a feat(analytics): record why the save-trip prompt ended (#1786)
+2026-08-05 19:31:26 +1000 ea6a7b7 feat(analytics): carry searchSessionId through to load_timetable_click (#1785)
+2026-08-05 19:10:07 +1000 2f9907c fix(analytics): send park and ride facility ids, mark truncated values (#1784)
+2026-08-04 20:34:49 +1000 a7fbb95 fix(analytics): sanitize location ids and names in event params (#1783)
 ```
 
-`git diff --stat aa3b25f..origin/main` touches exactly four files: two binary
-GTFS blobs (`NSW_BUSES_ROUTES.pb`, `NSW_STOPS.pb`), `Gemfile.lock`, and
-`SandookPreferences.kt` (the two GTFS version constants bumped from 66/39 to
-69/42, nothing else). **Zero `.md` files changed, zero new source
-directories added, zero `AnalyticsEvent.kt` changes.** No doc in the repo
-newly qualifies for classification or staleness action from this delta —
-every finding below is a re-verification of prior-run findings, not a new
-one.
+`git diff --stat 6ed9290..origin/main -- '*.md'` touches five markdown files:
+this repo's own `AUDIT.md` (the fourth run's own PR), two protected ledgers
+(`docs/ANALYTICS_EVENTS.md`, `docs/ANALYTICS_REGISTRY_HANDOFF.md` — expected
+churn from the six `feat(analytics)`/`fix(analytics)` commits above, no
+action possible or needed on protected content), and two docs verified below.
+
+- **`feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md`** (ux-contract,
+  updated in #1798 alongside the stop-count-gate revert it documents).
+  Re-read start to finish against current code:
+  - `AddressSearchCache` is claimed removed —
+    `grep -rn "AddressSearchCache" --include="*.kt" .` (excluding `build/`):
+    zero hits. Confirmed gone.
+  - `search_stop_address_max_local_stops` is claimed removed from the Remote
+    Config table — `grep -rln "search_stop_address_max_local_stops"
+    --include="*.kt" .`: zero hits. Confirmed gone.
+  - The three classes still documented in the table
+    (`AddressSearchEligibility.kt`, `AddressSearchQueryNormalizer.kt`,
+    `AddressSearchMinQueryLength.kt`) all still exist at the stated path.
+  - `STOPS_ALREADY_SUFFICIENT`/`CACHE_HIT` are described as historical-only
+    enum values that "may still carry" in old rows — `AnalyticsEvent.kt`
+    line 292 documents the same thing in its own comment, consistent.
+  - Verdict: **accurate**, no action. This is the standard this charter asks
+    for — the doc and the revert landed in the same PR.
+- **`sandook/Migrations.md`** (reference; pre-existing since #1728-era work,
+  not previously carried in this audit's classification) — extended in
+  #1802 with a new "Saved-trip identity invariant" section. Verified against
+  current code:
+  - `RealSandook.insertOrReplaceTrip` derives `canonicalTripId` from
+    `fromStopId`/`toStopId` as claimed (does not trust the caller-supplied
+    `tripId`).
+  - `KrailSandook.sq` has both `CHECK (tripId = fromStopId || '->' ||
+    toStopId)` and `UNIQUE (fromStopId, toStopId)` on `SavedTrip`, matching
+    the doc's constraint description.
+  - Migration `13.sqm` exists and rebuilds the table with those constraints,
+    matching the doc's migration guidance.
+  - Verdict: **accurate**, no action. Newly brought into this audit's
+    tracked set; classified `reference`.
+
+`fix(park-ride): stop car parks reading above 100% full` (#1791) touches only
+`feature/park-ride` source and test files, no doc — consistent with the
+carried-forward `feature/park-ride` coverage gap below, not a new finding.
+
+No new coverage-gap directories, no new broken links, no new plan/investigation
+docs this run. Every finding below is a re-verification of a prior-run
+finding, not a new one.
 
 ---
 
@@ -74,16 +124,19 @@ Re-verified this run; all still apply verbatim.
    mechanism.
 4. **`docs/ci_cd/ci-cd-architecture.md`** (priority 4: trim) — still lists
    `distribute-google-play-manual.yml` (line 42), which still does not exist
-   in `.github/workflows/` (14 workflow files present, none named that).
+   in `.github/workflows/`.
 5. **`docs/dimension-tokens-plan.md`** (no action) — Phase 2 migration still
    incomplete: `grep -rn "[0-9]\+\.dp\b" --include="*.kt" . | grep -v build |
-   grep -v /tokens/` now returns 236 hits (was 153 at the first run — the
-   codebase grew faster than the migration; still not fully implemented, so
-   still no archive action per the prune criteria).
+   grep -v /tokens/` still returns 236 hits (unchanged since the fourth run —
+   no `.kt` files in scope of that grep changed this delta), so still not
+   fully implemented and still no archive action per the prune criteria.
 6. **`docs/plans/STOP_LABEL_ANALYTICS_PLAN.md`** (priority 2: archive) —
-   still verified shipped against `AnalyticsEvent.kt`; zero `AnalyticsEvent.kt`
-   commits since the third run (confirmed in the delta review above), so
-   nothing to re-check.
+   still verified shipped against `AnalyticsEvent.kt`. This delta added six
+   analytics commits, but all target `search_stop_query`,
+   `load_timetable_click`, save-trip-prompt, and window-report events, none
+   of the four stop-label events this plan governs (confirmed by reading
+   the plan's event table, reproduced in the delta review above). Nothing to
+   re-check.
 7. **`feature/trip-planner/ui/LABEL_DISPLAY_PLAN.md`** (no action) — PR3
    (`StopSearchListItem`/`labelSubtitle`) still not found in code
    (re-ran `grep -rn "labelSubtitle"`: zero hits).
@@ -95,25 +148,21 @@ Re-verified this run; all still apply verbatim.
 10. **`docs/investigations/IN_APP_REVIEW_TIMING.md`** (priority 4: trim,
     found third run) — Status section (lines 7-19) still claims four
     `app-review`/`user-lifecycle-store` branches are "not yet raised as PRs";
-    they merged to `main` on 2026-07-21/22/24, unchanged since the third run
-    found this (see PR #1777 for the full `git log` evidence). Rest of the
-    doc (FINAL DESIGN, gate tables, `AppReviewThresholds.kt` values,
-    `SAVED_TRIP_OPEN` removal) still verified accurate. Still a trim
-    candidate, not archive: replace the Status table with a one-line
-    "shipped, flag off by default" note.
+    they merged to `main` back in July, unchanged since the third run found
+    this (see PR #1777 for the full `git log` evidence). Rest of the doc
+    still verified accurate. Still a trim candidate, not archive: replace
+    the Status table with a one-line "shipped, flag off by default" note.
 
-`SECURITY.md` (classified `guide` in the second run) re-checked: still no
-staleness surface (external links only).
+`SECURITY.md` re-checked: still no staleness surface (external links only).
 
 ### Coverage gaps (carried forward)
 
 Per the coverage duty (10+ source files, no README/doc), re-counted this run;
-no doc was added for any of these since they were first flagged (confirmed by
-the delta review above — zero `.md` files changed since the third run):
+no doc was added for any of these since they were first flagged:
 
 | Directory | Kotlin files | Doc? |
 |---|---|---|
-| `feature/park-ride` (found third run) | 19 | none |
+| `feature/park-ride` (found third run) | 19 | none — touched again this delta (#1791, a bug fix) with no accompanying doc |
 | `feature/track` (found first run) | 32 | none |
 | `feature/departures` (found first run) | 27 | none |
 | `discover` (found first run) | 16 | none |
@@ -121,7 +170,8 @@ the delta review above — zero `.md` files changed since the third run):
 | `core/app-review` (found third run) | 10 | none — `docs/investigations/IN_APP_REVIEW_TIMING.md` covers its design/rationale in detail; a short `core/app-review/README.md` pointing there plus summarizing module layout would still close the gap per the coverage duty's letter |
 | `core/remote-config` (found first run) | 10 | none |
 
-`park-ride` is the largest undocumented surface and the newest.
+`park-ride` remains the largest undocumented surface and is now also the
+most recently touched by shipped code.
 
 ---
 
@@ -140,7 +190,6 @@ action), since `report-only` makes no doc changes by design.
 4. Trim the stale `distribute-google-play-manual.yml` line from
    `docs/ci_cd/ci-cd-architecture.md`; trim the stale Status table in
    `docs/investigations/IN_APP_REVIEW_TIMING.md` (evidence above).
-5. Create small docs for the two new coverage gaps
-   (`feature/park-ride`, `core/app-review`) plus the carried-forward
-   `feature/debug-settings` gap, in that order — `park-ride` is the largest
-   undocumented surface (19 files) and the newest.
+5. Create small docs for the coverage gaps, `feature/park-ride` first (largest
+   and most recently active undocumented surface), then `core/app-review`,
+   then `feature/debug-settings`.


### PR DESCRIPTION
## What

Updates `.github/docs-gardener/AUDIT.md` with the fifth docs-gardener run. Run mode is `report-only` per the charter's current Part B setting, so **no documentation content was changed, moved, or deleted** — this PR touches exactly one file.

## Changes

- Run mode: `report-only`.
- Feedback ingestion: searched `is:pr label:docs-gardener` (any state) — four prior PRs (#1727, #1732, #1777, #1782), all merged, all with zero comments/reviews across issue comments, review comments, and review threads. Nothing to fold into the Steering Log this run.
- Charter Part A drift check: performed via `add_repo` (read access) + a shallow clone of `ksharma-xyz/krail-bff`, diffed its `.github/docs-gardener/CHARTER.md` Part A section against this repo's byte-for-byte. **No drift.**
- Delta review of `6ed9290..HEAD` (16 commits over 7 days: six analytics event changes, the address-search stop-count gate shipped then reverted, a park-ride bug fix, a saved-trips identity fix, an iOS TestFlight CI fix, a GTFS data bump, and a version bump):
  - Two non-protected markdown files changed and were re-verified against current code: `feature/trip-planner/ui/ADDRESS_SEARCH_ELIGIBILITY.md` (updated in the same PR as the gate revert it documents — confirmed `AddressSearchCache` and `search_stop_address_max_local_stops` are actually gone from the codebase) and `sandook/Migrations.md` (extended with a new saved-trip identity section — confirmed against `RealSandook.kt`, the `.sq` schema's `CHECK`/`UNIQUE` constraints, and migration `13.sqm`). Both verified accurate; `sandook/Migrations.md` is newly brought into this audit's tracked set (classified `reference`).
  - The two protected ledgers (`docs/ANALYTICS_EVENTS.md`, `docs/ANALYTICS_REGISTRY_HANDOFF.md`) also changed this delta, as expected from the six analytics commits — no action possible or needed on protected content.
  - The park-ride bug fix (#1791) touches only source/test files, consistent with the carried-forward `feature/park-ride` coverage gap, not a new finding.
- All 10 findings and all 7 coverage gaps carried forward from prior runs are re-verified as still open this run, each with fresh grep/`git log` evidence (e.g. confirmed the `STOP_LABEL_ANALYTICS_PLAN.md` finding is unaffected by this delta's analytics churn, since none of the six commits touch the four stop-label events that plan governs).
- The proposed action queue for a future `active`-mode run is unchanged from the fourth run.

## Testing

Docs-only change (one file under `.github/docs-gardener/`); no code, build files, or CI workflows touched. No test suite applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Gar1saR88UJvvvxmnUJ1D)_