### PR TITLE
feat(analytics): auto-flip registry rows via repository_dispatch

### DIFF
--- a/.github/workflows/analytics-registry-sync.yml
+++ b/.github/workflows/analytics-registry-sync.yml
@@ -2,13 +2,25 @@ name: Analytics registry sync
 
 # Receives a repository_dispatch from KRAIL-Analytics naming event(s) it has just
 # labelled, flips the matching Pending row(s) in docs/ANALYTICS_REGISTRY_HANDOFF.md to
-# Registered, and opens a PR. Runs entirely on this repo's own GITHUB_TOKEN: no
-# cross-repo secret writes to this repo, and KRAIL-Analytics only ever needs a token
-# scoped to trigger a dispatch on KRAIL, never to push here directly.
+# Registered, and opens a PR. Runs entirely on this repo's own GITHUB_TOKEN: KRAIL-Analytics
+# never pushes here directly, it only calls the dispatches API. That said, the token it
+# holds to do that (KRAIL_DISPATCH_TOKEN, a secret in that repo) needs Contents: write on
+# KRAIL to call that API - it is a real push-capable credential, not a narrower
+# dispatch-only grant, so containment is this repo's branch protection on main, not the
+# token's own scope.
 #
 # The dispatch's client_payload.events is untrusted input from another repo's
 # workflow, so it is passed to the flip script via an env var rather than interpolated
 # into a shell command, and never interpolated directly into a `run:` step either.
+#
+# The opened PR is authored by GITHUB_TOKEN, so it will NOT trigger this repo's
+# pull_request-triggered required check (code-quality / detekt) - that is a standing
+# GitHub restriction on the built-in token, not a bug here. Push an empty commit or use
+# the "Update branch" button as yourself before merging, same as any other
+# GITHUB_TOKEN-authored PR.
+#
+# The PR branch is named deterministically from the sorted flipped event names, so a
+# repeat dispatch for the same still-unmerged set is a no-op instead of a new PR.
 
 on:
   repository_dispatch:
@@ -37,16 +49,35 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           FLIPPED: ${{ steps.flip.outputs.flipped }}
         run: |
-          branch="analytics-sync/${{ github.run_id }}"
+          # Deterministic branch name (hash of the sorted flipped names): a repeat
+          # dispatch for the exact same still-open flip set lands on the same branch
+          # instead of opening a duplicate PR every time the daily backstop re-runs
+          # before the first one merges.
+          slug=$(printf '%s' "$FLIPPED" | tr ',' '\n' | sort | tr '\n' ',' | shasum -a 256 | cut -c1-12)
+          branch="analytics-sync/${slug}"
+
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Branch $branch already exists - this exact flip set is already an open PR. Nothing to do."
+            exit 0
+          fi
+
           git checkout -b "$branch"
           git config user.name "krail-analytics-sync[bot]"
           git config user.email "actions@users.noreply.github.com"
           git add docs/ANALYTICS_REGISTRY_HANDOFF.md
           git commit -m "docs(analytics): mark ${FLIPPED} registered"
           git push origin "$branch"
+
+          body_file=$(mktemp)
+          {
+            echo "Automated: KRAIL-Analytics has labelled \`${FLIPPED}\`, so this flips the matching row(s) in the ledger from Pending to Registered."
+            echo ""
+            echo "Note: this PR is authored by GITHUB_TOKEN, so the required \`code-quality / detekt\` check will not auto-run on it (a standing GitHub restriction, not a bug). Push an empty commit or click \"Update branch\" before merging."
+          } > "$body_file"
+
           gh pr create \
             --base main \
             --head "$branch" \
             --title "docs(analytics): mark event(s) registered" \
-            --body "Automated: KRAIL-Analytics has labelled \`${FLIPPED}\`, so this flips the matching row(s) in the ledger from Pending to Registered." \
+            --body-file "$body_file" \
             --label analytics-sync

--- a/.github/workflows/analytics-registry-sync.yml
+++ b/.github/workflows/analytics-registry-sync.yml
@@ -1,0 +1,52 @@
+name: Analytics registry sync
+
+# Receives a repository_dispatch from KRAIL-Analytics naming event(s) it has just
+# labelled, flips the matching Pending row(s) in docs/ANALYTICS_REGISTRY_HANDOFF.md to
+# Registered, and opens a PR. Runs entirely on this repo's own GITHUB_TOKEN: no
+# cross-repo secret writes to this repo, and KRAIL-Analytics only ever needs a token
+# scoped to trigger a dispatch on KRAIL, never to push here directly.
+#
+# The dispatch's client_payload.events is untrusted input from another repo's
+# workflow, so it is passed to the flip script via an env var rather than interpolated
+# into a shell command, and never interpolated directly into a `run:` step either.
+
+on:
+  repository_dispatch:
+    types: [analytics-registry-sync]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  flip:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Flip registered rows
+        id: flip
+        env:
+          EVENTS_JSON: ${{ toJson(github.event.client_payload.events) }}
+        run: python3 scripts/flip_registry_status.py
+
+      - name: Open PR
+        if: steps.flip.outputs.flipped != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FLIPPED: ${{ steps.flip.outputs.flipped }}
+        run: |
+          branch="analytics-sync/${{ github.run_id }}"
+          git checkout -b "$branch"
+          git config user.name "krail-analytics-sync[bot]"
+          git config user.email "actions@users.noreply.github.com"
+          git add docs/ANALYTICS_REGISTRY_HANDOFF.md
+          git commit -m "docs(analytics): mark ${FLIPPED} registered"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "docs(analytics): mark event(s) registered" \
+            --body "Automated: KRAIL-Analytics has labelled \`${FLIPPED}\`, so this flips the matching row(s) in the ledger from Pending to Registered." \
+            --label analytics-sync

--- a/.github/workflows/analytics-registry-sync.yml
+++ b/.github/workflows/analytics-registry-sync.yml
@@ -53,7 +53,7 @@ jobs:
           # dispatch for the exact same still-open flip set lands on the same branch
           # instead of opening a duplicate PR every time the daily backstop re-runs
           # before the first one merges.
-          slug=$(printf '%s' "$FLIPPED" | tr ',' '\n' | sort | tr '\n' ',' | shasum -a 256 | cut -c1-12)
+          slug=$(printf '%s' "$FLIPPED" | tr ',' '\n' | sort | tr '\n' ',' | sha256sum | cut -c1-12)
           branch="analytics-sync/${slug}"
 
           if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ business/strategy context. The skill has the template and full content policy.
 Exception: the automated docs gardener (single, non-stacked, docs-only PRs labeled
 `docs-gardener`, policy in `.github/docs-gardener/CHARTER.md`) may use `gh pr create`.
 
+Exception: the automated analytics registry sync bot (`.github/workflows/analytics-registry-sync.yml`,
+single docs-only PRs labeled `analytics-sync`, flipping `docs/ANALYTICS_REGISTRY_HANDOFF.md`
+rows from Pending to Registered once KRAIL-Analytics has labelled the event) may use
+`gh pr create`.
+
 We stack PRs. Break work into focused, layered branches and submit the full stack with `gt submit --stack --publish`.
 
 **Max 500 lines of change per PR.** If a branch exceeds this, split it before submitting:

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -19,6 +19,13 @@ and similar per-feature docs stay accurate: **update it in the same PR** that ch
 table will never be large (Firebase caps the app at 500 event names, ever — see
 `docs/ANALYTICS_EVENTS.md`).
 
+New-event rows (`Event` column marked `(NEW EVENT)`, or `Param(s)` starting `NEW
+event:`) get flipped automatically: when KRAIL-Analytics labels the event, its CI
+fires a `repository_dispatch` naming it, and `.github/workflows/analytics-registry-sync.yml`
+opens a PR here flipping the row (labeled `analytics-sync`). Param and user-property
+rows have no per-item registry surface on the analytics side, so they're never
+touched by the bot — flip those by hand once their shape is final.
+
 **New event name vs new param on an existing event** — both go in this ledger the same
 way, distinguished by the `Event` column. Read `docs/ANALYTICS_EVENTS.md` before adding
 either; most changes should be params on an existing event, not a new name.

--- a/docs/ANALYTICS_REGISTRY_HANDOFF.md
+++ b/docs/ANALYTICS_REGISTRY_HANDOFF.md
@@ -23,8 +23,9 @@ New-event rows (`Event` column marked `(NEW EVENT)`, or `Param(s)` starting `NEW
 event:`) get flipped automatically: when KRAIL-Analytics labels the event, its CI
 fires a `repository_dispatch` naming it, and `.github/workflows/analytics-registry-sync.yml`
 opens a PR here flipping the row (labeled `analytics-sync`). Param and user-property
-rows have no per-item registry surface on the analytics side, so they're never
-touched by the bot — flip those by hand once their shape is final.
+rows are never touched by the bot — they have no per-item registry surface on the
+analytics side to check against, so mark those `Documented` by hand instead once
+their shape is final (see `Status = Documented` below).
 
 **New event name vs new param on an existing event** — both go in this ledger the same
 way, distinguished by the `Event` column. Read `docs/ANALYTICS_EVENTS.md` before adding

--- a/scripts/flip_registry_status.py
+++ b/scripts/flip_registry_status.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Flip docs/ANALYTICS_REGISTRY_HANDOFF.md rows from Pending to Registered for event
+names KRAIL-Analytics has just labelled.
+
+Reads the newly-labelled event names from the EVENTS_JSON env var (a JSON array of
+strings, forwarded from a repository_dispatch client_payload). Only touches rows for a
+brand new event name (Event column has "(NEW EVENT)", or Param(s) has "NEW event") --
+param and user-property rows have no per-item registry surface on the analytics side
+and are never flipped by this script.
+
+Writes the flipped event names to $GITHUB_OUTPUT as `flipped` (comma-separated) when
+run in CI, or just prints them otherwise. Writes nothing and exits quietly if no row
+matched -- this is the common case, since most dispatches won't name a new event.
+"""
+
+import json
+import os
+import re
+
+LEDGER_PATH = "docs/ANALYTICS_REGISTRY_HANDOFF.md"
+
+
+def is_new_event_row(event_cell: str, param_cell: str) -> bool:
+    return "(NEW EVENT)" in event_cell.upper() or "NEW EVENT" in param_cell.upper()
+
+
+def event_name_from_cell(event_cell: str) -> str:
+    name = event_cell.replace("`", "")
+    name = re.sub(r"\(NEW EVENT\)", "", name, flags=re.IGNORECASE)
+    return name.strip()
+
+
+def main() -> None:
+    events = set(json.loads(os.environ.get("EVENTS_JSON", "[]")))
+    if not events:
+        print("No event names in EVENTS_JSON; nothing to do.")
+        return
+
+    with open(LEDGER_PATH, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    flipped = []
+    for i, line in enumerate(lines):
+        if "| Pending |" not in line:
+            continue
+        cells = [c.strip() for c in line.split("|")]
+        if len(cells) < 4:
+            continue
+        event_cell, param_cell = cells[2], cells[3]
+        if not is_new_event_row(event_cell, param_cell):
+            continue
+        event_name = event_name_from_cell(event_cell)
+        if event_name not in events:
+            continue
+        lines[i] = line.replace("| Pending |", "| Registered |")
+        flipped.append(event_name)
+
+    if not flipped:
+        print("No Pending row matched a dispatched event name.")
+        return
+
+    with open(LEDGER_PATH, "w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+    print(f"Flipped: {', '.join(flipped)}")
+
+    gh_output = os.environ.get("GITHUB_OUTPUT")
+    if gh_output:
+        with open(gh_output, "a", encoding="utf-8") as f:
+            f.write(f"flipped={','.join(flipped)}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a workflow that receives a `repository_dispatch` from KRAIL-Analytics naming
event(s) it has just labelled, flips the matching `Pending` row(s) in
`docs/ANALYTICS_REGISTRY_HANDOFF.md` to `Registered`, and opens a PR automatically.

## Changes

- New `.github/workflows/analytics-registry-sync.yml`: triggers on
  `repository_dispatch` type `analytics-registry-sync`, runs `scripts/flip_registry_status.py`
  against `client_payload.events`, and if anything flipped, commits and opens a PR
  labeled `analytics-sync` using this repo's own `GITHUB_TOKEN`
- New `scripts/flip_registry_status.py`: flips only new-event rows (`Event` column has
  `(NEW EVENT)`, or `Param(s)` starts `NEW event:`) whose name is in the dispatched
  set; param and user-property rows are never touched, matching the existing
  `Documented` status convention for those
- `client_payload.events` is untrusted input from another repo's workflow, so it's
  passed to the script via an env var and never interpolated directly into a shell
  `run:` step
- Added a matching Graphite-only-PR exception to `CLAUDE.md` for this bot, alongside
  the existing docs-gardener exception
- Noted the automation in the ledger's "How to use this file" section

## Testing

- `actionlint -shellcheck=` on the new workflow: clean
- `EVENTS_JSON='[...]' python3 scripts/flip_registry_status.py` against the current
  ledger content: correctly flipped only the targeted rows, left everything else
  untouched (verified then reverted the test edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
