### PR TITLE
feat(analytics): auto-merge the registry sync bot with a diff-shape guard

### DIFF
--- a/.github/workflows/analytics-registry-sync.yml
+++ b/.github/workflows/analytics-registry-sync.yml
@@ -22,11 +22,13 @@ name: Analytics registry sync
 # interpolated into a shell command, and never interpolated directly into a `run:`
 # step either.
 #
-# The push, PR, and merge run as KRAIL_BOT_PAT (a fine-grained PAT scoped to this
-# repo only, Contents: read/write), not the built-in GITHUB_TOKEN. Two reasons:
+# The push, PR, and merge run as the existing krail-gtfs-bot GitHub App (already used
+# by bump-after-release.yml; same KRAIL_BOT_APP_ID / KRAIL_BOT_PRIVATE_KEY secrets, no
+# new credential needed), not the built-in GITHUB_TOKEN. Two reasons:
 #   - A GITHUB_TOKEN-authored PR does not trigger this repo's pull_request-triggered
 #     required check (code-quality / detekt) - a standing GitHub restriction - which
-#     would leave every auto-merge attempt permanently blocked.
+#     would leave every auto-merge attempt permanently blocked. A GitHub App
+#     installation token is a distinct real actor and does not have that restriction.
 #   - Docs-gardener's charter explicitly forbids any bot here from auto-merging.
 #     This bot is a deliberate, narrow exception: its only possible edit is a single
 #     table cell, mechanically re-verified before every merge by validate_flip_diff.py,
@@ -50,9 +52,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Generate krail-bot token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.KRAIL_BOT_APP_ID }}
+          private-key: ${{ secrets.KRAIL_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.KRAIL_BOT_PAT }}
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Flip registered rows
         id: flip
@@ -67,8 +76,9 @@ jobs:
       - name: Push, open PR, and auto-merge
         if: steps.flip.outputs.flipped != ''
         env:
-          GH_TOKEN: ${{ secrets.KRAIL_BOT_PAT }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           FLIPPED: ${{ steps.flip.outputs.flipped }}
+          KRAIL_BOT_APP_ID: ${{ secrets.KRAIL_BOT_APP_ID }}
         run: |
           # Deterministic branch name (hash of the sorted flipped names): a repeat
           # dispatch for the exact same still-open flip set lands on the same branch
@@ -83,8 +93,8 @@ jobs:
           fi
 
           git checkout -b "$branch"
-          git config user.name "krail-analytics-sync[bot]"
-          git config user.email "actions@users.noreply.github.com"
+          git config user.name "krail-gtfs-bot[bot]"
+          git config user.email "${KRAIL_BOT_APP_ID}+krail-gtfs-bot[bot]@users.noreply.github.com"
           git add docs/ANALYTICS_REGISTRY_HANDOFF.md
           git commit -m "docs(analytics): mark ${FLIPPED} registered"
           git push origin "$branch"

--- a/.github/workflows/analytics-registry-sync.yml
+++ b/.github/workflows/analytics-registry-sync.yml
@@ -2,33 +2,48 @@ name: Analytics registry sync
 
 # Receives a repository_dispatch from KRAIL-Analytics naming event(s) it has just
 # labelled, flips the matching Pending row(s) in docs/ANALYTICS_REGISTRY_HANDOFF.md to
-# Registered, and opens a PR. Runs entirely on this repo's own GITHUB_TOKEN: KRAIL-Analytics
-# never pushes here directly, it only calls the dispatches API. That said, the token it
-# holds to do that (KRAIL_DISPATCH_TOKEN, a secret in that repo) needs Contents: write on
-# KRAIL to call that API - it is a real push-capable credential, not a narrower
-# dispatch-only grant, so containment is this repo's branch protection on main, not the
-# token's own scope.
+# Registered, opens a PR, and auto-merges it. No human touches this path.
+#
+# Two independent safety layers make that acceptable for a repo whose PR policy
+# otherwise requires a human:
+#
+#   1. scripts/flip_registry_status.py only ever rewrites the `| Pending |` -> `|
+#      Registered |` cell on a row whose event name was named in the dispatch; every
+#      other line is copied through unchanged.
+#   2. scripts/validate_flip_diff.py independently re-checks the ACTUAL `git diff`
+#      after that script runs, not flip_registry_status.py's own bookkeeping: exactly
+#      one file changed, no lines added or removed, and every changed line differs
+#      from its old version by nothing except that one substring. A future bug in
+#      either script, or a malformed dispatch payload, fails this step loudly and
+#      the job stops there - nothing is committed, pushed, opened, or merged.
 #
 # The dispatch's client_payload.events is untrusted input from another repo's
-# workflow, so it is passed to the flip script via an env var rather than interpolated
-# into a shell command, and never interpolated directly into a `run:` step either.
+# workflow, so it is passed to the flip script via an env var rather than
+# interpolated into a shell command, and never interpolated directly into a `run:`
+# step either.
 #
-# The opened PR is authored by GITHUB_TOKEN, so it will NOT trigger this repo's
-# pull_request-triggered required check (code-quality / detekt) - that is a standing
-# GitHub restriction on the built-in token, not a bug here. Push an empty commit or use
-# the "Update branch" button as yourself before merging, same as any other
-# GITHUB_TOKEN-authored PR.
+# The push, PR, and merge run as KRAIL_BOT_PAT (a fine-grained PAT scoped to this
+# repo only, Contents: read/write), not the built-in GITHUB_TOKEN. Two reasons:
+#   - A GITHUB_TOKEN-authored PR does not trigger this repo's pull_request-triggered
+#     required check (code-quality / detekt) - a standing GitHub restriction - which
+#     would leave every auto-merge attempt permanently blocked.
+#   - Docs-gardener's charter explicitly forbids any bot here from auto-merging.
+#     This bot is a deliberate, narrow exception: its only possible edit is a single
+#     table cell, mechanically re-verified before every merge by validate_flip_diff.py,
+#     which is a different risk profile to a bot that edits prose. See CLAUDE.md.
 #
 # The PR branch is named deterministically from the sorted flipped event names, so a
 # repeat dispatch for the same still-unmerged set is a no-op instead of a new PR.
+# Known gap, not yet handled: a GROWING set (a second event labelled while the first
+# PR is still open) opens a second, non-superseding PR instead of replacing the first.
+# Low-stakes - worst case is a hand-resolved conflict on a docs PR - but real.
 
 on:
   repository_dispatch:
     types: [analytics-registry-sync]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   flip:
@@ -36,6 +51,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.KRAIL_BOT_PAT }}
 
       - name: Flip registered rows
         id: flip
@@ -43,10 +60,14 @@ jobs:
           EVENTS_JSON: ${{ toJson(github.event.client_payload.events) }}
         run: python3 scripts/flip_registry_status.py
 
-      - name: Open PR
+      - name: Validate diff shape
+        if: steps.flip.outputs.flipped != ''
+        run: python3 scripts/validate_flip_diff.py
+
+      - name: Push, open PR, and auto-merge
         if: steps.flip.outputs.flipped != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.KRAIL_BOT_PAT }}
           FLIPPED: ${{ steps.flip.outputs.flipped }}
         run: |
           # Deterministic branch name (hash of the sorted flipped names): a repeat
@@ -69,11 +90,7 @@ jobs:
           git push origin "$branch"
 
           body_file=$(mktemp)
-          {
-            echo "Automated: KRAIL-Analytics has labelled \`${FLIPPED}\`, so this flips the matching row(s) in the ledger from Pending to Registered."
-            echo ""
-            echo "Note: this PR is authored by GITHUB_TOKEN, so the required \`code-quality / detekt\` check will not auto-run on it (a standing GitHub restriction, not a bug). Push an empty commit or click \"Update branch\" before merging."
-          } > "$body_file"
+          echo "Automated: KRAIL-Analytics has labelled \`${FLIPPED}\`, so this flips the matching row(s) in the ledger from Pending to Registered. Diff shape was independently validated before this PR was opened; auto-merging." > "$body_file"
 
           gh pr create \
             --base main \
@@ -81,3 +98,5 @@ jobs:
             --title "docs(analytics): mark event(s) registered" \
             --body-file "$body_file" \
             --label analytics-sync
+
+          gh pr merge "$branch" --squash --auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,16 @@ checklist.
 
 `AnalyticsEvent.kt` is the whole analytics job in this repo. The **KRAIL-Analytics** repo
 reads it at the latest published release tag and builds its own registry, labels and
-dashboard groupings — there is no contract file to keep in sync, no per-PR analytics test,
-and no registration step here. Just define the event well and it reaches analytics after
-the next release.
+dashboard groupings — there is no contract file to keep in sync and no per-PR analytics
+test.
+
+There IS one registration step: **any PR that adds a new event name, or changes params on
+an existing event, must add a row to `docs/ANALYTICS_REGISTRY_HANDOFF.md` in the same PR**
+(`Status = Pending`). New-event rows get flipped to `Registered` automatically once
+KRAIL-Analytics labels them — see `docs/ANALYTICS_REGISTRY_SYNC.md` for how. Param and
+user-property rows have no per-item registry surface on the analytics side, so mark those
+`Documented` by hand once their shape is final. Read the ledger's own "How to use this
+file" section for the exact row format before adding one.
 
 ## Test Commands
 
@@ -104,7 +111,14 @@ Exception: the automated docs gardener (single, non-stacked, docs-only PRs label
 Exception: the automated analytics registry sync bot (`.github/workflows/analytics-registry-sync.yml`,
 single docs-only PRs labeled `analytics-sync`, flipping `docs/ANALYTICS_REGISTRY_HANDOFF.md`
 rows from Pending to Registered once KRAIL-Analytics has labelled the event) may use
-`gh pr create`.
+`gh pr create` **and may auto-merge** — the one bot here allowed to. Every other bot,
+including docs-gardener, is explicitly forbidden from auto-merging (docs-gardener's
+charter: "Never merge, approve, or enable auto-merge"). This bot is narrower than a
+prose-editing bot: its only possible edit is flipping one table cell from `Pending` to
+`Registered`, and `scripts/validate_flip_diff.py` independently re-checks the actual
+git diff before every push and refuses (no push, no PR, no merge) unless the change is
+exactly that. If you ever widen what this bot can touch, remove the auto-merge
+exception and put a human back in the loop.
 
 We stack PRs. Break work into focused, layered branches and submit the full stack with `gt submit --stack --publish`.
 
@@ -362,3 +376,6 @@ that contradicts the doc should also update the doc in the same change.
   `collapseSameRouteQuickWalks()` merges same-route-number legs split by a trivial walk;
   read before changing leg-merge/split logic in `TripResponseMapper.kt` or
   `TripResponseLegMapper.kt`.
+- `docs/ANALYTICS_REGISTRY_SYNC.md` — how new-event rows in
+  `docs/ANALYTICS_REGISTRY_HANDOFF.md` auto-flip from `Pending` to `Registered`; read
+  before touching `.github/workflows/analytics-registry-sync.yml` or its scripts.

--- a/docs/ANALYTICS_REGISTRY_SYNC.md
+++ b/docs/ANALYTICS_REGISTRY_SYNC.md
@@ -47,13 +47,16 @@ exception in `CLAUDE.md` and put a human back in the loop.
 
 ## Setup (one-time)
 
-`KRAIL_BOT_PAT` — a fine-grained PAT, scoped to this repo only, Contents: read/write,
-stored as a secret in **this** repo. Needed because a PR authored by the built-in
+Nothing new on this side. The push/PR/merge steps authenticate as the existing
+krail-gtfs-bot GitHub App (`KRAIL_BOT_APP_ID` / `KRAIL_BOT_PRIVATE_KEY`, already a
+secret here for `bump-after-release.yml`) via `actions/create-github-app-token`, the
+same pattern that workflow already uses. Needed because a PR authored by the built-in
 `GITHUB_TOKEN` never triggers `pull_request`-scoped required checks (a standing GitHub
 restriction), which would leave every auto-merge attempt permanently blocked on the
-required `code-quality / detekt` check.
+required `code-quality / detekt` check — a GitHub App installation token is a distinct
+real actor and doesn't have that restriction.
 
-`KRAIL_DISPATCH_TOKEN` — a separate fine-grained PAT, scoped to this repo only,
+`KRAIL_DISPATCH_TOKEN` — a fine-grained PAT, scoped to this repo only,
 Contents: read/write, stored as a secret in the **KRAIL-Analytics** repo. This is what
 lets that repo call `POST /repos/ksharma-xyz/KRAIL/dispatches`. It is a real write
 credential on this repo, not a narrower "dispatch-only" grant — GitHub has no such

--- a/docs/ANALYTICS_REGISTRY_SYNC.md
+++ b/docs/ANALYTICS_REGISTRY_SYNC.md
@@ -1,0 +1,75 @@
+# Analytics registry sync — how the Pending -> Registered flip is automated
+
+Read `docs/ANALYTICS_REGISTRY_HANDOFF.md` first — this doc explains the automation that
+keeps its `Status` column current. It does not replace that file's own "How to use this
+file" section.
+
+## What's still manual (by design)
+
+Adding a row is manual and stays that way: when a PR adds a new event name, or changes
+params on an existing event, add a `Pending` row to
+`docs/ANALYTICS_REGISTRY_HANDOFF.md` in the same PR. This is now stated directly in this
+repo's `CLAUDE.md` under "Analytics events" — a Claude session (or a human) working on
+`AnalyticsEvent.kt` should see it there without needing to already know this doc exists.
+
+Marking param and user-property rows `Documented` is also manual — they have no
+per-item registry surface on the KRAIL-Analytics side to check against, so nothing can
+verify them automatically. Mark those by hand once their shape is final.
+
+## What's automated: new-event rows only
+
+A row for a **brand new event name** (`Event` column has `(NEW EVENT)`, or `Param(s)`
+starts `NEW event:`) gets flipped from `Pending` to `Registered` without a human, once
+KRAIL-Analytics has labelled it.
+
+1. KRAIL-Analytics labels the event in `dashboard/lib/eventLabels.ts`.
+2. Its `dispatch-registry-sync.yml` workflow (on push to that file, or the daily
+   22:40 UTC backstop) computes which Pending new-event rows in KRAIL's ledger are now
+   labelled, and fires a `repository_dispatch` at KRAIL naming them. Only event names
+   cross the boundary — no metrics, no other data.
+3. KRAIL's `analytics-registry-sync.yml` receives it, flips the matching row(s), and
+   opens a PR labeled `analytics-sync`.
+4. `scripts/validate_flip_diff.py` independently re-checks the actual git diff before
+   that PR is even opened: exactly one file changed, no lines added or removed, every
+   changed line differs from its old version by nothing except the `Pending` ->
+   `Registered` substring. Anything else fails the job — no push, no PR.
+5. The PR auto-merges. Nobody needs to look at it or click anything.
+
+## Why this bot is allowed to auto-merge and no other bot here is
+
+Every other automated PR in this repo (docs-gardener included) requires a human to
+merge it — see the Pull Requests section of `CLAUDE.md`. This bot is a deliberate,
+narrow exception: its only possible edit is one table cell, and step 4 above
+mechanically guarantees that on every single run, independent of whatever the flip
+script itself believes it did. That is a different risk profile to a bot that edits
+prose. If this bot's scope ever grows beyond that one cell, remove the auto-merge
+exception in `CLAUDE.md` and put a human back in the loop.
+
+## Setup (one-time)
+
+`KRAIL_BOT_PAT` — a fine-grained PAT, scoped to this repo only, Contents: read/write,
+stored as a secret in **this** repo. Needed because a PR authored by the built-in
+`GITHUB_TOKEN` never triggers `pull_request`-scoped required checks (a standing GitHub
+restriction), which would leave every auto-merge attempt permanently blocked on the
+required `code-quality / detekt` check.
+
+`KRAIL_DISPATCH_TOKEN` — a separate fine-grained PAT, scoped to this repo only,
+Contents: read/write, stored as a secret in the **KRAIL-Analytics** repo. This is what
+lets that repo call `POST /repos/ksharma-xyz/KRAIL/dispatches`. It is a real write
+credential on this repo, not a narrower "dispatch-only" grant — GitHub has no such
+permission. Containment is this repo's branch protection on `main` (it can push a
+branch, not merge to `main`), not the token's own scope.
+
+Both tokens expire on whatever schedule you set when creating them. An expired token
+fails the relevant workflow run loudly (non-zero exit), it does not fail silently.
+
+## Known gap
+
+If a second event gets labelled while the first flip PR is still open, the daily
+backstop dispatches the growing set, and the branch-name dedup (keyed on the exact
+sorted event-name set) doesn't recognize it as the same PR — it opens a second one
+instead of superseding the first. Merging both in sequence can produce a conflict on
+the first event's row. Low-stakes (worst case is a hand-resolved conflict on a
+docs-only PR) since auto-merge means neither PR sits open for long in practice, but if
+it starts happening in practice, the fix is closing superseded `analytics-sync` PRs
+(any whose flipped set is a strict subset of a new dispatch) before opening a new one.

--- a/scripts/validate_flip_diff.py
+++ b/scripts/validate_flip_diff.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Guard run before any push/PR/auto-merge in analytics-registry-sync.yml.
+
+flip_registry_status.py has already rewritten docs/ANALYTICS_REGISTRY_HANDOFF.md on
+disk (uncommitted) by the time this runs. This script independently re-checks the
+actual `git diff` rather than trusting that script's own bookkeeping, so a future bug
+in either script (or a malformed dispatch payload) gets caught here instead of
+reaching a PR that then auto-merges unreviewed.
+
+Passes only if ALL of:
+  - Exactly one file changed: docs/ANALYTICS_REGISTRY_HANDOFF.md
+  - No lines added or removed as whole lines (line count unchanged)
+  - Every changed line differs from its old version by nothing except the literal
+    substring "| Pending |" -> "| Registered |"
+
+Anything else (a deleted row, a rewritten row, an edited unrelated section, a second
+file touched) fails loudly and non-zero. The caller must not proceed to git add/commit/
+push on a non-zero exit.
+"""
+
+import subprocess
+import sys
+
+LEDGER_PATH = "docs/ANALYTICS_REGISTRY_HANDOFF.md"
+OLD_MARKER = "| Pending |"
+NEW_MARKER = "| Registered |"
+
+
+def fail(message: str) -> None:
+    print(f"::error::{message}")
+    sys.exit(1)
+
+
+def main() -> None:
+    changed_files = subprocess.run(
+        ["git", "diff", "--name-only"], capture_output=True, text=True, check=True
+    ).stdout.split()
+
+    if changed_files != [LEDGER_PATH]:
+        fail(f"Expected only {LEDGER_PATH} changed, got: {changed_files or '(nothing)'}")
+
+    diff = subprocess.run(
+        ["git", "diff", "-U0", "--", LEDGER_PATH], capture_output=True, text=True, check=True
+    ).stdout
+
+    removed, added = [], []
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("-"):
+            removed.append(line[1:])
+        elif line.startswith("+"):
+            added.append(line[1:])
+
+    if len(removed) != len(added):
+        fail(f"Line count changed: {len(removed)} removed vs {len(added)} added (rows must only be edited, never added/removed)")
+
+    if not removed:
+        fail("No changed lines found, but a diff was expected")
+
+    for old, new in zip(removed, added):
+        if old.replace(OLD_MARKER, NEW_MARKER) != new:
+            fail(f"Row changed by more than the status flip:\n  old: {old}\n  new: {new}")
+        if OLD_MARKER not in old or NEW_MARKER not in new:
+            fail(f"Row does not contain the expected Pending/Registered markers:\n  old: {old}\n  new: {new}")
+
+    print(f"✓ Diff validated: {len(removed)} row(s) changed, each only Pending -> Registered")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Switches the registry-sync bot from `GITHUB_TOKEN` to the existing krail-gtfs-bot
GitHub App and enables auto-merge, guarded by an independent post-hoc diff validator.

## Changes

- `.github/workflows/analytics-registry-sync.yml`: checkout, push, and PR creation now
  authenticate as the existing krail-gtfs-bot GitHub App (`KRAIL_BOT_APP_ID` /
  `KRAIL_BOT_PRIVATE_KEY`, already a secret here for `bump-after-release.yml`, same
  `actions/create-github-app-token` pattern) instead of the built-in `GITHUB_TOKEN`. A
  `GITHUB_TOKEN`-authored PR never triggers this repo's `pull_request`-scoped required
  check (`code-quality / detekt` — a standing GitHub restriction), which left every
  merge blocked on a manual empty-commit nudge. A GitHub App installation token is a
  distinct real actor and doesn't have that restriction, so the check runs on its own
  and the PR auto-merges.
- New `scripts/validate_flip_diff.py`: runs after the flip script and before any
  `git add`/commit/push. Independently re-checks the actual `git diff` (not the flip
  script's own bookkeeping) — exactly one file changed, no lines added or removed,
  every changed line differing from its old version by nothing except the
  `Pending` -> `Registered` substring. Fails the job loudly on anything else, so a
  future bug in either script can't reach an auto-merged PR unreviewed.
- Auto-merge is otherwise forbidden for every bot in this repo (docs-gardener's charter
  is explicit: "Never merge, approve, or enable auto-merge"). Documented this bot's
  narrow exception in `CLAUDE.md` next to the existing `gh pr create` exception, with
  the reasoning and a note to remove it if this bot's scope ever grows past one cell.
- Fixed `CLAUDE.md`'s Analytics events section, which said "no registration step
  here" — directly contradicting `docs/ANALYTICS_REGISTRY_HANDOFF.md`'s own "update it
  in the same PR" rule, with no pointer to that file from the one place a session
  would actually be looking when adding an event.
- New `docs/ANALYTICS_REGISTRY_SYNC.md`: explains the full pipeline end to end and why
  this bot gets the auto-merge exception. Linked from `CLAUDE.md`'s per-feature docs
  list.

## Testing

- `actionlint` on the updated workflow: clean
- `scripts/validate_flip_diff.py` tested against three scenarios on a real ledger
  snapshot: a clean single-row flip (passes), an unrelated line appended alongside the
  flip (fails: line-count mismatch), an unrelated row deleted alongside the flip
  (fails: line-count mismatch) — then reverted, working tree left clean
- Repo already has `allow_auto_merge: true` (confirmed via API), so `gh pr merge --auto`
  needs no repo-setting change

## Setup needed before this is live

None. Reuses the existing krail-gtfs-bot GitHub App instead of a new PAT — no new
credential to create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
