### PR TITLE
docs(store-listing): record approved screenshot decisions

### DIFF
--- a/store-listing/framework/AGENT-GUIDE.md
+++ b/store-listing/framework/AGENT-GUIDE.md
@@ -6,12 +6,14 @@ on previous chat context. Read these files in order:
 1. `store-listing/framework/README.md`
 2. `store-listing/framework/QA-CHECKLIST.md`
 3. `store-listing/<app>/README.md`
-4. `store-listing/<app>/listing-qa.json`
-5. `store-listing/<app>/manifest.json`
+4. `store-listing/<app>/DECISIONS.md`
+5. `store-listing/<app>/listing-qa.json`
+6. `store-listing/<app>/manifest.json`
 
 ## Required behaviour
 
 - Inspect the existing report and all raw captures before changing copy or layout
+- Reconcile panel order and intent across the manifest, report, QA config and output filenames
 - Preserve app-specific canonical routes, labels, themes and data
 - Use committed Maestro flows for state arrangement
 - Pin device identifiers in every automation command
@@ -77,3 +79,4 @@ Do not call an asset ready when any of these is true:
 - the submitted build does not contain the shown feature or label
 - a score appears without passed checks, exact deductions, remediation and policy impact
 - a rejection-risk statement lacks an official source and checked date
+- manifest panel order differs from the report configuration or generated outputs

--- a/store-listing/framework/README.md
+++ b/store-listing/framework/README.md
@@ -15,6 +15,7 @@ Each app keeps this structure:
 ```text
 store-listing/<app>/
   README.md                    app-specific runbook and canonical data
+  DECISIONS.md                 approved feedback and rejected experiments
   listing-qa.json              machine-readable QA contract and scores
   manifest.json                product story, palette and panel intent
   capture-flows/               committed Maestro state-arrangement flows
@@ -66,12 +67,12 @@ geometry so text, device tops and device bottoms do not jump between panels.
 10. Never display a score without explaining the baseline, passed checks, deductions and fixes directly below it
 11. Treat conversion quality, parity, policy warnings and upload blockers as separate severities
 12. Quote store policy sparingly, link the official source and record when it was checked
-10. Centre portrait copy; align landscape-tablet copy to its device composition
-11. Keep badges outside the headline bounding box with a full line of clearance
-12. Accent one meaningful word or phrase, consistently across device classes
-13. Do not use decorative underlines when they reduce legibility
-14. Do not capture permission prompts, banners, keyboards, loading states or errors
-15. Distinct panels must use distinct source captures
+13. Centre portrait copy; align landscape-tablet copy to its device composition
+14. Keep badges outside the headline bounding box with a full line of clearance
+15. Accent one meaningful word or phrase, consistently across device classes
+16. Do not use decorative underlines when they reduce legibility
+17. Do not capture permission prompts, banners, keyboards, loading states or errors
+18. Distinct panels must use distinct source captures
 
 `template.css`, `template.html` and `devices.json` define the reusable geometry.
 Apps may tune sizes by device class, but must preserve safe borders and stable
@@ -91,21 +92,24 @@ slots.
 ## Automated gate
 
 Copy `project.example.json` into the app directory as `listing-qa.json`, fill in
-the real paths and run:
+the real paths, copy `manifest.example.json` as `manifest.json`, define the
+approved panel order and run:
 
 ```bash
 python3 store-listing/framework/verify-listing.py \
   store-listing/<app>/listing-qa.json
 ```
 
-The command validates source identity by native pixel size, rendered specs,
-opacity, file size, counts, duplicate captures, copy limits, punctuation,
-device headings and QA scores. Visual claims and crop quality still require a
-human or screenshot-based visual review; they are represented as explicit
-score deductions instead of being silently ignored. Each deduction must include
-its category, visible impact, exact improvement and store-review risk. A report
-must also show platform strengths, a policy verdict and conditional rejection
-gates. Active blockers fail validation; warnings remain visible without being
-misrepresented as guaranteed rejection.
+The command validates manifest/report/output order, source identity by native
+pixel size, rendered specs, opacity, file size, counts, duplicate captures,
+copy limits, punctuation, device headings and QA scores. This manifest drift
+gate prevents an abandoned product story from surviving beside approved
+artwork. Visual claims and crop quality still require a human or screenshot-
+based visual review; they are represented as explicit score deductions instead
+of being silently ignored. Each deduction must include its category, visible
+impact, exact improvement and store-review risk. A report must also show
+platform strengths, a policy verdict and conditional rejection gates. Active
+blockers fail validation; warnings remain visible without being misrepresented
+as guaranteed rejection.
 
 See [QA-CHECKLIST.md](QA-CHECKLIST.md) for the release gate.

--- a/store-listing/framework/manifest.example.json
+++ b/store-listing/framework/manifest.example.json
@@ -1,0 +1,33 @@
+{
+  "version": 2,
+  "status": "approved",
+  "app": "Example App",
+  "sourceOfTruth": "example-screenshot-listing.html",
+  "palette": {
+    "primary": { "g1": "#007A5E", "g2": "#004C3B", "accent": "#FFFFFF" }
+  },
+  "panelOrder": [
+    {
+      "id": 1,
+      "slug": "example",
+      "intent": "State the customer benefit",
+      "colour": "primary",
+      "screenTheme": "primary/light",
+      "headline": "Show the benefit",
+      "proof": "Describe the native app state that proves the claim"
+    }
+  ],
+  "platformRules": {
+    "phone": "Centre concise copy above the native portrait app frame",
+    "tablet": "Compose around the genuine wide or split-view tablet layout"
+  },
+  "motifRules": [
+    "Keep supporting decoration outside copy and device bounds"
+  ],
+  "captureRules": [
+    "Capture the exact build and canonical app state intended for submission"
+  ],
+  "avoid": [
+    "Permission prompts, placeholder data and substituted device classes"
+  ]
+}

--- a/store-listing/framework/project.example.json
+++ b/store-listing/framework/project.example.json
@@ -1,7 +1,33 @@
 {
-  "version": 1,
+  "version": 2,
   "report": "example-screenshot-listing.html",
+  "manifest": "manifest.json",
   "outputIndex": "store-images/index.json",
+  "scoring": {
+    "baseline": 100,
+    "method": "Every platform starts at 100 after mandatory checks pass, with documented deductions for remaining weaknesses"
+  },
+  "policySources": [
+    {
+      "id": "official-store-source",
+      "store": "Store name",
+      "title": "Official screenshot requirement",
+      "url": "https://example.com/replace-with-official-store-policy",
+      "quote": "Short quotation also present in the report",
+      "checked": "YYYY-MM-DD"
+    }
+  ],
+  "submissionGates": [
+    {
+      "severity": "blocker",
+      "triggered": false,
+      "title": "Submitted build must match the screenshots",
+      "trigger": "The review build differs from the captured app state",
+      "outcome": "The listing may be rejected as inaccurate",
+      "action": "Verify every shown feature in the submitted build",
+      "sourceIds": ["official-store-source"]
+    }
+  ],
   "copyRules": {
     "forbidFullStops": true,
     "headlineMaxWords": 7,
@@ -16,8 +42,13 @@
       "sourceDimensions": [1242, 2688],
       "outputDimensions": [1242, 2688],
       "outputDir": "store-images/iphone-6-5",
-      "uploadDir": "upload-ready/2026-08-09/app-store/iphone-6.5-inch",
+      "uploadDir": "upload-ready/YYYY-MM-DD/app-store/iphone-6.5-inch",
       "uploadCount": 1,
+      "strengths": [
+        "Uses a genuine native capture",
+        "Meets the configured output dimensions",
+        "Shows one clear benefit with visible proof"
+      ],
       "panels": [
         {
           "source": "screenshots/iphone65/01_example.png",
@@ -25,8 +56,23 @@
         }
       ],
       "deductions": [
-        { "points": 2, "reason": "Example visual-review deduction" }
-      ]
+        {
+          "points": 2,
+          "category": "Example category",
+          "reason": "Example visible weakness",
+          "impact": "Explain the user or merchandising impact",
+          "improvement": "Describe the exact improvement",
+          "storeRisk": "State whether this is quality, warning or blocker risk"
+        }
+      ],
+      "policyReview": {
+        "status": "pass",
+        "title": "No current screenshot blocker detected",
+        "issue": "Summarize the reviewed requirements",
+        "reviewOutcome": "State the expected review outcome without guaranteeing approval",
+        "remediation": "State the condition that must remain true at submission",
+        "sourceIds": ["official-store-source"]
+      }
     }
   ]
 }

--- a/store-listing/framework/verify-listing.py
+++ b/store-listing/framework/verify-listing.py
@@ -87,6 +87,43 @@ def main() -> int:
         if not ok:
             failures.append(f"{scope}: {message}")
 
+    manifest_path = root / config.get("manifest", "manifest.json")
+    manifest: dict = {}
+    check(manifest_path.exists(), "Manifest", f"missing {manifest_path.name}")
+    if manifest_path.exists():
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as error:
+            check(False, "Manifest", f"invalid JSON: {error}")
+
+    check(manifest.get("status") == "approved", "Manifest",
+          "status must be 'approved'")
+    check(manifest.get("sourceOfTruth") == config["report"], "Manifest",
+          "sourceOfTruth must match the configured report")
+    manifest_panels = manifest.get("panelOrder", [])
+    check(isinstance(manifest_panels, list) and bool(manifest_panels), "Manifest",
+          "panelOrder must be a non-empty list")
+    manifest_slugs: list[str] = []
+    if isinstance(manifest_panels, list):
+        for index, panel in enumerate(manifest_panels, start=1):
+            panel_scope = f"Manifest panel {index:02d}"
+            if not isinstance(panel, dict):
+                check(False, panel_scope, "panel must be an object")
+                continue
+            for field in ("id", "slug", "intent", "colour", "screenTheme", "headline", "proof"):
+                check(bool(panel.get(field)), panel_scope, f"{field} is missing")
+            check(panel.get("id") == index, panel_scope,
+                  f"id must be {index}, found {panel.get('id')!r}")
+            slug = panel.get("slug", "")
+            check(bool(re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug)), panel_scope,
+                  f"invalid slug {slug!r}")
+            manifest_slugs.append(slug)
+    check(len(manifest_slugs) == len(set(manifest_slugs)), "Manifest",
+          "panel slugs must be unique")
+    check(bool(manifest.get("motifRules")), "Manifest", "motifRules are missing")
+    check(bool(manifest.get("captureRules")), "Manifest", "captureRules are missing")
+    check(bool(manifest.get("avoid")), "Manifest", "avoid rules are missing")
+
     scoring = config.get("scoring", {})
     baseline = scoring.get("baseline")
     check(baseline == 100, "Scoring", f"baseline must be 100, found {baseline!r}")
@@ -139,6 +176,12 @@ def main() -> int:
 
         articles = re.findall(r'(<article class="store-panel.*?</article>)', body, re.S)
         panels = platform["panels"]
+        output_slugs = [
+            re.sub(r"^\d+_", "", pathlib.Path(panel["output"]).stem)
+            for panel in panels
+        ]
+        check(output_slugs == manifest_slugs, scope,
+              "configured output order does not match manifest panelOrder")
         check(len(articles) == len(panels), scope,
               f"report has {len(articles)} panels, config has {len(panels)}")
 
@@ -229,6 +272,18 @@ def main() -> int:
             report_source = source_match.group(1) if source_match else None
             check(report_source == panel["source"], panel_scope,
                   f"report source is {report_source!r}, expected {panel['source']!r}")
+
+            manifest_panel = (
+                manifest_panels[index]
+                if isinstance(manifest_panels, list)
+                and index < len(manifest_panels)
+                and isinstance(manifest_panels[index], dict)
+                else {}
+            )
+            headline_match = re.search(r"<strong[^>]*>(.*?)</strong>", article, re.S)
+            report_headline = plain(headline_match.group(1)) if headline_match else ""
+            check(report_headline == manifest_panel.get("headline"), panel_scope,
+                  "report headline does not match the approved manifest headline")
 
             copy_fragments: list[tuple[str, str, int]] = []
             for tag, label, limit in (

--- a/store-listing/krail/DECISIONS.md
+++ b/store-listing/krail/DECISIONS.md
@@ -1,0 +1,96 @@
+# KRAIL Store Listing Decisions
+
+This is the durable feedback record for the approved 2026-08-09 KRAIL store
+listing set. Future sessions must read it before changing captures, copy,
+composition or upload folders. The rendered report remains the visual source of
+truth; `manifest.json` is its machine-readable seven-panel contract.
+
+## What worked
+
+- Use real native app captures instead of generated, reconstructed or generic imagery
+- Lead with a seven-panel benefit story: Saved Trips, Live Times, Parking, Service Alerts, Live Delays, Planning and Dark Mode
+- Make the device class the prominent report heading and keep store/count metadata secondary
+- Show genuine phone, Android tablet and iPad layouts rather than scaling one device class into another
+- Use KRAIL product colours as a sequence: train orange, bus blue, Metro teal, alert amber, Light Rail red, ferry green and a dark finish
+- Keep the default appearance light and reserve genuine dark mode for the final panel
+- Expand the route to prove the complete journey and expand the first service alert on tablet and iOS
+- Keep canonical labels, routes, parking data and themes consistent across platforms
+- Prefer concise everyday language such as `Start to finish` over technical transport terms such as `leg`
+- Accent one useful word or phrase with colour while preserving strong contrast
+- Vary the circular ring position between panels so the composition does not feel stamped out
+- Integrate the white Metro-coloured `P` badge with the parking headline alignment
+- Show a platform score only with passed checks, deductions, fixes and store-review risk
+- Use one horizontal HTML report to compare all four device classes together
+
+## What did not work
+
+- Squiggly or decorative underlines made the typography less legible and were removed
+- Repeating `delays` across both panels 04 and 05 blurred the difference between service alerts and live delays
+- `Live times every leg` was technical and unclear for everyday passengers
+- Full stops in listing copy added visual noise and are forbidden by the QA contract
+- Long parking copy and Tallawong-only claims understated KRAIL's broader Park and Ride coverage
+- Text touching the Alerts or Any time pill made the hierarchy look accidental
+- Placing the parking icon at the extreme left disconnected it from the title
+- Putting the circular ring in the bottom-right of every panel made the set repetitive
+- Phone UI presented as iPad or tablet evidence could be misleading and risk store rejection
+- Dark mode across most panels reduced clarity; it is now one deliberate final proof point
+- Location-permission banners made captures look unfinished and obscured product value
+- Routes such as Schofields to Central contradicted the approved Bondi Junction to Circular Quay story
+- Placeholder labels such as `Work 1` looked like test data and were removed
+- Leaving a timetable screen open continued API polling after capture
+- Generated or inferred app imagery was not acceptable when native captures were available
+
+## Copy and layout rules
+
+- One benefit and one visual proof per panel
+- Headlines contain at most seven words, sublines at most eight words and neither uses a full stop
+- Phone and iPad headlines use no more than two lines; landscape tablet copy uses one or two compact lines
+- Portrait copy is centred above the app frame
+- Landscape tablet copy aligns with the wider app composition and does not collide with pills or badges
+- Foreground copy, badges and devices stay inside the safe border with visible colour around every device edge
+- Badges have clear separation from copy; no label may touch or overlap another element
+- The parking `P` badge sits directly before or above the title and follows the title alignment
+- Decorative accents support hierarchy but never replace readable type or authentic app evidence
+
+## Canonical capture state
+
+- Journey: Bondi Junction Station to Circular Quay Station
+- Service: route 333 with 15 stops and an expanded journey for the timetable panel
+- Saved labels: Home to Work and Home to Uni
+- Parking: Tallawong and Schofields, with Tallawong P1, P2 and P3 visible in detail
+- Themes: train orange for Saved Trips, bus blue for Live Times, Metro teal for Parking, ferry green for Planning and train dark for Dark Mode
+- Appearance: light except the explicit final dark-mode panel
+- Location: permission granted with Sydney GPS at `-33.8688,151.2093`
+- Alerts: first card expanded on Android tablet, iPhone and iPad
+- Exit state: Saved Trips or a stopped emulator, never an actively polling timetable
+
+## Device decisions
+
+- Android phone: portrait 1080 x 1920 store panels from 1080 x 2400 native captures
+- Android tablet: genuine landscape 1920 x 1080 output from 2560 x 1600 native tablet captures
+- iPhone: accepted 1242 x 2688 6.5-inch assets using genuine iPhone captures
+- iPad: accepted 2064 x 2752 13-inch assets using the native split-view app layout
+- The Android tablet's added marketing copy has a documented Google large-screen crop warning; retain a UI-only fallback if Play Console previewing crops it
+
+## Workflow and release decisions
+
+- Commit raw captures, generated panels, report assets and upload files through Git LFS
+- Treat dated `upload-ready/<date>/` folders as immutable release artifacts
+- Upload store assets only from the matching dated `upload-ready` subfolder
+- Boot one iOS simulator, pin its UDID and use `xcrun simctl io` for final pixels
+- Use committed Maestro flows for repeatable state arrangement and assertions
+- Rerender all affected platforms after source, copy or layout changes
+- Run `verify-listing.py`, inspect full-size panels and compare all platforms before sign-off
+- Record scores as review aids, with positives, exact deductions, remediation and policy impact
+- Cite official Apple and Google policy with a checked date for any rejection-risk claim
+- Commit checkpoints as work progresses and use one intentional Graphite/GitHub PR per coherent change
+
+## Accepted non-blocking caveats
+
+- Android phone panel 04 has a collapsed first alert; the claim remains visible and accurate
+- Android phone Saved Trips contains an older parking state than the newer tablet and iOS captures
+- Android tablet marketing copy may crop on some Google Play promotional surfaces
+
+These are documented quality or presentation issues, not current upload
+blockers. The mandatory release gate remains that the submitted build must
+contain the screens, labels, themes and behaviour shown in the listing.

--- a/store-listing/krail/README.md
+++ b/store-listing/krail/README.md
@@ -22,15 +22,18 @@ permission banners into this listing set.
 - `capture-flows/`: repeatable Maestro interactions and capture runbook
 - `screenshots/`: raw native device captures; do not resize these
 - `krail-screenshot-listing.html`: horizontal review report and panel source
+- `DECISIONS.md`: approved feedback, rejected experiments and capture lessons
 - `render-store-images.py`: renders exact store-size panels from the report
 - `store-images/`: generated complete seven-panel sets for review
 - `upload-ready/2026-08-09/`: approved files grouped by store upload target
 - `listing-qa.json`: dimensions, filenames, copy rules and QA deductions
-- `manifest.json`: KRAIL palette and product-story notes
+- `manifest.json`: approved seven-panel order, palette, intent and proof contract
 
 Both raw captures and generated panels are committed through Git LFS. The
 dated upload directory is intentionally immutable: make a new dated directory
 for a later release rather than silently replacing a previously submitted set.
+Future sessions must read `DECISIONS.md` before editing and keep the manifest,
+report, QA configuration and generated filenames synchronized.
 
 ## Rebuild and verify
 

--- a/store-listing/krail/listing-qa.json
+++ b/store-listing/krail/listing-qa.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
   "report": "krail-screenshot-listing.html",
+  "manifest": "manifest.json",
   "outputIndex": "store-images/index.json",
   "scoring": {
     "baseline": 100,

--- a/store-listing/krail/manifest.json
+++ b/store-listing/krail/manifest.json
@@ -1,44 +1,113 @@
 {
+  "version": 2,
+  "status": "approved",
   "app": "KRAIL",
-  "font": "Roboto Black (brand face); in-app screens render Antonio",
+  "sourceOfTruth": "krail-screenshot-listing.html",
+  "font": "Roboto Black for listing copy; Antonio inside native app captures",
   "palette": {
-    "train":  { "g1": "#F6891F", "g2": "#C25706", "hi": "rgba(255,255,255,.16)", "lo": "rgba(59,26,2,.18)" },
-    "bus":    { "g1": "#00B5EF", "g2": "#00719F", "hi": "rgba(255,255,255,.16)", "lo": "rgba(1,34,46,.20)" },
-    "metro":  { "g1": "#00A87E", "g2": "#005A43", "hi": "rgba(255,255,255,.15)", "lo": "rgba(0,36,27,.22)" },
-    "ferry":  { "g1": "#63B93A", "g2": "#2F711E", "hi": "rgba(255,255,255,.16)", "lo": "rgba(19,45,8,.20)" },
-    "lrail":  { "g1": "#E4022D", "g2": "#8F0219", "hi": "rgba(255,255,255,.16)", "lo": "rgba(50,1,10,.22)" },
-    "dark":   { "g1": "#2C070E", "g2": "#120305", "hi": "rgba(228,2,45,.30)",   "lo": "rgba(228,2,45,.12)" }
+    "train": { "g1": "#F6891F", "g2": "#BD5306", "accent": "#2B1603" },
+    "bus": { "g1": "#00B5EF", "g2": "#007AA8", "accent": "#FFE15A" },
+    "metro": { "g1": "#00A57F", "g2": "#006C56", "accent": "#FFE15A" },
+    "alert": { "g1": "#E6AB22", "g2": "#A96900", "accent": "#382300" },
+    "lightRail": { "g1": "#EC1742", "g2": "#A00022", "accent": "#FFE15A" },
+    "ferry": { "g1": "#5ABF32", "g2": "#2C7F21", "accent": "#17390D" },
+    "dark": { "g1": "#2A2522", "g2": "#11100F", "accent": "#F6891F" }
   },
-  "panels": [
-    { "id": 1, "colour": "train", "screenTheme": "train/light",
-      "headline": [["l1","Save your"],["l1","trip"],["l2","See it live"]],
-      "sticker": { "label": "Live", "style": "live" }, "ghost": "Sydney",
-      "screen": "saved trips home, six trips incl Home to Work and Home to Uni labels, no parking in frame" },
-    { "id": 2, "colour": "bus", "screenTheme": "bus/light",
-      "headline": [["l1","Know when"],["l1","to get off"]],
-      "sticker": { "label": "748" }, "ghost": "Central",
-      "screen": "expanded 748 journey: leg stops, get-off stop, walk leg" },
-    { "id": 3, "colour": "metro", "screenTheme": "metro/light",
-      "headline": [["l0","Tallawong fills by"],["l1 num","7:05am"],["l2","See spaces first"]],
-      "badge": "P", "ghost": "Tallawong",
-      "screen": "Tallawong card expanded, P1/P2/P3 live spot counts, card top clean" },
-    { "id": 4, "colour": "ferry", "screenTheme": "ferry/light",
-      "headline": [["l1","Free. No ads."],["l2","Made in Sydney"]],
-      "sticker": { "label": "SYD" }, "ghost": "Krail",
-      "screen": "plan-your-trip bottom sheet over the timetable" },
-    { "id": 5, "colour": "lrail", "screenTheme": "pink/light",
-      "headline": [["l1","Every stop"],["l1","on the map"]],
-      "sticker": { "label": "CBD" }, "ghost": "Wynyard",
-      "screen": "select-on-map, Sydney CBD stop pins, stop sheet open" },
-    { "id": 6, "colour": "dark", "screenTheme": "pink/dark",
-      "headline": [["l0","Built for the"],["l1","6am dark"]],
-      "sticker": { "label": "6am" }, "ghost": "Schofields",
-      "screen": "dark home, saved trips only" }
+  "panelOrder": [
+    {
+      "id": 1,
+      "slug": "saved-trips",
+      "intent": "Lead with the daily habit",
+      "colour": "train",
+      "screenTheme": "train/light",
+      "headline": "Save your trips",
+      "proof": "Saved Trips shows the canonical Home to Work and Home to Uni labels"
+    },
+    {
+      "id": 2,
+      "slug": "live-times",
+      "intent": "Prove a complete journey at a glance",
+      "colour": "bus",
+      "screenTheme": "bus/light",
+      "headline": "Live times Start to finish",
+      "proof": "Route 333 from Bondi Junction to Circular Quay is expanded with all 15 stops"
+    },
+    {
+      "id": 3,
+      "slug": "parking",
+      "intent": "Show useful Park and Ride information before driving",
+      "colour": "metro",
+      "screenTheme": "metro/light",
+      "headline": "Check parking first",
+      "proof": "Tallawong Park and Ride shows live P1, P2 and P3 availability"
+    },
+    {
+      "id": 4,
+      "slug": "service-alerts",
+      "intent": "Separate network alerts from live delay information",
+      "colour": "alert",
+      "screenTheme": "light",
+      "headline": "Check service alerts",
+      "proof": "The first service alert is expanded on tablet, iPhone and iPad"
+    },
+    {
+      "id": 5,
+      "slug": "live-delays",
+      "intent": "Make real-time disruption visibility unmistakable",
+      "colour": "lightRail",
+      "screenTheme": "light-rail/light",
+      "headline": "See delays in real time",
+      "proof": "The timetable visibly shows a delayed service and updated timing"
+    },
+    {
+      "id": 6,
+      "slug": "plan-your-day",
+      "intent": "Show leave-now and arrive-by planning flexibility",
+      "colour": "ferry",
+      "screenTheme": "ferry/light",
+      "headline": "Plan around your day",
+      "proof": "The trip-planning sheet exposes date, time, leave and arrive controls"
+    },
+    {
+      "id": 7,
+      "slug": "dark-mode",
+      "intent": "Finish with a deliberate low-light use case",
+      "colour": "dark",
+      "screenTheme": "train/dark",
+      "headline": "Made for the 6am dark",
+      "proof": "Saved Trips is captured in genuine app dark mode"
+    }
   ],
-  "captureNotes": [
-    "Seed via SQLite (run-as pull/push krailSandook.db): SavedTrip, StopLabels, Theme.productClass (1 train, 2 metro, 5 bus, 9 ferry, 100 pink). Removing db-wal on push is mandatory; a db push also restores Theme, so set it in the same push.",
-    "Pin emulator GPS to Sydney (adb emu geo fix 151.2093 -33.8688) and pm-grant location, or maps open on Googleplex with a permission toast.",
-    "Force clean status bars (simctl status_bar override / Android demo mode); times in the 7:00-7:30 window.",
-    "Tablet AVD: krail_tablet (medium_tablet, android-36); portrait via user_rotation 1."
+  "platformRules": {
+    "phone": "Centre copy above a dominant portrait app frame and keep headlines to two lines",
+    "androidTablet": "Use a genuine landscape tablet capture with compact copy aligned to the wide app composition",
+    "ipad": "Use a genuine iPad split view with centred copy, safe edges and no enlarged phone UI",
+    "darkMode": "Use dark mode only for the final panel; all other panels use light mode"
+  },
+  "motifRules": [
+    "Accent only one meaningful word or phrase and keep the treatment consistent across device classes",
+    "Do not use squiggly or decorative underlines",
+    "Vary the circular ring position so it does not repeat in the bottom-right corner",
+    "Align the white parking P badge with the parking headline rather than the page edge",
+    "Keep badges and pills clear of all headline and subline text",
+    "Keep visible colour field and safe space around every device edge"
+  ],
+  "captureRules": [
+    "Use native captures from the current main build rather than generated or substituted device imagery",
+    "Use Bondi Junction to Circular Quay, route 333, Home to Work and Home to Uni consistently",
+    "Grant location permission and set GPS to Sydney before capture",
+    "Expand the timetable journey and the first service alert where the device set requires it",
+    "Return the app to Saved Trips or stop the emulator after capture so timetable polling does not continue",
+    "Capture final iOS pixels with simctl while exactly one target simulator is booted"
+  ],
+  "avoid": [
+    "Full stops in listing headlines, sublines, stickers or ghost labels",
+    "Technical passenger copy such as leg",
+    "Long parking claims focused on one facility when the feature covers many stations",
+    "Placeholder labels such as Work 1",
+    "Arbitrary routes such as Schofields to Central",
+    "Permission banners, dialogs, keyboards, loading states or errors",
+    "Phone screenshots presented as tablet or iPad screenshots",
+    "Repeated delay wording on both the service-alert and live-delay panels"
   ]
 }


### PR DESCRIPTION
## What

Records the approved KRAIL store-listing direction and makes stale panel concepts fail validation.

## Changes

- replaces the obsolete six-panel manifest with the approved seven-panel story
- records successful and rejected design, copy, capture, and release decisions
- adds app-agnostic manifest and QA examples for future store-listing projects
- validates manifest status, required fields, panel order, output slugs, and report headlines
- updates the framework handoff and repository documentation

## Testing

- `python3 store-listing/framework/verify-listing.py store-listing/krail/listing-qa.json`
- `python3 -m py_compile store-listing/framework/verify-listing.py`
- JSON validation for KRAIL and framework example manifests/configuration
- `git diff --check`

No screenshot pixels or upload-ready assets are changed by this PR.