### PR TITLE
feat(trip-planner): add the StopTextResolver capability interface

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -31,6 +31,9 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.InviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.RealInviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputViewModel
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.ChainedStopTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopLabelTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopSearchTextResolver
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealRemoteAddressResultsManager
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealSearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.RealStopResultsManager
@@ -89,7 +92,14 @@ val viewModelsModule = module {
         AiSearchInputViewModel(
             aiTextService = get(),
             speechToTextService = get(),
-            stopResultsManager = get(),
+            // Order is precedence. Labels first: "work" is the rider naming a stop
+            // themselves, which beats a coincidental match against every stop in the state.
+            stopTextResolver = ChainedStopTextResolver(
+                listOf(
+                    StopLabelTextResolver(sandook = get()),
+                    StopSearchTextResolver(stopResultsManager = get()),
+                ),
+            ),
             nearbyStopsRepository = get(),
             resolveCurrentLocation = resolveCurrentLocation,
             isAiSearchInputEnabled = isAiSearchInputEnabled,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -16,8 +16,7 @@ import xyz.ksharma.krail.core.maps.data.repository.NearbyStopsRepository
 import xyz.ksharma.krail.core.speechtotext.SpeechToTextAvailability
 import xyz.ksharma.krail.core.speechtotext.SpeechToTextResult
 import xyz.ksharma.krail.core.speechtotext.SpeechToTextService
-import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
-import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopTextResolver
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 private const val NEARBY_STOP_RADIUS_KM = 1.0
@@ -41,7 +40,10 @@ private const val NEARBY_STOP_RADIUS_KM = 1.0
 class AiSearchInputViewModel(
     private val aiTextService: AiTextService,
     private val speechToTextService: SpeechToTextService,
-    private val stopResultsManager: StopResultsManager,
+    // A chain of capabilities rather than one search call, so what counts as "smart" about
+    // resolving a place is declared in one ordered list (see StopTextResolver) instead of
+    // growing branches in here.
+    private val stopTextResolver: StopTextResolver,
     private val nearbyStopsRepository: NearbyStopsRepository,
     // A lambda, not a UserLocationManager, because UserLocationManager only exists as
     // `rememberUserLocationManager()` — a @Composable factory (its underlying permission/
@@ -201,18 +203,13 @@ class AiSearchInputViewModel(
     }
 
     /**
-     * Top result from the exact same [StopResultsManager] search [SearchStopViewModel
-     * ][xyz.ksharma.krail.trip.planner.ui.searchstop.SearchStopViewModel] uses, treated as a
-     * guess — no auto-pick concept exists anywhere else in this codebase either, this is
-     * the first place introducing one, deliberately scoped to only this AI-guess context. A
-     * miss (no stop results, or only address/POI/trip results) resolves to `null`; route
-     * search is skipped (`searchRoutesEnabled = false`) since a place name is never a route.
+     * Hands the extracted text to [stopTextResolver], whose chain decides which capability
+     * answers: the rider's own labels first, then the same stop search the search-stop screen
+     * uses. The answer is treated as a guess — no auto-pick concept exists anywhere else in
+     * this codebase, and it stays deliberately scoped to this AI context — so a miss resolves
+     * to `null` and leaves the field for the rider to fill by hand.
      */
-    private suspend fun resolveStop(query: String): StopItem? {
-        val results = stopResultsManager.fetchStopResults(query, searchRoutesEnabled = false)
-        val topStop = results.filterIsInstance<SearchStopState.SearchResult.Stop>().firstOrNull() ?: return null
-        return StopItem(stopName = topStop.stopName, stopId = topStop.stopId)
-    }
+    private suspend fun resolveStop(query: String): StopItem? = stopTextResolver.resolve(query)
 
     /**
      * The rider didn't say where they're leaving from ("need to be at Central by 6:30pm" —

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/ChainedStopTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/ChainedStopTextResolver.kt
@@ -11,7 +11,7 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
  * specific first, so a rider's own words for a place beat a generic search over every stop in
  * the state.
  */
-class ChainedStopTextResolver(
+internal class ChainedStopTextResolver(
     private val resolvers: List<StopTextResolver>,
 ) : StopTextResolver {
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/ChainedStopTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/ChainedStopTextResolver.kt
@@ -1,0 +1,31 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import xyz.ksharma.krail.core.log.log
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Runs [resolvers] in order and takes the first answer.
+ *
+ * Order is the whole design: it is where precedence between capabilities is declared, in one
+ * readable list, instead of being buried in conditionals. Callers build the chain most
+ * specific first, so a rider's own words for a place beat a generic search over every stop in
+ * the state.
+ */
+class ChainedStopTextResolver(
+    private val resolvers: List<StopTextResolver>,
+) : StopTextResolver {
+
+    override val name: String = "chain(${resolvers.joinToString(",") { it.name }})"
+
+    override suspend fun resolve(query: String): StopItem? {
+        for (resolver in resolvers) {
+            val resolved = resolver.resolve(query)
+            if (resolved != null) {
+                log("StopTextResolver: '${resolver.name}' resolved '$query' -> ${resolved.stopName}")
+                return resolved
+            }
+        }
+        log("StopTextResolver: nothing resolved '$query'")
+        return null
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopLabelTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopLabelTextResolver.kt
@@ -1,0 +1,49 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import kotlinx.coroutines.flow.first
+import xyz.ksharma.krail.sandook.Sandook
+import xyz.ksharma.krail.sandook.StopLabels
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Resolves a rider's own name for a place: "work", "home", "uni", or any label they made
+ * themselves.
+ *
+ * A label already carries the stop it points at, so a hit needs no search at all. This sits
+ * first in the chain because a label is the rider deliberately naming a stop, which is
+ * stronger evidence than a text match against every stop in the state. Someone who labels a
+ * stop "Central" and then says "to central" means their stop.
+ *
+ * Matching is deliberately exact (case- and space-insensitive) rather than fuzzy: a label is
+ * a short word the rider chose, and loose matching here would let "home" capture "homebush".
+ * Anything not an exact label falls through to the next capability.
+ */
+internal class StopLabelTextResolver(
+    private val sandook: Sandook,
+) : StopTextResolver {
+
+    override val name: String = "label"
+
+    override suspend fun resolve(query: String): StopItem? {
+        val normalised = query.normaliseLabel()
+        if (normalised.isEmpty()) return null
+
+        // A label the rider made but never pointed at a stop resolves to null, same as no
+        // match: there is nothing to fill the field with.
+        return sandook.observeStopLabels().first()
+            .firstOrNull { it.label.normaliseLabel() == normalised }
+            ?.toStopItemOrNull()
+    }
+}
+
+/**
+ * Labels are entered by hand, so "Work", "work " and "WORK" are the same label to a rider
+ * even though they are three different strings.
+ */
+private fun String.normaliseLabel(): String = trim().lowercase()
+
+private fun StopLabels.toStopItemOrNull(): StopItem? {
+    val id = stop_id
+    val name = stop_name
+    return if (id != null && name != null) StopItem(stopId = id, stopName = name) else null
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopSearchTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopSearchTextResolver.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Resolves a place name against the same stop search the search-stop screen uses, taking the
+ * top stop result as the answer.
+ *
+ * This is the general fallback and belongs last: it can match almost anything, so putting it
+ * earlier would let a coincidental stop-name match beat a rider's own label.
+ *
+ * Route search is off — a place name is never a route — and non-stop results (addresses, POIs,
+ * trips) are ignored, so a query with no stop match resolves to `null` rather than to
+ * something of the wrong kind.
+ */
+internal class StopSearchTextResolver(
+    private val stopResultsManager: StopResultsManager,
+) : StopTextResolver {
+
+    override val name: String = "stopSearch"
+
+    override suspend fun resolve(query: String): StopItem? {
+        val results = stopResultsManager.fetchStopResults(query, searchRoutesEnabled = false)
+        val topStop = results.filterIsInstance<SearchStopState.SearchResult.Stop>().firstOrNull() ?: return null
+        return StopItem(stopName = topStop.stopName, stopId = topStop.stopId)
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolver.kt
@@ -1,0 +1,26 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * One way of turning a scrap of extracted text ("work", "central", "the airport") into a
+ * real [StopItem].
+ *
+ * Each resolver is a single capability with a single question to answer, which is what makes
+ * them testable in isolation and cheap to add: a new kind of smartness (a rider's saved trips,
+ * recent searches, an address lookup) is a new implementation rather than another branch in
+ * one growing function.
+ *
+ * Contract:
+ * - Return `null` for "not mine to answer", never a guess. The chain relies on `null` to fall
+ *   through to the next capability, so a resolver that returns something weak swallows the
+ *   turn that a better-informed one would have handled correctly.
+ * - Be side-effect free. Resolvers run on whatever the AI extracted, which may be nonsense.
+ */
+interface StopTextResolver {
+
+    /** Stable, human-readable id used in logs to show which capability answered. */
+    val name: String
+
+    suspend fun resolve(query: String): StopItem?
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -14,6 +14,10 @@ import xyz.ksharma.krail.core.aitext.TripIntentExtraction
 import xyz.ksharma.krail.core.maps.data.model.NearbyStop
 import xyz.ksharma.krail.core.speechtotext.SpeechToTextAvailability
 import xyz.ksharma.krail.core.speechtotext.SpeechToTextResult
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.ChainedStopTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopLabelTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopSearchTextResolver
 import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.JourneyTimeOptions
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAiTextService
@@ -36,6 +40,16 @@ class AiSearchInputViewModelTest {
     private val aiTextService = FakeAiTextService()
     private val speechToTextService = FakeSpeechToTextService()
     private val stopResultsManager = FakeStopResultsManager()
+    private val sandook = FakeSandook()
+
+    // The real chain, not a stub: these tests exercise resolution end to end, so a
+    // change in capability order shows up here rather than only in production.
+    private val stopTextResolver = ChainedStopTextResolver(
+        listOf(
+            StopLabelTextResolver(sandook),
+            StopSearchTextResolver(stopResultsManager),
+        ),
+    )
     private val nearbyStopsRepository = FakeNearbyStopsRepository()
     private lateinit var viewModel: AiSearchInputViewModel
 
@@ -45,7 +59,7 @@ class AiSearchInputViewModelTest {
         viewModel = AiSearchInputViewModel(
             aiTextService = aiTextService,
             speechToTextService = speechToTextService,
-            stopResultsManager = stopResultsManager,
+            stopTextResolver = stopTextResolver,
             nearbyStopsRepository = nearbyStopsRepository,
             isAiSearchInputEnabled = { true },
         )
@@ -61,7 +75,7 @@ class AiSearchInputViewModelTest {
         viewModel = AiSearchInputViewModel(
             aiTextService = aiTextService,
             speechToTextService = speechToTextService,
-            stopResultsManager = stopResultsManager,
+            stopTextResolver = stopTextResolver,
             nearbyStopsRepository = nearbyStopsRepository,
             isAiSearchInputEnabled = { false },
         )
@@ -113,6 +127,32 @@ class AiSearchInputViewModelTest {
         assertEquals(StopItem(stopName = "Town Hall", stopId = "10102"), resolved?.toStopItem)
         assertEquals(listOf("train"), resolved?.modeHints)
         assertTrue(resolved?.hasAnyStop == true)
+    }
+
+    @Test
+    fun `a stop label resolves as a destination`() = runTest(testDispatcher) {
+        // "let's go to work" - the rider's own word for a place, which no stop is named.
+        sandook.upsertStopLabel(
+            label = "work",
+            emoji = "💼",
+            stopId = "10102",
+            stopName = "Town Hall",
+            sortOrder = 0L,
+        )
+        aiTextService.extractionResult = TripIntentExtraction(
+            originText = "Central Station",
+            destinationText = "work",
+            timeIntent = null,
+        )
+        viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("let's go to work"))
+
+        viewModel.onEvent(AiSearchInputEvent.Submit)
+        advanceUntilIdle()
+
+        assertEquals(
+            StopItem(stopName = "Town Hall", stopId = "10102"),
+            viewModel.uiState.value.resolved?.toStopItem,
+        )
     }
 
     @Test
@@ -284,7 +324,7 @@ class AiSearchInputViewModelTest {
         viewModel = AiSearchInputViewModel(
             aiTextService = aiTextService,
             speechToTextService = speechToTextService,
-            stopResultsManager = stopResultsManager,
+            stopTextResolver = stopTextResolver,
             nearbyStopsRepository = nearbyStopsRepository,
             resolveCurrentLocation = { TEST_LOCATION },
             isAiSearchInputEnabled = { true },
@@ -309,7 +349,7 @@ class AiSearchInputViewModelTest {
         viewModel = AiSearchInputViewModel(
             aiTextService = aiTextService,
             speechToTextService = speechToTextService,
-            stopResultsManager = stopResultsManager,
+            stopTextResolver = stopTextResolver,
             nearbyStopsRepository = nearbyStopsRepository,
             resolveCurrentLocation = { null },
             isAiSearchInputEnabled = { true },

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolverTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolverTest.kt
@@ -1,0 +1,108 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private val WORK_STOP = StopItem(stopId = "10102", stopName = "Town Hall")
+
+/** Assigns [stop] to [label]; a null stop is a label the rider made but never pointed anywhere. */
+private fun FakeSandook.putLabel(label: String, stop: StopItem?) {
+    upsertStopLabel(
+        label = label,
+        emoji = "\uD83D\uDCCD",
+        stopId = stop?.stopId,
+        stopName = stop?.stopName,
+        sortOrder = 0L,
+    )
+}
+
+class StopLabelTextResolverTest {
+
+    private val sandook = FakeSandook()
+    private val resolver = StopLabelTextResolver(sandook)
+
+    @Test
+    fun `resolves a label to the stop it points at`() = runTest {
+        sandook.putLabel("work", WORK_STOP)
+
+        assertEquals(WORK_STOP, resolver.resolve("work"))
+    }
+
+    @Test
+    fun `label matching ignores case and surrounding space`() = runTest {
+        sandook.putLabel("Work", WORK_STOP)
+
+        assertEquals(WORK_STOP, resolver.resolve("  WORK "))
+    }
+
+    @Test
+    fun `custom labels resolve the same way the built-in ones do`() = runTest {
+        val gym = StopItem(stopId = "20001", stopName = "Redfern Station")
+        sandook.putLabel("the gym", gym)
+
+        assertEquals(gym, resolver.resolve("the gym"))
+    }
+
+    @Test
+    fun `a label with no stop assigned yet resolves to null`() = runTest {
+        sandook.putLabel("uni", null)
+
+        assertNull(resolver.resolve("uni"))
+    }
+
+    @Test
+    fun `partial matches are not labels`() = runTest {
+        sandook.putLabel("home", WORK_STOP)
+
+        // "homebush" is a stop name, not this rider's "home" label.
+        assertNull(resolver.resolve("homebush"))
+    }
+
+    @Test
+    fun `unknown text falls through`() = runTest {
+        sandook.putLabel("work", WORK_STOP)
+
+        assertNull(resolver.resolve("central"))
+    }
+}
+
+class ChainedStopTextResolverTest {
+
+    private val sandook = FakeSandook()
+    private val stopResultsManager = FakeStopResultsManager()
+
+    private val chain = ChainedStopTextResolver(
+        listOf(
+            StopLabelTextResolver(sandook),
+            StopSearchTextResolver(stopResultsManager),
+        ),
+    )
+
+    @Test
+    fun `a label wins over a stop of the same name`() = runTest {
+        // FakeStopResultsManager knows a stop called "Central Station"; the rider has also
+        // labelled a different stop "central". Their own word wins.
+        val theirCentral = StopItem(stopId = "99999", stopName = "Redfern Station")
+        sandook.putLabel("central", theirCentral)
+
+        assertEquals(theirCentral, chain.resolve("central"))
+    }
+
+    @Test
+    fun `falls through to stop search when no label matches`() = runTest {
+        assertEquals(
+            StopItem(stopId = "10101", stopName = "Central Station"),
+            chain.resolve("Central Station"),
+        )
+    }
+
+    @Test
+    fun `resolves to null when no capability can answer`() = runTest {
+        assertNull(chain.resolve("Nonexistent Place"))
+    }
+}


### PR DESCRIPTION
## What

<!-- One or two sentences: what this PR changes, in code terms. -->

## Changes

<!-- Bullet list of concrete changes. -->
<!-- Public repo: describe WHAT changed and technical WHY only. -->
<!-- No internal metrics, analytics numbers, or business/strategy context. -->

## Testing

<!-- Test tasks run, detekt status, compile targets verified. -->

## Snapshots

<!-- Required when UI is touched, otherwise delete this section. -->
<!-- Build snapshots and embed as a compact table. Use width-limited thumbnails -->
<!-- (width="220"), never full-size images. They bloat the PR description. -->

| Screen | Before | After |
|---|---|---|
| ScreenName | <img src="" width="220"> | <img src="" width="220"> |
