### PR TITLE
fix(trip-planner): stop the AI filling a field from a word inside another word

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopSearchTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopSearchTextResolver.kt
@@ -4,16 +4,19 @@ import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
+private const val MIN_QUERY_TOKEN_LENGTH_TO_MATCH_AS_PREFIX = 3
+
 /**
  * Resolves a place name against the same stop search the search-stop screen uses, taking the
- * top stop result as the answer.
+ * top stop result — but only when that result is a good enough match to fill a field with
+ * unattended.
  *
- * This is the general fallback and belongs last: it can match almost anything, so putting it
- * earlier would let a coincidental stop-name match beat a rider's own label.
+ * This is the general fallback and belongs last in the chain: it can match almost anything, so
+ * putting it earlier would let a coincidental stop-name match beat a rider's own label.
  *
  * Route search is off — a place name is never a route — and non-stop results (addresses, POIs,
- * trips) are ignored, so a query with no stop match resolves to `null` rather than to
- * something of the wrong kind.
+ * trips) are ignored, so a query with no stop match resolves to `null` rather than to something
+ * of the wrong kind.
  */
 internal class StopSearchTextResolver(
     private val stopResultsManager: StopResultsManager,
@@ -23,7 +26,45 @@ internal class StopSearchTextResolver(
 
     override suspend fun resolve(query: String): StopItem? {
         val results = stopResultsManager.fetchStopResults(query, searchRoutesEnabled = false)
-        val topStop = results.filterIsInstance<SearchStopState.SearchResult.Stop>().firstOrNull() ?: return null
+        val topStop = results.filterIsInstance<SearchStopState.SearchResult.Stop>()
+            .firstOrNull { it.stopName.matchesOnTokenBoundaries(query) }
+            ?: return null
         return StopItem(stopName = topStop.stopName, stopId = topStop.stopId)
     }
 }
+
+/**
+ * Whether every word of [query] starts a word of this stop name.
+ *
+ * The stop search is tuned for a rider reading a list of ten results and picking one, where a
+ * loose match is a helpful suggestion. This path picks for them, silently, which is a different
+ * bet: "work" matching *Powder**work**s Rd* put a stop on the northern beaches into a rider's
+ * destination with nothing to show anything had gone wrong.
+ *
+ * Matching on word starts rather than anywhere in the string is what separates the two:
+ * "central" still finds *Central Station*, "st" still finds *Central Street*, and "work" no
+ * longer finds *Powderworks*.
+ *
+ * The cost is deliberate. A misheard or misspelt word ("sentral") no longer resolves, so the
+ * field is left empty for the rider to fill. An empty field is a problem they can see; a
+ * confident wrong one is a problem they find out about on a platform.
+ */
+private fun String.matchesOnTokenBoundaries(query: String): Boolean {
+    val candidateTokens = tokenise()
+    val queryTokens = query.tokenise()
+    if (queryTokens.isEmpty()) return false
+
+    return queryTokens.all { queryToken ->
+        candidateTokens.any { candidateToken ->
+            if (queryToken.length >= MIN_QUERY_TOKEN_LENGTH_TO_MATCH_AS_PREFIX) {
+                candidateToken.startsWith(queryToken)
+            } else {
+                // One and two letter tokens prefix far too much to be trusted as a prefix.
+                candidateToken == queryToken
+            }
+        }
+    }
+}
+
+private fun String.tokenise(): List<String> =
+    lowercase().split(' ', ',', '-', '/', '(', ')', '.', '\'').filter { it.isNotBlank() }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -156,6 +156,25 @@ class AiSearchInputViewModelTest {
     }
 
     @Test
+    fun `an unlabelled word does not become a stop that merely contains it`() =
+        runTest(testDispatcher) {
+            // Same sentence as the label test, on a phone with no "work" label. Rather than
+            // filling the destination with "70 Powderworks Rd", it resolves to nothing and
+            // leaves the field for the rider.
+            aiTextService.extractionResult = TripIntentExtraction(
+                originText = "Central Station",
+                destinationText = "work",
+                timeIntent = null,
+            )
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("let's go to work"))
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.resolved?.toStopItem)
+        }
+
+    @Test
     fun `one stop resolving is still a result - the other field is left for manual entry`() =
         runTest(testDispatcher) {
             aiTextService.extractionResult = TripIntentExtraction(

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolverTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolverTest.kt
@@ -71,6 +71,47 @@ class StopLabelTextResolverTest {
     }
 }
 
+class StopSearchTextResolverTest {
+
+    private val resolver = StopSearchTextResolver(FakeStopResultsManager())
+
+    @Test
+    fun `a query inside a longer word is not a match`() = runTest {
+        // The bug this exists for: the stop search offers "70 Powderworks Rd" for "work",
+        // which is a fine row to show a rider choosing from a list and a terrible thing to
+        // fill a field with on their behalf.
+        assertNull(resolver.resolve("work"))
+    }
+
+    @Test
+    fun `a whole word still matches`() = runTest {
+        assertEquals(
+            StopItem(stopId = "10101", stopName = "Central Station"),
+            resolver.resolve("Central Station"),
+        )
+    }
+
+    @Test
+    fun `a word start still matches`() = runTest {
+        // "central" prefixes "Central"; the rider does not have to say "Station".
+        assertEquals(
+            StopItem(stopId = "10101", stopName = "Central Station"),
+            resolver.resolve("central"),
+        )
+    }
+
+    @Test
+    fun `every query word has to land somewhere`() = runTest {
+        // "town" matches, "beach" does not, so the whole query does not.
+        assertNull(resolver.resolve("town beach"))
+    }
+
+    @Test
+    fun `nothing matching resolves to null`() = runTest {
+        assertNull(resolver.resolve("Nonexistent Place"))
+    }
+}
+
 class ChainedStopTextResolverTest {
 
     private val sandook = FakeSandook()

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeStopResultsManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeStopResultsManager.kt
@@ -29,6 +29,13 @@ class FakeStopResultsManager : StopResultsManager {
             stopName = "Town Hall",
             transportModeType = persistentListOf(NswTransportMode.Train)
         ),
+        // A real stop, kept because it is the one that made "work" resolve to a bus stop on
+        // the northern beaches: "work" appears inside "Powderworks".
+        SearchStopState.SearchResult.Stop(
+            stopId = "10104",
+            stopName = "70 Powderworks Rd",
+            transportModeType = persistentListOf(NswTransportMode.Bus)
+        ),
         SearchStopState.SearchResult.Stop(
             stopId = "10103",
             stopName = "Parramatta Station",


### PR DESCRIPTION
## What

<!-- One or two sentences: what this PR changes, in code terms. -->

## Changes

<!-- Bullet list of concrete changes. -->
<!-- Public repo: describe WHAT changed and technical WHY only. -->
<!-- No internal metrics, analytics numbers, or business/strategy context. -->

## Testing

<!-- Test tasks run, detekt status, compile targets verified. -->

## Snapshots

<!-- Required when UI is touched, otherwise delete this section. -->
<!-- Build snapshots and embed as a compact table. Use width-limited thumbnails -->
<!-- (width="220"), never full-size images. They bloat the PR description. -->

| Screen | Before | After |
|---|---|---|
| ScreenName | <img src="" width="220"> | <img src="" width="220"> |
