### PR TITLE
fix(trip-planner): with the feature off, there is no way in

### DIFF
--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -25,7 +25,7 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 
 | # | Failure | Rider sees | Test |
 |---|---|---|---|
-| 1 | Feature flag off | **Nothing at all.** Continue does nothing | `submit while flag is off does nothing` — the no-op is tested, the dead button is not fixed |
+| 1 | Feature flag off | **No way in.** The wheel is not drawn | `with the flag off there is no way in`, `with the flag on the way in is there and opens`, `starting over keeps the way in`, plus `submit while flag is off does nothing` |
 | 2 | Model not downloaded, or downloading | "still downloading… try again in a moment" | `model downloadable lands in DOWNLOADING`, `model downloading lands in DOWNLOADING too` |
 | 3 | Device unsupported | Generic unresolved message | `unsupported device lands in UNRESOLVED, not DOWNLOADING` — reads as a parse failure rather than "not available here" |
 | 4 | Model returns nothing usable | "did not come through, have another go" | `failed extraction resolves to UNRESOLVED`, `a model that gives nothing back is its own kind of failure` |
@@ -39,12 +39,18 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 | 12 | Time understood ("by 6pm") | **Dropped.** Parsed, then thrown away | `resolves a time intent into the confirm state` proves we parse it. Nothing covers it being lost, because it is lost outside this ViewModel |
 | 13 | Dismissed mid-flight | Mic stopped, draft discarded | `closing the box while listening stops the mic`, `closing the box throws the draft away` |
 
-Two of these are open defects rather than behaviour:
+One of these is still an open defect rather than behaviour:
 
-- **#1** is a dead button. The flag reaches the ViewModel but not the UI, so the entry point
-  shows and does nothing when the feature is off. It should hide the wheel instead.
-- **#12** is worse than not parsing at all: `navigateToTimeTable` has no date/time parameter, so
-  a rider who says "by 6pm" is understood and then ignored. Fixing it means a route parameter.
+- **#12** is worse than not parsing at all: `AiTripIntentTimeResolver` already produces a
+  complete `DateTimeSelectionItem`, and a rider who says "by 6pm" is understood and then
+  ignored. The gap is not really navigation. The date/time picker exists only on the timetable
+  screen, so there is nowhere on the search surface for a time to land, by any route, AI or
+  not. Fixing it properly means a when-chip the rider can see and change, and
+  `TimeTableRoute` carrying the selection through.
+
+**#1 is fixed.** The flag now reaches the state as `isFeatureEnabled`, the row does not draw
+the wheel without it, and `OpenInput` refuses as well as the button being absent — a caller
+that has not been told cannot open a sheet whose only action would be inert.
 
 ## Parked, deliberately
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -84,6 +84,7 @@ fun SearchStopRow(
     onCollapseRequest: (() -> Unit)? = null,
     onSearchButtonClick: () -> Unit = {},
     onAiEvent: (AiSearchInputEvent) -> Unit = {},
+    isAiSearchAvailable: Boolean = false,
 ) {
     val themeColorHex by LocalThemeColor.current
     val navBarPadding = with(LocalDensity.current) {
@@ -141,6 +142,7 @@ fun SearchStopRow(
                 onCollapseRequest = onCollapseRequest,
                 onSearchButtonClick = onSearchButtonClick,
                 onAiEvent = onAiEvent,
+                isAiSearchAvailable = isAiSearchAvailable,
             )
         } else {
             CollapsedPill(
@@ -239,6 +241,7 @@ private fun ExpandedSearchRow(
     modifier: Modifier = Modifier,
     onCollapseRequest: (() -> Unit)? = null,
     onAiEvent: (AiSearchInputEvent) -> Unit = {},
+    isAiSearchAvailable: Boolean = false,
 ) {
     val dim = KrailTheme.dimensions
 
@@ -297,7 +300,9 @@ private fun ExpandedSearchRow(
                     modifier = Modifier.padding(start = dim.spacingXL),
                     verticalArrangement = Arrangement.spacedBy(SearchFieldSpacing),
                 ) {
-                    AiSheetEntryButton(onAiEvent = onAiEvent)
+                    if (isAiSearchAvailable) {
+                        AiSheetEntryButton(onAiEvent = onAiEvent)
+                    }
 
                     SearchButton(onSearchButtonClick = onSearchButtonClick)
                 }
@@ -400,6 +405,10 @@ private fun StopFieldText(text: String, isActive: Boolean, slideUp: Boolean, lab
  * The way into the AI search sheet. Opening is all it does: the sheet owns speaking, typing
  * and every failure they can hit, so this button has one job and one look. It used to change
  * into a mic and back, which meant the row had to explain a mode it was not showing.
+ *
+ * Not rendered at all when the feature is off. It used to render regardless, because the flag
+ * stopped at the ViewModel — the sheet opened, the rider typed a sentence, and Continue did
+ * nothing.
  */
 @Composable
 private fun AiSheetEntryButton(onAiEvent: (AiSearchInputEvent) -> Unit) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -242,6 +242,7 @@ fun SavedTripsScreen(
                 toButtonClick = toButtonClick,
                 onSearchButtonClick = { onSearchButtonClick() },
                 onAiEvent = onAiEvent,
+                isAiSearchAvailable = aiState.isFeatureEnabled,
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -314,6 +314,7 @@ internal fun BoxScope.SavedTripsBottomSearchRow(
     onSearchButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
     onAiEvent: (AiSearchInputEvent) -> Unit = {},
+    isAiSearchAvailable: Boolean = false,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -334,6 +335,7 @@ internal fun BoxScope.SavedTripsBottomSearchRow(
             toButtonClick = toButtonClick,
             onSearchButtonClick = onSearchButtonClick,
             onAiEvent = onAiEvent,
+            isAiSearchAvailable = isAiSearchAvailable,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputUiState.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputUiState.kt
@@ -20,6 +20,10 @@ enum class UnresolvedReason { NO_PLACE_MENTIONED, STOP_NOT_FOUND, COULD_NOT_READ
  * rather than as `rememberSaveable` in the screen so that closing-on-resolve and the reset
  * that follows it happen in one state emission — a screen-local flag would race with
  * [AiSearchInputEvent.StartOver] and could leave an empty sheet open.
+ * @param isFeatureEnabled Whether the feature flag is on. The way in has to know this: the
+ * flag reached the ViewModel, which refused to submit, but never reached the UI, so with the
+ * feature off the wheel still rendered and did nothing when tapped. A button that does
+ * nothing is worse than no button.
  */
 data class AiSearchInputUiState(
     val typedText: String = "",
@@ -32,6 +36,7 @@ data class AiSearchInputUiState(
     val unresolvedReason: UnresolvedReason? = null,
     /** The place the rider named that no stop matched, quoted back to them. */
     val unmatchedPlace: String? = null,
+    val isFeatureEnabled: Boolean = false,
 )
 
 /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -80,6 +80,15 @@ class AiSearchInputViewModel(
     private val _uiState = MutableStateFlow(AiSearchInputUiState())
     val uiState: StateFlow<AiSearchInputUiState> = _uiState.asStateFlow()
 
+    init {
+        // Read here rather than through `stateIn(WhileSubscribed)`: this state is read
+        // directly as `uiState.value` in places with no active collector, and a shared flow
+        // would report its initial value to all of them. The ViewModel is built on screen
+        // entry, so this is re-read often enough, and [AiSearchInputEvent.OpenInput] reads it
+        // again at the moment it matters.
+        _uiState.update { it.copy(isFeatureEnabled = isAiSearchInputEnabled()) }
+    }
+
     private var listeningJob: Job? = null
     private var listeningTimeoutJob: Job? = null
 
@@ -103,10 +112,18 @@ class AiSearchInputViewModel(
 
             AiSearchInputEvent.SpeechUnsupported ->
                 _uiState.update { it.copy(isListening = false, speechUnavailableReason = MIC_UNSUPPORTED) }
-            AiSearchInputEvent.OpenInput -> _uiState.update { it.copy(isInputOpen = true) }
+            // Guarded as well as hidden. The button is gone when the feature is off, so this
+            // can only be reached by a caller that has not been told; opening a sheet whose
+            // only action is inert is the failure this is here to prevent.
+            AiSearchInputEvent.OpenInput -> _uiState.update {
+                it.copy(isInputOpen = isAiSearchInputEnabled(), isFeatureEnabled = isAiSearchInputEnabled())
+            }
             AiSearchInputEvent.CloseInput -> closeInput()
             AiSearchInputEvent.Submit -> submit()
-            AiSearchInputEvent.StartOver -> _uiState.update { AiSearchInputUiState() }
+            // Everything the rider produced is thrown away; what the app knows about itself
+            // is not, or starting over would hide the way back in.
+            AiSearchInputEvent.StartOver ->
+                _uiState.update { AiSearchInputUiState(isFeatureEnabled = it.isFeatureEnabled) }
             AiSearchInputEvent.StartListening -> startListening()
             AiSearchInputEvent.StopListening -> stopListening()
         }
@@ -128,7 +145,7 @@ class AiSearchInputViewModel(
         listeningTimeoutJob?.cancel()
         listeningTimeoutJob = null
         if (_uiState.value.isListening) speechToTextService.stopListening()
-        _uiState.update { AiSearchInputUiState() }
+        _uiState.update { AiSearchInputUiState(isFeatureEnabled = it.isFeatureEnabled) }
     }
 
     /**

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -87,6 +88,47 @@ class AiSearchInputViewModelTest {
         advanceUntilIdle()
 
         assertEquals(AiSearchInputPhase.IDLE, viewModel.uiState.value.phase)
+    }
+
+    @Test
+    fun `with the flag off there is no way in`() = runTest(testDispatcher) {
+        viewModel = AiSearchInputViewModel(
+            aiTextService = aiTextService,
+            speechToTextService = speechToTextService,
+            stopTextResolver = stopTextResolver,
+            nearbyStopsRepository = nearbyStopsRepository,
+            isAiSearchInputEnabled = { false },
+        )
+
+        // The state the row reads to decide whether to draw the button at all.
+        assertFalse(viewModel.uiState.value.isFeatureEnabled)
+
+        // And if something opens it anyway, it does not open. A sheet whose only action is
+        // inert is the defect this pair of guards exists for.
+        viewModel.onEvent(AiSearchInputEvent.OpenInput)
+        assertFalse(viewModel.uiState.value.isInputOpen)
+    }
+
+    @Test
+    fun `with the flag on the way in is there and opens`() = runTest(testDispatcher) {
+        assertTrue(viewModel.uiState.value.isFeatureEnabled)
+
+        viewModel.onEvent(AiSearchInputEvent.OpenInput)
+
+        assertTrue(viewModel.uiState.value.isInputOpen)
+    }
+
+    @Test
+    fun `starting over keeps the way in`() = runTest(testDispatcher) {
+        viewModel.onEvent(AiSearchInputEvent.OpenInput)
+        viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
+
+        viewModel.onEvent(AiSearchInputEvent.StartOver)
+
+        // The draft goes; what the app knows about itself does not, or the row would lose the
+        // button the moment a rider started again.
+        assertEquals("", viewModel.uiState.value.typedText)
+        assertTrue(viewModel.uiState.value.isFeatureEnabled)
     }
 
     @Test


### PR DESCRIPTION
## What

The AI search feature flag reached the ViewModel but not the UI. With the feature off, the wheel still rendered in the search row, still opened the sheet, and Continue did nothing. This makes the entry point disappear instead.

## Changes

- `AiSearchInputUiState` gains `isFeatureEnabled`, read from the existing flag lambda in the ViewModel's `init`.
- `SearchStopRow` takes `isAiSearchAvailable` and does not compose `AiSheetEntryButton` without it. Threaded through `SavedTripsBottomSearchRow` from `SavedTripsScreen`.
- `OpenInput` now refuses when the flag is off, so a caller that has not been told cannot open a sheet whose only action would be inert.
- `StartOver` and `closeInput` rebuild the state from scratch, so both carry the flag across. Without this, starting over would remove the button the rider had just used.
- `AI_SEARCH_UX.md` failure-mode row 1 updated; it was documented as a known dead button.

Read in `init` rather than via `stateIn(WhileSubscribed)`. This state is read as `uiState.value` in places with no active collector, and a shared flow would hand those callers its initial value instead. `OpenInput` re-reads the flag at the moment it matters, so a value that changes mid-session still removes the entry point.

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green, three new cases: no way in with the flag off (state false and `OpenInput` does not open), the way in is present and opens with the flag on, and starting over keeps it.
- `:composeApp:testAndroidHostTest` green.
- `detekt --continue` green.

## Snapshots

No snapshot change: with the flag on, which is what the screenshot tests render, the row is identical. The change is the absence of a button in the flag-off case, which has no baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
