### PR TITLE
feat(trip-planner): carry a chosen departure time through to the timetable

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripUiEvent.kt
@@ -36,6 +36,12 @@ sealed interface SavedTripUiEvent {
     data class FromStopChanged(val fromJson: String) : SavedTripUiEvent
     data class ToStopChanged(val toJson: String) : SavedTripUiEvent
 
+    /**
+     * A departure or arrival time understood before a timetable was opened. `null` clears it
+     * back to now, which is what starting a fresh search means.
+     */
+    data class DateTimeSelectionChanged(val dateTimeJson: String?) : SavedTripUiEvent
+
     data object StopTracking : SavedTripUiEvent
 
     data class MoveSavedTripToIndex(val tripId: String, val targetIndex: Int) : SavedTripUiEvent

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/savedtrip/SavedTripsState.kt
@@ -6,6 +6,7 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import xyz.ksharma.krail.info.tile.state.InfoTileData
+import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 
@@ -21,6 +22,12 @@ data class SavedTripsState(
     // Stop selection state managed by ViewModel
     val fromStop: StopItem? = null,
     val toStop: StopItem? = null,
+    /**
+     * A departure or arrival time chosen before any timetable was opened. Only the AI search
+     * sheet sets this today: it is the one surface that can hear "by 6pm" while the rider is
+     * still choosing stops. Null means now, which is what pressing Search has always meant.
+     */
+    val dateTimeSelectionItem: DateTimeSelectionItem? = null,
     val hasSeenInviteFriendsTile: Boolean = false,
     val stopLabels: ImmutableList<StopLabel> = persistentListOf(),
     // Default true so the tip is hidden until the preference is loaded from DB.

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -36,21 +36,37 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 | 9 | Origin unstated, destination found, GPS off or denied | From left empty | `nearby-stop resolver failure leaves origin unresolved, not a crash` |
 | 10 | Microphone denied, blocked, unsupported, or the recogniser errors | A different message for each; a blocked mic opens Settings | `speech unavailable surfaces the reason`, `a recogniser error is reported as itself` |
 | 11 | Recogniser never reports an end | Stops itself at 20s | `listening stops itself once it hits the ceiling` |
-| 12 | Time understood ("by 6pm") | **Dropped.** Parsed, then thrown away | `resolves a time intent into the confirm state` proves we parse it. Nothing covers it being lost, because it is lost outside this ViewModel |
+| 12 | Time understood ("by 6pm") | Shown on the search row, and the timetable opens with it | `resolves a time intent into the confirm state`, plus three in `TimeTableViewModelTest` covering the route carrying it, no time meaning now, and unreadable JSON falling back to now |
 | 13 | Dismissed mid-flight | Mic stopped, draft discarded | `closing the box while listening stops the mic`, `closing the box throws the draft away` |
 
-One of these is still an open defect rather than behaviour:
+Both of the open defects recorded here are now fixed.
 
-- **#12** is worse than not parsing at all: `AiTripIntentTimeResolver` already produces a
-  complete `DateTimeSelectionItem`, and a rider who says "by 6pm" is understood and then
-  ignored. The gap is not really navigation. The date/time picker exists only on the timetable
-  screen, so there is nowhere on the search surface for a time to land, by any route, AI or
-  not. Fixing it properly means a when-chip the rider can see and change, and
-  `TimeTableRoute` carrying the selection through.
+**#1.** The flag now reaches the state as `isFeatureEnabled`, the row does not draw the wheel
+without it, and `OpenInput` refuses as well as the button being absent — a caller that has not
+been told cannot open a sheet whose only action would be inert.
 
-**#1 is fixed.** The flag now reaches the state as `isFeatureEnabled`, the row does not draw
-the wheel without it, and `OpenInput` refuses as well as the button being absent — a caller
-that has not been told cannot open a sheet whose only action would be inert.
+**#12.** The parse was never the problem: `AiTripIntentTimeResolver` has always produced a
+complete `DateTimeSelectionItem`. There was nowhere to put it. The date/time picker existed
+only on the timetable, so a time understood while the rider was still choosing stops had no
+home, by any route, AI or not. It now lands in `SavedTripsState`, shows on the search row as a
+chip built from the same `SubtleButton` and the same `toDateTimeText()` the timetable uses, and
+travels to the timetable on `TimeTableRoute`.
+
+On the route rather than handed over after navigation, for two reasons. The back stack is
+serialised, so a rider whose app is killed in the background comes back to the time they chose
+instead of to now. And `TimeTableViewModel.dateTimeSelectionItem` is a plain `var` outside
+`uiState`, which survives rotation but not process death — the route is what makes it durable
+without moving that field.
+
+### Still to do on the time path
+
+- The chip clears on tap. It should open the existing date/time picker, which wants
+  `DateTimeSelectorRoute` reachable from the home screen.
+- The grammar reads clock times and relative minutes only. Days ("tomorrow", "tonight",
+  "Friday") are pure date arithmetic on a well-tested seam and are the obvious next addition.
+- Vague day-parts stay unresolved on purpose. "morning = 9am" is invented precision. If they
+  are ever handled, the phrase should reach the chip unresolved and open the picker at roughly
+  that time, so the rider supplies the precision and the app only supplies the shortcut.
 
 ## Parked, deliberately
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -59,6 +59,7 @@ import xyz.ksharma.krail.taj.components.AiWheelMark
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
+import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextFieldButton
 import xyz.ksharma.krail.taj.components.ThemeTextFieldPlaceholderText
@@ -85,6 +86,8 @@ fun SearchStopRow(
     onSearchButtonClick: () -> Unit = {},
     onAiEvent: (AiSearchInputEvent) -> Unit = {},
     isAiSearchAvailable: Boolean = false,
+    dateTimeSelectionText: String? = null,
+    onDateTimeSelectionClear: () -> Unit = {},
 ) {
     val themeColorHex by LocalThemeColor.current
     val navBarPadding = with(LocalDensity.current) {
@@ -143,6 +146,8 @@ fun SearchStopRow(
                 onSearchButtonClick = onSearchButtonClick,
                 onAiEvent = onAiEvent,
                 isAiSearchAvailable = isAiSearchAvailable,
+                dateTimeSelectionText = dateTimeSelectionText,
+                onDateTimeSelectionClear = onDateTimeSelectionClear,
             )
         } else {
             CollapsedPill(
@@ -242,6 +247,8 @@ private fun ExpandedSearchRow(
     onCollapseRequest: (() -> Unit)? = null,
     onAiEvent: (AiSearchInputEvent) -> Unit = {},
     isAiSearchAvailable: Boolean = false,
+    dateTimeSelectionText: String? = null,
+    onDateTimeSelectionClear: () -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
 
@@ -266,6 +273,13 @@ private fun ExpandedSearchRow(
         ) {
             if (onCollapseRequest != null) {
                 CollapseHandle(onClick = onCollapseRequest)
+            }
+
+            // Only drawn when something set a time, which today only the AI sheet can do.
+            // It has to be visible before Search is pressed: a time held in state that the
+            // rider cannot see would quietly change what the button does.
+            if (dateTimeSelectionText != null) {
+                WhenChip(text = dateTimeSelectionText, onClear = onDateTimeSelectionClear)
             }
 
             val navBarPaddingDp = with(LocalDensity.current) { navBarPadding.dp }
@@ -398,6 +412,31 @@ private fun StopFieldText(text: String, isActive: Boolean, slideUp: Boolean, lab
         label = label,
     ) { targetText ->
         ThemeTextFieldPlaceholderText(text = targetText, isActive = isActive)
+    }
+}
+
+/**
+ * The departure or arrival time the search will run with, when one was understood before any
+ * timetable existed. Deliberately the same `SubtleButton` and the same `toDateTimeText()`
+ * wording the timetable's own time button uses, so the rider meets one control twice rather
+ * than two controls that happen to agree.
+ *
+ * Tapping clears it back to now. Opening the picker from here is the next step and wants the
+ * selector route to be reachable from this screen first.
+ */
+@Composable
+private fun WhenChip(text: String, onClear: () -> Unit) {
+    val dim = KrailTheme.dimensions
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = dim.pageHorizontalPadding)
+            .padding(top = dim.spacingM),
+    ) {
+        SubtleButton(onClick = onClear, dimensions = ButtonDefaults.mediumButtonSize()) {
+            Text(text = text)
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
@@ -17,7 +17,19 @@ interface TripPlannerNavigator {
         labelKey: String? = null,
         editTripLeg: Boolean = false,
     )
-    fun navigateToTimeTable(fromStopId: String, fromStopName: String, toStopId: String, toStopName: String)
+
+    /**
+     * @param dateTimeSelectionJson A serialised
+     * [xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem] when a
+     * departure or arrival time was chosen before the timetable opened. Null means now.
+     */
+    fun navigateToTimeTable(
+        fromStopId: String,
+        fromStopName: String,
+        toStopId: String,
+        toStopName: String,
+        dateTimeSelectionJson: String? = null,
+    )
     fun navigateToJourneyMap(journeyId: String)
     fun navigateToSettings()
     fun navigateToDiscover()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
@@ -39,6 +39,7 @@ internal class TripPlannerNavigatorImpl(
         fromStopName: String,
         toStopId: String,
         toStopName: String,
+        dateTimeSelectionJson: String?,
     ) {
         baseNavigator.pushSingleInstance(
             TimeTableRoute(
@@ -46,6 +47,7 @@ internal class TripPlannerNavigatorImpl(
                 fromStopName = fromStopName,
                 toStopId = toStopId,
                 toStopName = toStopName,
+                dateTimeSelectionJson = dateTimeSelectionJson,
             ),
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
@@ -45,6 +45,17 @@ data class TimeTableRoute(
     val fromStopName: String,
     val toStopId: String,
     val toStopName: String,
+    /**
+     * A [xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem] as
+     * JSON, when the rider chose a departure or arrival time before the timetable was opened.
+     * Null means "now", which is what every existing caller passes and what the timetable has
+     * always defaulted to.
+     *
+     * On the route rather than handed over after navigation, because the back stack is
+     * serialised: a rider who chose "arrive 6pm" and then had the app killed in the background
+     * comes back to 6pm rather than to now.
+     */
+    val dateTimeSelectionJson: String? = null,
 ) : TripPlannerRoute
 
 /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -76,6 +76,15 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
                 resolved.toStopItem?.let {
                     viewModel.onEvent(SavedTripUiEvent.ToStopChanged(it.toJsonString()))
                 }
+                // "by 6pm" used to be understood and then dropped on the floor here. It is
+                // held with the two stops and travels with them when the rider presses
+                // Search. Sent even when null, so a fresh sentence with no time in it clears
+                // a time left over from the previous one.
+                viewModel.onEvent(
+                    SavedTripUiEvent.DateTimeSelectionChanged(
+                        resolved.dateTimeSelectionItem?.toJsonString(),
+                    ),
+                )
                 // The AI screen is still up at this point, with its border decelerating. It
                 // closes a beat later so that ending is seen rather than cut off; the fields
                 // behind it are already written, so the row is correct the moment it goes.
@@ -139,6 +148,7 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
                     toStop = savedTripState.toStop,
                     viewModel = viewModel,
                     tripPlannerNavigator = tripPlannerNavigator,
+                    dateTimeSelectionJson = savedTripState.dateTimeSelectionItem?.toJsonString(),
                 )
             },
             aiState = aiSearchInputState,
@@ -170,6 +180,7 @@ private fun triggerTripSearch(
     toStop: StopItem?,
     viewModel: SavedTripsViewModel,
     tripPlannerNavigator: TripPlannerNavigator,
+    dateTimeSelectionJson: String? = null,
 ) {
     if (fromStop != null && toStop != null && fromStop.stopId != toStop.stopId) {
         viewModel.onEvent(
@@ -183,6 +194,7 @@ private fun triggerTripSearch(
             fromStopName = fromStop.stopName,
             toStopId = toStop.stopId,
             toStopName = toStop.stopName,
+            dateTimeSelectionJson = dateTimeSelectionJson,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -133,6 +133,12 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                 toStopId = key.toStopId,
                 toStopName = key.toStopName,
                 forceReload = !hasInitializedTrip,
+                // Passed every time and filtered inside the ViewModel, which is the only
+                // place that knows whether it still holds a selection of its own. Gating it
+                // on `hasInitializedTrip` here would look right and be wrong: that flag is
+                // rememberSaveable, so after process death it restores as true while the
+                // ViewModel it is meant to describe has been rebuilt from nothing.
+                dateTimeSelectionJson = key.dateTimeSelectionJson,
             )
             hasInitializedTrip = true
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/TimeTableEntry.kt
@@ -101,17 +101,17 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
             mutableStateOf(persistentSetOf())
         }
 
-        // State for date/time selection - survives rotation but clears when trip changes
+        // State for date/time selection - survives rotation but clears when trip changes.
+        //
+        // Seeded from the route, because this is what the screen displays and what it pushes
+        // into the ViewModel. Seeding only the ViewModel left the two disagreeing: the trip
+        // loaded at the right time and the button still read "Plan your trip", until the sync
+        // below pushed this null back over it and the timetable reloaded at now.
         var dateTimeSelectionItem by rememberSaveable(
             tripId,
             stateSaver = dateTimeSelectionSaver(),
         ) {
-            mutableStateOf<DateTimeSelectionItem?>(null)
-        }
-
-        // Sync date/time selection with ViewModel on first composition
-        LaunchedEffect(Unit) {
-            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(dateTimeSelectionItem))
+            mutableStateOf(key.dateTimeSelectionJson?.let(DateTimeSelectionItem::fromJsonString))
         }
 
         // False only on the FIRST composition of a freshly pushed nav entry;
@@ -141,6 +141,15 @@ internal fun EntryProviderScope<NavKey>.TimeTableEntry(
                 dateTimeSelectionJson = key.dateTimeSelectionJson,
             )
             hasInitializedTrip = true
+        }
+
+        // Runs after the trip is initialised, not before it. This state is the one the screen
+        // shows, so it has the final say; the ViewModel has just been given the route's value
+        // and on a fresh navigation the two already agree, making this a no-op. It earns its
+        // place after process death, where this restores the time the rider actually chose
+        // while the route still carries the one they arrived with.
+        LaunchedEffect(Unit) {
+            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(dateTimeSelectionItem))
         }
 
         // Stop picked from the leg-scoped search opened via the timetable header

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -243,6 +243,8 @@ fun SavedTripsScreen(
                 onSearchButtonClick = { onSearchButtonClick() },
                 onAiEvent = onAiEvent,
                 isAiSearchAvailable = aiState.isFeatureEnabled,
+                dateTimeSelectionText = savedTripsState.dateTimeSelectionItem?.toDateTimeText(),
+                onDateTimeSelectionClear = { onEvent(SavedTripUiEvent.DateTimeSelectionChanged(null)) },
                 modifier = Modifier.align(Alignment.BottomCenter),
             )
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -315,6 +315,8 @@ internal fun BoxScope.SavedTripsBottomSearchRow(
     modifier: Modifier = Modifier,
     onAiEvent: (AiSearchInputEvent) -> Unit = {},
     isAiSearchAvailable: Boolean = false,
+    dateTimeSelectionText: String? = null,
+    onDateTimeSelectionClear: () -> Unit = {},
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -336,6 +338,8 @@ internal fun BoxScope.SavedTripsBottomSearchRow(
             onSearchButtonClick = onSearchButtonClick,
             onAiEvent = onAiEvent,
             isAiSearchAvailable = isAiSearchAvailable,
+            dateTimeSelectionText = dateTimeSelectionText,
+            onDateTimeSelectionClear = onDateTimeSelectionClear,
         )
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -55,6 +55,7 @@ import xyz.ksharma.krail.sandook.SavedTrip
 import xyz.ksharma.krail.trip.planner.ui.searchstop.SearchSessionStore
 import xyz.ksharma.krail.trip.planner.ui.searchstop.StopResultsManager
 import xyz.ksharma.krail.trip.planner.ui.settings.ReferFriendManager.getReferText
+import xyz.ksharma.krail.trip.planner.ui.state.datetimeselector.DateTimeSelectionItem
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
@@ -187,6 +188,9 @@ class SavedTripsViewModel(
             is SavedTripUiEvent.InfoTileExpand -> onInfoTileExpand(key = event.key)
             is SavedTripUiEvent.FromStopChanged -> onFromStopChanged(event.fromJson)
             is SavedTripUiEvent.ToStopChanged -> onToStopChanged(event.toJson)
+            is SavedTripUiEvent.DateTimeSelectionChanged -> updateUiState {
+                copy(dateTimeSelectionItem = event.dateTimeJson?.let(DateTimeSelectionItem::fromJsonString))
+            }
             SavedTripUiEvent.StopTracking -> trackingManager.stop()
             is SavedTripUiEvent.MoveSavedTripToIndex -> onMoveSavedTrip(event.tripId, event.targetIndex)
             SavedTripUiEvent.MarkReorderTipSeen -> onMarkReorderTipSeen()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -225,6 +225,7 @@ class TimeTableViewModel(
         toStopId: String,
         toStopName: String,
         forceReload: Boolean = false,
+        dateTimeSelectionJson: String? = null,
     ) {
         val currentRoute = Pair(fromStopId, toStopId)
         // Check if this is the EXACT SAME route we just initialized.
@@ -260,7 +261,11 @@ class TimeTableViewModel(
         // Call LoadTimeTable - it will handle logic:
         // - If trip changed: Clear date/time, clear cache, fetch from API
         // - If same trip (rotation/nav back): Preserve state, skip API call
-        onLoadTimeTable(trip)
+        //
+        // The route's own selection is handed to it rather than applied afterwards. Applying
+        // it after would mean two fetches: one for "now" and one for the time the rider
+        // actually asked for, with the wrong one able to land second.
+        onLoadTimeTable(trip, dateTimeSelection = dateTimeSelectionJson?.let(DateTimeSelectionItem::fromJsonString))
     }
 
     fun onEvent(event: TimeTableUiEvent) {
@@ -1040,7 +1045,12 @@ class TimeTableViewModel(
         }
     }
 
-    private fun onLoadTimeTable(trip: Trip) {
+    /**
+     * @param dateTimeSelection Applied instead of the usual clear when this is a different
+     * trip. Null, which every caller but [initializeTrip] passes, keeps the old behaviour of
+     * a new trip starting at "now".
+     */
+    private fun onLoadTimeTable(trip: Trip, dateTimeSelection: DateTimeSelectionItem? = null) {
         log("🗺️ onLoadTimeTable -- fromStopId: ${trip.fromStopId}, toStopId: ${trip.toStopId}")
 
         // Check if this is the same trip or a different one
@@ -1062,7 +1072,7 @@ class TimeTableViewModel(
         if (!isSameTrip) {
             // Different trip - clear state and fetch new data
             log("🗺️ onLoadTimeTable -- Different trip, clearing cache and fetching")
-            dateTimeSelectionItem = null
+            dateTimeSelectionItem = dateTimeSelection
             journeys.clear()
             resetPaginationCaches()
             rawJourneyDataByJourneyId.clear()

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -951,6 +951,61 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN a time chosen before the timetable opened WHEN the trip is initialized THEN it is used`() =
+        runTest {
+            tripPlanningService.isSuccess = true
+            val chosen = DateTimeSelectionItem(
+                option = JourneyTimeOptions.ARRIVE,
+                hour = 18,
+                minute = 0,
+                date = Clock.System.now().toLocalDateTime(currentSystemDefault()).date,
+            )
+
+            viewModel.initializeTrip(
+                fromStopId = "stop_a",
+                fromStopName = "Stop A",
+                toStopId = "stop_b",
+                toStopName = "Stop B",
+                dateTimeSelectionJson = chosen.toJsonString(),
+            )
+            advanceUntilIdle()
+
+            // A new trip normally clears the selection back to now. The route's own value has
+            // to survive that clear, or "by 6pm" is understood and then thrown away.
+            assertEquals(chosen, viewModel.dateTimeSelectionItem)
+        }
+
+    @Test
+    fun `GIVEN no time on the route WHEN the trip is initialized THEN the timetable still starts at now`() =
+        runTest {
+            tripPlanningService.isSuccess = true
+
+            viewModel.initializeTrip("stop_a", "Stop A", "stop_b", "Stop B")
+            advanceUntilIdle()
+
+            assertNull(viewModel.dateTimeSelectionItem)
+        }
+
+    @Test
+    fun `GIVEN unreadable time json WHEN the trip is initialized THEN it falls back to now`() =
+        runTest {
+            tripPlanningService.isSuccess = true
+
+            viewModel.initializeTrip(
+                fromStopId = "stop_a",
+                fromStopName = "Stop A",
+                toStopId = "stop_b",
+                toStopName = "Stop B",
+                dateTimeSelectionJson = "not json",
+            )
+            advanceUntilIdle()
+
+            // A route serialised by an older build, or corrupted in the saved back stack,
+            // must not take the timetable down with it.
+            assertNull(viewModel.dateTimeSelectionItem)
+        }
+
+    @Test
     fun `GIVEN initialized route WHEN initializeTrip called with different route THEN new trip is loaded`() =
         runTest {
             tripPlanningService.isSuccess = true

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -987,6 +987,68 @@ class TimeTableViewModelTest {
         }
 
     @Test
+    fun `GIVEN a seeded time WHEN the same selection is sent again THEN nothing reloads`() =
+        runTest {
+            tripPlanningService.isSuccess = true
+            val chosen = DateTimeSelectionItem(
+                option = JourneyTimeOptions.ARRIVE,
+                hour = 9,
+                minute = 0,
+                date = Clock.System.now().toLocalDateTime(currentSystemDefault()).date,
+            )
+
+            viewModel.initializeTrip(
+                fromStopId = "stop_a",
+                fromStopName = "Stop A",
+                toStopId = "stop_b",
+                toStopName = "Stop B",
+                dateTimeSelectionJson = chosen.toJsonString(),
+            )
+            advanceUntilIdle()
+            val triggersAfterLoad = rateLimiter.triggerCount
+
+            // The screen syncs its own copy of the selection to here after the trip loads.
+            // On a fresh navigation the two already agree, and that has to cost nothing:
+            // if it reloaded, every AI-planned trip would fetch twice.
+            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(chosen))
+            advanceUntilIdle()
+
+            assertEquals(chosen, viewModel.dateTimeSelectionItem)
+            assertEquals(triggersAfterLoad, rateLimiter.triggerCount)
+        }
+
+    @Test
+    fun `GIVEN a seeded time WHEN null is sent afterwards THEN the time is lost`() =
+        runTest {
+            tripPlanningService.isSuccess = true
+            val chosen = DateTimeSelectionItem(
+                option = JourneyTimeOptions.ARRIVE,
+                hour = 9,
+                minute = 0,
+                date = Clock.System.now().toLocalDateTime(currentSystemDefault()).date,
+            )
+
+            viewModel.initializeTrip(
+                fromStopId = "stop_a",
+                fromStopName = "Stop A",
+                toStopId = "stop_b",
+                toStopName = "Stop B",
+                dateTimeSelectionJson = chosen.toJsonString(),
+            )
+            advanceUntilIdle()
+
+            viewModel.onEvent(TimeTableUiEvent.DateTimeSelectionChanged(null))
+            advanceUntilIdle()
+
+            // Last writer wins, by design: the screen owns the selection and must be able to
+            // clear it. This test exists to pin the consequence, which is that anything
+            // syncing a null into here AFTER the trip is seeded silently throws the rider's
+            // time away and reloads at now. TimeTableEntry sends its sync after
+            // initializeTrip for exactly this reason; sending it before was the defect.
+            assertNull(viewModel.dateTimeSelectionItem)
+        }
+
+    @Test
     fun `GIVEN unreadable time json WHEN the trip is initialized THEN it falls back to now`() =
         runTest {
             tripPlanningService.isSuccess = true


### PR DESCRIPTION
Stacked on #1847.

## What

A departure or arrival time understood by the AI search sheet ("by 6pm") was parsed into a complete `DateTimeSelectionItem` and then discarded. It now shows on the search row and opens the timetable with it.

The parse was never missing. `AiTripIntentTimeResolver` has always returned a full selection. There was nowhere to put it: the date/time picker exists only on the timetable screen, so a time chosen while the rider is still picking stops had no home, by any route, AI or not.

## Changes

- `SavedTripsState` gains `dateTimeSelectionItem`, set by a new `SavedTripUiEvent.DateTimeSelectionChanged`. The AI resolve effect sends it, including when null, so a fresh sentence with no time clears one left over from the previous.
- `SearchStopRow` draws a chip when a time is set, using the same `SubtleButton` and the same `toDateTimeText()` as the timetable's own time button. Tapping clears it.
- `TimeTableRoute` and `navigateToTimeTable` gain `dateTimeSelectionJson`; `triggerTripSearch` passes it.
- `TimeTableViewModel.initializeTrip` takes the JSON and hands the decoded value to `onLoadTimeTable`, which assigns it in the different-trip branch instead of clearing to null. Every existing caller passes null and keeps today's behaviour exactly.

On the route rather than handed over after navigating, for two reasons. The back stack is serialised, so an app killed in the background comes back to the chosen time rather than to now. And `TimeTableViewModel.dateTimeSelectionItem` is a plain `var` outside `uiState`, which survives rotation but not process death; the route makes it durable without moving that field.

`onLoadTimeTable` takes the selection rather than having it applied after. Applying after would mean two fetches, one for now and one for the time asked for, with the wrong one able to land second.

`TimeTableEntry` passes the route value on every initialise and lets the ViewModel decide. Gating on `hasInitializedTrip` would look right and be wrong: it is `rememberSaveable`, so after process death it restores as true while describing a ViewModel rebuilt from nothing.

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green, three new cases: a time on the route survives the new-trip clear, no time still starts at now, and unreadable JSON falls back to now rather than failing (a route serialised by an older build must not take the timetable down).
- `:composeApp:testAndroidHostTest` green, including `NavKeySerializationConfigTest`. The new route field is a nullable `String`, so no `SerializersModule` change was needed.
- `./scripts/fullQualityChecks.sh` green: Android compile, iOS simulator compile, detekt.
- `AI_SEARCH_UX.md` failure mode 12 updated, and the remaining work on this path recorded there (chip should open the picker; day grammar; why vague day-parts stay unresolved).

## Snapshots

Not captured. The chip only renders when a time is set, which no screenshot-tested state produces yet, and the row is unchanged without one.

Device QA not yet run: no device was connected. Rotation and process-death behaviour on this path are argued from the code above, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
