### PR TITLE
feat(trip-planner): understand named days like tomorrow and friday

### DIFF
--- a/core/ai-text/src/androidMain/kotlin/xyz/ksharma/krail/core/aitext/AndroidAiTextService.kt
+++ b/core/ai-text/src/androidMain/kotlin/xyz/ksharma/krail/core/aitext/AndroidAiTextService.kt
@@ -168,7 +168,9 @@ private fun buildExtractionPrompt(riderText: String): String = """
       false for "leave at" / "leaving around" / "departing at". timeIntent is null if the
       rider gave no time at all.
     - timeIntent.timeText is the time phrase verbatim as the rider said it (e.g. "9am",
-      "6:30pm") — do not convert or resolve it.
+      "6:30pm") — do not convert or resolve it. Include any day word said with it
+      ("tomorrow at 9am", "friday 6pm", "tonight at 7"), because the day is part of when
+      they are travelling and is resolved later from this same string.
     - modeHints lists any transport mode words mentioned (e.g. "train", "bus"), verbatim,
       lowercase. Empty array if none mentioned.
     - If the rider names only ONE place, decide which field it belongs in from the
@@ -182,6 +184,7 @@ private fun buildExtractionPrompt(riderText: String): String = """
     Examples:
     "let's go home" -> {"originText": null, "destinationText": "home", "timeIntent": null, "modeHints": []}
     "leaving home around 9" -> {"originText": "home", "destinationText": null, "timeIntent": {"isArrival": false, "timeText": "around 9"}, "modeHints": []}
+    "town hall to bondi junction by 6pm friday" -> {"originText": "town hall", "destinationText": "bondi junction", "timeIntent": {"isArrival": true, "timeText": "6pm friday"}, "modeHints": []}
 
     Rider's message: "$riderText"
 

--- a/core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift
+++ b/core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift
@@ -66,7 +66,9 @@ import FoundationModels
                 is true for "arrive by"/"need to be there by", false for "leave at"/ \
                 "leaving around" - omit the whole time field if the rider gave no time. \
                 timeText is the time phrase verbatim (e.g. "9am", "6:30pm"), never \
-                resolved. modeHints lists any transport mode words mentioned, verbatim, \
+                resolved, and includes any day word said with it ("tomorrow at 9am", \
+                "friday 6pm") because the day is resolved later from this same string. \
+                modeHints lists any transport mode words mentioned, verbatim, \
                 lowercase. Never invent a field the rider didn't actually say. If the \
                 rider names only one place, decide from the phrasing: "go home", "take \
                 me to X" and "heading to X" mean X is the destination and origin is \

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -35,7 +35,7 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 | 8 | Only one end resolves | That field fills, the other is left | `one stop resolving is still a result` |
 | 9 | Origin unstated, destination found, GPS off or denied | From left empty | `nearby-stop resolver failure leaves origin unresolved, not a crash` |
 | 10 | Microphone denied, blocked, unsupported, or the recogniser errors | A different message for each; a blocked mic opens Settings | `speech unavailable surfaces the reason`, `a recogniser error is reported as itself` |
-| 11 | Recogniser never reports an end | Stops itself at 20s | `listening stops itself once it hits the ceiling` |
+| 11 | Recogniser never reports an end | Stops itself at 10s, or 15s if words were still arriving | `listening stops itself once it hits the ceiling`, `a rider still speaking at the ceiling is given longer`, `words that stopped before the ceiling do not earn the extension` |
 | 12 | Time understood ("by 6pm") | Shown on the search row, and the timetable opens with it | `resolves a time intent into the confirm state`, plus three in `TimeTableViewModelTest` covering the route carrying it, no time meaning now, and unreadable JSON falling back to now |
 | 13 | Dismissed mid-flight | Mic stopped, draft discarded | `closing the box while listening stops the mic`, `closing the box throws the draft away` |
 
@@ -66,8 +66,14 @@ actually write ("fri", "tues"). A named day beats the next-occurrence rollover, 
 rider who said Friday meant Friday and guessing past their own word overrules them. Day
 matching is on word boundaries so "sun" is not read out of "sunset".
 
-Both platform prompts are told to keep the day word in `timeText`, since the day is resolved
-later from that same string. Dropping it there loses the day silently.
+Both platform prompts are told to keep the day word in `timeText`. They do not always: "10am
+Monday work" came back with Monday swallowed into the place, leaving "10am", which had already
+passed and rolled to tomorrow. So the day is looked for in the **rider's whole sentence** as
+well, and the prompt is now an optimisation rather than the thing correctness rests on. The
+extracted phrase still wins when both name a day, being the more precise signal.
+
+The general lesson: anything a prompt is asked to preserve should have a deterministic path
+that does not need the prompt to have worked.
 
 ### Still to do on the time path
 

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -58,21 +58,54 @@ instead of to now. And `TimeTableViewModel.dateTimeSelectionItem` is a plain `va
 `uiState`, which survives rotation but not process death — the route is what makes it durable
 without moving that field.
 
+### What the time grammar reads
+
+Clock times ("9am", "6:30pm"), relative offsets ("in 20 minutes", "in 2 hours"), and named
+days: "today", "tonight", "tomorrow", and weekday names including the short forms riders
+actually write ("fri", "tues"). A named day beats the next-occurrence rollover, because a
+rider who said Friday meant Friday and guessing past their own word overrules them. Day
+matching is on word boundaries so "sun" is not read out of "sunset".
+
+Both platform prompts are told to keep the day word in `timeText`, since the day is resolved
+later from that same string. Dropping it there loses the day silently.
+
 ### Still to do on the time path
 
 - The chip clears on tap. It should open the existing date/time picker, which wants
   `DateTimeSelectorRoute` reachable from the home screen.
-- The grammar reads clock times and relative minutes only. Days ("tomorrow", "tonight",
-  "Friday") are pure date arithmetic on a well-tested seam and are the obvious next addition.
+- A day on its own still resolves to nothing. A date with no time is not a departure, and
+  picking an hour for it would be a guess.
 - Vague day-parts stay unresolved on purpose. "morning = 9am" is invented precision. If they
   are ever handled, the phrase should reach the chip unresolved and open the picker at roughly
   that time, so the rider supplies the precision and the app only supplies the shortcut.
 
 ## Parked, deliberately
 
-**Offer a choice when confidence is low.** #7 is the only failure with no visible failure, and
-the honest answer to a weak match is to ask rather than commit: two or three candidates with
-the reason each was suggested (your label, a saved trip, a name that looks similar), and no
-auto-fill below the bar. `FuzzyStopRanker` already computes the score this needs and discards
-it at the interface boundary, so the groundwork is a scored result type rather than new
-matching. Not being built today; this note is the record of why it should be.
+**Offer a choice when confidence is low.** For a match that is not clearly right, ask rather
+than commit: two or three candidates with the reason each was suggested (your label, a saved
+trip, a name that looks similar).
+
+This note used to say the groundwork was exposing `FuzzyStopRanker`'s score, which it computes
+and discards at the resolver boundary. **That was wrong**, and it is written down here so the
+same reasoning does not produce the same plan again:
+
+1. **The score is not the boundary.** `RealStopResultsManager` returns exact SQL matches first
+   and only falls back to the fuzzy ranker when there are few of them. The results this path
+   picks from are usually not scored at all, so there is no score to expose for them.
+2. **The score does not encode the safety property.** `StopSearchTextResolver`'s word-boundary
+   guard is not a duplicate of the ranker. The ranker scores "work" against *70 Powderworks Rd*
+   at ~1.0, through the longest-common-substring signal it uses on purpose so a rider reading a
+   list gets loose suggestions. Replacing the guard with a score threshold reintroduces exactly
+   the bug the guard exists for.
+3. **The score does not encode priority.** For "central", *Central Station* and *Central Ave*
+   score identically. What puts the station first is `prioritiseByRelevance`, which knows about
+   major interchanges. Picking by score would be worse than picking by the order the manager
+   already returns.
+
+So the ranker's score is not the missing piece, and the guard should stay. A real version of
+this needs a genuine ambiguity signal, and the ordering the manager already produces is a
+better starting point than any number the ranker computes.
+
+Worth noting the failure is also milder than "silent": the sheet writes into the visible From
+and To fields and stops there, so a rider sees the wrong stop before pressing Search. Loading
+the timetable was deliberately left as their action.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -23,14 +23,20 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 private const val NEARBY_STOP_RADIUS_KM = 1.0
 
-// Hard ceiling on one listening session. Ending it is normally the recogniser's call: it stops
-// when the rider stops talking, with the silence windows widened on the Android side so a
-// thinking pause mid sentence does not count as finished. Those windows are hints an OEM
-// recogniser may ignore, and a recogniser that never reports an end leaves a live microphone and
-// a running waveform on screen with no way out but backing off the sheet. Twenty seconds is far
-// longer than anyone takes to say where they are going, so hitting this is a fault rather than a
-// rider being slow.
-private const val MAX_LISTENING_MILLIS = 20_000L
+// Ceiling on one listening session. The rider's stop button is the real control; ending it
+// otherwise is normally the recogniser's call, since it stops when they stop talking, with the
+// silence windows widened on the Android side so a thinking pause mid sentence does not count as
+// finished. Those windows are hints an OEM recogniser may ignore, and one that never reports an
+// end leaves a live microphone and a running waveform with no way out but backing off the sheet.
+//
+// Ten seconds is longer than anyone takes to say where they are going. A rider still mid sentence
+// at ten is not cut off: STILL_SPEAKING_WINDOW is the stretch before the ceiling that decides
+// whether words are still arriving, and if they are, EXTENSION runs the session to fifteen, which
+// is a hard stop. Measured on words arriving in that window rather than at all, because every
+// session has words in it somewhere.
+private const val LISTENING_CEILING_MILLIS = 10_000L
+private const val LISTENING_EXTENSION_MILLIS = 5_000L
+private const val STILL_SPEAKING_WINDOW_MILLIS = 2_000L
 
 private const val AI_OUTCOME_TAG = "[AI_OUTCOME]"
 
@@ -91,6 +97,9 @@ class AiSearchInputViewModel(
 
     private var listeningJob: Job? = null
     private var listeningTimeoutJob: Job? = null
+
+    // Only ever compared against an earlier reading of itself, never read as a total.
+    private var wordsHeardSoFar: Int = 0
 
     fun onEvent(event: AiSearchInputEvent) {
         when (event) {
@@ -186,8 +195,13 @@ class AiSearchInputViewModel(
 
             speechToTextService.startListening().collect { result ->
                 when (result) {
-                    is SpeechToTextResult.Partial ->
+                    is SpeechToTextResult.Partial -> {
+                        // Counted, not timestamped: the ceiling only needs to know whether new
+                        // words arrived during a window, and a counter is readable from a test
+                        // running on virtual time where a wall clock is not.
+                        wordsHeardSoFar++
                         _uiState.update { it.copy(speechTranscript = result.text) }
+                    }
 
                     is SpeechToTextResult.Final -> {
                         _uiState.update {
@@ -209,11 +223,32 @@ class AiSearchInputViewModel(
      * The backstop for a recogniser that never says it is done. Stopping is the same graceful
      * stop the rider's own stop button does, so whatever was said up to that point still comes
      * back through the flow as a final transcript rather than being thrown away.
+     *
+     * The rider's stop button is the real control; this only decides when to stop waiting for
+     * someone who has finished but whose recogniser has not noticed.
+     *
+     * Ten seconds is the ordinary ceiling, which is longer than any trip anyone says out loud.
+     * A rider still mid-sentence at ten seconds is not cut off: the extension runs to fifteen,
+     * which is a hard stop. "Still speaking" is measured by whether new words arrived in the
+     * two seconds before the ceiling, not by whether any arrived at all, since every session
+     * has words in it somewhere.
      */
     private fun startListeningTimeout() {
         listeningTimeoutJob?.cancel()
         listeningTimeoutJob = viewModelScope.launch {
-            delay(MAX_LISTENING_MILLIS)
+            delay(LISTENING_CEILING_MILLIS - STILL_SPEAKING_WINDOW_MILLIS)
+            val wordsBeforeTheWindow = wordsHeardSoFar
+            delay(STILL_SPEAKING_WINDOW_MILLIS)
+
+            if (wordsHeardSoFar > wordsBeforeTheWindow) {
+                delay(LISTENING_EXTENSION_MILLIS)
+                if (_uiState.value.isListening) {
+                    logOutcome(reason = "listening_hit_extended_ceiling")
+                    stopListening()
+                }
+                return@launch
+            }
+
             if (_uiState.value.isListening) {
                 logOutcome(reason = "listening_hit_ceiling")
                 stopListening()
@@ -291,7 +326,8 @@ class AiSearchInputViewModel(
 
                 else -> null to null
             }
-            val dateTimeSelectionItem = resolveTimeIntent(extraction.timeIntent) ?: leaveNowDateTimeSelectionItem()
+            val dateTimeSelectionItem =
+                resolveTimeIntent(extraction.timeIntent, riderText = text) ?: leaveNowDateTimeSelectionItem()
 
             val intent = ResolvedTripIntent(
                 fromText = fromText,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolver.kt
@@ -24,6 +24,23 @@ private val HOUR_RANGE = 0 until HOURS_PER_DAY
 private val MINUTE_RANGE = 0 until MINUTES_PER_HOUR
 
 private const val ON_THE_HOUR_MINUTE = 0
+private const val DAYS_PER_WEEK = 7
+
+private val TODAY_WORDS = setOf("today", "tonight", "this evening", "this afternoon", "this morning")
+private const val TOMORROW_WORD = "tomorrow"
+
+// Ordered so the index is the offset from Monday, matching kotlinx.datetime's DayOfWeek
+// ordinal. "tues"/"thurs"/"weds" are here because riders write them, not because a general
+// abbreviation scheme would produce them.
+private val WEEKDAY_WORDS: List<List<String>> = listOf(
+    listOf("monday", "mon"),
+    listOf("tuesday", "tues", "tue"),
+    listOf("wednesday", "weds", "wed"),
+    listOf("thursday", "thurs", "thu"),
+    listOf("friday", "fri"),
+    listOf("saturday", "sat"),
+    listOf("sunday", "sun"),
+)
 
 private data class ResolvedClock(val hour: Int, val minute: Int, val date: LocalDate)
 
@@ -83,11 +100,45 @@ internal fun resolveTimeIntent(
     val option = if (timeIntent.isArrival) JourneyTimeOptions.ARRIVE else JourneyTimeOptions.LEAVE
     val text = timeIntent.timeText.trim()
 
-    val resolved = resolveClockTime(text, nowLocal.date, nowLocal.hour, nowLocal.minute)
+    // A day named in the sentence overrides the "next occurrence" rollover: a rider who said
+    // Friday means Friday, even for a time that has already gone today.
+    val namedDay = resolveNamedDay(text, nowLocal.date)
+
+    val resolved = resolveClockTime(text, nowLocal.date, nowLocal.hour, nowLocal.minute, namedDay)
         ?: resolveRelativeMinutes(text, nowLocal.hour, nowLocal.minute, nowLocal.date)
         ?: return null
 
     return DateTimeSelectionItem(option = option, hour = resolved.hour, minute = resolved.minute, date = resolved.date)
+}
+
+/**
+ * The date a day word in [text] refers to, or null when no day was named.
+ *
+ * Only days, never times. "tonight" resolves to today's date and nothing else: turning it into
+ * an hour would be inventing precision the rider did not give, which is the same line
+ * [resolveTimeIntent] draws for every other vague phrase. Without a clock time alongside it, a
+ * day on its own still resolves to nothing, because a date with no time is not a departure.
+ *
+ * A named weekday means its next occurrence, counting today. "Friday" said on a Friday is that
+ * day, not the one a week later, which is what a rider means and also what makes the phrase
+ * useful at all on the day itself.
+ */
+private fun resolveNamedDay(text: String, today: LocalDate): LocalDate? {
+    val lower = text.lowercase()
+    return when {
+        lower.contains(TOMORROW_WORD) -> today.plus(1, DateTimeUnit.DAY)
+        TODAY_WORDS.any { lower.contains(it) } -> today
+        else -> resolveWeekday(lower, today)
+    }
+}
+
+private fun resolveWeekday(lowercaseText: String, today: LocalDate): LocalDate? {
+    val weekdayIndex = WEEKDAY_WORDS.indexOfFirst { names ->
+        names.any { name -> Regex("\\b$name\\b").containsMatchIn(lowercaseText) }
+    }
+    if (weekdayIndex < 0) return null
+    val daysAhead = (weekdayIndex - today.dayOfWeek.ordinal + DAYS_PER_WEEK) % DAYS_PER_WEEK
+    return today.plus(daysAhead, DateTimeUnit.DAY)
 }
 
 /**
@@ -121,8 +172,17 @@ internal fun leaveNowDateTimeSelectionItem(
  * time, matching [resolveRelativeMinutes]'s own day-rollover for the relative-minutes path
  * just below. A match for the exact current minute stays today ("leaving at 9am" said at
  * 9:00am means now, not this time tomorrow).
+ *
+ * [namedDay] switches that off. A rider who said which day meant it, and guessing forward from
+ * their own word would be the app overruling them.
  */
-private fun resolveClockTime(text: String, today: LocalDate, nowHour: Int, nowMinute: Int): ResolvedClock? {
+private fun resolveClockTime(
+    text: String,
+    today: LocalDate,
+    nowHour: Int,
+    nowMinute: Int,
+    namedDay: LocalDate? = null,
+): ResolvedClock? {
     val clockMatch = CLOCK_TIME_REGEX.findAll(text)
         .mapNotNull(::parseClockMatch)
         .firstOrNull { it.isPlausible() }
@@ -132,7 +192,8 @@ private fun resolveClockTime(text: String, today: LocalDate, nowHour: Int, nowMi
     if (hour24 !in HOUR_RANGE) return null
 
     val hasAlreadyPassedToday = hour24 < nowHour || (hour24 == nowHour && clockMatch.minute < nowMinute)
-    val date = if (hasAlreadyPassedToday) today.plus(1, DateTimeUnit.DAY) else today
+    val date = namedDay
+        ?: if (hasAlreadyPassedToday) today.plus(1, DateTimeUnit.DAY) else today
     return ResolvedClock(hour24, clockMatch.minute, date)
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolver.kt
@@ -94,6 +94,7 @@ internal fun resolveTimeIntent(
     timeIntent: TimeIntent?,
     now: Instant = Clock.System.now(),
     timeZone: TimeZone = TimeZone.of("Australia/Sydney"),
+    riderText: String = "",
 ): DateTimeSelectionItem? {
     if (timeIntent == null) return null
     val nowLocal = now.toLocalDateTime(timeZone)
@@ -102,7 +103,15 @@ internal fun resolveTimeIntent(
 
     // A day named in the sentence overrides the "next occurrence" rollover: a rider who said
     // Friday means Friday, even for a time that has already gone today.
+    //
+    // Looked for in the rider's whole sentence, not only in the extracted time phrase. The
+    // model is asked to keep the day word with the time, and does not always: "10am Monday
+    // work" came back with "10am" as the time and Monday swallowed into the place, so the
+    // day was lost and an already-passed 10am rolled to tomorrow. A day word is a fact about
+    // the sentence, so reading it from the sentence removes the model from that decision
+    // entirely rather than relying on a prompt to hold.
     val namedDay = resolveNamedDay(text, nowLocal.date)
+        ?: resolveNamedDay(riderText.trim(), nowLocal.date)
 
     val resolved = resolveClockTime(text, nowLocal.date, nowLocal.hour, nowLocal.minute, namedDay)
         ?: resolveRelativeMinutes(text, nowLocal.hour, nowLocal.minute, nowLocal.date)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolver.kt
@@ -17,10 +17,12 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
  *   turn that a better-informed one would have handled correctly.
  * - Be side-effect free. Resolvers run on whatever the AI extracted, which may be nonsense.
  */
-// Exploratory, not scheduled: a weak match is the only failure here with no visible failure,
-// and the honest answer is to offer two or three candidates with the reason each was suggested
-// rather than commit to one. That needs a scored result rather than a StopItem? — FuzzyStopRanker
-// already computes the score and discards it at this boundary. See AI_SEARCH_UX.md.
+// Exploratory, not scheduled: offering two or three candidates with the reason each was
+// suggested, rather than committing to one, for a match that is not clearly right.
+//
+// This used to say the groundwork was exposing FuzzyStopRanker's score, which it discards at
+// this boundary. That was wrong on three counts and the note is kept so it is not proposed
+// again from the same reasoning. See AI_SEARCH_UX.md for the long version.
 interface StopTextResolver {
 
     /** Stable, human-readable id used in logs to show which capability answered. */

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -661,12 +661,52 @@ class AiSearchInputViewModelTest {
 
         // A recogniser that never reports an end would otherwise leave a live microphone and a
         // running waveform on screen with no way out but backing off the sheet.
-        advanceTimeBy(MAX_LISTENING_MILLIS_IN_TEST + 1)
+        advanceTimeBy(LISTENING_CEILING_IN_TEST + 1)
         runCurrent()
 
         assertEquals(false, viewModel.uiState.value.isListening)
         assertEquals(1, speechToTextService.stopListeningCallCount)
     }
+
+    @Test
+    fun `a rider still speaking at the ceiling is given longer`() = runTest(testDispatcher) {
+        viewModel.onEvent(AiSearchInputEvent.StartListening)
+        runCurrent()
+
+        // Words arriving inside the window just before the ceiling: this rider is mid
+        // sentence, and cutting them off there is the thing the extension exists to prevent.
+        advanceTimeBy(LISTENING_CEILING_IN_TEST - 1_000)
+        runCurrent()
+        speechToTextService.results.emit(SpeechToTextResult.Partial("central to town"))
+        advanceTimeBy(1_001)
+        runCurrent()
+
+        assertTrue(viewModel.uiState.value.isListening, "should not stop at the ordinary ceiling")
+
+        advanceTimeBy(LISTENING_EXTENSION_IN_TEST)
+        runCurrent()
+
+        // Fifteen seconds is a hard stop, extension or not.
+        assertEquals(false, viewModel.uiState.value.isListening)
+    }
+
+    @Test
+    fun `words that stopped before the ceiling do not earn the extension`() =
+        runTest(testDispatcher) {
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+
+            // Said early, then silence. Every session has words in it somewhere, so the test
+            // is whether they were still arriving at the end, not whether there were any.
+            speechToTextService.results.emit(SpeechToTextResult.Partial("central"))
+            runCurrent()
+
+            advanceTimeBy(LISTENING_CEILING_IN_TEST + 1)
+            runCurrent()
+
+            assertEquals(false, viewModel.uiState.value.isListening)
+        }
 }
 
-private const val MAX_LISTENING_MILLIS_IN_TEST = 20_000L
+private const val LISTENING_CEILING_IN_TEST = 10_000L
+private const val LISTENING_EXTENSION_IN_TEST = 5_000L

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolverTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolverTest.kt
@@ -94,4 +94,68 @@ class AiTripIntentTimeResolverTest {
         assertNull(resolveTimeIntent(TimeIntent(isArrival = false, timeText = "this evening"), fixedNow, utc))
         assertNull(resolveTimeIntent(TimeIntent(isArrival = true, timeText = "tomorrow morning"), fixedNow, utc))
     }
+
+    // region Named days
+
+    @Test
+    fun `tomorrow with a clock time lands on tomorrow`() {
+        val result = resolveTimeIntent(TimeIntent(isArrival = false, timeText = "tomorrow at 9am"), fixedNow, utc)
+
+        assertEquals(LocalDate(2026, 8, 11), result?.date)
+        assertEquals(9, result?.hour)
+    }
+
+    @Test
+    fun `a named weekday lands on its next occurrence`() {
+        // now is Monday 10 Aug; the next Friday is the 14th.
+        val result = resolveTimeIntent(TimeIntent(isArrival = true, timeText = "friday 6pm"), fixedNow, utc)
+
+        assertEquals(LocalDate(2026, 8, 14), result?.date)
+        assertEquals(18, result?.hour)
+    }
+
+    @Test
+    fun `today's own weekday means today, not a week away`() {
+        // Said on a Monday. "Monday" has to mean this one, or the word is useless on the day
+        // a rider is most likely to say it.
+        val result = resolveTimeIntent(TimeIntent(isArrival = false, timeText = "monday 11am"), fixedNow, utc)
+
+        assertEquals(LocalDate(2026, 8, 10), result?.date)
+    }
+
+    @Test
+    fun `a named day beats the next-occurrence rollover`() {
+        // now is 09:00, so 8am has gone. Without a named day this rolls to tomorrow; with one
+        // it must not, because the rider said which day and guessing past that overrules them.
+        val result = resolveTimeIntent(TimeIntent(isArrival = false, timeText = "today at 8am"), fixedNow, utc)
+
+        assertEquals(LocalDate(2026, 8, 10), result?.date)
+        assertEquals(8, result?.hour)
+    }
+
+    @Test
+    fun `tonight names the day and nothing else`() {
+        val withTime = resolveTimeIntent(TimeIntent(isArrival = false, timeText = "tonight at 7pm"), fixedNow, utc)
+        assertEquals(LocalDate(2026, 8, 10), withTime?.date)
+        assertEquals(19, withTime?.hour)
+
+        // On its own it is still a day-part with no hour in it, and inventing one is the thing
+        // this resolver refuses to do.
+        assertNull(resolveTimeIntent(TimeIntent(isArrival = false, timeText = "tonight"), fixedNow, utc))
+    }
+
+    @Test
+    fun `a day word inside a longer word is not a day`() {
+        // "sun" must not be read out of "sunset"; the same guard is why day matching is on
+        // word boundaries rather than substrings.
+        assertNull(resolveTimeIntent(TimeIntent(isArrival = false, timeText = "around sunset"), fixedNow, utc))
+    }
+
+    @Test
+    fun `a named day with no clock time still resolves to nothing`() {
+        // A date with no time is not a departure, and picking one would be a guess.
+        assertNull(resolveTimeIntent(TimeIntent(isArrival = false, timeText = "friday"), fixedNow, utc))
+    }
+
+    // endregion Named days
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolverTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiTripIntentTimeResolverTest.kt
@@ -152,6 +152,50 @@ class AiTripIntentTimeResolverTest {
     }
 
     @Test
+    fun `a day the model left out of the time phrase is still read from the sentence`() {
+        // The real failure: "10am Monday work" came back with the day swallowed into the
+        // place, leaving "10am", which had already passed and rolled to tomorrow. now is
+        // Monday, so the day that was dropped means today.
+        val result = resolveTimeIntent(
+            timeIntent = TimeIntent(isArrival = true, timeText = "10am"),
+            now = fixedNow,
+            timeZone = utc,
+            riderText = "10am Monday work",
+        )
+
+        assertEquals(LocalDate(2026, 8, 10), result?.date)
+        assertEquals(10, result?.hour)
+    }
+
+    @Test
+    fun `the time phrase wins when both name a day`() {
+        val result = resolveTimeIntent(
+            timeIntent = TimeIntent(isArrival = false, timeText = "tomorrow at 9am"),
+            now = fixedNow,
+            timeZone = utc,
+            riderText = "friday something tomorrow at 9am",
+        )
+
+        // The extracted phrase is the more precise signal; the sentence is only the fallback
+        // for when the day never made it into that phrase.
+        assertEquals(LocalDate(2026, 8, 11), result?.date)
+    }
+
+    @Test
+    fun `a sentence with no day in it still rolls forward as before`() {
+        // now is Monday 09:00, so 8am has gone and means tomorrow. The fallback must not
+        // invent a day out of a sentence that has none.
+        val result = resolveTimeIntent(
+            timeIntent = TimeIntent(isArrival = false, timeText = "8am"),
+            now = fixedNow,
+            timeZone = utc,
+            riderText = "central to town hall at 8am",
+        )
+
+        assertEquals(LocalDate(2026, 8, 11), result?.date)
+    }
+
+    @Test
     fun `a named day with no clock time still resolves to nothing`() {
         // A date with no time is not a departure, and picking one would be a guess.
         assertNull(resolveTimeIntent(TimeIntent(isArrival = false, timeText = "friday"), fixedNow, utc))


### PR DESCRIPTION
## What

The AI time grammar read clock times and offsets from now, so "friday 6pm" landed on 6pm today or tomorrow, and "tomorrow at 9am" on whichever 9am came next. It now reads named days.

## Changes

- `AiTripIntentTimeResolver` resolves "today", "tonight", "tomorrow", and weekday names including the short forms riders write ("fri", "tues", "weds"). Word-boundary matching, so "sun" is not read out of "sunset".
- A named day overrides the next-occurrence rollover. Without one, an already-past clock time rolls to tomorrow, which is right for a bare "at 8am". With one it must not: the rider said which day.
- Named days resolve dates only. "tonight" gives today's date and no hour; a day with no clock time still resolves to nothing, because a date without a time is not a departure and choosing an hour would be the invented precision this resolver refuses everywhere else.
- Both platform prompts (`AndroidAiTextService`, `AiTextBridge.swift`) now say to keep the day word inside `timeText`. They asked for the time phrase alone, so the day was dropped before the resolver saw it.

## Correction to a note this repo carried

The comment on `StopTextResolver` said the groundwork for offering candidates on a weak match was exposing `FuzzyStopRanker`'s score, which it discards at that boundary. That is wrong on three counts, now written down in `AI_SEARCH_UX.md` so the same plan is not re-derived:

1. The score is not what this path picks from. `RealStopResultsManager` returns exact SQL matches first and only falls back to the ranker when there are few of them, so most results carry no score at all.
2. The score does not carry the safety property. The word-boundary guard in `StopSearchTextResolver` is not a duplicate of the ranker: the ranker scores "work" against *70 Powderworks Rd* at roughly 1.0 through its longest-common-substring signal, which it uses deliberately so a rider reading a list gets loose suggestions. Swapping the guard for a score threshold reintroduces the exact bug the guard exists for.
3. The score does not carry priority. "central" scores *Central Station* and *Central Ave* identically; `prioritiseByRelevance` is what puts the station first.

No code was changed for this. The point of the commit is that the note no longer sends the next reader down that path.

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green, seven new cases: tomorrow with a time, a weekday landing on its next occurrence, today's own weekday meaning today, a named day beating the rollover, "tonight" naming the day and nothing else, a day word inside a longer word not counting, and a day with no time resolving to nothing.
- `./scripts/fullQualityChecks.sh` green: Android compile, iOS simulator compile, detekt.

Prompt changes are not covered by tests on either platform; they are instructions to an on-device model. The resolver is tested against the strings a model is asked to produce.

## Second commit: found on a device

"10am Monday work" put the rider on tomorrow. The model returned "10am" as the time phrase with Monday swallowed into the place, so no day reached the resolver and an already-passed 10am rolled forward the way a bare time should.

The prompt asks for the day word to stay with the time. A request is not a mechanism. The day is now read from the rider's whole sentence as well, which takes the model out of the decision: a day word is a fact about the text. The extracted phrase still wins when both name a day, and a sentence with no day rolls forward exactly as before. Three more tests, including that exact input.

Also caps a listening session at ten seconds rather than twenty, extending to fifteen when words are still arriving in the two seconds before the ceiling. Twenty left a live microphone running well past the point a rider had finished. The extension is measured on words arriving during that window rather than any words at all, since every session has words in it somewhere. The stop button remains the real control.

Device tested on a Pixel 10 Pro: named days, the arrive-by chip, and the timetable opening at the chosen time all confirmed by hand.

## Snapshots

No UI change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
