### PR TITLE
fix(speech): wait longer before deciding a rider has finished

### DIFF
--- a/core/speech-to-text/src/androidMain/kotlin/xyz/ksharma/krail/core/speechtotext/AndroidSpeechToTextService.kt
+++ b/core/speech-to-text/src/androidMain/kotlin/xyz/ksharma/krail/core/speechtotext/AndroidSpeechToTextService.kt
@@ -15,8 +15,18 @@ import kotlinx.coroutines.flow.callbackFlow
 import xyz.ksharma.krail.core.log.log
 
 private const val EARLIEST_THE_RECOGNISER_MAY_FINISH_MILLIS = 3_000L
-private const val SILENCE_THAT_ENDS_THE_SESSION_MILLIS = 2_500L
-private const val SILENCE_AFTER_A_COMPLETE_SOUNDING_PHRASE_MILLIS = 1_800L
+
+// Both widened by roughly a second and a half after a rider reported being cut off while still
+// thinking. The phrase window is the one that does it: a trip said out loud usually ends on
+// something that sounds finished ("...on Monday morning"), and the recogniser treats a
+// complete-sounding phrase as licence to close much sooner than an unfinished one.
+//
+// Erring long is the cheap direction here. A rider who has finished has a stop button in front
+// of them and pays nothing for a generous window; a rider who was drawing breath loses their
+// sentence and has to start again. The ceiling in AiSearchInputViewModel is what stops these
+// from running forever.
+private const val SILENCE_THAT_ENDS_THE_SESSION_MILLIS = 4_000L
+private const val SILENCE_AFTER_A_COMPLETE_SOUNDING_PHRASE_MILLIS = 3_000L
 
 /**
  * `android.speech.SpeechRecognizer`, not ML Kit — see this module's README for why.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -34,9 +34,16 @@ private const val NEARBY_STOP_RADIUS_KM = 1.0
 // whether words are still arriving, and if they are, EXTENSION runs the session to fifteen, which
 // is a hard stop. Measured on words arriving in that window rather than at all, because every
 // session has words in it somewhere.
+//
+// STILL_SPEAKING_WINDOW must not be shorter than the recogniser's own silence tolerance
+// (SILENCE_THAT_ENDS_THE_SESSION_MILLIS in AndroidSpeechToTextService, currently the same four
+// seconds). If it were, this ceiling could end a session the recogniser still considered live:
+// a rider who paused at eight seconds and was about to carry on would look finished to us and
+// unfinished to it, and we would be the ones who cut them off. Kept in step by hand, since the
+// two live in different modules on purpose - this one must not depend on a platform source set.
 private const val LISTENING_CEILING_MILLIS = 10_000L
 private const val LISTENING_EXTENSION_MILLIS = 5_000L
-private const val STILL_SPEAKING_WINDOW_MILLIS = 2_000L
+private const val STILL_SPEAKING_WINDOW_MILLIS = 4_000L
 
 private const val AI_OUTCOME_TAG = "[AI_OUTCOME]"
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -675,10 +675,12 @@ class AiSearchInputViewModelTest {
 
         // Words arriving inside the window just before the ceiling: this rider is mid
         // sentence, and cutting them off there is the thing the extension exists to prevent.
-        advanceTimeBy(LISTENING_CEILING_IN_TEST - 1_000)
+        // Three seconds before the ceiling is inside the four-second window, and is also a
+        // pause the recogniser itself would still be waiting through.
+        advanceTimeBy(LISTENING_CEILING_IN_TEST - 3_000)
         runCurrent()
         speechToTextService.results.emit(SpeechToTextResult.Partial("central to town"))
-        advanceTimeBy(1_001)
+        advanceTimeBy(3_001)
         runCurrent()
 
         assertTrue(viewModel.uiState.value.isListening, "should not stop at the ordinary ceiling")


### PR DESCRIPTION
## What

The speech recogniser was ending sessions while the rider was still thinking. Both silence windows widen by about a second and a half.

## Changes

- `AndroidSpeechToTextService`: `SILENCE_AFTER_A_COMPLETE_SOUNDING_PHRASE_MILLIS` 1800 to 3000, `SILENCE_THAT_ENDS_THE_SESSION_MILLIS` 2500 to 4000. `EARLIEST_THE_RECOGNISER_MAY_FINISH_MILLIS` unchanged.
- `AiSearchInputViewModel`: `STILL_SPEAKING_WINDOW_MILLIS` 2000 to 4000, to match the recogniser's new tolerance.

The phrase window is the one that caused it. A trip said out loud usually ends on something that sounds finished ("...on Monday morning"), and the recogniser treats a complete-sounding phrase as licence to close much sooner than an unfinished one. A session measured on a device ran 6.4 seconds for roughly 4.5 seconds of speech, which is that 1800ms window behaving exactly as configured.

Erring long is the cheap direction: a rider who has finished has a stop button in front of them and pays nothing for a generous window, while a rider drawing breath loses the sentence and starts again.

## Why the second constant had to move too

`STILL_SPEAKING_WINDOW_MILLIS` decides whether words are still arriving as the app's own ceiling approaches. It must not be shorter than the recogniser's silence tolerance. At 2000 against a 4000 tolerance, a rider who paused at eight seconds would look finished to the ViewModel and unfinished to the recogniser, and the app would be the one cutting them off. The two live in different modules on purpose (this one must not depend on a platform source set), so the relationship is stated in a comment on both sides.

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green. The extension test now pauses three seconds rather than one, so it exercises a gap the recogniser itself would still be waiting through.
- `./scripts/fullQualityChecks.sh` green: Android compile, iOS simulator compile, detekt.
- Installed on a Pixel 10 Pro. The cut-off was reproduced before the change and the timing above was read from logcat.

iOS is unaffected: these are `RecognizerIntent` extras and have no equivalent in the iOS bridge.
