### PR TITLE
fix(android): stop the system panning the window for the keyboard

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.Krail">
+            android:theme="@style/Theme.Krail"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
## What

`MainActivity` declared no `windowSoftInputMode`, so it defaulted to `ADJUST_UNSPECIFIED` and the system resolved it to **pan**. The app is edge to edge via `enableEdgeToEdge()` + `setDecorFitsSystemWindows(window, false)` and pads for the IME in Compose, so both mechanisms compensated for the same keyboard: the layout shrank by the keyboard height, and the system then slid the whole window up by it again.

## Changes

- `androidApp/src/main/AndroidManifest.xml`: `MainActivity` declares `android:windowSoftInputMode="adjustResize"`

## How it was found

Visible on any screen with a bottom-anchored field. Measured with `onGloballyPositioned`: the node reported a position correctly above the IME while the screenshot painted it a keyboard's height higher, with the content above it clipped off the top of the screen.

A gap between where a node is laid out and where it is drawn can only be the window moving, never the Compose tree. Detekt, both compile targets and every unit test were green throughout.

Screens whose fields sit near the top were unaffected, because the pan distance computes to roughly zero there.

## Testing

- Device QA on a physical Pixel: keyboard open and closed, rotation, light and dark, on both the Ask KRAIL surface and SearchStopScreen
- `./scripts/fullQualityChecks.sh` green
- A guard against this regressing ships later in the stack (#1861)
