### PR TITLE
feat(taj): add send icon, regular-weight headline, and text field size overrides

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/SendIcon.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/SendIcon.kt
@@ -1,0 +1,41 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * An upward arrow: send, in the shape every message field on a phone uses for it.
+ *
+ * Authored as path data for the same reason [MicIcon] and [StopIcon] are, and stroked rather
+ * than filled so it holds its weight next to them at the same size.
+ *
+ * The no-arrows rule this repo has is about arrows in *copy*, where a word carries the meaning
+ * better. This is a glyph on a button whose whole job is a direction.
+ */
+val SendIcon: ImageVector by lazy {
+    ImageVector.Builder(
+        name = "Send",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).apply {
+        path(
+            stroke = SolidColor(Color.White),
+            strokeLineWidth = 2.2f,
+            strokeLineCap = StrokeCap.Round,
+            strokeLineJoin = StrokeJoin.Round,
+        ) {
+            moveTo(12f, 19f)
+            lineTo(12f, 5f)
+            moveTo(5f, 12f)
+            lineTo(12f, 5f)
+            lineTo(19f, 12f)
+        }
+    }.build()
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/TextField.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -87,6 +88,15 @@ fun TextField(
     // drops both so the caller's own height/shape apply (see [shape]).
     lineLimits: TextFieldLineLimits = TextFieldLineLimits.SingleLine,
     shape: Shape? = null,
+    // Overrides the multiline branch's own minimum. A caller that wants a field which starts
+    // as a one line pill and grows only when the words need it passes the single line height
+    // here; without it a multiline field is 128dp tall the moment it is composed, which is a
+    // box rather than a pill no matter what [shape] says.
+    minHeight: Dp? = null,
+    // Overrides the inset between the box's edge and its text. Defaults keep every existing
+    // field exactly as it was; a field that is the whole point of its screen wants a roomier
+    // one than a field in a list of them.
+    contentPadding: PaddingValues? = null,
     // Fires on the IME action key (e.g. Send) - null means the platform's default
     // behaviour (usually just dismissing the keyboard) applies.
     onSubmit: (() -> Unit)? = null,
@@ -96,7 +106,7 @@ fun TextField(
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val contentAlpha = if (enabled) 1f else TextFieldTokens.DisabledLabelOpacity
-    val layout = textFieldLayout(lineLimits = lineLimits, shape = shape)
+    val layout = textFieldLayout(lineLimits = lineLimits, shape = shape, minHeight = minHeight)
 
     // Hoisted state takes precedence — callers that need to mutate the text from
     // outside (e.g. selecting a suggestion chip that fills the field) must pass
@@ -158,10 +168,23 @@ fun TextField(
                             // makes up the difference below, so the control sits an equal
                             // gap from the field's top and end while the text keeps its own
                             // roomier inset. Unequal insets on a control read as bolted on.
-                            .padding(vertical = if (trailingIcon != null) SpacingTokens.M else layout.verticalPadding)
-                            .padding(
-                                end = if (trailingIcon != null) SpacingTokens.M else SpacingTokens.XL,
-                                start = if (leadingIcon != null) 0.dp else SpacingTokens.XL,
+                            .then(
+                                if (contentPadding != null) {
+                                    Modifier.padding(contentPadding)
+                                } else {
+                                    Modifier
+                                        .padding(
+                                            vertical = if (trailingIcon != null) {
+                                                SpacingTokens.M
+                                            } else {
+                                                layout.verticalPadding
+                                            },
+                                        )
+                                        .padding(
+                                            end = if (trailingIcon != null) SpacingTokens.M else SpacingTokens.XL,
+                                            start = if (leadingIcon != null) 0.dp else SpacingTokens.XL,
+                                        )
+                                },
                             ),
                         horizontalArrangement = Arrangement.Start,
                         verticalAlignment = layout.verticalAlignment,
@@ -228,7 +251,11 @@ private class TextFieldLayout(
     val placeholderMaxLines: Int,
 )
 
-private fun textFieldLayout(lineLimits: TextFieldLineLimits, shape: Shape?): TextFieldLayout =
+private fun textFieldLayout(
+    lineLimits: TextFieldLineLimits,
+    shape: Shape?,
+    minHeight: Dp? = null,
+): TextFieldLayout =
     if (lineLimits == TextFieldLineLimits.SingleLine) {
         TextFieldLayout(
             heightModifier = Modifier.height(TextFieldHeight),
@@ -251,7 +278,7 @@ private fun textFieldLayout(lineLimits: TextFieldLineLimits, shape: Shape?): Tex
             heightModifier = Modifier,
             containerModifier = Modifier
                 .fillMaxWidth()
-                .heightIn(min = TextFieldDefaults.MultiLineMinHeight),
+                .heightIn(min = minHeight ?: TextFieldDefaults.MultiLineMinHeight),
             shape = shape ?: RoundedCornerShape(RadiusTokens.XL),
             verticalPadding = SpacingTokens.M,
             verticalAlignment = Alignment.Top,
@@ -303,6 +330,13 @@ object TextFieldDefaults {
      * this tall, or the swap resizes the layout around it.
      */
     val MultiLineMinHeight = 128.dp
+
+    /**
+     * The height a single line field is, published so a multiline caller can ask to start at
+     * exactly one line and grow from there. Passed as `minHeight`, it is what makes a field a
+     * pill on open rather than a box, without giving up multiline once the words need it.
+     */
+    val SingleLineHeight = TextFieldHeight
 
     private const val INVERTED_PLACEHOLDER_ALPHA = 0.7f
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailTypography.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailTypography.kt
@@ -18,6 +18,7 @@ data class KrailTypography(
     val displayMedium: TextStyle,
     val displaySmall: TextStyle,
     val headlineLarge: TextStyle,
+    val headlineLargeRegular: TextStyle,
     val headlineMedium: TextStyle,
     val headlineSmall: TextStyle,
     val labelLarge: TextStyle,
@@ -42,6 +43,7 @@ internal val LocalKrailTypography = staticCompositionLocalOf {
         displayMedium = TextStyle.Default,
         displaySmall = TextStyle.Default,
         headlineLarge = TextStyle.Default,
+        headlineLargeRegular = TextStyle.Default,
         headlineMedium = TextStyle.Default,
         headlineSmall = TextStyle.Default,
         labelLarge = TextStyle.Default,
@@ -116,6 +118,16 @@ internal val krailTypography = KrailTypography(
     headlineLarge = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Bold,
+        fontSize = 28.sp,
+        lineHeight = 36.sp,
+        letterSpacing = 0.sp,
+    ),
+    // headlineLarge's size at the weight a sentence is read at rather than announced at. Bold
+    // is how this scale is used for a heading over content; a line that IS the content, with
+    // nothing under it to be a heading for, only reads as shouting at that weight.
+    headlineLargeRegular = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
         fontSize = 28.sp,
         lineHeight = 36.sp,
         letterSpacing = 0.sp,


### PR DESCRIPTION
## What

Three additions to `:taj` that the Ask KRAIL surface needs. None of them change an existing caller: the typography entry is new, the icon is new, and both `TextField` parameters default to the behaviour that was already there.

## Changes

- `KrailTypography`: adds `headlineLargeRegular`, `headlineLarge`'s 28sp at `FontWeight.Normal`, for a line that IS the content rather than a heading over it. Follows the existing `titleMediumRegular` precedent
- `SendIcon`: stroked up-arrow `ImageVector`, sized to match `MicIcon` and `StopIcon`
- `TextField`: adds `minHeight` and `contentPadding` overrides. The multiline branch hardcoded a 128dp minimum, so no caller could build a pill-shaped field regardless of the modifier it passed. Both default to null and resolve to the previous values

## Testing

- `./gradlew :taj:testAndroidHostTest` green
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS compile, detekt)
- No behaviour change for existing callers, so no existing test needed updating
