### PR TITLE
feat(taj): make the cloud field configurable and fix its dark-mode tints

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudFieldSpec.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudFieldSpec.kt
@@ -1,0 +1,52 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.taj.tokens.AiThemeGradientTokens
+
+/**
+ * How much the field moves, how fast, and what colours it is made of.
+ *
+ * [Ambient] is the wallpaper tuning: one hue, barely-there drift, meant to be noticed only if
+ * you stare. A surface where the field IS the subject wants more travel and more than one hue,
+ * and says so rather than the component guessing from context.
+ */
+@Immutable
+data class CloudFieldSpec(
+    /** Three colours, nearest blob first. `null` uses the theme colour and two tints of it. */
+    val colors: List<Color>? = null,
+    /** Multiplies how far each blob travels from its home position. */
+    val motionScale: Float = 1f,
+    /** Multiplies how fast it travels. Periods stay pairwise coprime as they scale. */
+    val speedScale: Float = 1f,
+    /** Multiplies peak alpha. Several saturated hues at once need less than one hue does. */
+    val alphaScale: Float = 1f,
+) {
+    companion object {
+        val Ambient = CloudFieldSpec()
+
+        /**
+         * The AI pair for the rider's theme, drifting.
+         *
+         * One factory rather than a spec built at each call site, because the three surfaces
+         * that wear this field (the AI input, and both of SearchStop's panes) have to look
+         * like the same weather. Only [motionScale] differs: a field that IS the screen can
+         * travel further than one sitting behind a list of stops being read.
+         */
+        fun aiPair(
+            themeColorHex: String,
+            motionScale: Float = AI_PAIR_MOTION_SCALE,
+        ): CloudFieldSpec = CloudFieldSpec(
+            colors = AiThemeGradientTokens.stopsFor(themeColorHex),
+            motionScale = motionScale,
+            speedScale = AI_PAIR_SPEED_SCALE,
+            alphaScale = AI_PAIR_ALPHA_SCALE,
+        )
+    }
+}
+
+// Alpha comes down as the hue count goes up: three saturated brand colours at the ambient peak
+// fight each other and whatever text sits on top of them.
+private const val AI_PAIR_MOTION_SCALE = 2.6f
+private const val AI_PAIR_SPEED_SCALE = 1.5f
+private const val AI_PAIR_ALPHA_SCALE = 0.85f

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackground.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackground.kt
@@ -77,14 +77,31 @@ import kotlin.math.sin
 fun CloudGradientBackground(
     modifier: Modifier = Modifier,
     themeColor: Color = themeColor(),
+    spec: CloudFieldSpec = CloudFieldSpec.Ambient,
     content: @Composable BoxScope.() -> Unit = {},
 ) {
     val surface = KrailTheme.colors.surface
     val darkMode = isAppInDarkMode()
-    val peakAlpha = if (darkMode) DARK_PEAK_ALPHA else LIGHT_PEAK_ALPHA
+    val peakAlpha = (if (darkMode) DARK_PEAK_ALPHA else LIGHT_PEAK_ALPHA) * spec.alphaScale
 
-    val tintA = lerp(themeColor, surface, BLOB_TINT_A_BLEND)
-    val tintB = lerp(themeColor, surface, BLOB_TINT_B_BLEND)
+    // Both companion blobs are the theme colour pulled towards the FAR end of the theme, not
+    // always towards `surface`. Pulling towards surface is right in light mode, where surface
+    // is white and the blob softens. In dark mode surface is near black, so the same lerp
+    // walked the colour down towards black: a saturated blue turned into navy sludge and the
+    // field read as a dark smear rather than as light. Pulling towards `onSurface` in dark mode
+    // lightens instead, which is what a glow does.
+    val (tintA, tintB) = cloudBlobTints(
+        themeColor = themeColor,
+        surface = surface,
+        onSurface = KrailTheme.colors.onSurface,
+        darkMode = darkMode,
+    )
+    // Explicit colours win, one per blob. Falling back per index rather than all-or-nothing
+    // means a caller can hand over two and still get a sensible third.
+    val blob1 = spec.colors?.getOrNull(0) ?: themeColor
+    val blob2 = spec.colors?.getOrNull(1) ?: tintA
+    val blob3 = spec.colors?.getOrNull(2) ?: tintB
+    val amp = spec.motionScale
 
     val windowSize = LocalWindowInfo.current.containerSize
     val refSize: Size? = remember(windowSize.width, windowSize.height) {
@@ -99,19 +116,25 @@ fun CloudGradientBackground(
     val t1 by transition.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(BLOB_1_PERIOD_MS, easing = LinearEasing)),
+        animationSpec = infiniteRepeatable(
+            tween(scaledPeriod(BLOB_1_PERIOD_MS, spec.speedScale), easing = LinearEasing),
+        ),
         label = "cloud-blob-1",
     )
     val t2 by transition.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(BLOB_2_PERIOD_MS, easing = LinearEasing)),
+        animationSpec = infiniteRepeatable(
+            tween(scaledPeriod(BLOB_2_PERIOD_MS, spec.speedScale), easing = LinearEasing),
+        ),
         label = "cloud-blob-2",
     )
     val t3 by transition.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(BLOB_3_PERIOD_MS, easing = LinearEasing)),
+        animationSpec = infiniteRepeatable(
+            tween(scaledPeriod(BLOB_3_PERIOD_MS, spec.speedScale), easing = LinearEasing),
+        ),
         label = "cloud-blob-3",
     )
     // Separate "breathe" phase drives radius pulsing — independent of position
@@ -119,7 +142,9 @@ fun CloudGradientBackground(
     val breathe by transition.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
-        animationSpec = infiniteRepeatable(tween(BREATHE_PERIOD_MS, easing = LinearEasing)),
+        animationSpec = infiniteRepeatable(
+            tween(scaledPeriod(BREATHE_PERIOD_MS, spec.speedScale), easing = LinearEasing),
+        ),
         label = "cloud-breathe",
     )
 
@@ -135,31 +160,31 @@ fun CloudGradientBackground(
 
                 drawBlob(
                     referenceSize = ref,
-                    color = themeColor,
+                    color = blob1,
                     peakAlpha = peakAlpha,
                     centerFrac = Offset(
-                        x = BLOB_1_CENTER_X + BLOB_1_AMP_X * sin(t1 * TWO_PI),
-                        y = BLOB_1_CENTER_Y + BLOB_1_AMP_Y * cos(t1 * TWO_PI),
+                        x = BLOB_1_CENTER_X + BLOB_1_AMP_X * amp * sin(t1 * TWO_PI),
+                        y = BLOB_1_CENTER_Y + BLOB_1_AMP_Y * amp * cos(t1 * TWO_PI),
                     ),
                     rFrac = BLOB_1_RADIUS_FRAC + pulse,
                 )
                 drawBlob(
                     referenceSize = ref,
-                    color = tintA,
+                    color = blob2,
                     peakAlpha = peakAlpha,
                     centerFrac = Offset(
-                        x = BLOB_2_CENTER_X + BLOB_2_AMP_X * cos(t2 * TWO_PI),
-                        y = BLOB_2_CENTER_Y + BLOB_2_AMP_Y * sin(t2 * TWO_PI),
+                        x = BLOB_2_CENTER_X + BLOB_2_AMP_X * amp * cos(t2 * TWO_PI),
+                        y = BLOB_2_CENTER_Y + BLOB_2_AMP_Y * amp * sin(t2 * TWO_PI),
                     ),
                     rFrac = BLOB_2_RADIUS_FRAC + antiPulse,
                 )
                 drawBlob(
                     referenceSize = ref,
-                    color = tintB,
+                    color = blob3,
                     peakAlpha = peakAlpha * BLOB_3_ALPHA_SCALE,
                     centerFrac = Offset(
-                        x = BLOB_3_CENTER_X + BLOB_3_AMP_X * sin(t3 * TWO_PI),
-                        y = BLOB_3_CENTER_Y + BLOB_3_AMP_Y * cos(t3 * TWO_PI),
+                        x = BLOB_3_CENTER_X + BLOB_3_AMP_X * amp * sin(t3 * TWO_PI),
+                        y = BLOB_3_CENTER_Y + BLOB_3_AMP_Y * amp * cos(t3 * TWO_PI),
                     ),
                     rFrac = BLOB_3_RADIUS_FRAC + pulse * BLOB_3_BREATHE_SCALE,
                 )
@@ -191,6 +216,25 @@ private fun DrawScope.drawBlob(
         center = center,
     )
 }
+
+/**
+ * The blob tints, as a pure function of the theme colour and the mode.
+ *
+ * Pulled out of the composable so the palette can be checked by arithmetic instead of by
+ * looking at a phone: [CloudGradientBackgroundTintTest] asserts every theme style in both
+ * modes lands lighter than its surface, which is the property that failed in dark mode.
+ */
+fun cloudBlobTints(themeColor: Color, surface: Color, onSurface: Color, darkMode: Boolean): Pair<Color, Color> {
+    val tintTarget = if (darkMode) onSurface else surface
+    return lerp(themeColor, tintTarget, BLOB_TINT_A_BLEND) to
+        lerp(themeColor, tintTarget, BLOB_TINT_B_BLEND)
+}
+
+/** Faster means a shorter period. Guarded so a zero or negative scale cannot divide by zero. */
+private fun scaledPeriod(periodMs: Int, speedScale: Float): Int =
+    (periodMs / speedScale.coerceAtLeast(MIN_SPEED_SCALE)).toInt()
+
+private const val MIN_SPEED_SCALE = 0.1f
 
 private const val TWO_PI = (2 * PI).toFloat()
 

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.taj.tokens
 import androidx.compose.ui.graphics.Color
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.magic_yellow
 
 /**
  * The gradient the AI search surface wears: the rider's own theme colour, plus one other
@@ -31,11 +32,16 @@ object AiThemeGradientTokens {
     private val PurpleDrip = Color(0xFFAC00C9)
     private val Ferry = Color(0xFF5AB031)
     private val BarbiePink = Color(0xFFE0218A)
+    private val MagicYellow = magic_yellow
 
     private val partners: Map<KrailThemeStyle, Pair<Color, Color>> = mapOf(
         KrailThemeStyle.Train to (Train to PurpleDrip),
         KrailThemeStyle.Metro to (Metro to PurpleDrip),
-        KrailThemeStyle.Bus to (Bus to BarbiePink),
+        // Yellow, not pink. Blue into pink travels through purple and reads as somebody
+        // else's AI product; blue into yellow is the one pair here that crosses from cool to
+        // warm, so the two ends stay told apart wherever the gradient is in its drift. It is
+        // also KRAIL's own yellow rather than a colour invented for this.
+        KrailThemeStyle.Bus to (Bus to MagicYellow),
         KrailThemeStyle.PurpleDrip to (PurpleDrip to Bus),
         KrailThemeStyle.Ferry to (Ferry to BarbiePink),
         KrailThemeStyle.BarbiePink to (BarbiePink to Bus),

--- a/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackgroundTintTest.kt
+++ b/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/components/CloudGradientBackgroundTintTest.kt
@@ -1,0 +1,91 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.md_theme_dark_onSurface
+import xyz.ksharma.krail.taj.theme.md_theme_dark_surface
+import xyz.ksharma.krail.taj.theme.md_theme_light_onSurface
+import xyz.ksharma.krail.taj.theme.md_theme_light_surface
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The cloud field's palette, decided by arithmetic rather than by looking at a device.
+ *
+ * The property that matters is simple and was the thing that broke: **a glow has to be lighter
+ * than what it sits on.** In dark mode both blob tints were being pulled towards `surface`,
+ * which is near black, so a saturated theme colour walked *down* towards black and the field
+ * read as navy sludge instead of light. In light mode pulling towards surface is correct,
+ * because there surface is white.
+ *
+ * Every theme style is checked in both modes, so adding a theme colour that breaks in one mode
+ * fails here instead of on somebody's phone.
+ */
+class CloudGradientBackgroundTintTest {
+
+    @Test
+    fun darkMode_bothTintsAreLighterThanTheSurfaceTheySitOn() {
+        val surfaceLuminance = md_theme_dark_surface.luminance()
+
+        KrailThemeStyle.entries.forEach { style ->
+            val (tintA, tintB) = tintsFor(style, darkMode = true)
+
+            assertTrue(
+                tintA.luminance() > surfaceLuminance,
+                "${style.name}: tintA luminance ${tintA.luminance()} should exceed the dark " +
+                    "surface's $surfaceLuminance. A tint darker than its background is a smear, " +
+                    "not a glow.",
+            )
+            assertTrue(
+                tintB.luminance() > surfaceLuminance,
+                "${style.name}: tintB luminance ${tintB.luminance()} should exceed the dark " +
+                    "surface's $surfaceLuminance.",
+            )
+        }
+    }
+
+    @Test
+    fun darkMode_theFarTintIsLighterThanTheNearOne() {
+        KrailThemeStyle.entries.forEach { style ->
+            val (tintA, tintB) = tintsFor(style, darkMode = true)
+
+            // B is pulled further towards the light end than A, so the field brightens outward
+            // rather than banding.
+            assertTrue(
+                tintB.luminance() > tintA.luminance(),
+                "${style.name}: tintB (${tintB.luminance()}) should be lighter than tintA " +
+                    "(${tintA.luminance()}) in dark mode.",
+            )
+        }
+    }
+
+    @Test
+    fun lightMode_bothTintsStayLighterThanTheThemeColourItself() {
+        KrailThemeStyle.entries.forEach { style ->
+            val themeColor = style.hexColorCode.hexToComposeColor()
+            val (tintA, tintB) = tintsFor(style, darkMode = false)
+
+            // Towards white, so both soften rather than intensify. This is what stops a
+            // saturated theme colour reading as a hot spot on a white screen.
+            assertTrue(
+                tintA.luminance() > themeColor.luminance(),
+                "${style.name}: tintA should be lighter than the raw theme colour in light mode.",
+            )
+            assertTrue(
+                tintB.luminance() > tintA.luminance(),
+                "${style.name}: tintB should be lighter than tintA in light mode.",
+            )
+        }
+    }
+
+    private fun tintsFor(style: KrailThemeStyle, darkMode: Boolean): Pair<Color, Color> {
+        return cloudBlobTints(
+            themeColor = style.hexColorCode.hexToComposeColor(),
+            surface = if (darkMode) md_theme_dark_surface else md_theme_light_surface,
+            onSurface = if (darkMode) md_theme_dark_onSurface else md_theme_light_onSurface,
+            darkMode = darkMode,
+        )
+    }
+}


### PR DESCRIPTION
## What

`CloudGradientBackground` was one hue with two tints of itself, at a fixed amplitude, hardcoded for a wallpaper role behind a list. Both become callable decisions, and the dark-mode tint was outright wrong.

## Changes

- `CloudFieldSpec`: colours, motion, speed and alpha as one value. `Ambient` reproduces the existing behaviour exactly, so SearchStop is unchanged by this PR. `aiPair()` builds the theme's AI gradient trio for surfaces where the field is the subject rather than the backdrop
- **Dark-mode tint fix**: both blob tints lerped towards `surface`, which is near black in dark mode, so the further-out blob walked *down* towards black. The field darkened as it spread instead of reading as light. Now lerps towards `onSurface` in dark mode and `surface` in light
- `cloudBlobTints()` extracted as a pure function, so the palette can be asserted by arithmetic instead of by looking at a device
- `AiThemeGradientTokens`: Bus pairs with magic yellow instead of pink. Blue into pink travels through purple; blue into yellow is the one pair in the set that crosses cool to warm, so the two ends stay distinguishable wherever the gradient sits in its drift

Hue arcs were measured rather than eyeballed: blue-pink 132 degrees, blue-yellow 148. The documented range in `AiThemeGradientTokens` moves from 97-134 to 97-148 rather than being quietly broken.

## Testing

- `CloudGradientBackgroundTintTest`: across all six theme styles in both modes, asserts tints stay lighter than the surface they sit on and brighten outward
- **Mutation-checked**: under the old rule the suite fails with `tintB (0.076) should be lighter than tintA (0.165) in dark mode`, so it genuinely catches this rather than passing regardless
- `./scripts/fullQualityChecks.sh` green
