### PR TITLE
feat(trip-planner): add the Ask KRAIL situations table

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituations.kt
@@ -1,0 +1,95 @@
+package xyz.ksharma.krail.trip.planner.ui.components.ai
+
+/**
+ * When the suggestion applies, which way the journey runs, and what time it asks for.
+ *
+ * This table is the whole time-and-day dimension of the suggestion line, as data rather than as
+ * control flow. Adding a situation ("Friday night", "public holiday", "school term morning") is
+ * one row here, in a list whose order IS the priority: first match wins.
+ *
+ * It was an `if` for the weekend and another `if` for the clause, which was shorter and not
+ * extendible. A seventh case meant editing the middle of a function and hoping the ordering
+ * still held; here a case is a line, and the ordering is visible.
+ *
+ * The other dimension, WHICH two stops, is deliberately not in here. That is a fallback ladder
+ * over the rider's own data (labels, then a saved trip, then two known stations) and it runs the
+ * same way regardless of the hour. Putting it in every row would mean repeating it in every row.
+ *
+ * ## Configurable later
+ *
+ * [suggestionSituations] is the only seam that needs to change. A Remote Config version returns
+ * the parsed list instead of the constant one and nothing that renders a suggestion has to know.
+ * That is deliberately NOT wired yet: copy that changes a few times a year does not need a
+ * remote pipe, and a remote-driven string that renders to every rider is its own validation
+ * problem. Build the seam, wire the pipe when there is something that cannot wait for a release.
+ */
+internal data class SuggestionSituation(
+    /** Stable across copy changes, so config and tests can name a row without quoting it. */
+    val id: String,
+    val dayKind: DayKind,
+    /** Inclusive. May be greater than [toHour], which means the band wraps past midnight. */
+    val fromHour: Int,
+    /** Exclusive. */
+    val toHour: Int,
+    val direction: Direction,
+    /**
+     * Appended verbatim, leading space included. Must still be true at every hour in the band:
+     * "by 9am" at 11am would be the app suggesting a trip into the past.
+     */
+    val clause: String,
+)
+
+internal enum class DayKind { Weekday, Weekend, Any }
+
+/** Out is home to the other place; Back is the reverse. */
+internal enum class Direction { Out, Back }
+
+// Relative, so it is correct at any hour. The absolute clauses each sit in a band that ends
+// before the time they name.
+internal const val CLAUSE_SOON = " in 20 minutes"
+
+private val DEFAULT_SITUATIONS = listOf(
+    // Arrive-by is what a weekday morning is for, and the only place the app demonstrates that
+    // this surface understands a deadline rather than just a departure.
+    // Ends AT nine, not after it. Running to ten meant a rider opening this at 09:30 was told
+    // to try arriving by 9am, which is the app suggesting a trip into the past.
+    SuggestionSituation("weekday-morning", DayKind.Weekday, 5, 9, Direction.Out, " by 9am"),
+    SuggestionSituation("weekday-midday", DayKind.Weekday, 9, 15, Direction.Out, CLAUSE_SOON),
+    // From mid-afternoon the journey people are about to take is the one home.
+    SuggestionSituation("weekday-evening", DayKind.Weekday, 15, 18, Direction.Back, " after 6pm"),
+    SuggestionSituation("weekday-night", DayKind.Weekday, 18, 23, Direction.Back, CLAUSE_SOON),
+    // No "by 9am" at a weekend: nobody is being got to work for nine on a Saturday, and the
+    // suggestion is the one line on the screen that is supposed to show the app paying attention.
+    SuggestionSituation("weekend-day", DayKind.Weekend, 5, 15, Direction.Out, CLAUSE_SOON),
+    SuggestionSituation("weekend-evening", DayKind.Weekend, 15, 23, Direction.Back, CLAUSE_SOON),
+    // Last, and Any, so it catches whatever the bands above did not on either kind of day.
+    SuggestionSituation("late-night", DayKind.Any, 23, 5, Direction.Out, CLAUSE_SOON),
+)
+
+/** The single seam. See the note on [SuggestionSituation] about making this remote. */
+internal fun suggestionSituations(): List<SuggestionSituation> = DEFAULT_SITUATIONS
+
+/**
+ * First row whose day and hour both match.
+ *
+ * Falls back to the first row rather than returning null: a rider opening this screen at an hour
+ * somebody forgot to cover should see a slightly wrong suggestion, never a blank space where the
+ * one explanatory line was meant to be. `everyHourOfEveryDayHasASituation` in the test makes
+ * that fallback unreachable, and is there to keep it unreachable as rows are added.
+ */
+internal fun situationFor(
+    hour: Int,
+    isWeekend: Boolean,
+    situations: List<SuggestionSituation> = suggestionSituations(),
+): SuggestionSituation {
+    val dayKind = if (isWeekend) DayKind.Weekend else DayKind.Weekday
+    return situations.firstOrNull { situation ->
+        situation.matchesDay(dayKind) && situation.matchesHour(hour)
+    } ?: situations.first()
+}
+
+private fun SuggestionSituation.matchesDay(dayKind: DayKind): Boolean =
+    this.dayKind == DayKind.Any || this.dayKind == dayKind
+
+private fun SuggestionSituation.matchesHour(hour: Int): Boolean =
+    if (fromHour <= toHour) hour in fromHour until toHour else hour >= fromHour || hour < toHour

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituationsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituationsTest.kt
@@ -1,0 +1,115 @@
+package xyz.ksharma.krail.trip.planner.ui.components.ai
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The situations table is meant to be added to. These hold the properties that make adding a row
+ * safe, so a seventh situation cannot silently open a gap or shadow an existing one.
+ */
+class AiSuggestionSituationsTest {
+
+    @Test
+    fun `every hour of every kind of day has a situation`() {
+        // The gap this prevents is invisible: `situationFor` falls back to the first row, so a
+        // missed hour shows a wrong suggestion rather than crashing, and nobody notices for
+        // months. The wrapping band past midnight is where it would happen.
+        listOf(true, false).forEach { weekend ->
+            (0..23).forEach { hour ->
+                val matches = suggestionSituations().filter { situation ->
+                    val dayMatches = situation.dayKind == DayKind.Any ||
+                        (situation.dayKind == DayKind.Weekend) == weekend
+                    val hourMatches = if (situation.fromHour <= situation.toHour) {
+                        hour in situation.fromHour until situation.toHour
+                    } else {
+                        hour >= situation.fromHour || hour < situation.toHour
+                    }
+                    dayMatches && hourMatches
+                }
+                assertTrue(
+                    matches.isNotEmpty(),
+                    "hour $hour weekend=$weekend matches no situation",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every situation has a unique id`() {
+        // Ids are how config and tests name a row without quoting its copy. Two rows sharing one
+        // makes the second unaddressable.
+        val ids = suggestionSituations().map { it.id }
+
+        assertEquals(ids.size, ids.toSet().size, "duplicate situation id in $ids")
+    }
+
+    @Test
+    fun `every situation asks for a time`() {
+        // A situation with no clause would quietly drop the one capability this screen has that
+        // the search row does not.
+        suggestionSituations().forEach { situation ->
+            assertTrue(situation.clause.isNotBlank(), "${situation.id} carries no time")
+            assertTrue(situation.clause.startsWith(" "), "${situation.id} would run into the stop name")
+        }
+    }
+
+    @Test
+    fun `an absolute clause never appears in a band that has already passed it`() {
+        // "by 9am" at 11am is a trip into the past. Checked against the band rather than against
+        // one sampled hour, so a row widened later fails here instead of on a phone.
+        suggestionSituations().forEach { situation ->
+            ABSOLUTE_CLAUSES.forEach { (clause, deadlineHour) ->
+                if (situation.clause.contains(clause)) {
+                    assertTrue(
+                        situation.toHour <= deadlineHour && situation.fromHour <= situation.toHour,
+                        "${situation.id} offers \"$clause\" in a band running to ${situation.toHour}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `no weekend situation asks to arrive by nine`() {
+        // Nobody is being got to work for nine on a Saturday.
+        suggestionSituations()
+            .filter { it.dayKind == DayKind.Weekend }
+            .forEach { situation ->
+                assertTrue(
+                    !situation.clause.contains("9am"),
+                    "${situation.id} suggests a nine o'clock start at a weekend",
+                )
+            }
+    }
+
+    @Test
+    fun `the journey turns around in the afternoon on both kinds of day`() {
+        assertEquals(Direction.Out, situationFor(hour = 8, isWeekend = false).direction)
+        assertEquals(Direction.Back, situationFor(hour = 17, isWeekend = false).direction)
+        assertEquals(Direction.Out, situationFor(hour = 10, isWeekend = true).direction)
+        assertEquals(Direction.Back, situationFor(hour = 19, isWeekend = true).direction)
+    }
+
+    @Test
+    fun `the first matching situation wins`() {
+        // Order is the priority, so a row added at the top must be able to shadow one below it.
+        // That is the mechanism by which a special case (a holiday, an event) gets added later.
+        val special = SuggestionSituation(
+            id = "special",
+            dayKind = DayKind.Any,
+            fromHour = 0,
+            toHour = 24,
+            direction = Direction.Back,
+            clause = CLAUSE_SOON,
+        )
+        val situations = listOf(special) + suggestionSituations()
+
+        assertEquals("special", situationFor(hour = 8, isWeekend = false, situations = situations).id)
+    }
+
+    private companion object {
+        /** Clause to the hour by which it stops being in the future. */
+        val ABSOLUTE_CLAUSES = mapOf("9am" to 9, "6pm" to 18)
+    }
+}


### PR DESCRIPTION
## What

When an Ask KRAIL suggestion applies, which way the journey runs, and what time it asks for, as an ordered table where first match wins. Nothing reads it yet; the suggestion built on it is #1857.

## Changes

- `AiSuggestionSituations.kt`: `SuggestionSituation` rows plus `situationFor()`. Seven rows covering weekday morning/midday/evening/night, weekend day/evening, and a wrapping late-night band

This replaces what would otherwise have been an `if` for the weekend and another for the time clause. Adding a case ("Friday night", "public holiday") is one row, and the priority is visible in the ordering rather than implied by control flow.

`suggestionSituations()` is the single seam if this ever needs to come from Remote Config. Deliberately not wired: copy that changes a few times a year does not need a remote pipe, and a remote-driven string rendering to every rider is its own validation problem.

Which two stops the suggestion names is **not** in this table. That is a fallback ladder over the rider's data and it runs the same way at every hour, so putting it in each row would repeat it seven times.

## Testing

7 tests holding the properties that make adding a row safe:

- every hour on both kinds of day matches at least one row
- ids are unique
- every row carries a time clause, correctly prefixed
- no absolute clause appears in a band that outruns it
- no weekend row asks to arrive by nine
- direction turns around in the afternoon on both kinds of day
- a row added at the top can shadow one below it

One of them caught a live bug: `weekday-morning` ran to hour 10 while offering "by 9am", so a rider opening the screen at 09:30 was told to try arriving by 9am. The band now ends at nine.
