### PR TITLE
feat(trip-planner): pick the Ask KRAIL suggestion from the rider's own stops

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
@@ -1,0 +1,175 @@
+package xyz.ksharma.krail.trip.planner.ui.components.ai
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import kotlin.time.Clock
+
+/**
+ * The one line above the field: a journey this rider could actually ask for, right now.
+ *
+ * There used to be six hand-written greetings ("Morning.", "Still out?") with an example under
+ * each. That was two lines saying two different things on a screen whose field already says
+ * `Ask KRAIL`, and the greetings carried no information: the rider knows what time it is.
+ *
+ * So the copy is gone and the variety moved to where it can be true. The line is built from the
+ * rider's own stops plus the calendar, which means it changes across a day and across a week
+ * without anybody writing six moods, and every version of it is a sentence they could say back.
+ *
+ * Ordered by how much each source proves the app knows them:
+ *
+ * 1. **Their labels, in their own words** — `Home to Work`. This is the only place the app ever
+ *    shows that typing "work" resolves to their stop; nobody finds that on their own.
+ * 2. **A saved trip, as real station names** — `Seven Hills to Wynyard`. Their trip, so the
+ *    stations are ones they recognise.
+ * 3. **Two known stations** — the first-launch case, where anything personal would be invented.
+ *
+ * Recents used to sit between 2 and 3. The parameter existed, `SavedTripsScreen` never passed
+ * anything to it, and the rung never ran. It is gone rather than left looking implemented.
+ */
+internal data class AiGreeting(val suggestion: String)
+
+// The rider's word for a place they go on a schedule. Excluded at weekends outright: suggesting
+// a commute on a Sunday is the app telling someone it has not been paying attention, and about
+// a third of trips here are loaded at a weekend. Matched case-insensitively against the label
+// the rider typed, so a free-text "Gym" or "Beach" is never caught by it.
+private val COMMUTE_LABELS = setOf("work", "uni", "school")
+
+private const val HOME_LABEL = "home"
+private const val DEFAULT_FROM = "Central"
+private const val DEFAULT_TO = "Parramatta"
+
+// A weekend rider with nothing but commute data gets somewhere people actually go at a weekend,
+// rather than their own commute handed back to them on a Sunday.
+private const val WEEKEND_DEFAULT_TO = "Bondi Junction"
+
+// Two NSW station names and a time clause can run past two lines in the fixed-height slot, and
+// the slot cannot grow without moving the field. Over the cap the clause goes first, then the
+// whole rung.
+private const val LONGEST_LINE = 38
+
+private const val STATION_SUFFIX = " Station"
+
+/**
+ * The suggestion for a given moment, as a pure function so it can be checked without a device.
+ */
+internal fun suggestionFor(
+    hour: Int,
+    isWeekend: Boolean,
+    labels: List<StopLabel>,
+    savedTrips: List<Trip>,
+): String {
+    val pair = labelPair(labels, isWeekend)
+        ?: eligibleTrip(savedTrips, labels, isWeekend)?.let { trip ->
+            trip.fromStopName.withoutStationSuffix() to trip.toStopName.withoutStationSuffix()
+        }
+        ?: defaultPair(isWeekend)
+
+    // Everything about the hour and the day comes from the situations table, so this function
+    // only has to know how to turn two stops plus a situation into a sentence.
+    val situation = situationFor(hour = hour, isWeekend = isWeekend)
+    val (from, to) = if (situation.direction == Direction.Back) pair.second to pair.first else pair
+
+    // Longest first, then what to give up. The clause goes before the stops do, because a
+    // journey with no time still describes their journey and a time with the wrong stops does
+    // not describe anything.
+    val fallbacks = listOf(
+        "$from to $to${situation.clause}",
+        "$from to $to",
+        "$DEFAULT_FROM to $DEFAULT_TO",
+    )
+    return fallbacks.firstOrNull { it.length <= LONGEST_LINE } ?: "$DEFAULT_FROM to $DEFAULT_TO"
+}
+
+private fun defaultPair(isWeekend: Boolean): Pair<String, String> =
+    DEFAULT_FROM to if (isWeekend) WEEKEND_DEFAULT_TO else DEFAULT_TO
+
+/**
+ * The first saved trip that is not the rider's commute in disguise.
+ *
+ * Excluding commute LABELS at weekends was not enough, and this is the hole it left: a rider
+ * whose only saved trip is the trip to work saw exactly that suggested on a Sunday, because the
+ * label rung was skipped and the saved-trip rung had no opinion about the day. The exclusion has
+ * to follow the stops, not the words, since the same two platforms are the commute whether or
+ * not anybody has labelled them.
+ */
+private fun eligibleTrip(savedTrips: List<Trip>, labels: List<StopLabel>, isWeekend: Boolean): Trip? {
+    if (!isWeekend) return savedTrips.firstOrNull()
+
+    val commuteStopIds = labels
+        .filter { it.isSet && it.label.lowercase() in COMMUTE_LABELS }
+        .mapNotNull { it.stopId }
+        .toSet()
+
+    return savedTrips.firstOrNull { trip ->
+        trip.fromStopId !in commuteStopIds && trip.toStopId !in commuteStopIds
+    }
+}
+
+/**
+ * Home plus one other place the rider has named, in their own words.
+ *
+ * Both halves have to be `isSet`. A label exists from the moment it is created, before any stop
+ * is pinned to it, and suggesting "Home to Work" to a rider for whom typing "work" resolves to
+ * nothing would be the app teaching a trick it cannot do.
+ *
+ * On a weekday the commute label wins if there is one, because that is the trip being taken. At
+ * a weekend commute labels are dropped entirely and any other named place is used instead, which
+ * is how "Home to Gym" turns up on a Saturday without anybody writing a Saturday template.
+ */
+private fun labelPair(labels: List<StopLabel>, isWeekend: Boolean): Pair<String, String>? {
+    val set = labels.filter { it.isSet }
+    val home = set.firstOrNull { it.label.equals(HOME_LABEL, ignoreCase = true) }
+
+    val others = set.filterNot { it.label.equals(HOME_LABEL, ignoreCase = true) }
+    val eligible = if (isWeekend) {
+        others.filterNot { it.label.lowercase() in COMMUTE_LABELS }
+    } else {
+        others.sortedByDescending { it.label.lowercase() in COMMUTE_LABELS }
+    }
+    val other = eligible.firstOrNull()
+
+    return if (home != null && other != null) home.label to other.label else null
+}
+
+/**
+ * `Seven Hills Station` reads as `Seven Hills`. Only the trailing word goes: everything else in
+ * a NSW stop name is doing work, including the `Light Rail` and `Wharf` suffixes that tell two
+ * otherwise identical names apart.
+ */
+private fun String.withoutStationSuffix(): String = removeSuffix(STATION_SUFFIX)
+
+/**
+ * The suggestion for right now.
+ *
+ * Remembered on the hour rather than per recomposition: nothing here changes inside one, and
+ * re-reading the clock while a rider types would be work for nothing.
+ */
+@Composable
+internal fun rememberAiGreeting(
+    stopLabels: List<StopLabel>,
+    savedTrips: List<Trip>,
+): AiGreeting {
+    val now = Clock.System.now().toLocalDateTime(TimeZone.of(SYDNEY))
+    val hour = now.hour
+    val isWeekend = now.dayOfWeek == DayOfWeek.SATURDAY || now.dayOfWeek == DayOfWeek.SUNDAY
+
+    return remember(hour, isWeekend, stopLabels, savedTrips) {
+        AiGreeting(
+            suggestion = suggestionFor(
+                hour = hour,
+                isWeekend = isWeekend,
+                labels = stopLabels,
+                savedTrips = savedTrips,
+            ),
+        )
+    }
+}
+
+// Sydney, not the device zone, for the same reason the time resolver fixes it: this is a
+// Sydney app, and a traveller's phone still on another clock would get the wrong day entirely.
+private const val SYDNEY = "Australia/Sydney"

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreetingTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreetingTest.kt
@@ -1,0 +1,231 @@
+package xyz.ksharma.krail.trip.planner.ui.components.ai
+
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The suggestion line is the only thing on this screen the rider does not already know, so the
+ * rules that build it are worth holding. Every case here is arithmetic on the clock and their
+ * saved data, which means none of it needs a device to check.
+ */
+class AiGreetingTest {
+
+    private val home = StopLabel(emoji = "🏠", label = "Home", stopId = "1", stopName = "Seven Hills Station")
+    private val work = StopLabel(emoji = "💼", label = "Work", stopId = "2", stopName = "Wynyard Station")
+    private val gym = StopLabel(emoji = "🏋", label = "Gym", stopId = "3", stopName = "Bondi Junction")
+    private val unsetWork = StopLabel(emoji = "💼", label = "Work")
+    private val savedTrip = Trip(
+        fromStopId = "1",
+        fromStopName = "Seven Hills Station",
+        toStopId = "2",
+        toStopName = "Wynyard Station",
+    )
+
+    private fun suggestion(
+        hour: Int,
+        isWeekend: Boolean = false,
+        labels: List<StopLabel> = emptyList(),
+        savedTrips: List<Trip> = emptyList(),
+    ) = suggestionFor(hour = hour, isWeekend = isWeekend, labels = labels, savedTrips = savedTrips)
+
+    // region Always a complete line
+
+    @Test
+    fun `every hour of every kind of day produces a complete line`() {
+        // A half-built suggestion is worse than a generic one, and the empty-data case is the
+        // state every rider is in exactly once.
+        listOf(true, false).forEach { weekend ->
+            (0..23).forEach { hour ->
+                val line = suggestion(hour, weekend)
+                assertTrue(line.isNotBlank(), "hour $hour weekend=$weekend produced nothing")
+                assertTrue(line.contains(" to "), "\"$line\" is not a journey")
+            }
+        }
+    }
+
+    @Test
+    fun `no line outgrows the fixed height slot`() {
+        // The slot cannot grow without moving the field, which is the one thing this layout
+        // promises never to do.
+        val longNames = listOf(
+            StopLabel(emoji = "🏠", label = "Home", stopId = "1", stopName = "Seven Hills Station"),
+            StopLabel(emoji = "💼", label = "Work", stopId = "2", stopName = "Wynyard Station"),
+        )
+        val longTrip = Trip(
+            fromStopId = "1",
+            fromStopName = "International Airport Station",
+            toStopId = "2",
+            toStopName = "Sydney Olympic Park Station",
+        )
+        (0..23).forEach { hour ->
+            listOf(true, false).forEach { weekend ->
+                listOf(
+                    suggestion(hour, weekend, labels = longNames),
+                    suggestion(hour, weekend, savedTrips = listOf(longTrip)),
+                ).forEach { line ->
+                    assertTrue(line.length <= LONGEST_LINE_FOR_TEST, "\"$line\" is ${line.length} chars")
+                }
+            }
+        }
+    }
+
+    // endregion
+
+    // region Weekends
+
+    @Test
+    fun `a weekend never suggests the commute`() {
+        // About a third of trips here are loaded at a weekend. Suggesting work on a Sunday is
+        // the app saying out loud that it has not been paying attention.
+        listOf("Work", "Uni", "School").forEach { commuteLabel ->
+            val labels = listOf(home, StopLabel(emoji = "💼", label = commuteLabel, stopId = "2", stopName = "Wynyard"))
+            (0..23).forEach { hour ->
+                val line = suggestion(hour, isWeekend = true, labels = labels)
+                assertFalse(
+                    line.contains(commuteLabel, ignoreCase = true),
+                    "\"$line\" suggests $commuteLabel at the weekend",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a weekend does not hand back the commute through a saved trip`() {
+        // The bug this rule exists for: the label rung is skipped at weekends, and a rider
+        // whose only saved trip IS the trip to work then saw exactly that on a Sunday.
+        val commuteTrip = Trip(
+            fromStopId = "1",
+            fromStopName = "Seven Hills Station",
+            toStopId = "2",
+            toStopName = "Wynyard Station",
+        )
+        val line = suggestion(
+            hour = 11,
+            isWeekend = true,
+            labels = listOf(home, work),
+            savedTrips = listOf(commuteTrip),
+        )
+
+        assertFalse(line.contains("Wynyard"), "\"$line\" is the commute on a weekend")
+        assertTrue(line.contains("Bondi Junction"), "\"$line\" should offer somewhere else")
+    }
+
+    @Test
+    fun `a weekend keeps a saved trip that is not the commute`() {
+        val beachTrip = Trip(
+            fromStopId = "9",
+            fromStopName = "Central Station",
+            toStopId = "8",
+            toStopName = "Bondi Junction",
+        )
+        val line = suggestion(
+            hour = 11,
+            isWeekend = true,
+            labels = listOf(home, work),
+            savedTrips = listOf(beachTrip),
+        )
+
+        assertTrue(line.startsWith("Central to Bondi Junction"), "\"$line\" dropped a fine trip")
+    }
+
+    @Test
+    fun `a weekend uses another named place when there is one`() {
+        val line = suggestion(hour = 10, isWeekend = true, labels = listOf(home, work, gym))
+
+        assertTrue(line.startsWith("Home to Gym"), "\"$line\" should use the non-commute label")
+    }
+
+    @Test
+    fun `a weekday prefers the commute label over other places`() {
+        val line = suggestion(hour = 8, isWeekend = false, labels = listOf(home, gym, work))
+
+        assertTrue(line.startsWith("Home to Work"), "\"$line\" should lead with the commute")
+    }
+
+    // endregion
+
+    // region Which source wins
+
+    @Test
+    fun `labels are used in the rider's own words`() {
+        // The only place the app ever shows that typing "work" resolves to their stop.
+        val line = suggestion(hour = 8, labels = listOf(home, work))
+
+        assertTrue(line.startsWith("Home to Work"), "\"$line\" should use the labels, not stop names")
+    }
+
+    @Test
+    fun `a label with no stop pinned to it is not a label`() {
+        // It exists from the moment it is created. Suggesting it would teach a trick the app
+        // cannot do, so this falls through to the saved trip.
+        val line = suggestion(hour = 8, labels = listOf(home, unsetWork), savedTrips = listOf(savedTrip))
+
+        assertTrue(line.startsWith("Seven Hills to Wynyard"), "\"$line\" should have fallen to the saved trip")
+    }
+
+    @Test
+    fun `a saved trip is shown as station names with the suffix trimmed`() {
+        val line = suggestion(hour = 8, savedTrips = listOf(savedTrip))
+
+        assertTrue(line.startsWith("Seven Hills to Wynyard"), "\"$line\" kept its Station suffix")
+    }
+
+    @Test
+    fun `a rider with nothing at all still gets a real journey`() {
+        val line = suggestion(hour = 11)
+
+        assertTrue(line.startsWith("Central to Parramatta"), "\"$line\" is not a real journey")
+    }
+
+    // endregion
+
+    // region Time
+
+    @Test
+    fun `every suggestion carries a time`() {
+        // The time is the only thing this screen understands that the search row does not. A
+        // rider who never sees it demonstrated has no reason to believe they can type it.
+        listOf(true, false).forEach { weekend ->
+            (0..23).forEach { hour ->
+                val line = suggestion(hour, weekend, labels = listOf(home, gym))
+                assertTrue(
+                    TIME_WORDS.any { line.contains(it) },
+                    "\"$line\" at hour $hour carries no time",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `no suggestion proposes a time that has already passed`() {
+        // "by 9am" at 11am is the app suggesting a trip into the past, which reads as broken
+        // rather than as an example.
+        (10..23).forEach { hour ->
+            val line = suggestion(hour, labels = listOf(home, work))
+            assertFalse(line.contains("by 9am"), "\"$line\" at $hour points backwards")
+        }
+        (18..23).forEach { hour ->
+            val line = suggestion(hour, labels = listOf(home, work))
+            assertFalse(line.contains("after 6pm"), "\"$line\" at $hour points backwards")
+        }
+    }
+
+    @Test
+    fun `the journey runs back from mid afternoon`() {
+        assertTrue(suggestion(hour = 8, labels = listOf(home, work)).startsWith("Home to Work"))
+        assertTrue(suggestion(hour = 17, labels = listOf(home, work)).startsWith("Work to Home"))
+    }
+
+    // endregion
+
+    private companion object {
+        // Mirrors LONGEST_LINE in AiGreeting.kt. Duplicated rather than exposed: the production
+        // constant is an implementation detail, and a test that reads it cannot fail when it
+        // changes.
+        const val LONGEST_LINE_FOR_TEST = 38
+        val TIME_WORDS = listOf("by 9am", "in 20 minutes", "after 6pm")
+    }
+}


### PR DESCRIPTION
## What

Which two stops the Ask KRAIL suggestion names, as a fallback ladder over what the rider already has. Reads the situations table from #1856 for the time and direction. Nothing renders it yet.

## Changes

- `AiGreeting.kt`: `suggestionFor()` plus `rememberAiGreeting()`

Ordered by how much each source proves the app knows them:

1. **Their labels, in their own words** (`Home to Work`) — the only place the app ever shows that typing "work" resolves to their stop
2. **A saved trip**, as station names with the `" Station"` suffix trimmed
3. **Two known stations**, for a first launch where anything personal would be invented

Commute labels (`work`, `uni`, `school`) are dropped at weekends, and the exclusion follows **stop IDs**, not label names. Names alone left a hole: a rider whose only saved trip is the trip to work saw exactly that suggested on a Sunday, because the label rung was skipped and the saved-trip rung had no opinion about the day.

A label with no stop pinned to it is not usable, even though it exists from the moment it is created. Suggesting it would teach a trick the app cannot do.

## Testing

13 tests:

- every hour on both kinds of day yields a complete journey
- nothing outgrows the fixed-height slot, checked with the longest NSW station names
- weekends never surface a commute by either route, including the saved-trip hole above
- a non-commute saved trip is still kept at a weekend
- the ladder falls in order, including the unset-label case
- no line proposes a time that has already passed
