### PR TITLE
feat(trip-planner): stop listening at a ceiling and drop the invented time

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -104,12 +104,27 @@ class AiSearchInputViewModel(
     fun onEvent(event: AiSearchInputEvent) {
         when (event) {
             is AiSearchInputEvent.TypedTextChanged -> _uiState.update {
-                // Typing is the way out of a mic problem, so the warning clears as they type.
+                // Typing is the way out of every problem this surface can show, so the message
+                // clears as they type rather than needing a control of its own to dismiss. A
+                // banner with an X on it asks the rider to tidy up after a failure that was
+                // not theirs; editing the sentence is already them saying they have moved on.
+                //
                 // Only on real text: the text field reports its initial empty value as soon as
-                // it composes, which would otherwise clear the warning before it is ever read.
+                // it composes, which would otherwise clear the message before it is ever read.
+                val startedEditing = event.text.isNotEmpty()
                 it.copy(
                     typedText = event.text,
-                    speechUnavailableReason = if (event.text.isEmpty()) it.speechUnavailableReason else null,
+                    speechUnavailableReason = if (startedEditing) null else it.speechUnavailableReason,
+                    // An unresolved result is a problem about the last sentence. The moment the
+                    // rider changes that sentence it is stale, and leaving it up makes the new
+                    // attempt look like it has already failed.
+                    phase = if (startedEditing && it.phase == AiSearchInputPhase.UNRESOLVED) {
+                        AiSearchInputPhase.IDLE
+                    } else {
+                        it.phase
+                    },
+                    unresolvedReason = if (startedEditing) null else it.unresolvedReason,
+                    unmatchedPlace = if (startedEditing) null else it.unmatchedPlace,
                 )
             }
 
@@ -326,8 +341,12 @@ class AiSearchInputViewModel(
 
                 else -> null to null
             }
-            val dateTimeSelectionItem =
-                resolveTimeIntent(extraction.timeIntent, riderText = text) ?: leaveNowDateTimeSelectionItem()
+            // No fallback to "leave now". A rider who mentioned no time gets no time, because
+            // the home screen now shows this as a chip: falling back produced "Leave Today
+            // 12:29 AM" on a sentence that said nothing about when, which is the app inventing
+            // a decision and then displaying it back as though the rider had made it. Null
+            // already means now everywhere downstream.
+            val dateTimeSelectionItem = resolveTimeIntent(extraction.timeIntent, riderText = text)
 
             val intent = ResolvedTripIntent(
                 fromText = fromText,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -132,6 +132,24 @@ class AiSearchInputViewModelTest {
     }
 
     @Test
+    fun `editing the sentence clears the problem it produced`() = runTest(testDispatcher) {
+        aiTextService.extractionResult = null
+        viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("take me to hogwarts"))
+        viewModel.onEvent(AiSearchInputEvent.Submit)
+        advanceUntilIdle()
+        assertEquals(AiSearchInputPhase.UNRESOLVED, viewModel.uiState.value.phase)
+
+        // No dismiss control by design: a banner with an X asks the rider to tidy up after a
+        // failure that was not theirs. Changing the sentence is already them moving on, and
+        // leaving the old message up makes the new attempt look like it has failed too.
+        viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("take me to central"))
+
+        assertEquals(AiSearchInputPhase.IDLE, viewModel.uiState.value.phase)
+        assertNull(viewModel.uiState.value.unresolvedReason)
+        assertNull(viewModel.uiState.value.unmatchedPlace)
+    }
+
+    @Test
     fun `submit with blank text does nothing`() = runTest(testDispatcher) {
         viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("   "))
 
@@ -361,7 +379,7 @@ class AiSearchInputViewModelTest {
     }
 
     @Test
-    fun `no time mentioned defaults to leave-now, not left unset`() = runTest(testDispatcher) {
+    fun `no time mentioned means no time, not a time we chose`() = runTest(testDispatcher) {
         aiTextService.extractionResult = TripIntentExtraction(
             originText = "Central Station",
             destinationText = "Town Hall",
@@ -372,8 +390,12 @@ class AiSearchInputViewModelTest {
         viewModel.onEvent(AiSearchInputEvent.Submit)
         advanceUntilIdle()
 
-        val resolved = viewModel.uiState.value.resolved
-        assertEquals(JourneyTimeOptions.LEAVE, resolved?.dateTimeSelectionItem?.option)
+        // This used to fall back to "leave now", which was harmless while nothing displayed it
+        // and became wrong the moment the home screen grew a chip: a rider who said nothing
+        // about when saw "Leave Today 12:29 AM" and read it as a decision they had made. Null
+        // already means now everywhere downstream, so the fallback was never carrying meaning,
+        // only manufacturing it.
+        assertNull(viewModel.uiState.value.resolved?.dateTimeSelectionItem)
     }
 
     @Test


### PR DESCRIPTION
## What

Three behaviours in `AiSearchInputViewModel` that the rebuilt surface exposed.

## Changes

- **Listening stops itself** at a 10 second ceiling, extended to 15 if words were still arriving in the last 4. The recogniser does not always report an end, and a mic that stays open with no way out is worse than one that closes early
- `TypedTextChanged` now clears the `UNRESOLVED` phase, its reason and the unmatched place. Editing after a failure left the old error on screen while the rider was already fixing it
- **The leave-now fallback is gone.** A sentence with no time in it produced a `DateTimeSelectionItem` for the current moment, so the search row showed a time chip the rider never asked for. No time means no chip

## Testing

- `AiSearchInputViewModelTest` covers the ceiling, that words which stopped before it do not earn the extension, and the updated expectation for a sentence carrying no time
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
