### PR TITLE
feat(trip-planner): paint every AI surface from the rider's theme pair

### DIFF
--- a/feature/trip-planner/ui/ALERT_SUMMARY_UX.md
+++ b/feature/trip-planner/ui/ALERT_SUMMARY_UX.md
@@ -18,7 +18,7 @@ This shape was chosen over "card on the Timetable screen" (bigger blast radius, 
 | `AlertSummaryUiState` | same | Sealed: `Generating` (model running) / `Resolved(text, vote)`. `null` at the call site — not a third case — means render nothing. |
 | `AlertSummaryEvent` | same | `SummaryRequested(alerts)` / `VoteClicked(vote)` — the only way `ServiceAlertScreen` talks to the ViewModel. No Koin in the composable. |
 | `AiAlertSummaryCard` | same | The card itself: wheel mark + label, skeleton lines while `Generating`, summary text + vote row while `Resolved`. |
-| `AiWheelMark`, `Modifier.aiGradientBorder` | `:taj` | KRAIL's on-device-AI mark (a wheel, not a sparkle) and its matching rotating gradient border. Reusable for any future AI surface, not alert-specific. |
+| `AiWheelMark`, `Modifier.aiGradientBorder` | `:taj` | KRAIL's on-device-AI mark (a wheel, not a sparkle) and its matching rotating gradient border. Reusable for any future AI surface, not alert-specific. Both default to the fixed cool gradient; this card passes `AiThemeGradientTokens.stopsFor(themeColorHex)` to **both** from one value, so they cannot drift apart. |
 | `AlertFeedbackVote` | `:taj` | Generic thumbs-up/down component; not alert-specific either. |
 
 ## Gating: three independent switches, one outcome
@@ -42,6 +42,18 @@ simply disappears rather than being replaced by an error. There is nothing for a
 see as broken in any of these cases.
 
 ## Animation: settle, never swap
+
+### Colour: the rider's theme, not a fixed gradient
+
+The mark and the border are drawn from `AiThemeGradientTokens.stopsFor(themeColorHex)`: the
+theme colour, its HSV mid-stop, and a partner hue 97 to 134 degrees around the wheel. They used
+to take the components' default, a fixed blue/violet/pink that ignores the theme. That was
+defensible while this card was the only AI surface in the app. It no longer is: the AI input
+surface and both of SearchStop's panes are now painted from this same pair, so a card in a
+different blue and violet reads as another product's card dropped into KRAIL.
+
+The value is computed once in the card and handed to both, because they have to look like one
+object (see the rotation rule below).
 
 Both `AiWheelMark` and `Modifier.aiGradientBorder` share one rotation driver
 (`rememberAiSpinAngle` in `:taj`, `taj/animations/AiSpinAnimation.kt`) so the wheel and the

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/summary/AiAlertSummaryCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/summary/AiAlertSummaryCard.kt
@@ -10,9 +10,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.AiWheelMark
 import xyz.ksharma.krail.taj.components.AlertFeedbackVote
 import xyz.ksharma.krail.taj.components.AlertFeedbackVoteChoice
@@ -22,6 +25,7 @@ import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.tokens.AiThemeGradientTokens
 
 private val SkeletonLineHeight = 12.dp
 private val SkeletonLineCornerRadius = 6.dp
@@ -42,6 +46,12 @@ fun AiAlertSummaryCard(
 ) {
     val dim = KrailTheme.dimensions
     val spinning = state is AlertSummaryUiState.Generating
+    // The rider's theme, not the fixed cool gradient both of these default to. Every other AI
+    // surface in the app is painted from this pair now, and a card in somebody else's blue and
+    // violet reads as a different product's card. Passed to the border and the mark from one
+    // value so the two cannot drift: the doc's rule is that they read as a single object.
+    val themeColorHex by LocalThemeColor.current
+    val aiColors = remember(themeColorHex) { AiThemeGradientTokens.stopsFor(themeColorHex) }
 
     Column(
         modifier = modifier
@@ -50,7 +60,11 @@ fun AiAlertSummaryCard(
                 color = KrailTheme.colors.surface,
                 shape = RoundedCornerShape(dim.cardCornerRadius),
             )
-            .aiGradientBorder(spinning = spinning, cornerRadius = dim.cardCornerRadius)
+            .aiGradientBorder(
+                spinning = spinning,
+                cornerRadius = dim.cardCornerRadius,
+                colors = aiColors,
+            )
             .padding(horizontal = dim.spacingXL, vertical = dim.spacingXL),
         verticalArrangement = Arrangement.spacedBy(dim.spacingL),
     ) {
@@ -58,7 +72,7 @@ fun AiAlertSummaryCard(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
         ) {
-            AiWheelMark(spinning = spinning)
+            AiWheelMark(spinning = spinning, colors = aiColors)
             Text(
                 text = if (spinning) "Summarizing" else "AI Summary",
                 style = KrailTheme.typography.labelSmall,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -45,12 +45,14 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import krail.feature.trip_planner.ui.generated.resources.Res
+import krail.feature.trip_planner.ui.generated.resources.ic_clock
 import krail.feature.trip_planner.ui.generated.resources.ic_search
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
@@ -59,12 +61,13 @@ import xyz.ksharma.krail.taj.components.AiWheelMark
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
-import xyz.ksharma.krail.taj.components.SubtleButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextFieldButton
 import xyz.ksharma.krail.taj.components.ThemeTextFieldPlaceholderText
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.taj.tokens.AiThemeGradientTokens
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
@@ -427,6 +430,14 @@ private fun StopFieldText(text: String, isActive: Boolean, slideUp: Boolean, lab
 @Composable
 private fun WhenChip(text: String, onClear: () -> Unit) {
     val dim = KrailTheme.dimensions
+    // The row's own surface, the same one the From and To pills use. As bare text on the
+    // coloured row this was white and bold and read as a heading, louder than the two stops
+    // it qualifies. In a pill of its own it belongs to the row instead of shouting over it,
+    // and the label can take an ordinary readable colour rather than fighting the theme.
+    val chipBackground = KrailTheme.colors.surface
+    // Checked against the pill it actually sits on rather than assumed, so it holds up on
+    // every theme and in both light and dark.
+    val chipForeground = getForegroundColor(backgroundColor = chipBackground)
 
     Row(
         modifier = Modifier
@@ -434,11 +445,37 @@ private fun WhenChip(text: String, onClear: () -> Unit) {
             .padding(horizontal = dim.pageHorizontalPadding)
             .padding(top = dim.spacingM),
     ) {
-        SubtleButton(onClick = onClear, dimensions = ButtonDefaults.mediumButtonSize()) {
-            Text(text = text)
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(percent = CHIP_CORNER_PERCENT))
+                .background(chipBackground)
+                .clickable(onClick = onClear)
+                .padding(horizontal = dim.spacingL, vertical = dim.spacingS),
+            horizontalArrangement = Arrangement.spacedBy(dim.spacingS),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // A clock says "this is a time" before a word of it is read, which is the whole
+            // job of a chip sitting beside two stop names.
+            Image(
+                painter = painterResource(Res.drawable.ic_clock),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(chipForeground),
+                modifier = Modifier.size(dim.iconSmall),
+            )
+            Text(
+                text = text,
+                // Smaller than the stop names beside it: this qualifies the search, it is not
+                // the search.
+                style = KrailTheme.typography.bodySmall,
+                // Checked against the pill it actually sits on rather than assumed, so it
+                // holds up on every theme and in both light and dark.
+                color = chipForeground,
+            )
         }
     }
 }
+
+private const val CHIP_CORNER_PERCENT = 50
 
 /**
  * The way into the AI search sheet. Opening is all it does: the sheet owns speaking, typing
@@ -452,10 +489,18 @@ private fun WhenChip(text: String, onClear: () -> Unit) {
 @Composable
 private fun AiSheetEntryButton(onAiEvent: (AiSearchInputEvent) -> Unit) {
     val dim = KrailTheme.dimensions
+    val themeColorHex by LocalThemeColor.current
 
     RoundIconButton(
         content = {
-            AiWheelMark(spinning = false, markSize = dim.iconDefault)
+            // The theme's own pair, not the fixed cool gradient the mark defaults to. This
+            // button is the door to a surface that is now painted in these exact colours, so a
+            // wheel in somebody else's blue and violet reads as a different product's button.
+            AiWheelMark(
+                spinning = false,
+                markSize = dim.iconDefault,
+                colors = AiThemeGradientTokens.stopsFor(themeColorHex),
+            )
         },
         onClick = { onAiEvent(AiSearchInputEvent.OpenInput) },
     )

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -70,6 +70,7 @@ import xyz.ksharma.krail.core.transport.TransportMode
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
+import xyz.ksharma.krail.taj.components.CloudFieldSpec
 import xyz.ksharma.krail.taj.components.CloudGradientBackground
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
@@ -100,6 +101,11 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 import krail.feature.trip_planner.ui.generated.resources.Res as TripPlannerRes
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+// Less travel than the AI input surface uses. There the field is the screen and can move as
+// much as it likes; here it sits behind a list of stop names that a rider is reading, and the
+// same amplitude pulls the eye off the words.
+private const val SEARCH_FIELD_MOTION_SCALE = 1.6f
+
 @Composable
 fun SearchStopScreen(
     searchStopState: SearchStopState,
@@ -460,6 +466,10 @@ private fun SearchStopScreenSinglePane(
                     .fillMaxSize()
                     .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
                 themeColor = themeColor.hexToComposeColor(),
+                spec = CloudFieldSpec.aiPair(
+                    themeColorHex = themeColor,
+                    motionScale = SEARCH_FIELD_MOTION_SCALE,
+                ),
             ) {
                 SearchStopListContent(
                     listState = searchStopState.listState,
@@ -575,6 +585,10 @@ private fun SearchStopScreenDualPane(
                     .fillMaxSize()
                     .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
                 themeColor = themeColor.hexToComposeColor(),
+                spec = CloudFieldSpec.aiPair(
+                    themeColorHex = themeColor,
+                    motionScale = SEARCH_FIELD_MOTION_SCALE,
+                ),
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
                     SearchTopBar(


### PR DESCRIPTION
## What

`AiWheelMark` and `Modifier.aiGradientBorder` both default to a fixed blue/violet/pink that ignores the theme. That was defensible while the alert summary was the only AI surface in the app. It no longer is, and a wheel in another palette reads as a different product's button.

## Changes

- The AI entry wheel on the search row takes `AiThemeGradientTokens.stopsFor(themeColorHex)`
- SearchStop's clouds take `CloudFieldSpec.aiPair`, so both panes wear the same three colours as the Ask KRAIL surface. Motion is lower there than on the AI screen: the field sits behind a list of stop names being read, and the larger amplitude pulls the eye off the words
- `AiAlertSummaryCard` passes the pair to its border and its mark from one value, because `ALERT_SUMMARY_UX.md` requires the two read as a single object
- The time chip on the search row uses a clock icon, `bodySmall`, and `getForegroundColor()` against its own background rather than a hardcoded colour

`ALERT_SUMMARY_UX.md` is updated in the same change, since it documented the fixed gradient as the deliberate choice.

## Testing

- `./scripts/fullQualityChecks.sh` green
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
- Device QA: both SearchStop panes and the Ask KRAIL surface, light and dark
