### PR TITLE
docs(process): add layout rules, an analytics ledger, and guards for both

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,23 @@ We stack PRs. Break work into focused, layered branches and submit the full stac
 
 All three must be green before submitting the PR or handing the branch back.
 
+## Layout, insets and the keyboard
+
+Before changing a screen's root layout, adding a bottom-anchored input, or touching an
+inset modifier, read **`docs/LAYOUT_AND_INSETS.md`**. It holds the one-inset-authority rule,
+why `MainActivity` must keep `android:windowSoftInputMode="adjustResize"`, why
+`fillMaxSize()` silently does nothing on a non-weighted `Column` child, and the diagnosis
+playbook for when a node is drawn somewhere other than where it was laid out.
+
+`scripts/check_layout_invariants.py` enforces the two mechanical parts and runs inside
+`fullQualityChecks.sh`.
+
+**When a layout looks wrong on device, measure before theorising.** Log
+`onGloballyPositioned { it.positionInRoot().y }` at every level and compare it against a
+screenshot taken at the same moment. A node laid out at one position and drawn at another is
+the window moving, not the layout, and no amount of re-reading modifiers will show it. Part 2
+of the doc has the exact procedure.
+
 ## QA checklist before handing over code
 
 Detekt and unit tests prove the code compiles and its logic holds. They prove nothing about
@@ -254,6 +271,27 @@ xcrun simctl install <UDID> "<build-dir>/Build/Products/Debug-iphonesimulator/Kr
 xcrun simctl launch <UDID> xyz.ksharma.krail
 ```
 
+## Analytics-derived design decisions
+
+When a design decision is justified by KRAIL-Analytics data, add a row to
+**`docs/ANALYTICS_ASSUMPTIONS.md`** rather than only writing the finding into a code comment.
+Each row records the claim, what depends on it, how to re-check it, what would falsify it, and
+when it falls due (three months by default).
+
+`scripts/check_stale_assumptions.py` reports overdue rows and runs as a warning inside
+`fullQualityChecks.sh`; `--strict` exits non-zero for a scheduled job.
+
+**The file is qualitative only** — KRAIL is public, so no counts, percentages or rates go in it,
+same rule as PR bodies. Write "weekend openings are a substantial share", never the number.
+
+## Learning log
+
+`docs/learning/` records bugs that were expensive to find, and how the finding went wrong.
+Add an entry when the first fix was wrong and so was the second, when detekt and tests were
+green while the bug was live, or when diagnosis needed instrumentation rather than reading
+code. `docs/learning/README.md` has the format and the rules; prefer adding a check over
+adding a paragraph.
+
 ## Full Quality Checks
 
 To verify a branch compiles on both platforms and passes static analysis, run:
@@ -263,6 +301,8 @@ To verify a branch compiles on both platforms and passes static analysis, run:
 ```
 
 This runs, in order:
+0. `check_layout_invariants.py` — manifest and inset-authority guards, then
+   `check_stale_assumptions.py` — overdue analytics assumptions (warning only)
 1. `compileDebugSources` — Android compile
 2. `compileKotlinIosSimulatorArm64` — iOS Simulator compile
 3. `detekt --continue` — static analysis (auto-corrects imports and trailing commas)
@@ -370,6 +410,9 @@ that contradicts the doc should also update the doc in the same change.
   `onAddressSearchTextChanged` or the `search_stop_address_*` Remote Config contract.
 - `docs/TABLET_FOLDABLE_UX.md` — adaptive layout rules for tablets, foldables, and phone
   landscape (per-screen dual-pane behaviour, compact-height adaptations, breakpoint contract).
+- `docs/LAYOUT_AND_INSETS.md` — inset authority, `adjustResize`, `weight` vs `fillMaxSize`,
+  and how to tell a layout bug from the window moving; read before changing a screen root or
+  a bottom-anchored input.
 - `docs/POLLING_LIFECYCLE.md` — WhileSubscribed polling rules: `repeatOnLifecycle(STARTED)`
   pattern, why plain `LaunchedEffect` breaks background gating, all polling flows listed.
 - `docs/investigations/NSW_715_WALK_LEG_INVESTIGATION.md` — why `TripResponseMapper.kt`'s

--- a/docs/ANALYTICS_ASSUMPTIONS.md
+++ b/docs/ANALYTICS_ASSUMPTIONS.md
@@ -1,0 +1,57 @@
+# Analytics assumptions
+
+Design decisions in this app that were made from KRAIL-Analytics data, with the date each was
+last checked and the date it falls due.
+
+A decision justified by data is only as good as the last time anybody looked. These get written
+into code comments as settled fact ("about a third of trips are loaded at a weekend, so nothing
+presumes a commute"), and six months later nobody knows whether that is still true or whether it
+was ever measured. This file is where that gets recorded, and
+`scripts/check_stale_assumptions.py` is what stops it becoming a promise nobody keeps.
+
+## Content rule: qualitative only
+
+**KRAIL is a public repository.** Never write a number in this file. No user counts, no
+percentages, no rates, no ratios, no absolute event volumes. Write the shape of the finding
+instead:
+
+- Yes: "weekend openings are a substantial share of all openings"
+- No: "34% of openings are at weekends"
+
+Keep the real figures in local files. The same rule governs commit messages and PR bodies; see
+`.claude/skills/pr-desc/SKILL.md`.
+
+## How to use this file
+
+Each row is one assumption that some piece of code depends on.
+
+- **Assumption** — the claim, qualitatively. If a code comment states it, quote it the same way.
+- **Relies on it** — what breaks or becomes wrong if the claim stops holding.
+- **How to check** — the query or dashboard that answers it. Enough that a re-check is ten
+  minutes rather than an afternoon of rediscovering which event to look at.
+- **Would falsify it** — what a result would have to look like for the decision to be wrong.
+  The column people skip; it is the one that makes the re-check quick and honest.
+- **Last checked** / **Review by** — ISO dates. Review by is normally last checked plus three
+  months: these are travel-behaviour patterns and they move slowly.
+
+The script parses the two date columns and the id, so keep the table shape. Ids are stable
+across rewordings.
+
+When you re-check one: update **Last checked**, push **Review by** out, and if the finding moved,
+change the code in the same PR rather than leaving the row and the behaviour disagreeing.
+
+## Assumptions
+
+| Id | Assumption | Relies on it | How to check | Would falsify it | Last checked | Review by |
+|---|---|---|---|---|---|---|
+| `open-time-shape` | App opens peak in the morning and again in the late afternoon, with a substantial midday that is not far behind either, and a real tail into the evening. | The situation bands in `AiSuggestionSituations.kt`: where morning ends, when the journey turns around, how late the last band runs. | `load_timetable_click` grouped by hour, Sydney time, over 60 days. | A single peak, or an evening that falls away sharply enough that the late bands are dead weight. | 2026-08-16 | 2026-11-16 |
+| `weekend-share` | Weekend openings are a substantial share of all openings, not a rounding error. | The whole weekend half of the situations table, and the rule that nothing presumes a commute. If weekends were rare, six commute-shaped rows would be the better design. | `load_timetable_click` grouped by day of week, over 60 days. | Weekend openings becoming a small minority. | 2026-08-16 | 2026-11-16 |
+| `label-adoption` | Riders who use the app regularly tend to have Home set, and often a second label. | The suggestion ladder trying labels first, and the claim that the label rung is what most riders actually see. | Not yet measured. No event reports whether a rider has labels set. | If most riders reached the saved-trip or generic rung instead, the ladder's order would be teaching the wrong thing first. | — | 2026-11-16 |
+
+## Open gap
+
+`label-adoption` has never been checked, because nothing measures it. It is listed rather than
+left implicit: the suggestion ladder is built on it, and an assumption holding up a design is
+worth naming even when the data to test it does not exist yet. Measuring it would mean a
+parameter on an existing event rather than a new event name, given the 500-event cap. See
+`docs/ANALYTICS_EVENTS.md` before adding anything.

--- a/docs/LAYOUT_AND_INSETS.md
+++ b/docs/LAYOUT_AND_INSETS.md
@@ -1,0 +1,152 @@
+# Layout and window insets
+
+Rules for anything that fills space or moves for the keyboard, and the playbook for
+diagnosing it when it goes wrong. Read this before changing a screen's root layout, adding
+a bottom-anchored input, or touching an inset modifier.
+
+Every rule here is a bug that shipped in this repo, and every mechanism stated here was
+measured rather than recalled — one of these rules was originally written from memory and was
+wrong. `docs/learning/` records how each was found; this file is the short version you act on.
+
+---
+
+## Part 1 — Rules that stop it happening
+
+### 1.1 One inset authority per screen
+
+Exactly one composable in a screen's hierarchy applies the keyboard inset. Every other
+level applies none.
+
+```kotlin
+// The screen's root column. It must END where the keyboard starts.
+Column(modifier = Modifier.fillMaxSize().safeDrawingPadding()) { ... }
+```
+
+Do **not** also put `imePadding()` on the input inside it. `imePadding()` on a child adds
+the keyboard's height *to that child*, inside a parent that is still full height, so the
+child carries a keyboard-sized void beneath it and floats that far up the screen.
+
+If a screen renders another full-screen surface as a sibling (a cover, a sheet-like
+overlay), that surface owns its own inset and must not be a child of the host's padded
+box:
+
+```kotlin
+Box(Modifier.fillMaxSize()) {
+    Box(Modifier.fillMaxSize().imePadding()) { HomeContent() }   // host's authority
+    if (coverOpen) CoverSurface()                                // its own authority
+}
+```
+
+`safeDrawingPadding()` = system bars + IME + cutout. `systemBarsPadding()` deliberately
+excludes the IME; only use it when something else is handling the keyboard.
+
+### 1.2 `MainActivity` must declare `adjustResize`
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:windowSoftInputMode="adjustResize">
+```
+
+The app calls `enableEdgeToEdge()` and `WindowCompat.setDecorFitsSystemWindows(window, false)`,
+so Compose handles the IME itself. Without this attribute the mode defaults to
+`ADJUST_UNSPECIFIED`, the system resolves it to **pan**, and both mechanisms compensate for
+the same keyboard: the layout shrinks by the keyboard height and the system then slides the
+whole window up by it again.
+
+`scripts/check_layout_invariants.py` fails the build if the attribute goes missing.
+
+### 1.3 Unbounded constraints: know which parents actually do it
+
+A parent that measures a child with an **infinite** main axis makes `fillMaxHeight` /
+`fillMaxSize` a silent no-op, because those check `constraints.hasBoundedHeight`. The child
+wraps its content instead, and nothing warns you.
+
+The parents that do this are `verticalScroll` (and `horizontalScroll` on the other axis),
+`LazyColumn` / `LazyRow` item slots, and anything measuring with `Constraints()` defaults.
+
+**A plain `Column` is NOT one of them.** It hands a non-weighted child the *remaining*
+bounded height. Verified on this repo's setup: a non-weighted child of a fixed 800dp `Column`
+holding a 100dp spacer is measured with `maxHeight=1837 bounded=true`. So `fillMaxSize()` on
+a Column child fills the leftover space correctly, and swapping it for `weight(1f)` changes
+nothing about the result.
+
+Prefer `weight(1f)` anyway when a child should take the leftover space: it states the intent,
+and it keeps working if a sibling is added below. But do not go hunting for this as the cause
+of a misplaced child in a `Column` — it will not be.
+
+### 1.4 One scroller per axis
+
+A `verticalScroll` child measured by a `verticalScroll` parent gets an infinite height
+constraint and throws. If the content scrolls, the wrapper must not.
+
+---
+
+## Part 2 — Diagnosing it when it happens
+
+### 2.1 The question that ends the argument
+
+**Is the node laid out where you think, and is it drawn where it is laid out?**
+
+Those are two different questions and reading the code answers neither. Measure both:
+
+```kotlin
+Modifier.onGloballyPositioned {
+    log("[LAYOUT] node y=${it.positionInRoot().y} h=${it.size.height}")
+}
+```
+
+Put it on every level from the screen root down to the misplaced node, plus the raw insets:
+
+```kotlin
+val density = LocalDensity.current
+log(
+    "[LAYOUT] insets ime=${WindowInsets.ime.getBottom(density)} " +
+        "safeTop=${WindowInsets.safeDrawing.getTop(density)}",
+)
+```
+
+Then take a screenshot at the same moment:
+
+```sh
+adb -s <serial> shell screencap -p /sdcard/s.png
+adb -s <serial> pull /sdcard/s.png <scratch>/s.png
+```
+
+### 2.2 Reading the result
+
+Compare the logged `y` against where the screenshot actually paints the node.
+
+| What the numbers say | What it means | Where to look |
+|---|---|---|
+| Logged `y` is wrong, drawn where logged | Layout bug. The tree is measured wrong. | Constraints from the parent: a scroller or Lazy slot measuring unbounded (§1.3), wrong arrangement, a fixed height |
+| Logged `y` is right, drawn somewhere else | **The window moved, not the layout.** | `windowSoftInputMode`, a parent `graphicsLayer`/offset, a `Dialog`'s own window |
+| Heights don't sum to the parent's height | A child is measured against the wrong constraint | The first level where the sum breaks |
+| Heights sum correctly and everything is right | You are looking at the wrong composable | Is a second copy composed? Is this the dialog branch, not the full-screen one? |
+
+The second row is the one that costs days, because the Compose code is correct and reads
+correct. A gap between measured position and drawn position can only be the window. No
+amount of re-reading modifiers will show it.
+
+### 2.3 Order of work
+
+1. Reproduce on a device and capture a screenshot. Not a preview, not a description.
+2. Instrument positions at every level. One build, all levels at once.
+3. Compare logged position against drawn position **before forming any theory**.
+4. Fix the level the numbers point at.
+5. Rebuild, re-capture, confirm against the numbers again.
+6. Strip the instrumentation.
+
+Do not skip to step 4. Each unmeasured guess costs a full build, an install, and a round
+trip with whoever is holding the phone, and a wrong guess that half-works is worse than no
+fix because it moves the symptom.
+
+### 2.4 Why the usual checks will not save you
+
+`detekt`, unit tests and both compile targets pass on every bug in Part 1. They were all
+green while the input bar sat a keyboard's height above the keyboard. Static checks verify
+the code; these are defects in what the code *means* at measure and draw time, on a real
+window, with a real IME.
+
+The device QA checklist in `CLAUDE.md` is the layer that catches them. For any screen with
+a text field, the keyboard-open state is a required check, not an optional one.

--- a/docs/learning/2026-08-16-ime-pan-and-unbounded-column.md
+++ b/docs/learning/2026-08-16-ime-pan-and-unbounded-column.md
@@ -1,0 +1,119 @@
+# The AI input bar floated a keyboard's height above the keyboard
+
+**2026-08-16** · AI input surface, `MainActivity` manifest · roughly six builds, five install
+cycles, four wrong fixes
+
+## Symptom
+
+Opening the AI input surface with the keyboard up: the input bar sat in the upper third of
+the screen with a large empty gradient between it and the keyboard, and the greeting above
+it was clipped off the top edge of the screen. Typing made it look roughly normal, which
+made the whole thing read as a keyboard-padding problem.
+
+## Root cause
+
+**One bug: the window was panning.** `MainActivity` declared no `windowSoftInputMode`, so it
+defaulted to `ADJUST_UNSPECIFIED` and the system resolved it to pan. The app already calls
+`enableEdgeToEdge()` + `setDecorFitsSystemWindows(window, false)` and pads for the IME in
+Compose, so both mechanisms compensated for the same keyboard: the column shrank by the
+keyboard height, then the system slid the entire window up by it again. Fix:
+`android:windowSoftInputMode="adjustResize"`.
+
+That is why the other screens were fine: their fields sit near the top, where the pan
+distance computes to about zero. The AI surface was the first screen with a field pinned to
+the bottom.
+
+### The second "root cause" that was not one
+
+This entry originally claimed a second, stacked bug: that `Modifier.fillMaxSize()` on
+`AiInputContent` was a silent no-op because `Column` measures non-weighted children with an
+unbounded main axis. That was asserted from memory of the framework, never verified, and it
+is **wrong**. A `Column` hands a non-weighted child the remaining *bounded* height. A
+Robolectric probe settled it:
+
+```
+[PROBE] non-weighted child of fixed-height Column: maxHeight=1837 bounded=true
+```
+
+The `weight(1f)` change is equivalent to what it replaced. It is kept because it states the
+intent better, but it fixed nothing.
+
+The claim was caught by mutation-testing the unit test written to protect it: revert the call
+site to `fillMaxSize()`, expect a failure, and the test passed. A test that cannot fail on the
+bug it was written for is the signal that the bug was never there.
+
+## Why it took so long
+
+Four fixes were attempted before anything was measured. In order:
+
+1. **`safeDrawingPadding()` on the surface, `imePadding()` removed from the parent.** Sound
+   reasoning about single inset authority, and it *was* needed — but it was not the bug.
+2. **Moved `imePadding()` onto the input bar itself.** Actively wrong, and instructive:
+   `imePadding()` on a child adds the keyboard's height *to that child* inside a parent that
+   is still full height, so the bar carried a keyboard-sized void underneath it. This
+   produced a symptom nearly identical to the real one, which made it look like progress on
+   the right track.
+3. **Back to `safeDrawingPadding()` at surface level.** Correct, and still not sufficient,
+   because the real cause was untouched.
+4. **`weight(1f)`, with a confident explanation of why `fillMaxSize()` could not work.** The
+   explanation was false and the change was a no-op. The screen still looked wrong.
+
+Every one of these was reasoned from reading the code. All of them were reported to the
+maintainer as fixed. The maintainer had to say "still not fixed" four times, and was the one
+who eventually said to stop guessing and go read the documentation.
+
+What made step 4 especially convincing was that it came with an explanation of framework
+behaviour, delivered with confidence, that turned out to be false. A wrong mechanism that
+*sounds* like deep knowledge is more expensive than admitting ignorance, because it ends the
+search: it explained the symptom, so nobody looked further, and it went straight into the
+docs and the memory files as fact. It survived until a mutation test contradicted it.
+
+## What would have caught it sooner
+
+Position instrumentation, on the first failed fix rather than the fourth. It took one build
+and settled the question immediately:
+
+```
+[AI_LAYOUT] inputBar y=1031.0 h=289     ← laid out at 1031
+[AI_LAYOUT] insets ime=1048 safeTop=172 ← keyboard starts at 2410-1048 = 1362
+```
+
+Laid out at 1031, ending at 1320, correctly above a keyboard starting at 1362. The
+screenshot from the same moment painted it at ~363, with the greeting clipped above the
+screen's top edge.
+
+**A node measured at 1031 and drawn at 363 is not a layout bug.** Nothing inside a Compose
+tree moves a node 668px away from where it was measured. Only the window does that. From
+that number the manifest was the obvious and only place left to look, and it took two
+minutes.
+
+The general form: **measure whether the node is laid out where you think, and separately
+whether it is drawn where it is laid out.** Those are different failures with different
+causes, and reading modifiers cannot distinguish them. `onGloballyPositioned` +
+`positionInRoot()` + a screenshot at the same instant answers both.
+
+Second lesson, cheaper to state: detekt, both compile targets and the unit tests were green
+throughout. They verify the code. These were defects in what the code meant at measure and
+draw time, on a real window with a real IME. Only the device shows that.
+
+Third: the fix should not have been called done four times. "Installed, please check" is
+accurate; "fixed" needed evidence that did not exist yet.
+
+Fourth, and the one with the longest tail: **do not write a mechanism into a doc until it has
+been proven.** A `Layout {}` that logs the constraints it receives takes two minutes to write
+and would have killed the false claim before it was documented. Every new rule in
+`docs/LAYOUT_AND_INSETS.md` should be traceable to a measurement, not to recall.
+
+## Actions taken
+
+- [x] `docs/LAYOUT_AND_INSETS.md` — the rules and the diagnosis playbook
+- [x] `scripts/check_layout_invariants.py` — fails the build if the manifest loses
+      `adjustResize`, or if a file applies two inset authorities at once
+- [x] Wired that script into `scripts/fullQualityChecks.sh`
+- [x] Comment at the `safeDrawingPadding()` call recording why the manifest attribute must
+      stay
+- [x] `CLAUDE.md` points at the layout doc from the QA checklist
+- [x] `AiInputContentLayoutTest` — locks the bar to the bottom of its host. Honest scope: it
+      guards child ordering and anchoring, and it does **not** fail on `fillMaxSize()` vs
+      `weight(1f)`, which is how the false claim above was caught
+- [x] Corrected the wrong `Column` rule in `docs/LAYOUT_AND_INSETS.md` §1.3

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -1,0 +1,65 @@
+# Learning log
+
+A dated record of bugs that were expensive to find, and of how the finding went wrong.
+
+This is not a changelog and not a postmortem template. A changelog records what changed; a
+postmortem asks who was paged. This asks one question: **what would have made this cheaper,
+and can it be turned into a rule, a script, or a check?**
+
+An entry earns its place by being non-obvious. "Fixed a null check" does not go here. A bug
+that survived green detekt, green tests and a code read does.
+
+---
+
+## When to add an entry
+
+Write one when any of these is true:
+
+- The first fix was wrong, and so was the second
+- Detekt, unit tests and compile were all green while the bug was live
+- The cause was in a layer nobody was looking at (manifest, Gradle, the window, the platform)
+- Diagnosis needed instrumentation rather than reading code
+- The same class of bug could plausibly hit another screen or module
+
+## Format
+
+One file per incident: `YYYY-MM-DD-short-slug.md`.
+
+```markdown
+# Title: what broke, in one line
+
+**Date** · **Area** · **Cost** (rough: builds, install cycles, elapsed)
+
+## Symptom
+What was actually seen on the device. Screenshot description, not theory.
+
+## Root cause
+What was really wrong. If there were several, number them.
+
+## Why it took so long
+The honest part. Wrong theories in order, and what made each one look plausible.
+
+## What would have caught it sooner
+The technique, in a form reusable next time.
+
+## Actions taken
+Rules, scripts, tests or docs added. Link them. Unchecked boxes if not done yet.
+```
+
+## Rules for writing one
+
+- **Name the wrong turns.** An entry that only records the right answer teaches nothing.
+  The wrong theories are the content — they are what will look plausible again next time.
+- **Prefer a check over a paragraph.** If it can be a script or a test, write that and link
+  it. Prose is the fallback for what cannot be automated, not the default.
+- **No blame, no metrics, no user data.** These files are in a public repo. Describe code
+  and process only. See the content policy in `.claude/skills/pr-desc/SKILL.md`.
+- **Link outward.** If a rule came out of the entry, the rule lives in the relevant doc
+  (`docs/LAYOUT_AND_INSETS.md`, `docs/POLLING_LIFECYCLE.md`, …) and the entry points at it.
+  The entry is the story; the doc is the instruction.
+
+## Index
+
+| Date | Entry | Class of bug |
+|---|---|---|
+| 2026-08-16 | [IME pan and the unbounded Column child](2026-08-16-ime-pan-and-unbounded-column.md) | Layout / window insets |

--- a/scripts/check_layout_invariants.py
+++ b/scripts/check_layout_invariants.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Layout invariants that no compiler, test or detekt rule can see.
+
+Both checks here come from one incident, recorded in
+docs/learning/2026-08-16-ime-pan-and-unbounded-column.md. The rules they enforce are
+explained in docs/LAYOUT_AND_INSETS.md.
+
+Run standalone or via scripts/fullQualityChecks.sh. Exit code 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+MANIFEST = ROOT / "androidApp/src/main/AndroidManifest.xml"
+
+# safeDrawing already includes the IME, so a file holding both of these is applying the
+# keyboard inset twice unless one of them is deliberately scoped elsewhere.
+IME_AUTHORITIES = ("safeDrawingPadding()", "imePadding()")
+
+SEARCH_ROOTS = (
+    "feature",
+    "composeApp",
+    "taj",
+)
+
+
+def check_manifest_adjust_resize() -> list[str]:
+    """MainActivity must ask the system NOT to pan the window for the keyboard.
+
+    The app is edge to edge and pads for the IME in Compose. Without an explicit
+    adjustResize the mode defaults to ADJUST_UNSPECIFIED, the system resolves it to pan,
+    and the window slides up on top of the padding Compose already applied.
+    """
+    if not MANIFEST.exists():
+        return [f"{MANIFEST}: manifest not found"]
+
+    text = MANIFEST.read_text()
+    activity = re.search(
+        r"<activity[^>]*android:name=\"\.MainActivity\".*?>",
+        text,
+        re.DOTALL,
+    )
+    if activity is None:
+        return [f"{MANIFEST}: MainActivity block not found"]
+
+    if 'android:windowSoftInputMode="adjustResize"' in activity.group(0):
+        return []
+
+    return [
+        f"{MANIFEST}: MainActivity must declare "
+        'android:windowSoftInputMode="adjustResize". Without it the system pans the '
+        "window for the keyboard on top of Compose's own IME padding, and bottom "
+        "anchored inputs are drawn a keyboard's height above the keyboard. "
+        "See docs/LAYOUT_AND_INSETS.md."
+    ]
+
+
+def check_single_ime_authority() -> list[str]:
+    """One composable applies the keyboard inset per screen, never two in one file.
+
+    Advisory by nature: a file legitimately holding two independent surfaces can trip
+    this. Add the file to ALLOWED below with a comment saying why, rather than deleting
+    the check.
+    """
+    # SavedTripsScreen hosts two surfaces: the home screen's own ime-padded box, and the
+    # Ask KRAIL cover, which is a sibling of it and owns its inset separately. AskKrailScreen
+    # pads its content column with safeDrawing and anchors the cloud field with imePadding, so
+    # the light ends where the keyboard starts. Two different jobs, not two authorities.
+    allowed = {"SavedTripsScreen.kt", "AskKrailScreen.kt"}
+
+    problems: list[str] = []
+    for root in SEARCH_ROOTS:
+        for path in (ROOT / root).rglob("*.kt"):
+            if path.name in allowed:
+                continue
+            text = path.read_text()
+            if all(token in text for token in IME_AUTHORITIES):
+                rel = path.relative_to(ROOT)
+                problems.append(
+                    f"{rel}: applies both safeDrawingPadding() and imePadding(). "
+                    "safeDrawing already includes the IME, so this pads for the keyboard "
+                    "twice. One inset authority per screen: see docs/LAYOUT_AND_INSETS.md."
+                )
+    return problems
+
+
+def main() -> int:
+    problems = check_manifest_adjust_resize() + check_single_ime_authority()
+
+    if problems:
+        print("Layout invariant check FAILED:\n")
+        for problem in problems:
+            print(f"  - {problem}\n")
+        return 1
+
+    print("Layout invariants OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_stale_assumptions.py
+++ b/scripts/check_stale_assumptions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Report analytics assumptions that are due for a re-check.
+
+Reads the table in docs/ANALYTICS_ASSUMPTIONS.md and compares each row's "Review by" date
+against today. See that file for why the ledger exists and what a row means.
+
+Warns by default and exits 0, because a date passing is not a reason to block somebody's
+unrelated build. Pass --strict to exit 1 instead, which is what a scheduled job should use to
+raise an issue.
+
+Usage:
+    python3 scripts/check_stale_assumptions.py
+    python3 scripts/check_stale_assumptions.py --strict
+    python3 scripts/check_stale_assumptions.py --today 2027-01-01   # for testing
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LEDGER = ROOT / "docs/ANALYTICS_ASSUMPTIONS.md"
+
+# Rows look like: | `id` | assumption | relies | how | falsify | 2026-08-16 | 2026-11-16 |
+ROW = re.compile(
+    r"^\|\s*`(?P<id>[^`]+)`\s*\|.*\|\s*(?P<checked>\d{4}-\d{2}-\d{2}|—|-)\s*\|"
+    r"\s*(?P<review>\d{4}-\d{2}-\d{2})\s*\|\s*$"
+)
+
+
+def parse_rows(text: str) -> list[dict[str, str]]:
+    rows = []
+    for line in text.splitlines():
+        match = ROW.match(line)
+        if match:
+            rows.append(match.groupdict())
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--strict", action="store_true", help="exit 1 when anything is due")
+    parser.add_argument("--today", help="override today's date (YYYY-MM-DD), for testing")
+    args = parser.parse_args()
+
+    if not LEDGER.exists():
+        print(f"{LEDGER} not found.")
+        return 1
+
+    today = date.fromisoformat(args.today) if args.today else date.today()
+    rows = parse_rows(LEDGER.read_text())
+
+    if not rows:
+        print(f"{LEDGER}: no assumption rows parsed. Has the table shape changed?")
+        return 1
+
+    due = [row for row in rows if date.fromisoformat(row["review"]) <= today]
+    never = [row for row in due if row["checked"] in {"—", "-"}]
+
+    if not due:
+        nearest = min(date.fromisoformat(row["review"]) for row in rows)
+        print(f"Analytics assumptions OK. {len(rows)} tracked, next due {nearest}.")
+        return 0
+
+    print(f"{len(due)} analytics assumption(s) due for a re-check as of {today}:\n")
+    for row in due:
+        checked = "never checked" if row in never else f"last checked {row['checked']}"
+        print(f"  - {row['id']}: due {row['review']}, {checked}")
+    print(
+        f"\nRe-check them, then update the dates in {LEDGER.relative_to(ROOT)}. If a finding "
+        "moved, change the code in the same PR rather than leaving the row and the behaviour "
+        "disagreeing."
+    )
+
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fullQualityChecks.sh
+++ b/scripts/fullQualityChecks.sh
@@ -7,6 +7,16 @@ set -e
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+echo "▶ Layout invariants..."
+python3 scripts/check_layout_invariants.py
+
+echo ""
+echo "▶ Analytics assumptions..."
+# Warns only. A date passing is not a reason to block an unrelated build; a scheduled job
+# runs this with --strict to raise an issue instead.
+python3 scripts/check_stale_assumptions.py
+
+echo ""
 echo "▶ Android compile..."
 ./gradlew compileDebugSources
 


### PR DESCRIPTION
## What

The window-pan bug at the bottom of this stack (#1853) survived green detekt, green unit tests and both compile targets, because the Compose code was correct and the window was moving underneath it. Static checks cannot see that class of defect, so the guard has to sit outside them.

## Changes

- `docs/LAYOUT_AND_INSETS.md`: one inset authority per screen, why the manifest attribute must stay, which parents really do measure children unbounded, and a playbook for telling a layout bug from the window moving
- `scripts/check_layout_invariants.py`: fails if `MainActivity` loses `adjustResize`, or if one file applies both `safeDrawingPadding()` and `imePadding()`. Verified to **fail** by removing the attribute, not merely to pass
- `docs/ANALYTICS_ASSUMPTIONS.md`: design decisions taken from analytics data, with what depends on each, how to re-check it, what would falsify it, and a review date three months out
- `scripts/check_stale_assumptions.py`: reports overdue rows. Warns inside `fullQualityChecks.sh` and exits 0; `--strict` exits non-zero for a scheduled job. Both modes verified
- `docs/learning/`: dated record of bugs that were expensive to find and how the finding went wrong
- `CLAUDE.md` points at all of the above

## Notes

The assumptions ledger is **qualitative only** — no counts, percentages or rates — because this repository is public. The same rule that governs PR bodies.

One row in it, `label-adoption`, has never been measured, because nothing measures it. It is listed rather than left implicit: the suggestion ladder rests on it, and an assumption holding up a design is worth naming even when the data to test it does not exist yet.

The first learning entry covers #1853 honestly, including a diagnosis claim that was written up as fact and later disproved by mutation-testing the very test written to protect it.

## Testing

- Both scripts exercised in pass and fail modes
- `./scripts/fullQualityChecks.sh` green with both guards wired in
