### PR TITLE
fix(trip-planner): match a rider's own word for a place, and leave send to them

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.remember
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelSynonyms
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import kotlin.time.Clock
@@ -34,10 +35,14 @@ import kotlin.time.Clock
 internal data class AiGreeting(val suggestion: String)
 
 // The rider's word for a place they go on a schedule. Excluded at weekends outright: suggesting
-// a commute on a Sunday is the app telling someone it has not been paying attention, and about
-// a third of trips here are loaded at a weekend. Matched case-insensitively against the label
-// the rider typed, so a free-text "Gym" or "Beach" is never caught by it.
-private val COMMUTE_LABELS = setOf("work", "uni", "school")
+// a commute on a Sunday is the app telling someone it has not been paying attention. Matched
+// case-insensitively against the label the rider typed, so a free-text "Gym" or "Beach" is
+// never caught by it.
+//
+// Taken from LabelSynonyms rather than listed again, so a label named "Office" counts as the
+// commute for the weekend rule exactly as "Work" does. Two lists would have drifted the moment
+// one of them gained a word.
+private val COMMUTE_LABELS = LabelSynonyms.commuteLabels
 
 private const val HOME_LABEL = "home"
 private const val DEFAULT_FROM = "Central"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -173,10 +173,14 @@ class AiSearchInputViewModel(
     }
 
     /**
-     * A final transcript sets [AiSearchInputUiState.typedText] and calls [submit] directly
-     * instead of a separate speech-specific extraction path — same "just another way to
-     * produce the string" shape [xyz.ksharma.krail.core.textrecognition.TextRecognitionService]
-     * documents for OCR, so [AiTextService.extractTripIntent] only ever needs one caller.
+     * Speech writes into [AiSearchInputUiState.typedText] and nothing else — the same field
+     * typing fills, so [AiTextService.extractTripIntent] only ever needs one caller. Same "just
+     * another way to produce the string" shape
+     * [xyz.ksharma.krail.core.textrecognition.TextRecognitionService] documents for OCR.
+     *
+     * Both partial and final transcripts land there: partials so the rider can see the words
+     * arriving, the final so the last correction sticks. Neither submits. The rider presses
+     * send when what is in the box is what they meant.
      */
     private fun startListening() {
         // A previous session that is still winding down will fail a new start with a busy
@@ -215,14 +219,23 @@ class AiSearchInputViewModel(
                         // words arrived during a window, and a counter is readable from a test
                         // running on virtual time where a wall clock is not.
                         wordsHeardSoFar++
-                        _uiState.update { it.copy(speechTranscript = result.text) }
+                        // Into typedText, not just the transcript. The field renders typedText,
+                        // so writing only the transcript meant a rider watched an empty box
+                        // while they talked and everything appeared at once when they stopped.
+                        // Partials are what make speaking feel like it is being heard.
+                        _uiState.update { it.copy(speechTranscript = result.text, typedText = result.text) }
                     }
 
                     is SpeechToTextResult.Final -> {
+                        // Fills the field and stops. It used to submit here, which took the
+                        // decision away from the rider: the recogniser deciding it had heard a
+                        // full sentence is not the same as a rider deciding they have finished
+                        // saying one, and a mis-heard word was already on its way to a search
+                        // before they could look at it. Speaking is a way of typing; send is
+                        // still theirs to press.
                         _uiState.update {
                             it.copy(isListening = false, speechTranscript = result.text, typedText = result.text)
                         }
-                        submit()
                     }
 
                     is SpeechToTextResult.Error -> {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelSynonyms.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelSynonyms.kt
@@ -1,0 +1,52 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+/**
+ * The rider's word for a place, and the other words that mean the same place.
+ *
+ * Labels are matched exactly, which is what stops "home" capturing "Homebush". The cost is that
+ * a rider has to use the app's word rather than their own: someone whose label is `Work` says
+ * "office by Monday morning" and gets nothing, because "office" is not "work".
+ *
+ * Every entry here is still a whole word matched exactly, so the Homebush protection is
+ * untouched. Only the vocabulary widens.
+ *
+ * Kept deliberately small. A synonym that is nearly right is worse than none: it sends a rider
+ * to a stop they did not name, and they have no way to see why. Words go in only when they are
+ * the same place to anybody, in Australian English, without context. "Place", "mine" and "the
+ * city" are all excluded for that reason.
+ */
+internal object LabelSynonyms {
+
+    private val GROUPS: List<Set<String>> = listOf(
+        setOf("home", "house"),
+        setOf("work", "office", "job", "workplace"),
+        setOf("uni", "university", "campus", "college"),
+        setOf("school"),
+        setOf("gym"),
+    )
+
+    /**
+     * Labels for a place the rider goes on a schedule, in every accepted wording.
+     *
+     * Used to keep a commute off a weekend suggestion. Derived from the groups rather than
+     * listed again, so adding "office" to the work group covers both matching and the weekend
+     * rule at once.
+     */
+    val commuteLabels: Set<String> =
+        GROUPS.filter { group -> group.first() in setOf("work", "uni", "school") }.flatten().toSet()
+
+    /**
+     * The group a word belongs to, or the word itself when it belongs to none.
+     *
+     * Returning the word unchanged means a rider's own invented label ("Nan's", "Bouldering")
+     * still compares equal to itself and nothing else, so adding groups here can never break
+     * a label that is not in one.
+     */
+    fun canonical(label: String): String {
+        val normalised = label.trim().lowercase()
+        return GROUPS.firstOrNull { normalised in it }?.first() ?: normalised
+    }
+
+    /** True when two labels name the same kind of place. */
+    fun sameMeaning(first: String, second: String): Boolean = canonical(first) == canonical(second)
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopLabelTextResolver.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopLabelTextResolver.kt
@@ -17,6 +17,14 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
  * Matching is deliberately exact (case- and space-insensitive) rather than fuzzy: a label is
  * a short word the rider chose, and loose matching here would let "home" capture "homebush".
  * Anything not an exact label falls through to the next capability.
+ *
+ * Exact does not mean the app's vocabulary only. A rider whose label is `Work` says "office by
+ * Monday morning" and means it, so [LabelSynonyms] widens which WORDS count while keeping every
+ * comparison a whole-word exact one. The Homebush case is unaffected.
+ *
+ * Two passes, and the order matters: a rider with both a `Work` and an `Office` label has named
+ * two different stops, and "office" has to reach the one they called Office. Only when nothing
+ * matches literally does the synonym pass run.
  */
 internal class StopLabelTextResolver(
     private val sandook: Sandook,
@@ -28,11 +36,14 @@ internal class StopLabelTextResolver(
         val normalised = query.normaliseLabel()
         if (normalised.isEmpty()) return null
 
+        val labels = sandook.observeStopLabels().first()
+
         // A label the rider made but never pointed at a stop resolves to null, same as no
         // match: there is nothing to fill the field with.
-        return sandook.observeStopLabels().first()
-            .firstOrNull { it.label.normaliseLabel() == normalised }
-            ?.toStopItemOrNull()
+        val literal = labels.firstOrNull { it.label.normaliseLabel() == normalised }
+        val synonym = literal ?: labels.firstOrNull { LabelSynonyms.sameMeaning(it.label, normalised) }
+
+        return synonym?.toStopItemOrNull()
     }
 }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -587,23 +587,65 @@ class AiSearchInputViewModelTest {
     }
 
     @Test
-    fun `final transcript stops listening and submits automatically`() = runTest(testDispatcher) {
-        aiTextService.extractionResult = TripIntentExtraction(
-            originText = "Central Station",
-            destinationText = "Town Hall",
-            timeIntent = null,
-        )
-        viewModel.onEvent(AiSearchInputEvent.StartListening)
-        advanceUntilIdle()
+    fun `a final transcript fills the field and waits for the rider to send`() =
+        runTest(testDispatcher) {
+            // It used to submit here. The recogniser deciding it has heard a full sentence is
+            // not the rider deciding they have finished saying one, and a mis-heard word was
+            // already on its way to a search before they could look at it.
+            aiTextService.extractionResult = TripIntentExtraction(
+                originText = "Central Station",
+                destinationText = "Town Hall",
+                timeIntent = null,
+            )
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            advanceUntilIdle()
 
-        speechToTextService.results.emit(SpeechToTextResult.Final("central to town hall"))
-        advanceUntilIdle()
+            speechToTextService.results.emit(SpeechToTextResult.Final("central to town hall"))
+            advanceUntilIdle()
 
-        val state = viewModel.uiState.value
-        assertEquals(false, state.isListening)
-        assertEquals("central to town hall", state.typedText)
-        assertEquals(AiSearchInputPhase.RESOLVED, state.phase)
-    }
+            val state = viewModel.uiState.value
+            assertEquals(false, state.isListening)
+            assertEquals("central to town hall", state.typedText)
+            assertEquals(AiSearchInputPhase.IDLE, state.phase)
+        }
+
+    @Test
+    fun `pressing send after speaking runs the same submit typing does`() =
+        runTest(testDispatcher) {
+            aiTextService.extractionResult = TripIntentExtraction(
+                originText = "Central Station",
+                destinationText = "Town Hall",
+                timeIntent = null,
+            )
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            advanceUntilIdle()
+            speechToTextService.results.emit(SpeechToTextResult.Final("central to town hall"))
+            advanceUntilIdle()
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            assertEquals(AiSearchInputPhase.RESOLVED, viewModel.uiState.value.phase)
+        }
+
+    @Test
+    fun `words appear in the field while the rider is still speaking`() =
+        runTest(testDispatcher) {
+            // Partials used to land in speechTranscript only, which nothing renders, so a rider
+            // watched an empty box while they talked and the whole sentence appeared at once
+            // when they stopped.
+            // runCurrent, not advanceUntilIdle: advancing to idle runs virtual time past the
+            // listening ceiling, and the session would have stopped itself before the
+            // assertion.
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+
+            speechToTextService.results.emit(SpeechToTextResult.Partial("central to"))
+            runCurrent()
+
+            assertEquals("central to", viewModel.uiState.value.typedText)
+            assertTrue(viewModel.uiState.value.isListening)
+        }
 
     @Test
     fun `a recogniser error is reported as itself, not as a permission problem`() =
@@ -672,7 +714,9 @@ class AiSearchInputViewModelTest {
             speechToTextService.results.emit(SpeechToTextResult.Final("central to town hall"))
             advanceUntilIdle()
 
-            assertEquals(AiSearchInputPhase.RESOLVED, viewModel.uiState.value.phase)
+            // The late transcript still has to LAND. It no longer submits, so what proves it
+            // was not dropped is that it reached the field.
+            assertEquals("central to town hall", viewModel.uiState.value.typedText)
         }
 
     @Test

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelSynonymsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelSynonymsTest.kt
@@ -1,0 +1,76 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LabelSynonymsTest {
+
+    @Test
+    fun `office means work`() {
+        // The reported case: a rider whose label is Work said "office by Monday morning" and
+        // the resolver returned nothing, because "office" is not the string "work".
+        assertTrue(LabelSynonyms.sameMeaning("Work", "office"))
+        assertTrue(LabelSynonyms.sameMeaning("office", "Work"))
+    }
+
+    @Test
+    fun `the whole work group is interchangeable`() {
+        listOf("work", "office", "job", "workplace").forEach { first ->
+            listOf("work", "office", "job", "workplace").forEach { second ->
+                assertTrue(
+                    LabelSynonyms.sameMeaning(first, second),
+                    "\"$first\" and \"$second\" should mean the same place",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `groups do not leak into each other`() {
+        assertFalse(LabelSynonyms.sameMeaning("home", "work"))
+        assertFalse(LabelSynonyms.sameMeaning("uni", "school"))
+        assertFalse(LabelSynonyms.sameMeaning("gym", "office"))
+    }
+
+    @Test
+    fun `matching stays whole-word, so Homebush is still safe`() {
+        // The reason label matching is exact in the first place. Widening the vocabulary must
+        // not widen it into substrings.
+        assertFalse(LabelSynonyms.sameMeaning("home", "homebush"))
+        assertFalse(LabelSynonyms.sameMeaning("work", "workshop"))
+        assertFalse(LabelSynonyms.sameMeaning("uni", "union square"))
+    }
+
+    @Test
+    fun `a label the rider invented compares equal only to itself`() {
+        // Nothing here should touch labels outside the groups, however the groups grow.
+        assertTrue(LabelSynonyms.sameMeaning("Bouldering", "bouldering"))
+        assertFalse(LabelSynonyms.sameMeaning("Bouldering", "gym"))
+        assertFalse(LabelSynonyms.sameMeaning("Nan's", "home"))
+    }
+
+    @Test
+    fun `case and surrounding space do not matter`() {
+        assertTrue(LabelSynonyms.sameMeaning("  OFFICE ", "work"))
+        assertEquals("work", LabelSynonyms.canonical(" Office "))
+    }
+
+    @Test
+    fun `commute labels cover every accepted wording of the scheduled places`() {
+        // Used by the weekend rule. An Office label has to count as the commute exactly as a
+        // Work label does, or a rider gets their commute suggested on a Sunday.
+        listOf("work", "office", "job", "workplace", "uni", "university", "campus", "college", "school")
+            .forEach { label ->
+                assertTrue(label in LabelSynonyms.commuteLabels, "\"$label\" should count as a commute")
+            }
+    }
+
+    @Test
+    fun `home and gym are never commute labels`() {
+        listOf("home", "house", "gym").forEach { label ->
+            assertFalse(label in LabelSynonyms.commuteLabels, "\"$label\" is not a commute")
+        }
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolverTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopTextResolverTest.kt
@@ -56,6 +56,34 @@ class StopLabelTextResolverTest {
     }
 
     @Test
+    fun `a rider's own word for the place resolves to their label`() = runTest {
+        // Reported: label is "Work", rider said "office by Monday morning", nothing resolved.
+        sandook.putLabel("Work", WORK_STOP)
+
+        assertEquals(WORK_STOP, resolver.resolve("office"))
+        assertEquals(WORK_STOP, resolver.resolve("the job".removePrefix("the ")))
+    }
+
+    @Test
+    fun `a literal label wins over a synonym of another one`() = runTest {
+        // A rider with both has named two different stops, and "office" has to reach the one
+        // they actually called Office.
+        val office = StopItem(stopId = "30001", stopName = "Wynyard")
+        sandook.putLabel("Work", WORK_STOP)
+        sandook.putLabel("Office", office)
+
+        assertEquals(office, resolver.resolve("office"))
+        assertEquals(WORK_STOP, resolver.resolve("work"))
+    }
+
+    @Test
+    fun `a synonym of a label the rider never pinned resolves to null`() = runTest {
+        sandook.putLabel("Work", null)
+
+        assertNull(resolver.resolve("office"))
+    }
+
+    @Test
     fun `partial matches are not labels`() = runTest {
         sandook.putLabel("home", WORK_STOP)
 


### PR DESCRIPTION
## What

Three defects found while testing the Ask KRAIL surface on a device.

## Changes

### "office" did not reach the Work label

`StopLabelTextResolver` compared label strings exactly, so a rider whose label is `Work` said "office by Monday morning" and nothing resolved. Exact matching is there for a good reason — it is what stops "home" capturing "Homebush" — so this widens the **vocabulary**, not the matching.

- `LabelSynonyms` groups `work/office/job/workplace`, `home/house`, `uni/university/campus/college`. Every comparison is still a whole-word exact one
- Two passes, literal before synonym: a rider with both a `Work` and an `Office` label has named two different stops, and "office" has to reach the one they called Office
- The weekend commute rule reads its list from the same groups, so an `Office` label counts as a commute exactly as `Work` does. Two lists would have drifted the moment one gained a word

The group list is deliberately small. A synonym that is nearly right is worse than none: it sends a rider to a stop they did not name and gives them no way to see why.

### Speech submitted without being asked

The `Final` transcript called `submit()` directly. The recogniser deciding it has heard a full sentence is not the rider deciding they have finished saying one, and a mis-heard word was already on its way to a search before they could look at it.

It now fills the field and stops listening. Send stays the rider's to press.

### Words only appeared after speaking finished

The Android service emits partials correctly and sets `EXTRA_PARTIAL_RESULTS`. The ViewModel wrote them to `speechTranscript`, which nothing renders, while the field binds to `typedText`. Partials now land in `typedText`, so the sentence builds as it is spoken.

## Testing

- `LabelSynonymsTest` (8): group interchangeability, no leaking between groups, and that `homebush`, `workshop` and `union square` are still not matches. A rider's invented label compares equal only to itself
- `StopLabelTextResolverTest` (+3): the reported `office` case, literal-wins-over-synonym, and a synonym of a label with no stop pinned to it
- `AiSearchInputViewModelTest`: three rewritten for the new send behaviour, one added for partials appearing mid-sentence. The rewrite re-exposed the `advanceUntilIdle` hazard — it runs virtual time past the listening ceiling, so the session stops itself before the assertion; `runCurrent()` is correct there
- `./scripts/fullQualityChecks.sh` green
- Device QA on a physical Pixel: spoke a trip, watched the words arrive, confirmed nothing submitted until send was pressed
