### PR TITLE
feat(trip-planner): name the Ask KRAIL screen and drop the duplicate speak button

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputBar.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputBar.kt
@@ -44,13 +44,33 @@ import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputUiState
 
 private val BarCornerRadius = 28.dp
 private const val BAR_DARKEN_DARK = 0.45f
-private const val BAR_DARKEN_LIGHT = 0.09f
 private const val SEND_ENTER_SCALE = 0.5f
 private const val SEND_EXIT_SCALE = 0.35f
 private const val SEND_FADE_MILLIS = 140
 
 // Slower than the entry fade, so the shrink is still visible as the button goes.
 private const val SEND_EXIT_FADE_MILLIS = 200
+
+/**
+ * Opaque, and a different shade from the screen in each theme for a different reason.
+ *
+ * Light mode is plain `surface`: white. The colour behind the bar is the drifting cloud field,
+ * so a white bar reads as an object sitting on top of the light, which is exactly what it is.
+ * It was greyed for a while, from when the background was flat and white-on-white had no edge
+ * at all; against moving colour the grey only made it look dirty.
+ *
+ * Dark mode still darkens, because the opposite is true there: `surface` is already near black
+ * and the field's light passes straight through anything that does not sit below it.
+ *
+ * Either way the result is one opaque colour rather than a translucent tint. A tint takes its
+ * appearance from whatever happens to be behind it, and behind this is a gradient that moves.
+ */
+@Composable
+private fun barColor(): Color = if (isAppInDarkMode()) {
+    Color.Black.copy(alpha = BAR_DARKEN_DARK).compositeOver(KrailTheme.colors.surface)
+} else {
+    KrailTheme.colors.surface
+}
 
 /**
  * The whole input, as one object.
@@ -109,11 +129,7 @@ internal fun AiInputBar(
             // Same move in light mode, where it lands as a soft grey on white. Less of it,
             // because white needs far less shift to read as a distinct object than near black
             // does.
-            .background(
-                Color.Black
-                    .copy(alpha = if (isAppInDarkMode()) BAR_DARKEN_DARK else BAR_DARKEN_LIGHT)
-                    .compositeOver(KrailTheme.colors.surface),
-            )
+            .background(barColor())
             // Only ever while it is working out what was said. The border is the strongest
             // signal this surface has and spending it anywhere else would waste it.
             .aiGradientBorder(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputContent.kt
@@ -35,6 +35,11 @@ import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputUiState
 // the button all need the room more than an animation does.
 private const val FONT_SCALE_WHERE_DECORATION_COSTS_MORE_THAN_IT_SAYS = 1.5f
 
+// Past this scale the surface stops being a dialog and takes the whole screen. It no longer
+// changes the CONTROLS: there used to be a worded "Speak" button stacked under the bar here for
+// large font scales, from when the actions were a separate row below the field. Once mic and
+// send folded into the bar, that button was a second way to do the same thing sitting directly
+// under the first one, and the mic keeps its full touch target at every scale anyway.
 internal const val ACTIONS_STACK_SCALE = 1.8f
 
 // The greeting leaves slower than anything arrives. A welcome that snaps off the screen the
@@ -79,7 +84,6 @@ internal fun AiInputContent(
     val fontScale = LocalDensity.current.fontScale
     val workingBorder = rememberWorkingBorder(isWorking = state.isWorking)
     val showDecoration = fontScale < FONT_SCALE_WHERE_DECORATION_COSTS_MORE_THAN_IT_SAYS
-    val stackActions = fontScale >= ACTIONS_STACK_SCALE
     // A latch, not a condition. The greeting is a welcome, and a welcome is said once: tying it
     // to "the field is empty" brought it back every time a rider cleared what they had typed to
     // start again, which is exactly the moment they least need to be greeted.
@@ -135,14 +139,6 @@ internal fun AiInputContent(
             placeholder = AI_INPUT_PLACEHOLDER,
             onEvent = onEvent,
         )
-
-        // Only past the largest font scales, where a glyph in a column of worded controls is
-        // the odd one out and there is width to spare for the words. Below that the bar holds
-        // both controls itself.
-        if (stackActions) {
-            Spacer(modifier = Modifier.height(dim.spacingM))
-            AiVoiceControl(state = state, onEvent = onEvent, labelled = true)
-        }
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AskKrailScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AskKrailScreen.kt
@@ -39,6 +39,7 @@ import xyz.ksharma.krail.core.adaptiveui.rememberAdaptiveLayoutInfo
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.CloudFieldSpec
 import xyz.ksharma.krail.taj.components.CloudGradientBackground
+import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputEvent
@@ -167,11 +168,12 @@ private fun AskKrailFullScreen(
                 // clipped off the top of the screen. Never let that attribute be removed.
                 .safeDrawingPadding(),
         ) {
-            // Back button, no words. The field says Ask KRAIL, and a title bar repeating it
-            // over an otherwise empty screen was the app introducing itself twice. The bar is
-            // still here because the way out has to be.
+            // Named, like every other screen in the app. It was briefly title-less on the
+            // grounds that the field said Ask KRAIL too, but the field no longer does: it asks
+            // "Where to, and when?". The three lines now do three different jobs rather than
+            // repeating one instruction, which was the actual problem.
             TitleBar(
-                title = {},
+                title = { Text(text = AI_INPUT_QUESTION) },
                 onNavActionClick = onDismiss,
             )
             // Scrolling belongs to the content and only to the content. This column used to
@@ -191,7 +193,10 @@ private fun AskKrailFullScreen(
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = dim.pageHorizontalPadding)
-                    .padding(top = dim.spacingM, bottom = dim.spacingXL),
+                    // Enough to lift the bar off the keyboard without leaving a band of empty
+                    // colour under it. 16dp read as resting on the keyboard, 32dp as floating
+                    // away from it.
+                    .padding(top = dim.spacingM, bottom = dim.spacingXXL),
             )
         }
     }


### PR DESCRIPTION
## What

Four corrections to the Ask KRAIL surface, all found by using it on a device.

## Changes

### The app bar carries the title again

It was briefly wordless, on the grounds that the field said "Ask KRAIL" as well and the screen was introducing itself twice. The field now asks **"Where to, and when?"**, so the three lines do three different jobs — what this is, an example, what to type — rather than repeating one instruction. The repetition was the actual complaint, not the title.

### The duplicate "Speak" button is gone

At font scales ≥1.8 a worded `Speak` button rendered below the input bar. It dates from when mic and send were a row *underneath* the field, where a bare glyph among worded controls reads badly at large sizes.

Once both folded into the bar, that button became a second way to do the same thing sitting directly under the first one. The mic inside the bar keeps its full touch target at every font scale, so nothing was lost by removing it.

`ACTIONS_STACK_SCALE` stays — it still decides dialog vs full screen — but it no longer changes the controls.

### Padding between the bar and the keyboard: 16dp → 20dp

16 read as the bar resting on the keyboard. 32 was tried and read as floating away from it.

### The bar is plain `surface` in light mode

The grey dates from a flat background, where white on white had no edge at all. The background is now the drifting cloud field, so a white bar reads as an object sitting on top of the light — which is what it is. Against moving colour the grey only looked dirty.

Dark mode still darkens, because the opposite holds there: `surface` is already near black, and the field's light passes straight through anything that does not sit below it. Both branches resolve to one **opaque** colour rather than a translucent tint, since a tint takes its appearance from whatever happens to be behind it and behind this is a gradient that moves.

## Testing

- `./scripts/fullQualityChecks.sh` green (layout invariants, analytics assumptions, Android compile, iOS compile, detekt)
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
- Device QA on a physical Pixel in both themes, at a large font scale — which is the only place the duplicate button was visible
