### PR TITLE
feat(trip-planner): offer to get the rider home instead of two strangers' stops

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
@@ -45,6 +45,11 @@ internal data class AiGreeting(val suggestion: String)
 private val COMMUTE_LABELS = LabelSynonyms.commuteLabels
 
 private const val HOME_LABEL = "home"
+
+// The label is home by definition here, so the sentence says home rather than quoting whatever
+// casing the rider typed. "Get me home" is also what somebody would actually say out loud.
+private const val GET_ME_HOME = "Get me home"
+
 private const val DEFAULT_FROM = "Central"
 private const val DEFAULT_TO = "Parramatta"
 
@@ -67,17 +72,33 @@ internal fun suggestionFor(
     isWeekend: Boolean,
     labels: List<StopLabel>,
     savedTrips: List<Trip>,
+    isSunday: Boolean = false,
 ): String {
-    val pair = labelPair(labels, isWeekend)
-        ?: eligibleTrip(savedTrips, labels, isWeekend)?.let { trip ->
+    val situation = situationFor(hour = hour, isWeekend = isWeekend, isSunday = isSunday)
+
+    val pair = labelPair(labels, situation.allowsCommute)
+        ?: eligibleTrip(savedTrips, labels, situation.allowsCommute)?.let { trip ->
             trip.fromStopName.withoutStationSuffix() to trip.toStopName.withoutStationSuffix()
         }
-        ?: defaultPair(isWeekend)
 
-    // Everything about the hour and the day comes from the situations table, so this function
-    // only has to know how to turn two stops plus a situation into a sentence.
-    val situation = situationFor(hour = hour, isWeekend = isWeekend)
-    val (from, to) = if (situation.direction == Direction.Back) pair.second to pair.first else pair
+    // Home-bound because the situation asks for it, or because the day's rules disqualified
+    // everything the rider has.
+    //
+    // That second case is the one that matters. A rider whose only data IS the commute used to
+    // fall straight past the weekend rules to two unrelated stations, so every Saturday and
+    // Sunday showed strangers' stops. Falling back to the commute instead would have undone
+    // the weekend rule; falling back to home uses what they have, is true whenever they are
+    // out, and is the only line that shows the origin can be left out at all, since the
+    // nearby-stop resolver fills it from where they are.
+    val home = homeLabel(labels)
+    if ((situation.shape == SuggestionShape.HomeBound || pair == null) && home != null) {
+        return "$GET_ME_HOME${situation.clause}"
+    }
+
+    val resolved = pair ?: defaultPair(isWeekend)
+
+    val (from, to) =
+        if (situation.direction == Direction.Back) resolved.second to resolved.first else resolved
 
     // Longest first, then what to give up. The clause goes before the stops do, because a
     // journey with no time still describes their journey and a time with the wrong stops does
@@ -102,8 +123,8 @@ private fun defaultPair(isWeekend: Boolean): Pair<String, String> =
  * to follow the stops, not the words, since the same two platforms are the commute whether or
  * not anybody has labelled them.
  */
-private fun eligibleTrip(savedTrips: List<Trip>, labels: List<StopLabel>, isWeekend: Boolean): Trip? {
-    if (!isWeekend) return savedTrips.firstOrNull()
+private fun eligibleTrip(savedTrips: List<Trip>, labels: List<StopLabel>, allowsCommute: Boolean): Trip? {
+    if (allowsCommute) return savedTrips.firstOrNull()
 
     val commuteStopIds = labels
         .filter { it.isSet && it.label.lowercase() in COMMUTE_LABELS }
@@ -126,20 +147,24 @@ private fun eligibleTrip(savedTrips: List<Trip>, labels: List<StopLabel>, isWeek
  * a weekend commute labels are dropped entirely and any other named place is used instead, which
  * is how "Home to Gym" turns up on a Saturday without anybody writing a Saturday template.
  */
-private fun labelPair(labels: List<StopLabel>, isWeekend: Boolean): Pair<String, String>? {
+private fun labelPair(labels: List<StopLabel>, allowsCommute: Boolean): Pair<String, String>? {
     val set = labels.filter { it.isSet }
     val home = set.firstOrNull { it.label.equals(HOME_LABEL, ignoreCase = true) }
 
     val others = set.filterNot { it.label.equals(HOME_LABEL, ignoreCase = true) }
-    val eligible = if (isWeekend) {
-        others.filterNot { it.label.lowercase() in COMMUTE_LABELS }
-    } else {
+    val eligible = if (allowsCommute) {
         others.sortedByDescending { it.label.lowercase() in COMMUTE_LABELS }
+    } else {
+        others.filterNot { it.label.lowercase() in COMMUTE_LABELS }
     }
     val other = eligible.firstOrNull()
 
     return if (home != null && other != null) home.label to other.label else null
 }
+
+/** Whether the rider has a home pinned to a stop, which is all the home-bound line needs. */
+private fun homeLabel(labels: List<StopLabel>): String? =
+    labels.firstOrNull { it.isSet && it.label.equals(HOME_LABEL, ignoreCase = true) }?.label
 
 /**
  * `Seven Hills Station` reads as `Seven Hills`. Only the trailing word goes: everything else in
@@ -161,15 +186,17 @@ internal fun rememberAiGreeting(
 ): AiGreeting {
     val now = Clock.System.now().toLocalDateTime(TimeZone.of(SYDNEY))
     val hour = now.hour
-    val isWeekend = now.dayOfWeek == DayOfWeek.SATURDAY || now.dayOfWeek == DayOfWeek.SUNDAY
+    val isSunday = now.dayOfWeek == DayOfWeek.SUNDAY
+    val isWeekend = isSunday || now.dayOfWeek == DayOfWeek.SATURDAY
 
-    return remember(hour, isWeekend, stopLabels, savedTrips) {
+    return remember(hour, isWeekend, isSunday, stopLabels, savedTrips) {
         AiGreeting(
             suggestion = suggestionFor(
                 hour = hour,
                 isWeekend = isWeekend,
                 labels = stopLabels,
                 savedTrips = savedTrips,
+                isSunday = isSunday,
             ),
         )
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituations.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituations.kt
@@ -1,27 +1,21 @@
 package xyz.ksharma.krail.trip.planner.ui.components.ai
 
 /**
- * When the suggestion applies, which way the journey runs, and what time it asks for.
+ * When the suggestion applies, what shape it takes, which way it runs, and what time it asks
+ * for.
  *
  * This table is the whole time-and-day dimension of the suggestion line, as data rather than as
- * control flow. Adding a situation ("Friday night", "public holiday", "school term morning") is
- * one row here, in a list whose order IS the priority: first match wins.
- *
- * It was an `if` for the weekend and another `if` for the clause, which was shorter and not
- * extendible. A seventh case meant editing the middle of a function and hoping the ordering
- * still held; here a case is a line, and the ordering is visible.
+ * control flow. Adding a situation ("public holiday", "school term morning") is one row, in a
+ * list whose order IS the priority: first match wins.
  *
  * The other dimension, WHICH two stops, is deliberately not in here. That is a fallback ladder
- * over the rider's own data (labels, then a saved trip, then two known stations) and it runs the
- * same way regardless of the hour. Putting it in every row would mean repeating it in every row.
+ * over the rider's own data and it runs the same way at every hour, so putting it in every row
+ * would mean repeating it in every row.
  *
  * ## Configurable later
  *
  * [suggestionSituations] is the only seam that needs to change. A Remote Config version returns
  * the parsed list instead of the constant one and nothing that renders a suggestion has to know.
- * That is deliberately NOT wired yet: copy that changes a few times a year does not need a
- * remote pipe, and a remote-driven string that renders to every rider is its own validation
- * problem. Build the seam, wire the pipe when there is something that cannot wait for a release.
  */
 internal data class SuggestionSituation(
     /** Stable across copy changes, so config and tests can name a row without quoting it. */
@@ -31,18 +25,38 @@ internal data class SuggestionSituation(
     val fromHour: Int,
     /** Exclusive. */
     val toHour: Int,
+    val shape: SuggestionShape,
     val direction: Direction,
     /**
+     * Whether a commute label may be used here.
+     *
+     * False through the weekend, because suggesting the trip to work on a Saturday is the app
+     * saying out loud that it has not been paying attention. True again on a Sunday evening,
+     * which is the one weekend moment when the commute is exactly what somebody is thinking
+     * about.
+     */
+    val allowsCommute: Boolean,
+    /**
      * Appended verbatim, leading space included. Must still be true at every hour in the band:
-     * "by 9am" at 11am would be the app suggesting a trip into the past.
+     * "by 9pm" at 10pm would be the app suggesting a trip into the past.
      */
     val clause: String,
 )
 
-internal enum class DayKind { Weekday, Weekend, Any }
+internal enum class DayKind { Weekday, Weekend, Sunday, Any }
 
 /** Out is home to the other place; Back is the reverse. */
 internal enum class Direction { Out, Back }
+
+/**
+ * Whether the line names both ends or only where the rider is going.
+ *
+ * [HomeBound] exists because the origin can be left out entirely — the nearby-stop resolver
+ * fills it from where they are — and nothing on screen ever showed that. It is also the honest
+ * suggestion for a weekend evening: the app has no idea where somebody is on a Saturday night,
+ * but it is a fair bet they will want to get home from it.
+ */
+internal enum class SuggestionShape { Pair, HomeBound }
 
 // Relative, so it is correct at any hour. The absolute clauses each sit in a band that ends
 // before the time they name.
@@ -50,20 +64,95 @@ internal const val CLAUSE_SOON = " in 20 minutes"
 
 private val DEFAULT_SITUATIONS = listOf(
     // Arrive-by is what a weekday morning is for, and the only place the app demonstrates that
-    // this surface understands a deadline rather than just a departure.
-    // Ends AT nine, not after it. Running to ten meant a rider opening this at 09:30 was told
-    // to try arriving by 9am, which is the app suggesting a trip into the past.
-    SuggestionSituation("weekday-morning", DayKind.Weekday, 5, 9, Direction.Out, " by 9am"),
-    SuggestionSituation("weekday-midday", DayKind.Weekday, 9, 15, Direction.Out, CLAUSE_SOON),
+    // this surface understands a deadline rather than just a departure. Ends AT nine: running
+    // later meant a rider at 09:30 was told to try arriving by 9am.
+    SuggestionSituation(
+        id = "weekday-morning",
+        dayKind = DayKind.Weekday,
+        fromHour = 5,
+        toHour = 9,
+        shape = SuggestionShape.Pair,
+        direction = Direction.Out,
+        allowsCommute = true,
+        clause = " by 9am",
+    ),
+    SuggestionSituation(
+        id = "weekday-midday",
+        dayKind = DayKind.Weekday,
+        fromHour = 9,
+        toHour = 15,
+        shape = SuggestionShape.Pair,
+        direction = Direction.Out,
+        allowsCommute = true,
+        clause = CLAUSE_SOON,
+    ),
     // From mid-afternoon the journey people are about to take is the one home.
-    SuggestionSituation("weekday-evening", DayKind.Weekday, 15, 18, Direction.Back, " after 6pm"),
-    SuggestionSituation("weekday-night", DayKind.Weekday, 18, 23, Direction.Back, CLAUSE_SOON),
-    // No "by 9am" at a weekend: nobody is being got to work for nine on a Saturday, and the
-    // suggestion is the one line on the screen that is supposed to show the app paying attention.
-    SuggestionSituation("weekend-day", DayKind.Weekend, 5, 15, Direction.Out, CLAUSE_SOON),
-    SuggestionSituation("weekend-evening", DayKind.Weekend, 15, 23, Direction.Back, CLAUSE_SOON),
-    // Last, and Any, so it catches whatever the bands above did not on either kind of day.
-    SuggestionSituation("late-night", DayKind.Any, 23, 5, Direction.Out, CLAUSE_SOON),
+    SuggestionSituation(
+        id = "weekday-evening",
+        dayKind = DayKind.Weekday,
+        fromHour = 15,
+        toHour = 18,
+        shape = SuggestionShape.Pair,
+        direction = Direction.Back,
+        allowsCommute = true,
+        clause = " after 6pm",
+    ),
+    SuggestionSituation(
+        id = "weekday-night",
+        dayKind = DayKind.Weekday,
+        fromHour = 18,
+        toHour = 21,
+        shape = SuggestionShape.HomeBound,
+        direction = Direction.Back,
+        allowsCommute = true,
+        clause = " by 9pm",
+    ),
+    // Sunday from mid-afternoon is when people check tomorrow's commute. This is the one place
+    // the commute is welcome at a weekend, and it has to say tomorrow or it reads as a trip
+    // being suggested for tonight.
+    SuggestionSituation(
+        id = "sunday-evening",
+        dayKind = DayKind.Sunday,
+        fromHour = 15,
+        toHour = 23,
+        shape = SuggestionShape.Pair,
+        direction = Direction.Out,
+        allowsCommute = true,
+        clause = " by 9am tomorrow",
+    ),
+    // No "by 9am" at a weekend: nobody is being got to work for nine on a Saturday.
+    SuggestionSituation(
+        id = "weekend-day",
+        dayKind = DayKind.Weekend,
+        fromHour = 5,
+        toHour = 15,
+        shape = SuggestionShape.Pair,
+        direction = Direction.Out,
+        allowsCommute = false,
+        clause = CLAUSE_SOON,
+    ),
+    SuggestionSituation(
+        id = "weekend-evening",
+        dayKind = DayKind.Weekend,
+        fromHour = 15,
+        toHour = 21,
+        shape = SuggestionShape.HomeBound,
+        direction = Direction.Back,
+        allowsCommute = false,
+        clause = " by 9pm",
+    ),
+    // Past nine the deadline has gone, so the clause turns relative rather than naming an hour
+    // that has already been and gone.
+    SuggestionSituation(
+        id = "late-night",
+        dayKind = DayKind.Any,
+        fromHour = 21,
+        toHour = 5,
+        shape = SuggestionShape.HomeBound,
+        direction = Direction.Back,
+        allowsCommute = true,
+        clause = CLAUSE_SOON,
+    ),
 )
 
 /** The single seam. See the note on [SuggestionSituation] about making this remote. */
@@ -72,24 +161,30 @@ internal fun suggestionSituations(): List<SuggestionSituation> = DEFAULT_SITUATI
 /**
  * First row whose day and hour both match.
  *
- * Falls back to the first row rather than returning null: a rider opening this screen at an hour
- * somebody forgot to cover should see a slightly wrong suggestion, never a blank space where the
- * one explanatory line was meant to be. `everyHourOfEveryDayHasASituation` in the test makes
- * that fallback unreachable, and is there to keep it unreachable as rows are added.
+ * Sunday matches [DayKind.Sunday] and [DayKind.Weekend], in that order, so a Sunday-only row
+ * placed above the weekend rows shadows them and everything else still falls through to the
+ * general weekend behaviour.
+ *
+ * Falls back to the first row rather than returning null: a rider opening this screen at an
+ * hour somebody forgot to cover should see a slightly wrong suggestion, never a blank space
+ * where the one explanatory line was meant to be. A test makes that fallback unreachable and
+ * exists to keep it unreachable as rows are added.
  */
 internal fun situationFor(
     hour: Int,
     isWeekend: Boolean,
+    isSunday: Boolean = false,
     situations: List<SuggestionSituation> = suggestionSituations(),
 ): SuggestionSituation {
-    val dayKind = if (isWeekend) DayKind.Weekend else DayKind.Weekday
+    val kinds = when {
+        isSunday -> setOf(DayKind.Sunday, DayKind.Weekend, DayKind.Any)
+        isWeekend -> setOf(DayKind.Weekend, DayKind.Any)
+        else -> setOf(DayKind.Weekday, DayKind.Any)
+    }
     return situations.firstOrNull { situation ->
-        situation.matchesDay(dayKind) && situation.matchesHour(hour)
+        situation.dayKind in kinds && situation.matchesHour(hour)
     } ?: situations.first()
 }
-
-private fun SuggestionSituation.matchesDay(dayKind: DayKind): Boolean =
-    this.dayKind == DayKind.Any || this.dayKind == dayKind
 
 private fun SuggestionSituation.matchesHour(hour: Int): Boolean =
     if (fromHour <= toHour) hour in fromHour until toHour else hour >= fromHour || hour < toHour

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreetingTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreetingTest.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail.trip.planner.ui.components.ai
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -29,7 +30,14 @@ class AiGreetingTest {
         isWeekend: Boolean = false,
         labels: List<StopLabel> = emptyList(),
         savedTrips: List<Trip> = emptyList(),
-    ) = suggestionFor(hour = hour, isWeekend = isWeekend, labels = labels, savedTrips = savedTrips)
+        isSunday: Boolean = false,
+    ) = suggestionFor(
+        hour = hour,
+        isWeekend = isWeekend,
+        labels = labels,
+        savedTrips = savedTrips,
+        isSunday = isSunday,
+    )
 
     // region Always a complete line
 
@@ -109,8 +117,11 @@ class AiGreetingTest {
             savedTrips = listOf(commuteTrip),
         )
 
+        // Falls to home rather than to strangers' stations. Suggesting the commute here is what
+        // the weekend rule exists to stop; suggesting Central to Bondi Junction was what it did
+        // instead, and that told the rider nothing about their own trips.
         assertFalse(line.contains("Wynyard"), "\"$line\" is the commute on a weekend")
-        assertTrue(line.contains("Bondi Junction"), "\"$line\" should offer somewhere else")
+        assertTrue(line.startsWith("Get me home"), "\"$line\" should offer to get them home")
     }
 
     @Test
@@ -221,11 +232,58 @@ class AiGreetingTest {
 
     // endregion
 
+    @Test
+    fun `a rider whose only data is the commute is offered home at the weekend`() {
+        // The reported bug: every weekend showed "Central to Bondi Junction". The weekend rules
+        // disqualified the labels AND the saved trip, and the ladder fell to two stations the
+        // rider has nothing to do with.
+        val commuteTrip = Trip(
+            fromStopId = "1",
+            fromStopName = "Seven Hills Station",
+            toStopId = "2",
+            toStopName = "Wynyard Station",
+        )
+        val line = suggestion(
+            hour = 11,
+            isWeekend = true,
+            labels = listOf(home, work),
+            savedTrips = listOf(commuteTrip),
+        )
+
+        assertTrue(line.startsWith("Get me home"), "\"$line\" fell through to strangers' stops")
+        assertFalse(line.contains("Central"), "\"$line\" is not this rider's journey")
+    }
+
+    @Test
+    fun `a sunday evening offers tomorrow's commute`() {
+        val line = suggestion(hour = 18, isWeekend = true, isSunday = true, labels = listOf(home, work))
+
+        assertTrue(line.startsWith("Home to Work"), "\"$line\" should plan the commute")
+        assertTrue(line.endsWith("by 9am tomorrow"), "\"$line\" has to say tomorrow")
+    }
+
+    @Test
+    fun `a weekday evening offers to get them home, with a time`() {
+        // The time is the point: it is how a rider learns one can go in at all.
+        val line = suggestion(hour = 19, labels = listOf(home, work))
+
+        assertEquals("Get me home by 9pm", line)
+    }
+
+    @Test
+    fun `no home label means no home-bound line`() {
+        // Nothing to get them to, so it falls to the generic pair rather than promising a home
+        // that is not set.
+        val line = suggestion(hour = 19, labels = emptyList())
+
+        assertFalse(line.contains("Get me home"), "\"$line\" promises a home that is not set")
+    }
+
     private companion object {
         // Mirrors LONGEST_LINE in AiGreeting.kt. Duplicated rather than exposed: the production
         // constant is an implementation detail, and a test that reads it cannot fail when it
         // changes.
         const val LONGEST_LINE_FOR_TEST = 38
-        val TIME_WORDS = listOf("by 9am", "in 20 minutes", "after 6pm")
+        val TIME_WORDS = listOf("by 9am", "in 20 minutes", "after 6pm", "by 9pm")
     }
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituationsTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiSuggestionSituationsTest.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.components.ai
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -9,6 +10,31 @@ import kotlin.test.assertTrue
  * safe, so a seventh situation cannot silently open a gap or shadow an existing one.
  */
 class AiSuggestionSituationsTest {
+
+    @Test
+    fun `a sunday evening plans tomorrow's commute`() {
+        // The one weekend moment when the commute is what somebody is actually thinking about.
+        val situation = situationFor(hour = 18, isWeekend = true, isSunday = true)
+
+        assertEquals("sunday-evening", situation.id)
+        assertTrue(situation.allowsCommute, "Sunday evening has to be allowed the commute")
+        assertTrue(situation.clause.contains("tomorrow"), "or it reads as a trip for tonight")
+    }
+
+    @Test
+    fun `a saturday at the same hour does not`() {
+        val situation = situationFor(hour = 18, isWeekend = true, isSunday = false)
+
+        assertEquals("weekend-evening", situation.id)
+        assertFalse(situation.allowsCommute)
+    }
+
+    @Test
+    fun `no weekend situation outside sunday evening allows the commute`() {
+        suggestionSituations()
+            .filter { it.dayKind == DayKind.Weekend }
+            .forEach { assertFalse(it.allowsCommute, "${it.id} would suggest work at a weekend") }
+    }
 
     @Test
     fun `every hour of every kind of day has a situation`() {
@@ -59,6 +85,10 @@ class AiSuggestionSituationsTest {
         // "by 9am" at 11am is a trip into the past. Checked against the band rather than against
         // one sampled hour, so a row widened later fails here instead of on a phone.
         suggestionSituations().forEach { situation ->
+            // "by 9am tomorrow" names an hour that has not happened yet BECAUSE it says
+            // tomorrow, so the band it sits in is irrelevant.
+            if (situation.clause.contains("tomorrow")) return@forEach
+
             ABSOLUTE_CLAUSES.forEach { (clause, deadlineHour) ->
                 if (situation.clause.contains(clause)) {
                     assertTrue(
@@ -100,7 +130,9 @@ class AiSuggestionSituationsTest {
             dayKind = DayKind.Any,
             fromHour = 0,
             toHour = 24,
+            shape = SuggestionShape.Pair,
             direction = Direction.Back,
+            allowsCommute = true,
             clause = CLAUSE_SOON,
         )
         val situations = listOf(special) + suggestionSituations()
@@ -110,6 +142,6 @@ class AiSuggestionSituationsTest {
 
     private companion object {
         /** Clause to the hour by which it stops being in the future. */
-        val ABSOLUTE_CLAUSES = mapOf("9am" to 9, "6pm" to 18)
+        val ABSOLUTE_CLAUSES = mapOf("9am" to 9, "6pm" to 18, "9pm" to 21)
     }
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt
@@ -36,7 +36,10 @@ object AiThemeGradientTokens {
 
     private val partners: Map<KrailThemeStyle, Pair<Color, Color>> = mapOf(
         KrailThemeStyle.Train to (Train to PurpleDrip),
-        KrailThemeStyle.Metro to (Metro to PurpleDrip),
+        // Teal into yellow, not into purple. Purple Drip is a magenta, so the teal theme's
+        // gradient read as teal and pink, and the two ends fought rather than travelled. Yellow
+        // is the same cool-to-warm crossing that works for Bus, at 119 degrees.
+        KrailThemeStyle.Metro to (Metro to MagicYellow),
         // Yellow, not pink. Blue into pink travels through purple and reads as somebody
         // else's AI product; blue into yellow is the one pair here that crosses from cool to
         // warm, so the two ends stay told apart wherever the gradient is in its drift. It is


### PR DESCRIPTION
## What

The weekend suggestion was always `"Central to Bondi Junction"` for a rider whose only data is their commute.

The weekend rules disqualified their labels **and** their saved trip, and the ladder fell through to two stations they have nothing to do with — every Saturday and Sunday, deterministically.

## Why not just fall back to the commute

That was the first fix, and a test caught it immediately: it suggested `"Home to Work"` on a Saturday, which is precisely what the weekend exclusion exists to prevent. Undoing one bug with the other is not a fix.

Falling back to **home** uses what the rider actually has, without resurrecting the commute.

## Changes

- `SuggestionShape` adds `HomeBound`: `"Get me home by 9pm"`. Short enough never to trip the length cap, true whether or not they are actually out, and the only line that shows the origin can be **left out entirely** — which the nearby-stop resolver already supports but nothing on screen ever demonstrated
- Used when a situation asks for it, or whenever the day's rules disqualify everything the rider has. Only when a home stop is genuinely pinned; there is no promising a home that is not set
- `allowsCommute` moves onto the situation row, so weekday rows keep the commute and weekend rows do not. It was a boolean threaded through the resolver, which is the wrong place for a rule about what day it is
- **Sunday from 15:00 plans tomorrow**: `"Home to Work by 9am tomorrow"`. The one weekend moment when the commute is what somebody is actually thinking about, and it has to say *tomorrow* or it reads as a trip for tonight
- Evenings past 21:00 turn the clause relative, since "by 9pm" has already gone

### Resulting lines

| When | Line |
|---|---|
| Weekday morning | `Home to Work by 9am` |
| Weekday 15–18 | `Work to Home after 6pm` |
| Weekday 18–21 | `Get me home by 9pm` |
| Sunday 15:00+ | `Home to Work by 9am tomorrow` |
| Weekend, non-commute label | `Home to Gym in 20 minutes` |
| Weekend, only commute data | `Get me home by 9pm` |
| Any day past 21:00 | `Get me home in 20 minutes` |

### Metro pairs with yellow

Purple Drip is a magenta, so the teal theme's AI gradient read as teal and pink and the two ends fought rather than travelled. Measured rather than eyeballed: teal to yellow is **119°**, inside the 97–148 band the token file documents. Teal to green would have been 54°, well inside the muddy zone, so yellow is the pair that works.

## Testing

- 4 new greeting tests, including the exact reported case: only-commute data at a weekend now offers home and never reaches the generic pair
- 3 new situation tests for the Sunday exception, and that no other weekend row allows the commute
- The absolute-clause guard extended to `9pm`, and taught that a clause saying "tomorrow" is exempt from its band — `"by 9am tomorrow"` is legitimately in an evening row
- `./scripts/fullQualityChecks.sh` green, `:taj` and `:feature:trip-planner:ui` host tests green
- Device QA on a physical Pixel
