### PR TITLE
fix(trip-planner): never match a rider's label word against stop names

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputContent.kt
@@ -136,7 +136,9 @@ internal fun AiInputContent(
         // message names the real route and the shortcut waits until it can point at it.
         state.problemMessage()?.let { AiProblemBanner(message = it) }
 
-        Spacer(modifier = Modifier.height(dim.spacingM))
+        // The banner and the box are two different things and used to sit close enough to read
+        // as one block.
+        Spacer(modifier = Modifier.height(dim.spacingXL))
 
         AiInputBar(
             state = state,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputContent.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputContent.kt
@@ -129,6 +129,11 @@ internal fun AiInputContent(
         // Above the bar, not below it. The bar is pinned to the bottom edge, so a message that
         // grows to three lines would otherwise shove it and its controls upward. Above, it
         // takes room from the empty space, which is what that space is for.
+        // No action button yet, deliberately. The obvious destination, "Manage your labels",
+        // can only rename, reorder and remove — a label is CREATED from the stop search, by
+        // finding a stop and saving it under a name. A button landing a rider on a screen that
+        // cannot do the thing the message just told them to do is worse than no button, so the
+        // message names the real route and the shortcut waits until it can point at it.
         state.problemMessage()?.let { AiProblemBanner(message = it) }
 
         Spacer(modifier = Modifier.height(dim.spacingM))

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputPieces.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputPieces.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.trip.planner.ui.components.ai
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.ColorFilter
 import kotlinx.coroutines.launch
@@ -40,6 +42,7 @@ import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputUiState
 import xyz.ksharma.krail.trip.planner.ui.search.ai.MIC_NEEDS_SETTINGS
 import xyz.ksharma.krail.trip.planner.ui.search.ai.MIC_UNSUPPORTED
 import xyz.ksharma.krail.trip.planner.ui.search.ai.UnresolvedReason
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelSynonyms
 
 /**
  * What the slot shows while the surface is busy. Two states, two motions, one word each.
@@ -183,10 +186,15 @@ internal fun AiVoiceControl(
  * dark red. The container pair is designed for exactly this and is already tuned for both.
  */
 @Composable
-internal fun AiProblemBanner(message: String, modifier: Modifier = Modifier) {
+internal fun AiProblemBanner(
+    message: String,
+    modifier: Modifier = Modifier,
+    actionLabel: String? = null,
+    onActionClick: (() -> Unit)? = null,
+) {
     val dim = KrailTheme.dimensions
 
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .background(
@@ -194,12 +202,27 @@ internal fun AiProblemBanner(message: String, modifier: Modifier = Modifier) {
                 shape = RoundedCornerShape(dim.radiusM),
             )
             .padding(horizontal = dim.spacingL, vertical = dim.spacingM),
+        verticalArrangement = Arrangement.spacedBy(dim.spacingS),
     ) {
         Text(
             text = message,
             style = KrailTheme.typography.bodyMedium,
             color = KrailTheme.colors.onErrorContainer,
         )
+
+        // Only when the rider can actually do something about it. A message that names a fix
+        // and then leaves them to find it is barely better than one that does not.
+        if (actionLabel != null && onActionClick != null) {
+            Text(
+                text = actionLabel,
+                style = KrailTheme.typography.titleSmall,
+                color = KrailTheme.colors.onErrorContainer,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(dim.radiusS))
+                    .clickable(onClick = onActionClick)
+                    .padding(vertical = dim.spacingXS),
+            )
+        }
     }
 }
 
@@ -234,10 +257,19 @@ private fun AiSearchInputUiState.unresolvedMessage(): String = when (unresolvedR
         "No place in that one. Name a stop, like Central Station, and where you are going."
 
     // We know exactly which word failed, so it is quoted back rather than described.
+    //
+    // A label word gets different advice, because "try the name as it appears on the sign" is
+    // useless for it: there is no sign that says Work. The rider does not want a stop called
+    // work, they want their Work stop, and the thing they can act on is setting it.
     UnresolvedReason.STOP_NOT_FOUND ->
-        unmatchedPlace
-            ?.let { place -> "No stop called \"$place\". Try the name as it appears on the sign." }
-            ?: "That is not a stop I know. Try the name as it appears on the sign."
+        unmatchedPlace?.let { place ->
+            if (LabelSynonyms.isLabelWord(place)) {
+                "No stop saved as \"$place\" yet. Search for the stop, save it under that " +
+                    "name, and you can say it here."
+            } else {
+                "No stop called \"$place\". Try the name as it appears on the sign."
+            }
+        } ?: "That is not a stop I know. Try the name as it appears on the sign."
 
     // The model, not the sentence. Nothing about the wording is worth changing.
     UnresolvedReason.COULD_NOT_READ ->
@@ -245,6 +277,17 @@ private fun AiSearchInputUiState.unresolvedMessage(): String = when (unresolvedR
 
     null -> "Something is missing there. Name where you are going, and where from."
 }
+
+/**
+ * The unmatched place is a word the rider names places with, and they have not set it yet.
+ *
+ * Distinct from an ordinary unknown stop, because the fix is different: there is no sign that
+ * says Work, and telling them to check one is advice they cannot follow.
+ */
+internal val AiSearchInputUiState.missingStopLabel: String?
+    get() = unmatchedPlace?.takeIf {
+        unresolvedReason == UnresolvedReason.STOP_NOT_FOUND && LabelSynonyms.isLabelWord(it)
+    }
 
 internal val AiSearchInputUiState.needsSettingsForMic: Boolean
     get() = speechUnavailableReason == MIC_NEEDS_SETTINGS

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputPieces.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputPieces.kt
@@ -2,7 +2,6 @@ package xyz.ksharma.krail.trip.planner.ui.components.ai
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -15,7 +14,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.ColorFilter
 import kotlinx.coroutines.launch
@@ -27,6 +25,7 @@ import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.AiActivity
 import xyz.ksharma.krail.taj.components.AiListeningIndicator
+import xyz.ksharma.krail.taj.components.AlertIcon
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.MicIcon
 import xyz.ksharma.krail.taj.components.RoundIconButton
@@ -189,40 +188,38 @@ internal fun AiVoiceControl(
 internal fun AiProblemBanner(
     message: String,
     modifier: Modifier = Modifier,
-    actionLabel: String? = null,
-    onActionClick: (() -> Unit)? = null,
 ) {
     val dim = KrailTheme.dimensions
 
-    Column(
+    Row(
         modifier = modifier
             .fillMaxWidth()
             .background(
                 color = KrailTheme.colors.errorContainer,
                 shape = RoundedCornerShape(dim.radiusM),
             )
-            .padding(horizontal = dim.spacingL, vertical = dim.spacingM),
-        verticalArrangement = Arrangement.spacedBy(dim.spacingS),
+            .padding(horizontal = dim.spacingL, vertical = dim.spacingL),
+        horizontalArrangement = Arrangement.spacedBy(dim.spacingM),
     ) {
-        Text(
-            text = message,
-            style = KrailTheme.typography.bodyMedium,
-            color = KrailTheme.colors.onErrorContainer,
+        // Top aligned, not centred. The message runs to three lines often enough that a centred
+        // icon drifts into the middle of a paragraph and reads as punctuation rather than as a
+        // marker for the whole thing.
+        Image(
+            imageVector = AlertIcon,
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(KrailTheme.colors.onErrorContainer),
+            modifier = Modifier
+                .padding(top = dim.spacingXXS)
+                .size(dim.iconSmall),
         )
 
-        // Only when the rider can actually do something about it. A message that names a fix
-        // and then leaves them to find it is barely better than one that does not.
-        if (actionLabel != null && onActionClick != null) {
-            Text(
-                text = actionLabel,
-                style = KrailTheme.typography.titleSmall,
-                color = KrailTheme.colors.onErrorContainer,
-                modifier = Modifier
-                    .clip(RoundedCornerShape(dim.radiusS))
-                    .clickable(onClick = onActionClick)
-                    .padding(vertical = dim.spacingXS),
-            )
-        }
+        // Smaller than the rider's own sentence. This is the app talking, and it should not
+        // compete for weight with the words they wrote.
+        Text(
+            text = message,
+            style = KrailTheme.typography.bodySmall,
+            color = KrailTheme.colors.onErrorContainer,
+        )
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -32,6 +32,7 @@ import xyz.ksharma.krail.trip.planner.ui.savedtrips.RealInviteFriendsTileManager
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputViewModel
 import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.ChainedStopTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelWordGuard
 import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelledStopLocator
 import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.RiderOriginLocator
 import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopLabelTextResolver
@@ -99,7 +100,10 @@ val viewModelsModule = module {
             stopTextResolver = ChainedStopTextResolver(
                 listOf(
                     StopLabelTextResolver(sandook = get()),
-                    StopSearchTextResolver(stopResultsManager = get()),
+                    // Guarded: a label word that reached no label must resolve to nothing
+                    // rather than being searched for among stop names. "work" with no Work
+                    // label set matched Blacktown Workers Club.
+                    LabelWordGuard(StopSearchTextResolver(stopResultsManager = get())),
                 ),
             ),
             // Same precedence idea as the resolver chain above, applied to where a journey

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -84,6 +84,9 @@ class AiSearchInputViewModel(
     // layer builds the lambda and passes it through koinViewModel's parametersOf, the same
     // pattern TrackTripViewModel already uses.
     private val riderOriginLocator: RiderOriginLocator = RiderOriginLocator(),
+    // The rider's own label words, for the case where the model reads a sentence correctly and
+    // still finds no place in it because the place is a word like "work".
+    private val riderLabels: suspend () -> List<String> = { emptyList() },
     private val isAiSearchInputEnabled: () -> Boolean = { false },
 ) : ViewModel() {
 
@@ -341,7 +344,12 @@ class AiSearchInputViewModel(
                 logOutcome()
                 return@launch
             }
-            val extraction = rawExtraction.withSinglePlaceInTheRightField(text)
+            // "work by 9am tomm" came back with no place at all: to the model, "work" is an
+            // ordinary noun, not this rider's stop. Their own word, from their own text, matched
+            // against their own labels — nothing here comes from the model.
+            val extraction = rawExtraction
+                .withSinglePlaceInTheRightField(text)
+                .withLabelWordAsDestination(riderText = text, labels = riderLabels())
 
             val toStopItem = extraction.destinationText?.let { resolveStop(it) }
             val originText = extraction.originText

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/LabelWordFallback.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/LabelWordFallback.kt
@@ -1,0 +1,49 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai
+
+import xyz.ksharma.krail.core.aitext.TripIntentExtraction
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelSynonyms
+
+/**
+ * Rescues a sentence whose only place is a word the rider named themselves.
+ *
+ * Reported: "work by 9am tomm" came back with **no place at all** and the rider was told to name
+ * a stop. The model has no idea "work" is a place for this rider — it is an ordinary English
+ * noun — so it read the sentence as a time and nothing else.
+ *
+ * This is the deterministic half of the fix. When extraction finds no place, the rider's own
+ * text is scanned for a word that is one of their labels (or a synonym of one), and that word
+ * becomes the destination. The proper half is teaching the model that these words are places
+ * for this rider, which is a prompt change and a separate piece of work.
+ *
+ * ## Why this does not break the rule about model output
+ *
+ * `AI_SEARCH_UX.md` requires that nothing the model produces is displayed. Nothing here comes
+ * from the model. The word is taken from what the rider typed, matched against labels they
+ * created, and resolved through the ordinary label resolver. It is their word and their stop.
+ *
+ * ## Why whole words only
+ *
+ * Same reason label matching is exact: "homebush" contains "home" and is a different place
+ * entirely. Splitting on non-letters and comparing whole tokens keeps that safe.
+ */
+internal fun TripIntentExtraction.withLabelWordAsDestination(
+    riderText: String,
+    labels: List<String>,
+): TripIntentExtraction {
+    // Only when the model found nothing. A sentence it read correctly is never second-guessed.
+    if (originText != null || destinationText != null) return this
+    if (labels.isEmpty()) return this
+
+    val labelWord = riderText
+        .split(WORD_SEPARATORS)
+        .firstOrNull { token ->
+            token.isNotBlank() && labels.any { label -> LabelSynonyms.sameMeaning(label, token) }
+        }
+        ?: return this
+
+    return copy(destinationText = labelWord)
+}
+
+// Letters only. Splitting on everything else means "work," and "work." are the same word, and a
+// time like "9am" can never be mistaken for one.
+private val WORD_SEPARATORS = Regex("[^\\p{L}]+")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelSynonyms.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelSynonyms.kt
@@ -47,6 +47,19 @@ internal object LabelSynonyms {
         return GROUPS.firstOrNull { normalised in it }?.first() ?: normalised
     }
 
+    /**
+     * True when this word is one the app treats as a rider's name for a place.
+     *
+     * These must never reach a stop-name search. "work" with no Work label set matched
+     * **Blacktown Workers Club**, and a rider who says "work" has never in the history of
+     * anything meant a club whose name contains those letters. A label word either resolves to
+     * a label or to nothing at all.
+     */
+    fun isLabelWord(word: String): Boolean {
+        val normalised = word.trim().lowercase()
+        return GROUPS.any { normalised in it }
+    }
+
     /** True when two labels name the same kind of place. */
     fun sameMeaning(first: String, second: String): Boolean = canonical(first) == canonical(second)
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelWordGuard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelWordGuard.kt
@@ -1,0 +1,36 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+
+/**
+ * Stops a rider's word for a place from being matched against stop names.
+ *
+ * Reported, with no Work label set: "I wanna go to work tomorrow at 9am" filled the destination
+ * with **Blacktown Workers Club**. The label resolver found no Work label, the chain moved on,
+ * and the stop search happily matched the letters in "Workers".
+ *
+ * A rider who says "work" has never meant a club whose name contains those letters. These words
+ * are their vocabulary for places they name, not fragments to search stop names with, so a label
+ * word resolves to a label or to nothing at all.
+ *
+ * ## Why a wrapper rather than a rule inside the search resolver
+ *
+ * The stop search is a general capability with other callers, and "work" IS a legitimate thing
+ * to type into an ordinary stop search — somebody looking for Blacktown Workers Club has every
+ * right to find it by typing part of its name. What is wrong is reaching it through a *label
+ * word* in a sentence. That distinction belongs to this chain, not to the search.
+ *
+ * ## What the rider sees instead
+ *
+ * Nothing resolves, so the failure quotes their word back. That is the honest outcome, and it is
+ * also the hook for offering to set the label they clearly want — see §8 of `ASK_KRAIL_UX.md`.
+ */
+internal class LabelWordGuard(
+    private val delegate: StopTextResolver,
+) : StopTextResolver {
+
+    override val name: String = "label-word-guard(${delegate.name})"
+
+    override suspend fun resolve(query: String): StopItem? =
+        if (LabelSynonyms.isLabelWord(query)) null else delegate.resolve(query)
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelledStopLocator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelledStopLocator.kt
@@ -59,6 +59,18 @@ class LabelledStopLocator(
             ?.first
     }
 
+    /**
+     * Whether the rider is already standing at [stopId].
+     *
+     * Asked about the DESTINATION. Someone at home saying "to home by 9pm" is already there,
+     * and the honest answer is no journey at all — filling the origin with the next stop along
+     * the road produces a trip from one bus stop to its neighbour, which is not a trip.
+     */
+    suspend fun isStandingAt(stopId: String, latitude: Double, longitude: Double): Boolean {
+        val coordinates = sandook.selectStopCoordinatesBatch(listOf(stopId))[stopId] ?: return false
+        return distanceKm(latitude, longitude, coordinates.first, coordinates.second) <= RADIUS_KM
+    }
+
     private companion object {
 
         /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/RiderOriginLocator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/RiderOriginLocator.kt
@@ -35,6 +35,16 @@ class RiderOriginLocator(
     suspend fun originStop(excludeStopId: String?): StopItem? {
         val location = resolveCurrentLocation() ?: return null
 
+        // Already there. "To home by 9pm" while standing at home used to fill the origin with
+        // the next stop along the road, which is a journey from one bus stop to its neighbour.
+        // Leaving it blank says nothing untrue and leaves the field editable.
+        val alreadyThere = excludeStopId != null && labelledStopLocator?.isStandingAt(
+            stopId = excludeStopId,
+            latitude = location.latitude,
+            longitude = location.longitude,
+        ) == true
+        if (alreadyThere) return null
+
         return labelledStopLocator?.nearestLabelledStop(
             latitude = location.latitude,
             longitude = location.longitude,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/LabelWordFallbackTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/LabelWordFallbackTest.kt
@@ -1,0 +1,85 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai
+
+import xyz.ksharma.krail.core.aitext.TripIntentExtraction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LabelWordFallbackTest {
+
+    private val labels = listOf("Home", "Work")
+
+    @Test
+    fun `a sentence whose only place is a label word is rescued`() {
+        // Reported: "work by 9am tomm" produced no place at all and the rider was told to name
+        // a stop. To the model "work" is an ordinary noun.
+        val rescued = TripIntentExtraction().withLabelWordAsDestination("work by 9am tomm", labels)
+
+        assertEquals("work", rescued.destinationText)
+        assertNull(rescued.originText, "a one-ended sentence has no origin to invent")
+    }
+
+    @Test
+    fun `a synonym of a label counts`() {
+        val rescued = TripIntentExtraction().withLabelWordAsDestination("office by 9am", labels)
+
+        assertEquals("office", rescued.destinationText)
+    }
+
+    @Test
+    fun `an extraction that already found a place is never second-guessed`() {
+        val original = TripIntentExtraction(destinationText = "Central Station")
+
+        val result = original.withLabelWordAsDestination("home to central station", labels)
+
+        assertEquals("Central Station", result.destinationText)
+        assertNull(result.originText)
+    }
+
+    @Test
+    fun `an origin alone is also left alone`() {
+        val original = TripIntentExtraction(originText = "Central Station")
+
+        val result = original.withLabelWordAsDestination("from central station", labels)
+
+        assertEquals("Central Station", result.originText)
+        assertNull(result.destinationText)
+    }
+
+    @Test
+    fun `a word that merely contains a label is not a label`() {
+        // Same rule as label matching: Homebush is a place, and it is not this rider's home.
+        val result = TripIntentExtraction().withLabelWordAsDestination("homebush at 9am", labels)
+
+        assertNull(result.destinationText)
+    }
+
+    @Test
+    fun `punctuation does not hide a label word`() {
+        val result = TripIntentExtraction().withLabelWordAsDestination("work, by 9am.", labels)
+
+        assertEquals("work", result.destinationText)
+    }
+
+    @Test
+    fun `a sentence with no label word is left as it was`() {
+        val result = TripIntentExtraction().withLabelWordAsDestination("hey how are you", labels)
+
+        assertNull(result.destinationText)
+    }
+
+    @Test
+    fun `a rider with no labels gets no rescue`() {
+        val result = TripIntentExtraction().withLabelWordAsDestination("work by 9am", emptyList())
+
+        assertNull(result.destinationText)
+    }
+
+    @Test
+    fun `only labels the rider actually has are used`() {
+        // "gym" is a known synonym group, but this rider never made that label.
+        val result = TripIntentExtraction().withLabelWordAsDestination("gym at 6pm", labels)
+
+        assertNull(result.destinationText)
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelWordGuardTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelWordGuardTest.kt
@@ -1,0 +1,73 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LabelWordGuardTest {
+
+    /** Stands in for the stop search, which will match anything it is asked about. */
+    private class AlwaysMatches(private val stop: StopItem) : StopTextResolver {
+        override val name: String = "always"
+        var lastQuery: String? = null
+        override suspend fun resolve(query: String): StopItem? {
+            lastQuery = query
+            return stop
+        }
+    }
+
+    private val workersClub = StopItem(stopId = "99", stopName = "Blacktown Workers Club")
+
+    @Test
+    fun `a label word never reaches the stop search`() = runTest {
+        // The reported bug, exactly: no Work label set, rider says "work", and the search
+        // matched the letters in "Workers".
+        val search = AlwaysMatches(workersClub)
+
+        val result = LabelWordGuard(search).resolve("work")
+
+        assertNull(result, "\"work\" must not resolve to a stop that merely contains the letters")
+        assertNull(search.lastQuery, "the search should never have been asked")
+    }
+
+    @Test
+    fun `every label word is guarded`() = runTest {
+        val search = AlwaysMatches(workersClub)
+        val guard = LabelWordGuard(search)
+
+        listOf("home", "house", "work", "office", "job", "workplace", "uni", "university", "gym")
+            .forEach { word ->
+                assertNull(guard.resolve(word), "\"$word\" should not be searched for")
+            }
+    }
+
+    @Test
+    fun `case and space do not sneak a label word past the guard`() = runTest {
+        val guard = LabelWordGuard(AlwaysMatches(workersClub))
+
+        assertNull(guard.resolve("  WORK "))
+    }
+
+    @Test
+    fun `an ordinary place name passes straight through`() = runTest {
+        val search = AlwaysMatches(workersClub)
+
+        val result = LabelWordGuard(search).resolve("Blacktown Workers Club")
+
+        assertEquals(workersClub, result)
+        assertEquals("Blacktown Workers Club", search.lastQuery)
+    }
+
+    @Test
+    fun `a stop whose name merely contains a label word is still findable`() = runTest {
+        // The guard is about the WORD being a label word, not about the stop. Somebody typing
+        // the club's actual name has every right to find it.
+        val search = AlwaysMatches(workersClub)
+
+        val result = LabelWordGuard(search).resolve("workers club")
+
+        assertEquals(workersClub, result)
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelledStopLocatorTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelledStopLocatorTest.kt
@@ -115,6 +115,26 @@ class LabelledStopLocatorTest {
     }
 
     @Test
+    fun `a rider standing at the destination is already there`() = runTest {
+        // "To home by 9pm" while at home. The caller uses this to leave the origin blank rather
+        // than filling it with the stop next door, which would be a trip to a neighbour.
+        putLabel("Home", "20202", "Seven Hills Station", homeLat, homeLon)
+
+        val there = locator.isStandingAt("20202", latitude = homeLat, longitude = homeLon)
+
+        assertEquals(true, there)
+    }
+
+    @Test
+    fun `a rider well away from the destination is not already there`() = runTest {
+        putLabel("Home", "20202", "Seven Hills Station", homeLat, homeLon)
+
+        val there = locator.isStandingAt("20202", latitude = workLat, longitude = workLon)
+
+        assertEquals(false, there)
+    }
+
+    @Test
     fun `a rider with no labels at all resolves to nothing`() = runTest {
         val origin = locator.nearestLabelledStop(
             latitude = workLat,

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/AlertIcon.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/AlertIcon.kt
@@ -1,0 +1,49 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * A circle with an exclamation in it: something needs the rider's attention.
+ *
+ * Stroked rather than filled, and authored as path data for the same reason [MicIcon],
+ * [StopIcon] and [SendIcon] are, so it carries the same weight as the rest of the set at the
+ * same size.
+ *
+ * A triangle would read as danger. Nothing this marks is dangerous — a stop that did not
+ * resolve is a thing to correct, not a warning — so the calmer of the two shapes is right.
+ */
+val AlertIcon: ImageVector by lazy {
+    ImageVector.Builder(
+        name = "Alert",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).apply {
+        path(
+            stroke = SolidColor(Color.White),
+            strokeLineWidth = 2f,
+            strokeLineCap = StrokeCap.Round,
+            strokeLineJoin = StrokeJoin.Round,
+        ) {
+            // The circle, as four arcs.
+            moveTo(12f, 3f)
+            arcToRelative(9f, 9f, 0f, true, true, -0.01f, 0f)
+            close()
+
+            // The stem, stopping short of the dot.
+            moveTo(12f, 7.5f)
+            lineTo(12f, 13f)
+
+            // The dot.
+            moveTo(12f, 16.5f)
+            lineTo(12f, 16.6f)
+        }
+    }.build()
+}


### PR DESCRIPTION
## What

Four defects found testing on a device. Three share one root cause: the app treated a rider's word for a place (`work`, `home`, `office`) as ordinary search text.

## Changes

### `work` matched "Blacktown Workers Club"

With no Work label set, *"I wanna go to work tomorrow at 9am"* filled the destination with **Blacktown Workers Club**. The label resolver found nothing, the chain moved on, and the stop search matched the letters in "Workers".

A rider who says "work" has never meant a club containing those letters. `LabelWordGuard` wraps the stop search so a label word resolves to **a label or to nothing at all**.

Deliberately a wrapper rather than a rule inside the search: typing "workers club" into an ordinary stop search should still find it. What is wrong is reaching it *through a label word in a sentence*, and that distinction belongs to this chain.

### `work by 9am tomm` found no place at all

To the model, "work" is an ordinary noun, so it read a time and nothing else. `withLabelWordAsDestination` scans the rider's own text for a word matching their own labels and uses it as the destination.

Whole words only, so "homebush" is still not "home". It does nothing for a rider who has not made that label — which is why it correctly stayed silent in the no-Work-label case above. **Nothing here comes from the model**, so `AI_SEARCH_UX.md`'s rule holds: it is the rider's word, from their text, matched to their label.

### The advice was unfollowable

"Try the name as it appears on the sign" is useless for a label word — there is no sign that says Work. The message now names the real route: search for the stop and save it under that name.

### A journey from a bus stop to its neighbour

*"To home by 9pm"* while standing at home filled the origin with the next stop along the road. The same-stop guard did hold — they were two different stops — but the result was still nonsense.

Within walking distance of the destination the origin is now left **blank and editable**. Saying nothing beats saying something untrue.

## Deliberately not done

**No shortcut button on the message.** The obvious destination, "Manage your labels", can only rename, reorder and remove — a label is *created* from the stop search. A button landing a rider on a screen that cannot do what the message just asked of them is worse than no button.

`navigateToSearchStop` takes a `labelKey` and looks like the right target, but whether it accepts a label that does not exist yet is unverified, so the plumbing is out rather than half-right. Recorded in §8 of `ASK_KRAIL_UX.md`.

### Banner styling

Folded in rather than raised separately, because it is the same banner whose copy this PR
rewrites.

- `AlertIcon` (new, in `:taj`): a stroked circle with an exclamation, authored as path data like
  `MicIcon` / `StopIcon` / `SendIcon`. A circle rather than a triangle — a stop that did not
  resolve is something to correct, not a danger
- Top aligned, not centred: these messages run to three lines often enough that a centred icon
  drifts into the middle of a paragraph and reads as punctuation
- Message drops to `bodySmall`. This is the app talking, and it should not compete for weight
  with the sentence the rider wrote
- More room inside the banner, and the gap to the input box goes `spacingM` → `spacingXL`

## Testing

- `LabelWordGuardTest` (5): the Workers Club case, every label word guarded, case and spacing, and that the club is **still findable by its real name**
- `LabelWordFallbackTest` (9): the reported sentence, synonyms, punctuation, that an extraction which already found a place is never second-guessed, and that "homebush" is not "home"
- `LabelledStopLocatorTest` (+2): standing at the destination, and well away from it
- `./scripts/fullQualityChecks.sh` green, feature host tests green
- Device QA on a physical Pixel across all four reported sentences
