### PR TITLE
fix(trip-planner): keep the input bar's actions inside the bar

### DIFF
--- a/docs/LAYOUT_AND_INSETS.md
+++ b/docs/LAYOUT_AND_INSETS.md
@@ -75,7 +75,43 @@ Prefer `weight(1f)` anyway when a child should take the leftover space: it state
 and it keeps working if a sibling is added below. But do not go hunting for this as the cause
 of a misplaced child in a `Column` — it will not be.
 
-### 1.4 One scroller per axis
+### 1.4 Measurement order: what must survive a squeeze has to be measured first
+
+A `Column` measures its **non-weighted children first**, against the height it was given, and
+divides what is left among the weighted ones. A child measured past that bound is still laid
+out, at a position past the parent's bottom edge, and a `clip()` on the parent then removes it
+from the screen. The node is not off-screen and not missing: it is **inside its parent, below
+its parent's edge**.
+
+So in any container holding growable content plus controls, **the growable part is the one that
+gets the weight**, not the controls:
+
+```kotlin
+Column(modifier = Modifier.clip(shape)) {
+    TextField(
+        // Measured after the Row below, from what is left. fill = false so a short
+        // sentence still makes a short bar.
+        modifier = Modifier.weight(weight = 1f, fill = false),
+        lineLimits = TextFieldLineLimits.MultiLine(maxHeightInLines = 6),
+    )
+    Row { /* mic, send — unweighted, so measured first and always fit */ }
+}
+```
+
+Without the weight the field takes its natural height up to its line limit, and the controls
+fall off the bottom the moment the container is squeezed: keyboard up, something above it, or
+landscape. `AiInputBar.kt` shipped that bug; see
+`docs/learning/2026-08-16-clipped-inside-its-own-parent.md`.
+
+**Test it with `assertIsDisplayed()`, never with bounds arithmetic.**
+`getUnclippedBoundsInRoot()` reports where a node was laid out, not whether any of it can be
+seen — a clipped node returns perfectly legal on-screen bounds. Only a display assertion walks
+the clip chain. Render the surface at the height a keyboard actually leaves, with content long
+enough to overflow, then mutation-check the probe in both directions: remove the fix and watch
+it go red, restore it and watch it go green. A probe that cannot fail and a probe that cannot
+pass both look exactly like a probe that works.
+
+### 1.5 One scroller per axis
 
 A `verticalScroll` child measured by a `verticalScroll` parent gets an infinite height
 constraint and throws. If the content scrolls, the wrapper must not.

--- a/docs/learning/2026-08-16-clipped-inside-its-own-parent.md
+++ b/docs/learning/2026-08-16-clipped-inside-its-own-parent.md
@@ -1,0 +1,101 @@
+# The send button was clipped inside its own bar, and the probe that "proved" it lied twice
+
+**2026-08-16** · Ask KRAIL input bar (`AiInputBar.kt`) · ~10 builds, several install cycles, most of a session
+
+## Symptom
+
+On the Ask KRAIL surface with the keyboard up and more than a couple of lines typed, the mic
+and send buttons were gone. The sentence was there, the bar was there, and there was no way to
+send it. Dismissing the keyboard brought both buttons back. The same thing happened in
+landscape, where the surface is short for a different reason.
+
+## Root cause
+
+`AiInputBar`'s `Column` had one weighted child and one unweighted one, the wrong way round.
+
+A `Column` measures its **non-weighted children first**, against the height it was given, and
+divides what is left among the weighted ones. Here nothing was weighted: the `TextField` took
+its natural height, growing to its `maxHeightInLines = 6`, and the action `Row` underneath was
+measured after there was any room left for it. A child measured past the parent's bound is
+still laid out — at a position past the parent's bottom edge — and the parent's `clip()`
+removes it from the screen.
+
+So the buttons were not off-screen and not missing. They were **inside the bar, below the bar's
+own bottom edge, clipped by the bar's own rounded-corner clip.** The bar being squeezed is what
+made it visible: keyboard up, a result card above it, or landscape all take height away from
+the bar, and each one moved the row further past the edge.
+
+The fix is to make the text the flexible child so the controls are measured first and reserve
+their space:
+
+```kotlin
+modifier = Modifier
+    .fillMaxWidth()
+    .weight(weight = 1f, fill = false)
+```
+
+`fill = false` matters: with `fill = true` a one-line sentence would stretch the bar to the
+full height available. With it false, a short sentence still makes a short bar, and a long one
+scrolls inside the field instead of pushing the controls out. This is the shape every phone
+messaging field has — the action row is pinned to the bottom of the bar and the text scrolls
+within what is left.
+
+## Why it took so long
+
+The bug itself was diagnosed correctly on the first read. **The verification is what went
+wrong, three times in a row, and each failure looked like a result.**
+
+1. **The probe passed because the field was empty.** The test set `typedText` on the UI state
+   and rendered the surface at a squeezed height. But `AiInputBar` measures the
+   `TextFieldState` passed into it, not `state.typedText`, and the harness was handing it a
+   fresh `rememberTextFieldState()`. The field was one line tall, nothing overflowed, and the
+   test went green against a live bug.
+
+2. **The probe passed because bounds are not visibility.** Once the field was seeded, the
+   assertion compared `getUnclippedBoundsInRoot().bottom` against the host height. It passed.
+   `getUnclippedBoundsInRoot` reports **where a node was laid out, not whether any of it is on
+   screen** — the whole point of the bug is that the node has legal-looking bounds and is
+   clipped by an ancestor anyway. Forcing the assertion to fail printed
+   `mic bottom 372.1905.dp is past the host's 380.0.dp`, which is the number that should have
+   failed the assertion in the first place and did not. Only `assertIsDisplayed()` walks the
+   clip chain.
+
+3. **The probe failed because it asserted on a content description no node carries.** After
+   switching to `assertIsDisplayed()`, the mic passed and send failed, at every height, for
+   several rounds. That reads exactly like a partially-working layout fix — mic saved, send
+   still clipped — and it was reported as one. The send button's description is `"Continue"`,
+   not `"Send"`. The probe had been asserting on a string that matched nothing since it was
+   written; it would have failed on an empty screen.
+
+The through-line: **each wrong result was consistent with the theory being tested**, which is
+what made it stop the investigation instead of triggering it. A probe that cannot fail and a
+probe that cannot pass look identical to a probe that is working, unless it is checked in both
+directions.
+
+## What would have caught it sooner
+
+- **`assertIsDisplayed()`, never a bounds comparison, for "can the rider see this".** Bounds
+  answer where a node was placed. Clipping, zero size and a covered ancestor are all invisible
+  to them. There is now one probe per surface of this kind, not a bounds arithmetic helper.
+- **Mutation-check a layout probe in both directions before believing it.** Remove the fix, see
+  it go red; put the fix back, see it go green. Step 1 catches the probe that cannot fail; step
+  2 catches the probe that cannot pass. Both failures above survived a one-directional check.
+- **Resolve a finder against the tree, not against memory.** A `contentDescription` a test
+  asserts on is a string literal in two files that nothing ties together. When a node assertion
+  fails, print the semantics tree before theorising about layout: `onRoot().printToLog()` would
+  have ended round three immediately.
+- **Feed the component the state it actually measures.** Test harnesses that hand a
+  `TextFieldState` in must seed it from the same text the UI state claims; the two are separate
+  sources and only one of them affects layout.
+
+## Actions taken
+
+- [x] `AiInputBar`'s `TextField` takes `weight(1f, fill = false)`, with the reasoning in a
+      comment at the call site pointing here.
+- [x] `AiResultCardTest.shortHost_theBarsActionsStayInsideIt` renders the surface at the height
+      a keyboard leaves, with six lines of text, and asserts both controls with
+      `assertIsDisplayed()`. Mutation-checked: removing the weight fails it, restoring it passes.
+- [x] The send button's real content description is named in the test's companion, with why it
+      is worth naming.
+- [x] Rule added to `docs/LAYOUT_AND_INSETS.md`: measurement order inside a `Column`, and
+      `assertIsDisplayed` over bounds.

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -63,3 +63,4 @@ Rules, scripts, tests or docs added. Link them. Unchecked boxes if not done yet.
 | Date | Entry | Class of bug |
 |---|---|---|
 | 2026-08-16 | [IME pan and the unbounded Column child](2026-08-16-ime-pan-and-unbounded-column.md) | Layout / window insets |
+| 2026-08-16 | [Clipped inside its own parent](2026-08-16-clipped-inside-its-own-parent.md) | Layout / test that could not fail |

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiResultCardTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiResultCardTest.kt
@@ -5,13 +5,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -136,16 +139,36 @@ class AiResultCardTest {
         composeRule.onNodeWithContentDescription(MIC_DESCRIPTION).assertExists()
     }
 
+    @Test
+    fun shortHost_theBarsActionsStayInsideIt() {
+        // A keyboard takes roughly half the screen, and the surface's column ends where the
+        // keyboard starts. This is that column, not the whole screen.
+        setContent(
+            state(from = SEVEN_HILLS, to = WYNYARD, typed = SIX_LINES),
+            hostHeight = SQUEEZED_HOST_HEIGHT,
+        )
+
+        // assertIsDisplayed, not a bounds comparison. The bar is measured with whatever
+        // height is left after the result above it, and when that is less than its own content
+        // needs, the action row is clipped INSIDE the bar: its unclipped bounds still read as
+        // on screen while the rider can see none of it. Only a display check catches that.
+        composeRule.onNodeWithContentDescription(MIC_DESCRIPTION).assertIsDisplayed()
+        composeRule.onNodeWithContentDescription(SEND_DESCRIPTION).assertIsDisplayed()
+    }
+
     private fun setContent(
         state: AiSearchInputUiState,
         onSeeTimes: () -> Unit = {},
+        hostHeight: Dp = HOST_HEIGHT,
     ) {
         composeRule.setContent {
             PreviewTheme {
-                Column(modifier = Modifier.fillMaxWidth().height(HOST_HEIGHT)) {
+                Column(modifier = Modifier.fillMaxWidth().height(hostHeight)) {
                     AiInputContent(
                         state = state,
-                        textFieldState = rememberTextFieldState(),
+                        // Seeded the way AskKrailScreen seeds it, or the bar measures one line
+                        // tall no matter what the state says the rider typed.
+                        textFieldState = rememberTextFieldState(initialText = state.typedText),
                         suggestion = SUGGESTION,
                         onEvent = {},
                         modifier = Modifier.weight(1f),
@@ -160,9 +183,11 @@ class AiResultCardTest {
         from: StopItem?,
         to: StopItem?,
         phase: AiSearchInputPhase = AiSearchInputPhase.RESOLVED,
+        typed: String = "",
     ) = AiSearchInputUiState(
         isInputOpen = true,
         phase = phase,
+        typedText = typed,
         resolved = ResolvedTripIntent(
             fromText = from?.stopName,
             fromStopItem = from,
@@ -175,10 +200,22 @@ class AiResultCardTest {
 
     private companion object {
         val HOST_HEIGHT = 800.dp
+
+        // What AiInputContent actually gets on a Pixel with the keyboard open: roughly 800dp
+        // of screen, less the keyboard, the status bar, the title bar and this surface's own
+        // vertical padding. Measured against a device, not picked to make the test pass.
+        val SQUEEZED_HOST_HEIGHT = 340.dp
+
+        // The bar grows to six lines and then stops. Six is its worst case.
+        val SIX_LINES = (1..6).joinToString("\n") { "line $it of a long sentence" }
         const val SUGGESTION = "Home to Work by 9am"
         const val ARRIVE_TEXT = "Arrive"
         const val STARTING_FROM_PLACEHOLDER = "Starting from"
         const val MIC_DESCRIPTION = "Speak"
+        // The send button's own description, which is "Continue" and not "Send". Worth naming:
+        // a probe asserting on a description no node carries fails whatever the layout does, and
+        // this one did, for three rounds, while reading as a real clipping bug.
+        const val SEND_DESCRIPTION = "Continue"
         val SEVEN_HILLS = StopItem(stopId = "2147", stopName = "Seven Hills Station")
         val WYNYARD = StopItem(stopId = "200070", stopName = "Wynyard Station")
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputBar.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputBar.kt
@@ -170,7 +170,19 @@ internal fun AiInputBar(
             // stay readable while it is being worked out. Submitting twice is already guarded
             // in the ViewModel, so nothing needs the field to be inert.
             enabled = true,
-            modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+            // weight, with fill = false. The controls below are NOT weighted, so the Column
+            // measures them first and the sentence gets only what is left. Without this the
+            // field took its natural height up to six lines, and when the bar itself had been
+            // squeezed - keyboard up, a result above it, or landscape - the controls were laid
+            // out past the bar's own bottom edge and clipped INSIDE it. The rider saw a sentence
+            // with no way to send it, while the buttons' unclipped bounds still reported as on
+            // screen, which is why a bounds assertion missed this and only assertIsDisplayed
+            // caught it. fill = false so a short sentence still makes a short bar.
+            // See docs/learning/2026-08-16-clipped-inside-its-own-parent.md.
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(weight = 1f, fill = false)
+                .focusRequester(focusRequester),
             onTextChange = { onEvent(AiSearchInputEvent.TypedTextChanged(it.toString())) },
         )
 


### PR DESCRIPTION
## What

With the keyboard up and more than a couple of lines typed, the Ask KRAIL input bar showed a sentence with no way to send it: the mic and send buttons were gone. Dismissing the keyboard brought them back. Same in landscape, where the surface is short for a different reason.

They were never off-screen. They were inside the bar, laid out below the bar's own bottom edge, and removed by the bar's rounded-corner clip.

## Changes

### The fix

`AiInputBar`'s `Column` had no weighted child. A `Column` measures its non-weighted children first, against the height it was given, and divides what is left among the weighted ones — so the `TextField` took its natural height up to `maxHeightInLines = 6` and the action `Row` was measured from whatever remained. A child measured past the parent's bound is still laid out, at a position past the parent's edge, and the `clip()` does the rest.

- `TextField` takes `weight(weight = 1f, fill = false)`. The unweighted action row is now measured first and always fits; the sentence scrolls inside what is left. This is the shape every phone messaging field has
- `fill = false` so a short sentence still makes a short bar. With `fill = true` one line would stretch the bar to the full height available

### The test

`AiResultCardTest.shortHost_theBarsActionsStayInsideIt`: the surface rendered at the height a keyboard actually leaves, six lines of text, both controls asserted with `assertIsDisplayed()`.

`assertIsDisplayed()` and not a bounds comparison, deliberately. `getUnclippedBoundsInRoot()` reports where a node was laid out, not whether any of it can be seen, so a clipped node returns perfectly legal on-screen bounds — which is the entire bug. Only a display assertion walks the clip chain.

Mutation-checked both ways: removing the weight fails it, restoring it passes.

### Docs

- `docs/learning/2026-08-16-clipped-inside-its-own-parent.md`. The layout cause was read correctly first time; verification is what cost the session. Three probe failures in a row each looked like a result: a harness seeding the field from the wrong state so nothing overflowed, a bounds assertion that cannot detect clipping, and a `contentDescription` that matched no node in the tree
- `docs/LAYOUT_AND_INSETS.md` section 1.4: `Column` measurement order, the rule that the growable child is the one that takes the weight, and the two-way mutation check for any probe of this kind

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green, including the new probe
- `detekt --continue` green, no auto-corrections to commit
- Device QA on a physical Pixel: keyboard up with a long sentence, and at large font scale, both controls present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgGreZudXwvxuiKafkCcqa
