### PR TITLE
fix(remote-config): give every flag a default, and check that it has one

### DIFF
--- a/core/remote-config/build.gradle.kts
+++ b/core/remote-config/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
         namespace = "xyz.ksharma.krail.core.remoteconfig"
         compileSdk = AndroidVersion.COMPILE_SDK
         minSdk = AndroidVersion.MIN_SDK
+        withHostTest {}
     }
 
     iosArm64()

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -6,6 +6,15 @@ import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
  * Holds the default values for remote configuration.
  * Add new default values here. These will be used as fallbacks when the remote config is not available
  * due to network or other issues.
+ *
+ * **Every key in [FlagKeys] needs a row here, including the ones whose intended default is
+ * `false`.** A key that is absent from this list is not the same as a key defaulting to `false`,
+ * even though the two look identical today. Firebase returns an empty string for a key it has
+ * never heard of, `RemoteConfigFlag` classifies that as a `StringValue("")` rather than a
+ * boolean, and `asBoolean(fallback)` then returns `"".toBoolean()` — false — **without ever
+ * reading the fallback it was passed**. So a flag that is missing here reads as `false` whatever
+ * the call site asked for, and the day one wants to ship defaulting to `true` it would silently
+ * be off for every client that has not completed a fetch.
  */
 object RemoteConfigDefaults {
 
@@ -174,6 +183,23 @@ object RemoteConfigDefaults {
             ),
             Pair(
                 first = FlagKeys.ALERT_SUMMARY_ENABLED.key,
+                second = false,
+            ),
+            Pair(
+                first = FlagKeys.AI_SEARCH_INPUT_ENABLED.key,
+                second = false,
+            ),
+            // The one where the missing row was doing real harm. Its call site asks for
+            // asBoolean(fallback = true) and its own docs say "true/unset", but with no row here
+            // an unfetched client read false and took the direct GTFS-RT path instead of the BFF
+            // snapshot. Only reachable once the endpoint already resolves to the BFF, so this
+            // restores the documented default rather than turning anything on.
+            Pair(
+                first = FlagKeys.BFF_USE_FOR_TRACK.key,
+                second = true,
+            ),
+            Pair(
+                first = FlagKeys.JOURNEY_MAPS_AVAILABLE.key,
                 second = false,
             ),
         )

--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -189,18 +189,19 @@ object RemoteConfigDefaults {
                 first = FlagKeys.AI_SEARCH_INPUT_ENABLED.key,
                 second = false,
             ),
-            // The one where the missing row was doing real harm. Its call site asks for
-            // asBoolean(fallback = true) and its own docs say "true/unset", but with no row here
-            // an unfetched client read false and took the direct GTFS-RT path instead of the BFF
-            // snapshot. Only reachable once the endpoint already resolves to the BFF, so this
-            // restores the documented default rather than turning anything on.
+            // Off until it is turned on in the console, deliberately. Note this default is what
+            // decides the value, NOT the asBoolean(fallback = true) at the call site in
+            // BffGtfsRealtimeRepository: a key with a row here is a real boolean, so the
+            // fallback is never reached and the two disagreeing does not change behaviour. Same
+            // for the "true/unset" wording on FlagKeys.BFF_USE_FOR_TRACK. Read this row, not
+            // those, for what an unfetched client actually gets.
             Pair(
                 first = FlagKeys.BFF_USE_FOR_TRACK.key,
-                second = true,
+                second = false,
             ),
             Pair(
                 first = FlagKeys.JOURNEY_MAPS_AVAILABLE.key,
-                second = false,
+                second = true,
             ),
         )
     }

--- a/core/remote-config/src/commonTest/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaultsTest.kt
+++ b/core/remote-config/src/commonTest/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaultsTest.kt
@@ -1,0 +1,52 @@
+package xyz.ksharma.krail.core.remoteconfig
+
+import xyz.ksharma.krail.core.remoteconfig.flag.FlagKeys
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Every flag needs a default, and a missing one cannot be spotted by reading either file.
+ *
+ * `AI_SEARCH_INPUT_ENABLED` shipped without a row here and nothing caught it: not the compiler,
+ * not detekt, and not the feature working on a device, because a key Firebase has never heard of
+ * returns an empty string, which reads as `false` and happened to be the value that flag wanted.
+ * The trap is the flag that wants `true` — see the note on [RemoteConfigDefaults].
+ */
+class RemoteConfigDefaultsTest {
+
+    @Test
+    fun everyFlagKeyHasADefault() {
+        val defaults = RemoteConfigDefaults.getDefaults().map { it.first }.toSet()
+        val missing = FlagKeys.entries.map { it.key }.filterNot { it in defaults }
+
+        assertTrue(
+            missing.isEmpty(),
+            "FlagKeys with no row in RemoteConfigDefaults.getDefaults(): $missing. " +
+                "A key absent here reads as false for every client that has not completed a " +
+                "fetch, whatever fallback the call site passes.",
+        )
+    }
+
+    @Test
+    fun noDefaultIsDeclaredTwice() {
+        val keys = RemoteConfigDefaults.getDefaults().map { it.first }
+        val duplicated = keys.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+
+        // Which of two rows wins is an ordering detail of the array, so a duplicate is a flag
+        // whose value depends on where someone happened to paste it.
+        assertTrue(duplicated.isEmpty(), "Duplicate default rows: $duplicated")
+    }
+
+    @Test
+    fun noDefaultIsForAKeyThatNoLongerExists() {
+        val flagKeys = FlagKeys.entries.map { it.key }.toSet()
+        val orphans = RemoteConfigDefaults.getDefaults()
+            .map { it.first }
+            .filterNot { it in flagKeys }
+
+        // A default left behind after its FlagKeys entry was deleted is dead weight that reads
+        // as a live flag.
+        assertEquals(emptyList(), orphans, "Defaults with no matching FlagKeys entry: $orphans")
+    }
+}


### PR DESCRIPTION
## What

Three flags had no row in `RemoteConfigDefaults.getDefaults()`: `AI_SEARCH_INPUT_ENABLED`, `BFF_USE_FOR_TRACK` and `JOURNEY_MAPS_AVAILABLE`.

**A missing row is not the same as a default of `false`, although the two are indistinguishable until a flag wants to default to `true`.** Firebase returns an empty string for a key it has never heard of, `RemoteConfigFlag` classifies that as `StringValue("")` rather than a boolean, and `asBoolean(fallback)` then returns `"".toBoolean()` — false — **without ever reading the fallback it was passed**. So an absent flag is not off by decision, it is off by accident, and the accident is invisible until someone wants one on.

`JOURNEY_MAPS_AVAILABLE` is the case where that mattered: it is meant to default on, and was reading off.

## Changes

### Defaults declared

| Flag | Key | Default |
|---|---|---|
| `AI_SEARCH_INPUT_ENABLED` | `ai_search_input_enabled` | `false` |
| `BFF_USE_FOR_TRACK` | `bff_use_for_track` | `false` |
| `JOURNEY_MAPS_AVAILABLE` | `maps_journey` | `true` |

`bff_use_for_track` stays off until it is enabled in the console. Note that this row, not `BffGtfsRealtimeRepository`'s `asBoolean(fallback = true)`, is what decides the value: a key with a row here resolves as a real boolean, so the fallback is never reached, and the same goes for the "`true`/unset" wording on `FlagKeys.BFF_USE_FOR_TRACK`. Those two are left as they are and a comment on the row records which one wins, so the disagreement does not have to be re-derived by the next reader.

`maps_journey` is on. Worth flagging separately: **nothing in the app reads `JOURNEY_MAPS_AVAILABLE`.** It gets its declared default here rather than being deleted, since removing a flag is a separate decision.

### The check

`RemoteConfigDefaultsTest` walks `FlagKeys.entries` and fails with the names of any flag missing a default. It found `BFF_USE_FOR_TRACK` and `JOURNEY_MAPS_AVAILABLE` on its first run — neither was known about when this started, which is the argument for a test over a comment. Two further assertions cover the ways this rots later: a key declared twice (whichever row wins is an ordering detail of the array) and a default whose `FlagKeys` entry has since been deleted.

Required `withHostTest {}` on `:core:remote-config`, which had `commonTest` dependencies declared but no test source set.

The empty-string trap itself is written up on `RemoteConfigDefaults`' KDoc, since the test can only say a row is missing, not why an absent row is dangerous.

## Testing

- `:core:remote-config:testAndroidHostTest` green (3 tests). Verified it fails first: it named both unknown flags before they were fixed
- `./scripts/fullQualityChecks.sh` green — Android compile, iOS Simulator compile, detekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GgGreZudXwvxuiKafkCcqa
