### PR TITLE
feat(taj): per-surface spin speed for the AI gradient border, and no settle before a spin

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/AiSpinAnimation.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/AiSpinAnimation.kt
@@ -8,17 +8,19 @@ import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 
-internal const val AI_SPIN_DURATION_MS = 4500
+internal const val AI_SPIN_DURATION_MS = AiSpinDefaults.SPIN_DURATION_MILLIS
 internal const val AI_SETTLE_DURATION_MS = 1000
 private const val SETTLE_LINEAR_PORTION_MS = 550
 
-// Travel during the linear portion roughly matches the spin's own angular speed
-// (360deg / AI_SPIN_DURATION_MS), so the handoff from spinning to settling has no visible
-// speed jump — it just starts decelerating from wherever it already was.
+// Travel during the linear portion matches the spin's own angular speed (360deg over the
+// spin duration), so the handoff from spinning to settling has no visible speed jump — it
+// just starts decelerating from wherever it already was. Scaled from the spin duration for
+// the same reason: a faster spin has to enter its settle at its own speed, not the default's.
 private const val SETTLE_EASE_OUT_DEGREES = 50f
-private const val SETTLE_TOTAL_DEGREES = 140f
+private const val SETTLE_TAIL_DEGREES = 90f
 private const val FULL_TURN_DEGREES = 360f
 
 private val SettleEasing = CubicBezierEasing(0.16f, 1f, 0.3f, 1f)
@@ -33,28 +35,46 @@ private val SettleEasing = CubicBezierEasing(0.16f, 1f, 0.3f, 1f)
  * `false`, the current rotation decelerates to a full stop rather than cutting: linear for
  * the first ~55% of [AI_SETTLE_DURATION_MS], then an ease-out curve for the rest — reads as
  * physically slowing down, not switching off.
+ * @param spinDurationMillis One full turn while spinning. The default is the shared rhythm;
+ * a surface where the spin is the main event (the Ask KRAIL dialog frame) passes a shorter
+ * one. The settle's travel scales with it, so a faster spin also decelerates from its own
+ * speed instead of snapping down to the default's.
  */
 @Composable
-internal fun rememberAiSpinAngle(spinning: Boolean): Float {
+internal fun rememberAiSpinAngle(
+    spinning: Boolean,
+    spinDurationMillis: Int = AI_SPIN_DURATION_MS,
+): Float {
     val angle = remember { Animatable(0f) }
+    // The settle is a deceleration FROM a spin, so it only ever runs after one. Without this
+    // guard the effect's first composition (spinning = false, nothing to decelerate) ran the
+    // settle anyway, and a surface that shows its border at rest — the Ask KRAIL dialog —
+    // opened with a 140-degree twirl it had not earned, timed exactly with the keyboard
+    // arriving. A border at rest holds still until real work starts it.
+    val hasSpun = remember { mutableStateOf(false) }
 
-    LaunchedEffect(spinning) {
+    LaunchedEffect(spinning, spinDurationMillis) {
         if (spinning) {
+            hasSpun.value = true
             angle.animateTo(
                 targetValue = angle.value + FULL_TURN_DEGREES,
                 animationSpec = infiniteRepeatable(
-                    animation = tween(durationMillis = AI_SPIN_DURATION_MS, easing = LinearEasing),
+                    animation = tween(durationMillis = spinDurationMillis, easing = LinearEasing),
                 ),
             )
-        } else {
+        } else if (hasSpun.value) {
+            hasSpun.value = false
             val start = angle.value
+            val speedRatio = AI_SPIN_DURATION_MS.toFloat() / spinDurationMillis
+            val easeOutDegrees = SETTLE_EASE_OUT_DEGREES * speedRatio
+            val totalDegrees = easeOutDegrees + SETTLE_TAIL_DEGREES
             angle.animateTo(
-                targetValue = start + SETTLE_TOTAL_DEGREES,
+                targetValue = start + totalDegrees,
                 animationSpec = keyframes {
                     durationMillis = AI_SETTLE_DURATION_MS
                     start at 0 using LinearEasing
-                    (start + SETTLE_EASE_OUT_DEGREES) at SETTLE_LINEAR_PORTION_MS using SettleEasing
-                    (start + SETTLE_TOTAL_DEGREES) at AI_SETTLE_DURATION_MS
+                    (start + easeOutDegrees) at SETTLE_LINEAR_PORTION_MS using SettleEasing
+                    (start + totalDegrees) at AI_SETTLE_DURATION_MS
                 },
             )
         }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/AiSpinDefaults.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/animations/AiSpinDefaults.kt
@@ -1,0 +1,7 @@
+package xyz.ksharma.krail.taj.animations
+
+/** Public face of the spin rhythm, for callers setting [xyz.ksharma.krail.taj.modifier.aiGradientBorder]'s speed. */
+object AiSpinDefaults {
+    /** One full turn of the gradient. The shared rhythm every AI mark runs at by default. */
+    const val SPIN_DURATION_MILLIS = 4500
+}

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/AiGradientBorder.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/AiGradientBorder.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.unit.Dp
+import xyz.ksharma.krail.taj.animations.AiSpinDefaults
 import xyz.ksharma.krail.taj.animations.rememberAiSpinAngle
 import xyz.ksharma.krail.taj.tokens.AiGradientTokens
 import xyz.ksharma.krail.taj.tokens.StrokeTokens
@@ -54,8 +55,11 @@ fun Modifier.aiGradientBorder(
     // which is what a surface that only wears this while it works needs: without it the
     // border is simply always there, and "working" reads as a ring that stops turning.
     alpha: Float = 1f,
+    // One full turn of the paint. Default is the shared rhythm every AI mark uses; a surface
+    // where the spin is the whole show may run faster (see rememberAiSpinAngle).
+    spinDurationMillis: Int = AiSpinDefaults.SPIN_DURATION_MILLIS,
 ): Modifier {
-    val angle = rememberAiSpinAngle(spinning)
+    val angle = rememberAiSpinAngle(spinning, spinDurationMillis)
     if (alpha <= 0f) return this
     val brush = remember(colors) {
         Brush.sweepGradient(colors + colors.first())


### PR DESCRIPTION
## What

Gives the AI gradient border a per-surface spin speed and stops it from playing its settle animation before it has ever spun.

## Changes

- `AiSpinAnimation.kt`: `rememberAiSpinAngle` takes `spinDurationMillis` (default unchanged at 4500ms). The settle branch now runs only after a real spin (`hasSpun` guard); previously it ran on first composition, so a surface showing the ring at rest opened with an unearned rotation. Settle travel scales with the chosen speed so deceleration starts from the actual spin speed.
- `AiSpinDefaults.kt` (new): public home for the default spin duration, in its own file to satisfy `MatchingDeclarationName`.
- `AiGradientBorder.kt`: `aiGradientBorder` passes `spinDurationMillis` through.
- `AiWheelMark` and existing callers are untouched and keep the shared rhythm.

## Testing

- `./scripts/fullQualityChecks.sh` green (Android compile, iOS simulator compile, detekt)
- `:feature:trip-planner:ui:testAndroidHostTest` green (consumer module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
