### PR TITLE
fix(trip-planner): stop stale Ask KRAIL answers rewriting the rider's stop picks

### DIFF
--- a/docs/FEATURE_QUALITY_CHECKLIST.md
+++ b/docs/FEATURE_QUALITY_CHECKLIST.md
@@ -166,7 +166,26 @@ If a choice is non-obvious — why this key, why cached-first, why this is a no-
 comment saying *why* and a test pinning the behaviour. A future change should fail loudly
 rather than silently regress.
 
-## 10. Before handing anything over
+## 10. Effects that write state must survive being re-launched
+
+A `LaunchedEffect` re-launches every time its host recomposes into existence: navigating
+back to the screen, rotation, process restore. If the effect is keyed on observed state and
+**writes** other state when a condition holds, it will act again on the same stale condition
+unless the trigger is consumed.
+
+- [ ] Does any effect write app state when it sees a condition (a phase, a flag, a result)?
+- [ ] Is that condition **consumed** (stepped down, cleared) in the same emission the action
+      completes, so a re-launched collector sees nothing to do?
+- [ ] Test: after the action completes, assert the trigger no longer reads as actionable —
+      not just that the payload was right.
+
+Shipped example: the Ask KRAIL dialog wrote resolved stops into the home row while
+`phase == RESOLVED`, and kept the phase after closing. Coming back from the stop-search
+screen re-launched the writer and replayed the AI's stops over the rider's own manual picks.
+The fix steps the phase down as the dialog closes; `isHandoffActionable` is the gate and its
+transition is pinned by a test.
+
+## 11. Before handing anything over
 
 Never describe a change as working when only `./gradlew` has run.
 

--- a/feature/trip-planner/ui/ASK_KRAIL_UX.md
+++ b/feature/trip-planner/ui/ASK_KRAIL_UX.md
@@ -190,6 +190,12 @@ Rules that hold this together:
   so the timed close cannot pull the dialog out from under an edit.
 - **Reopening is a fresh prompt.** `OpenInput` resets the state; the last answer belongs to
   the row now, and showing it back would be a stale copy of a row the rider may have edited.
+- **A handoff is consumed, not observed.** The row's writes fire only while
+  `isHandoffActionable` (phase RESOLVED with a resolve present), and the phase steps down to
+  IDLE in the same emission that closes the dialog. The writing effect re-launches whenever
+  the home entry recomposes — back-navigation from the stop-search screen included — and a
+  state left at RESOLVED replayed the AI's stops over the rider's own later picks. Pinned by
+  `the row-write gate closes with the dialog`.
 
 ## 8. Layout rules that are not negotiable
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -18,8 +18,8 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
 import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsScreen
 import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
-import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputPhase
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputViewModel
+import xyz.ksharma.krail.trip.planner.ui.search.ai.isHandoffActionable
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
@@ -70,7 +70,7 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
         // they read them — on the surface that found them, rather than on the row behind it.
         LaunchedEffect(aiSearchInputState.phase, aiSearchInputState.resolved) {
             val resolved = aiSearchInputState.resolved
-            if (aiSearchInputState.phase == AiSearchInputPhase.RESOLVED && resolved != null) {
+            if (aiSearchInputState.isHandoffActionable && resolved != null) {
                 resolved.fromStopItem?.let {
                     viewModel.onEvent(SavedTripUiEvent.FromStopChanged(it.toJsonString()))
                 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -58,6 +58,12 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
         // SearchStop pick does (FromStopChanged/ToStopChanged) — per field, so a half-resolved
         // trip still fills the field it did find and leaves the other for a normal tap.
         //
+        // One-shot per resolve, enforced by the phase: this effect re-launches every time this
+        // entry recomposes (coming back from the stop-search screen included), so it must only
+        // act while the resolve is live. closeAfterHandoff steps the phase to IDLE as the
+        // dialog closes; without that, a back-navigation replayed the AI's stops over the
+        // rider's own later picks.
+        //
         // Loading a timetable is still the rider's call and always has been: they read the two
         // stops, decide the AI got it right, and press the button themselves. Doing it for them
         // takes that check away at the one moment it matters most. What changed is only where

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputUiState.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputUiState.kt
@@ -65,6 +65,20 @@ data class ResolvedTripIntent(
     val hasWholeTrip: Boolean get() = fromStopItem != null && toStopItem != null
 }
 
+/**
+ * The one gate for writing this state's resolve into anything outside the AI flow (the home
+ * row's From/To fields and time chip). True only while the resolve is LIVE — the dialog is
+ * showing its settle beat and the answer has not been handed over and consumed.
+ *
+ * The consumer (SavedTripsEntry's LaunchedEffect) re-launches every time its screen
+ * recomposes into existence, back-navigation included. Acting on `resolved != null` alone
+ * replayed old answers over stops the rider had since picked by hand; the phase stepping
+ * down at dialog close (closeAfterHandoff) is what turns this false and keeps a re-launched
+ * collector idle. Pinned by `the row-write gate closes with the dialog`.
+ */
+val AiSearchInputUiState.isHandoffActionable: Boolean
+    get() = phase == AiSearchInputPhase.RESOLVED && resolved != null
+
 sealed interface AiSearchInputEvent {
     data class TypedTextChanged(val text: String) : AiSearchInputEvent
     data object OpenInput : AiSearchInputEvent

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -427,7 +427,14 @@ class AiSearchInputViewModel(
         delay(HANDOFF_SETTLE_MILLIS)
         _uiState.update {
             if (it.phase == AiSearchInputPhase.RESOLVED && it.isInputOpen) {
-                it.copy(isInputOpen = false)
+                // The phase steps down WITH the close, in the same emission. The row's writes
+                // key off phase == RESOLVED (SavedTripsEntry), and that effect re-launches
+                // every time the home entry recomposes — coming back from the stop-search
+                // screen included. A state left at RESOLVED after the handoff replayed the
+                // AI's stops over whatever the rider had picked by hand since. IDLE makes the
+                // resolve a record, not an instruction: `resolved` itself is kept for the
+                // handoff spin and for anything that wants to read what happened.
+                it.copy(isInputOpen = false, phase = AiSearchInputPhase.IDLE)
             } else {
                 it
             }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -363,6 +363,28 @@ class AiSearchInputViewModelTest {
     }
 
     @Test
+    fun `the row-write gate closes with the dialog`() = runTest(testDispatcher) {
+        aiTextService.extractionResult = TripIntentExtraction(
+            originText = "Central Station",
+            destinationText = "Town Hall",
+            timeIntent = null,
+        )
+        viewModel.onEvent(AiSearchInputEvent.OpenInput)
+        viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
+        viewModel.onEvent(AiSearchInputEvent.Submit)
+        runCurrent()
+
+        // Live during the settle beat: this is the emission the home row writes on.
+        assertTrue(viewModel.uiState.value.isHandoffActionable)
+
+        // Closed and consumed after it. The writer re-launches whenever the home entry
+        // recomposes (coming back from the stop-search screen included); a gate still open
+        // here is the bug where old AI stops replayed over the rider's later manual picks.
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isHandoffActionable)
+    }
+
+    @Test
     fun `reopening after a handoff is a fresh prompt`() = runTest(testDispatcher) {
         aiTextService.extractionResult = TripIntentExtraction(
             originText = "Central Station",

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -182,7 +182,9 @@ class AiSearchInputViewModelTest {
         viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("from central to town hall"))
 
         viewModel.onEvent(AiSearchInputEvent.Submit)
-        advanceUntilIdle()
+        // Runs the submit but not the settle beat: RESOLVED is the phase the handoff fires
+        // on, and it steps down to IDLE once the close lands (covered by the settle-beat test).
+        runCurrent()
 
         val resolved = viewModel.uiState.value.resolved
         assertEquals(AiSearchInputPhase.RESOLVED, viewModel.uiState.value.phase)
@@ -252,14 +254,14 @@ class AiSearchInputViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.uiState.value
-            assertEquals(AiSearchInputPhase.RESOLVED, state.phase)
             assertEquals("Nonexistent Place", state.resolved?.fromText)
             assertNull(state.resolved?.fromStopItem)
             assertEquals(StopItem(stopName = "Town Hall", stopId = "10102"), state.resolved?.toStopItem)
             // One stop is still a handoff: the field it found is filled on the row, the other
             // stays for a normal tap, and the dialog has closed itself by now (advanceUntilIdle
-            // runs the settle beat through).
+            // runs the settle beat through) with the phase stepped down alongside.
             assertFalse(state.isInputOpen)
+            assertEquals(AiSearchInputPhase.IDLE, state.phase)
         }
 
     @Test
@@ -328,7 +330,12 @@ class AiSearchInputViewModelTest {
             advanceUntilIdle()
             val afterBeat = viewModel.uiState.value
             assertFalse(afterBeat.isInputOpen)
-            // The resolve itself is kept, not reset: the row's writes key off it.
+            // The resolve is kept as a record, but the phase steps down WITH the close. The
+            // row's writes fire only while phase == RESOLVED, and the writing effect re-runs
+            // whenever the home entry recomposes — coming back from the stop-search screen
+            // included. A state still reading RESOLVED here replayed the AI's stops over the
+            // rider's own later manual picks (the bug this pins down).
+            assertEquals(AiSearchInputPhase.IDLE, afterBeat.phase)
             assertTrue(afterBeat.resolved?.hasWholeTrip == true)
         }
 
@@ -693,9 +700,11 @@ class AiSearchInputViewModelTest {
             advanceUntilIdle()
 
             viewModel.onEvent(AiSearchInputEvent.Submit)
+            // Full idle runs the settle beat too, so the phase has already stepped down; the
+            // resolve itself is what proves the spoken sentence went through the same submit.
             advanceUntilIdle()
 
-            assertEquals(AiSearchInputPhase.RESOLVED, viewModel.uiState.value.phase)
+            assertTrue(viewModel.uiState.value.resolved?.hasWholeTrip == true)
         }
 
     @Test


### PR DESCRIPTION
## What

Fixes stale Ask KRAIL answers overwriting the rider's own stop picks, and names the row-write gate so the contract is explicit and pinned.

## Changes

- `AiSearchInputViewModel.kt`: `closeAfterHandoff` steps the phase to `IDLE` in the same emission that closes the dialog. `SavedTripsEntry` writes the resolved stops into the row inside a `LaunchedEffect` gated on the RESOLVED phase; that effect re-launches whenever the home entry recomposes (coming back from the stop-search screen included), so a state left at RESOLVED replayed the AI's stops over stops the rider had since picked by hand. The resolve stays in state as a record (the row wheel's handoff spin reads it); it stops reading as an instruction.
- `AiSearchInputUiState.kt`: new `isHandoffActionable` property is the single condition the row writer acts on, documented with the re-launch hazard; `SavedTripsEntry` uses it.
- `AiSearchInputViewModelTest`: settle-beat test now pins `phase == IDLE` after close (fails on the pre-fix code); new `the row-write gate closes with the dialog` pins the gate open during the beat and closed after; two tests that asserted RESOLVED after full idle adjusted to assert during the beat or via the resolve itself.
- `docs/FEATURE_QUALITY_CHECKLIST.md`: new section 10, effects that write state must survive being re-launched, with this defect as the shipped example.
- `ASK_KRAIL_UX.md`: records the handoff-is-consumed-not-observed rule.

## Testing

- `:feature:trip-planner:ui:testAndroidHostTest` green (44 ViewModel tests incl. the new gate test), detekt green, Android + iOS compile green.
- Emulator (KRAIL_QA): manual From selection survives back-navigation with the fix installed. The full AI-resolve-then-overwrite repro needs a device with the on-device model; fix build installed on a physical Pixel for hand verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
