### PR TITLE
ci(quality): drop the no-op `test` task, run the detekt-rules suite

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -100,6 +100,12 @@ jobs:
             echo "versionCode: ${CURRENT} (debug — not incrementing)"
           fi
 
+      # The debug line used to carry a bare `test` task alongside assembleDebug. It bought
+      # nothing. `./gradlew test --dry-run` resolves to exactly one task, `:androidApp:test`,
+      # and `androidApp/src` has only debug/main/release — no test source set — so it ran zero
+      # tests. Every library module is a KMP `androidLibrary { withHostTest {} }`, whose task is
+      # `testAndroidHostTest`, which the bare name never matches. The real suite runs in
+      # code-quality.yml, which build.yml already gates this workflow behind.
       - name: Build ${{ inputs.variant }}
         env:
           ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
@@ -107,7 +113,7 @@ jobs:
         run: |
           set -e
           if [[ "${{ inputs.variant }}" == "debug" ]]; then
-            ./gradlew :androidApp:assembleDebug test -PversionCode="${VERSION_CODE}" --rerun-tasks --stacktrace --no-configuration-cache
+            ./gradlew :androidApp:assembleDebug -PversionCode="${VERSION_CODE}" --rerun-tasks --stacktrace --no-configuration-cache
           elif [[ "${{ inputs.variant }}" == "release" ]]; then
             ./gradlew :androidApp:assembleRelease :androidApp:bundleRelease -PversionCode="${VERSION_CODE}" --no-configuration-cache
           fi

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -76,6 +76,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew testAndroidHostTest --continue -PciQuality=true
 
+      # The custom detekt rules (`:detekt-rules`, e.g. PublicImplementationClass) live in the
+      # `gradle/build-logic` included build, and its test suite ran nowhere: `./gradlew detekt`
+      # only compiles the rules, and a root-build `test` invocation cannot reach across the
+      # composite boundary. A rule could therefore stop flagging anything and CI would still
+      # be green. `-p` runs the task inside the included build directly.
+      - name: Run build-logic tests
+        id: build-logic-tests
+        if: always() && steps.detekt.conclusion != 'cancelled'
+        env:
+          CI: true
+          GITHUB_ACTIONS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew -p gradle/build-logic :detekt-rules:test
+
       - name: Upload Detekt reports
         if: always() && steps.detekt.conclusion != 'skipped'
         uses: actions/upload-artifact@v7
@@ -98,5 +112,7 @@ jobs:
           path: |
             **/build/reports/tests/**
             **/build/test-results/**
+            gradle/build-logic/detekt-rules/build/reports/tests/**
+            gradle/build-logic/detekt-rules/build/test-results/**
           if-no-files-found: ignore
           retention-days: 7

--- a/TESTING.md
+++ b/TESTING.md
@@ -103,6 +103,22 @@ also wired into `check`:
 | `verifyTestingModuleUsage` | Any `commonMain` / `androidMain` / `iosMain` configuration resolves `:core:testing`. Stops fakes from shipping in the app and breaks any `:core:testing → feature → :core:testing` cycle. |
 | `verifyNoAdHocBoundaryFakes` | New `object : Boundary { … }` stub or `private class Fake<Boundary>` appears in any test source set. Existing offenders are grandfathered via the baseline file above. |
 
+The same workflow also runs the custom detekt rules' own suite:
+
+```
+./gradlew -p gradle/build-logic :detekt-rules:test
+```
+
+`:detekt-rules` lives in the `gradle/build-logic` included build. `./gradlew detekt` compiles
+it but never runs its tests, and a root-build `test` invocation cannot reach across the
+composite boundary — so `PublicImplementationClassTest` had never executed in CI. A rule could
+have quietly stopped flagging anything with CI still green. `-p` runs the task inside the
+included build directly.
+
+Note on the bare `test` task: it is not a way to run anything here. `./gradlew test` resolves
+to exactly one task, `:androidApp:test`, and `:androidApp` has no test source set, so it runs
+zero tests. `testAndroidHostTest` is the only host-test task name that matches KMP modules.
+
 Snapshot verification is a separate job, `.github/workflows/snapshot-verify.yml`, called
 from `build.yml` in parallel with `code-quality`. It runs one step per golden-owning module:
 


### PR DESCRIPTION
## What

Removes a CI task that ran zero tests and adds the one test suite CI could never reach.

## Changes

- `.github/workflows/build-android.yml`: drops the bare `test` task from the `:androidApp:assembleDebug` invocation. `./gradlew test --dry-run` resolves to exactly one task, `:androidApp:test`, and `androidApp/src` holds only `debug`/`main`/`release` with no test source set, so it ran nothing and paid a full no-cache configuration for it. Library modules are KMP `androidLibrary { withHostTest {} }`, whose task is `testAndroidHostTest`, which the bare name cannot match. `code-quality.yml` already runs the real suite and `build.yml` gates this workflow behind it.
- `.github/workflows/code-quality.yml`: runs `./gradlew -p gradle/build-logic :detekt-rules:test` (12 tests) and collects its reports alongside the other test reports. `:detekt-rules` lives in the `gradle/build-logic` included build, so `PublicImplementationClassTest` had never run in CI: `detekt` compiles the custom rules without testing them, and a root-build `test` cannot cross the composite build boundary. A custom rule could have stopped flagging anything and CI would have stayed green.
- TESTING.md records both lanes and why the bare `test` name does not work in this project.

## Testing

- `./gradlew -p gradle/build-logic :detekt-rules:test` green, 12 tests.
- Workflow-only change otherwise; verified against this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
