### PR TITLE
test(trip-planner): adopt the krail.snapshot.testing convention plugin

### DIFF
--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.krail.kotlin.multiplatform)
     alias(libs.plugins.krail.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.roborazzi)
+    alias(libs.plugins.krail.snapshot.testing)
     alias(libs.plugins.krail.android.kmp.library)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
@@ -56,7 +56,7 @@ kotlin {
 
         commonMain {
             dependencies {
-                implementation(projects.core.snapshotTestingAnnotations)
+                // `:core:snapshot-testing-annotations` is added by `krail.snapshot.testing`.
                 implementation(projects.core.adaptiveUi)
                 implementation(projects.core.aiText)
                 implementation(projects.core.speechToText)
@@ -147,10 +147,14 @@ kotlin {
             kotlin.srcDir("src/androidHostTest/kotlin")
             resources.srcDir("src/androidHostTest/resources")
             dependencies {
-                implementation(projects.core.snapshotTesting)
+                // `:core:snapshot-testing` is added by `krail.snapshot.testing`, which also
+                // raises the host-test heap to 4g — this module's several hundred
+                // @ScreenshotTest previews exhaust the default heap.
+                //
                 // Robolectric's createComposeRule() launches a ComponentActivity via
                 // ActivityScenario, which needs it declared in a manifest to resolve the
-                // launch intent — this artifact ships exactly that debug-only manifest.
+                // launch intent — this artifact ships exactly that debug-only manifest, and
+                // the convention plugin does not add it.
                 implementation(libs.test.composeUiTestManifest)
             }
         }


### PR DESCRIPTION
## What

Replaces hand-wired snapshot-test setup in `feature/trip-planner/ui/build.gradle.kts` with the `krail.snapshot.testing` convention plugin.

The module applied the raw Roborazzi plugin and wired both snapshot modules itself, which is exactly the shape the convention plugin exists to replace (see `taj/build.gradle.kts`). Hand-wiring also missed the part that is not a dependency: the plugin raises every `Test` task's heap to 4g, and its own comment names this module as the one that reproducibly exhausts the default heap capturing its several hundred `@ScreenshotTest` previews. Confirmed with a task-graph probe: `maxHeapSize` was unset before, 4g after.

## Changes

- `feature/trip-planner/ui/build.gradle.kts`: applies `krail.snapshot.testing` in place of the raw Roborazzi plugin.
- Removes as now redundant: `implementation(projects.core.snapshotTestingAnnotations)` from `commonMain` and `implementation(projects.core.snapshotTesting)` from `androidHostTest`.
- Kept, because the plugin deliberately does not touch them: `androidLibrary { withHostTest { isIncludeAndroidResources } }`, the `androidResources { enable }` block, the explicit `androidHostTest` srcDirs, and `libs.test.composeUiTestManifest` (the debug-only manifest Robolectric needs to launch a `ComponentActivity`).

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green: 736 tests, 0 failures.
- `./gradlew detekt --continue` green.
- Build-script only change; Android and iOS compile lanes run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
