### PR TITLE
test(trip-planner): un-ignore OurStoryViewModelTest by defaulting the android stubs

### DIFF
--- a/feature/trip-planner/ui/build.gradle.kts
+++ b/feature/trip-planner/ui/build.gradle.kts
@@ -21,6 +21,20 @@ kotlin {
 
         withHostTest {
             isIncludeAndroidResources = true
+
+            // Needed by the Molecule presenter tests, which drive Compose on a plain JVM test
+            // (no Robolectric). `Recomposer.processCompositionError` calls `android.util.Log.e`
+            // through `compose.runtime.internal.Utils_androidKt.logError`, and the stub
+            // android.jar throws "Method e in android.util.Log not mocked" from inside Compose's
+            // own error handler — so composition dies on the logging call rather than on
+            // anything wrong with the presenter. Defaulting the stubs lets that handler
+            // complete and the composition proceed.
+            //
+            // Note this cannot be fixed by swapping kermit's log writer: the caller is the
+            // Compose runtime itself, not `:core:log`. Robolectric tests in this module are
+            // unaffected either way — they get Robolectric's android implementation, not these
+            // stubs.
+            isReturnDefaultValues = true
         }
 
         // MANDATORY for AGP 9 to include assets

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryviewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/story/OurStoryviewModelTest.kt
@@ -17,7 +17,6 @@ import xyz.ksharma.krail.trip.planner.ui.settings.story.OurStoryViewModel
 import xyz.ksharma.krail.trip.planner.ui.state.settings.story.OurStoryEvent
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -38,11 +37,6 @@ class OurStoryViewModelTest {
         Dispatchers.resetMain()
     }
 
-    // Disabled on testAndroidHostTest: something in the molecule/Compose path triggers
-    // android.util.Log (the JVM stub throws RuntimeException("Stub!")). Needs either
-    // returnDefaultValues opt-in on the androidLibrary host-test config, or replacing
-    // kermit's LogcatWriter with a no-op writer in tests. Out of scope for now.
-    @Ignore
     @Test
     fun `models emits correct state on init`() = runTest {
         val viewModel = OurStoryViewModel(analytics, flag)


### PR DESCRIPTION
## What

Un-ignores `OurStoryViewModelTest` by letting the module's host tests return default values from the stub `android.jar`.

The test was parked on the guess that something in the Molecule/Compose path triggers `android.util.Log` and that a no-op Kermit writer would be the narrow fix. The stack trace says otherwise, and Kermit does not appear in it at all:

```
RuntimeException: Method e in android.util.Log not mocked
  at android.util.Log.e
  at androidx.compose.runtime.internal.Utils_androidKt.logError
  at androidx.compose.runtime.Recomposer.processCompositionError
  at androidx.compose.runtime.Recomposer.composeInitial$runtime
  at app.cash.molecule.MoleculeKt.launchMolecule
```

The caller is the Compose runtime's own error handler, which cannot be reached by swapping a writer in `:core:log`. On a plain JVM test the stub `android.jar` throws from `Log.e`, so composition dies inside the handler rather than on anything the presenter did.

## Changes

- `feature/trip-planner/ui/build.gradle.kts`: sets `isReturnDefaultValues = true` on the module's host tests, which lets that handler return and the composition proceed. Robolectric tests in this module are unaffected: they run against Robolectric's android implementation, not these stubs.
- `OurStoryviewModelTest.kt`: removes the `@Ignore` and the note explaining it. The test now asserts real state instead of being skipped: it composes the presenter, records the OurStory screen-view event, and reads back `story`, `disclaimer` and `isLoading`.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` goes from 736 tests with 1 skipped to 736 with 0 skipped, still 0 failures.
- `./gradlew detekt --continue` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
