### PR TITLE
test(trip-planner): compose the real home entry in a flow-test harness

### DIFF
--- a/docs/FEATURE_QUALITY_CHECKLIST.md
+++ b/docs/FEATURE_QUALITY_CHECKLIST.md
@@ -178,6 +178,10 @@ unless the trigger is consumed.
       completes, so a re-launched collector sees nothing to do?
 - [ ] Test: after the action completes, assert the trigger no longer reads as actionable —
       not just that the payload was right.
+- [ ] Flow test: re-launch the effect for real. `FlowTest` (in `:feature:trip-planner:ui`
+      androidHostTest, documented in `docs/INTEGRATION_TESTING_PLAN.md`) composes the actual
+      navigation entry and gives you `leaveAndReturn()` and `recreate()`; a unit test cannot
+      re-run a collector, so this is the only layer that sees the second launch.
 
 Shipped example: the Ask KRAIL dialog wrote resolved stops into the home row while
 `phase == RESOLVED`, and kept the phase after closing. Coming back from the stop-search

--- a/docs/INTEGRATION_TESTING_PLAN.md
+++ b/docs/INTEGRATION_TESTING_PLAN.md
@@ -1,0 +1,234 @@
+# Integration testing plan
+
+Status: first milestone built. `FlowTest` lives in `:feature:trip-planner:ui`'s
+`androidHostTest` source set and runs in the ordinary `testAndroidHostTest` lane. The
+remaining targets below are still proposals.
+
+## Why this exists
+
+A shipped bug motivated it. The Ask KRAIL dialog hands its resolved stops to the home row
+through a `LaunchedEffect` in `SavedTripsEntry` keyed on the ViewModel's RESOLVED phase.
+That effect re-launches every time the entry recomposes — including coming back from the
+stop-search screen — and the state kept the phase after the handoff. Result: the AI's stops
+replayed over stops the rider had since picked by hand.
+
+Every existing test layer looked at this bug and shrugged:
+
+- ViewModel unit tests assert emissions. They never re-run the collector, so a collector
+  that misbehaves on its second launch is invisible.
+- Compose component tests (`AiInputContentLayoutTest`, `AskKrailStatusLineTest`) exercise
+  one composable with a handed-in state. They never navigate.
+- Snapshot tests capture pixels of static states.
+- Nothing tested a **navigation entry**, and nothing tested a **flow across screens**.
+
+The class of bug that lives in the seams — state observed in one place, written in another,
+across a navigation boundary or a recomposition lifecycle — reached the rider.
+
+## What exists today (so we do not rebuild it)
+
+| Layer | Where | What it covers |
+|---|---|---|
+| ViewModel unit tests | `commonTest` (e.g. `AiSearchInputViewModelTest`) | State machine emissions, one collector, virtual time |
+| Compose interaction tests | `androidHostTest` + Robolectric (e.g. `SearchStopScreenInteractionTest`) | One screen, real composition, fake data |
+| Layout invariant tests | `androidHostTest` (e.g. `AiInputContentLayoutTest`) | Anchoring/child-order rules |
+| Snapshot tests | `androidHostTest` + Roborazzi, `@ScreenshotTest` previews | Static visual states |
+| Serialization guard | `NavKeySerializationConfigTest` | Every route registered for back-stack restore |
+| **Flow tests** | `androidHostTest` + Robolectric, `flow/FlowTest` | A real navigation entry, real ViewModels, leave-and-return and recreation |
+
+All host-side. There are no instrumented `androidTest` targets, no emulator jobs in CI, and
+iOS is untested by policy.
+
+## The gap, named
+
+**Flow tests: real ViewModels + real composition + navigation-shaped lifecycle, fake edges.**
+
+A harness that can:
+
+1. Compose a navigation entry (or a small nav graph), not just a screen. **Built** — the real
+   entry, see below.
+2. Drive it through the lifecycle events that break things: leave and return (dispose and
+   recompose the entry), Activity recreation (`StateRestorationTester`), process-death
+   restore of the back stack. **Built for the first two**; process death is deferred, see
+   "Deferred".
+3. Wire real ViewModels with fake services at the module edges (the existing
+   `testfakes/` and `core/testing` fakes are most of this already). **Built** — `HomeFlowFakes`
+   adds nothing new, it only assembles what was already there.
+4. Assert on what the rider sees (semantics tree), not on internals. **Built** — every
+   assertion in a flow test goes through `onNodeWith*`.
+
+## The FlowTest API
+
+`feature/trip-planner/ui/src/androidHostTest/.../flow/`
+
+| Piece | What it is |
+|---|---|
+| `FlowTest` | Base class. Carries the Robolectric annotations, the compose rule, Koin start/stop, and the helpers below. Subclass it and write `@Test`s. |
+| `HomeFlowFakes` | Every collaborator the home entry reaches for, faked at the module edge. Builds the three real ViewModels and the Koin module that hands them out. |
+| `RecordingTripPlannerNavigator` | The navigation edge. Records which stop-search field the entry asked for; composes no second destination. |
+
+Helpers on `FlowTest`:
+
+| Call | What it does |
+|---|---|
+| `launchHome()` | Composes the real `SavedTripsEntry` and waits for the first load plus the row's slide-in. |
+| `leaveAndReturn()` | Disposes the entry and composes it again. Every `LaunchedEffect` in it is cancelled and re-launched; ViewModels are not. This is going to the stop-search screen and coming back. |
+| `recreate()` | `StateRestorationTester` round trip: the composition is saved, discarded and restored from its `rememberSaveable` values. ViewModels survive, matching a real configuration change. |
+| `letTimePass(millis)` | Advances the compose frame clock **and** the Robolectric main looper. Both are needed, see "Two clocks". |
+| `askKrail(sentence)` | Opens the Ask KRAIL surface, fills it and sends it, one composition apart. |
+| `pickStop(result)` | Plays the stop-search screen's part by putting a `StopSelectedResult` on the real `ResultEventBus`, which is exactly what `SearchStopScreen` does before navigating back. |
+
+```kotlin
+class MyFlowTest : FlowTest() {
+    @Test
+    fun theRowKeepsTheRidersOwnPick() {
+        fakes.aiTextService.extractionResult = TripIntentExtraction(
+            originText = "Central Station",
+            destinationText = "Town Hall",
+        )
+        launchHome()
+
+        askKrail("central to town hall")
+        letTimePass(SETTLE_BEAT_MILLIS)          // the surface closes itself
+        pickStop(
+            StopSelectedResult(
+                fieldType = SearchStopFieldType.FROM,
+                stopId = "10103",
+                stopName = "Parramatta Station",
+            ),
+        )
+
+        leaveAndReturn()                          // the effects re-launch here
+
+        composeRule.onNodeWithText("Central Station").assertDoesNotExist()
+        composeRule.onNodeWithText("Parramatta Station").assertIsDisplayed()
+    }
+}
+```
+
+## Robolectric and Navigation 3: what composed and what did not
+
+### Composed cleanly, no work needed
+
+- **The real entry.** `entryProvider<NavKey> { SavedTripsEntry(navigator) }` is the same
+  builder `collectEntryProviders` uses in `:composeApp`, and `NavEntry.Content()` is the same
+  call `NavDisplay` makes for the top of the back stack. Both work under Robolectric with the
+  plain `createComposeRule()`, so the harness needs no navigation scaffolding at all.
+- **Koin.** `startKoin { modules(...) }` in `@Before` is enough for the entry's
+  `koinViewModel()` calls, including the keyed one and the one taking `parametersOf`.
+- **`rememberUserLocationManager()`** — the aagya permission controller and dhruva location
+  tracker both build against Robolectric's `ComponentActivity`. This was the piece expected to
+  fight back and it did not. Nothing asks for a permission unless the location lambda is
+  called, which the harness never does.
+- **`rememberAdaptiveLayoutInfo()`**, `blur()` under `GraphicsMode.NATIVE`, the Ask KRAIL
+  surface's real `Dialog`, and the real singleton `ResultEventBus`.
+
+### Cut, and why
+
+- **`NavDisplay` and its decorators.** Rendering `Content()` directly skips
+  `SaveableStateHolderNavEntryDecorator` and the per-entry ViewModel store, so ViewModels are
+  scoped to the Activity rather than to the nav entry, and `rememberSaveable` inside the entry
+  is held by the Activity-level registry. Both survive `leaveAndReturn()` and `recreate()`,
+  which is the property the flow tests depend on, so the substitution is faithful for this
+  class of test. It would not be faithful for a test about a ViewModel being *cleared* when its
+  entry pops off the back stack; that needs the decorators, and therefore `NavDisplay`.
+- **The right pane.** `MapStopSelectionPane` (MapLibre) never composes because the Pixel6
+  portrait qualifier is single-pane. `MapStopSelectionViewModel` is still built, so its Koin
+  binding is still required. A dual-pane flow test would have to deal with MapLibre under
+  Robolectric, which is untried.
+- **The GPS lambda.** The entry passes `suspend { userLocationManager.getCurrentLocation() }`
+  through `parametersOf`; the harness's Koin definitions ignore params and pass
+  `resolveCurrentLocation = { null }`. A flow that needs a GPS-derived origin has to fake
+  `NearbyStopsRepository` instead.
+- **Typing into the Ask KRAIL field.** `askKrail` sends the surface's own events rather than
+  driving its text field through semantics. Assertions still go through the semantics tree;
+  only the input is shortcut.
+
+### Two clocks
+
+Compose animations run on the test frame clock (`composeRule.mainClock`). A `delay()` inside a
+ViewModel runs on the Robolectric main looper's queue. Neither advances the other, and a flow
+test usually needs both: the settle beat that closes the Ask KRAIL surface is a `delay`, and
+the row it closes onto is revealed by an animation. `letTimePass` advances both, and
+`launchHome`, `leaveAndReturn` and `recreate` all end with one.
+
+### A node can exist before it is displayed
+
+The bottom search row is held off screen until the saved-trips load has emitted once, then
+slides in. `assertIsDisplayed()` straight after composition fails with *"...is not displayed"*
+rather than *"could not find any node"*, which reads like a missing node and is not one. The
+harness settles the reveal so tests do not have to know this.
+
+### The surface answers back
+
+`TextField` (taj) reports its contents from a `LaunchedEffect` keyed on them, so composing the
+Ask KRAIL surface echoes a `TypedTextChanged` for the empty field and another when the field
+syncs to state. Sent as one batch, `OpenInput` + `TypedTextChanged` + `Submit` let those echoes
+land *during* the resolve, and `TypedTextChanged` steps the phase back to IDLE. The Ask KRAIL
+flow test passed under both the fixed and the pre-fix ViewModel until each event was composed
+through before the next one was sent.
+
+**This is the trap to remember about flow tests in general:** driving a real surface's
+ViewModel faster than the surface can compose produces a state no rider can reach, and a test
+standing on it proves nothing. The check that catches it is the one below.
+
+### Prove the test discriminates
+
+A flow test that cannot fail is worse than no test, because it reads as coverage. Before
+committing one, revert the fix it pins (`git revert --no-commit <fix>`), watch it fail, read
+the failure message to confirm it fails *for the reason you think*, and restore. For the Ask
+KRAIL replay test the pre-fix run fails with the AI's origin back on the row:
+
+```
+Failed: assertDoesNotExist.
+Reason: Did not expect any node but found '1' node that satisfies:
+  (Text + InputText + EditableText contains 'Central Station')
+Node found: Node #108 ... Role = 'Button'  Text = '[Central Station]'
+```
+
+## Remaining targets, in value order
+
+1. ~~**Ask KRAIL handoff replay**~~ — built: `AskKrailHandoffFlowTest`.
+2. **Search-stop round trip** — pick From, pick To, rotate between the two, assert both land
+   in the row and survive recreation.
+3. **Time chip journey** — AI-resolved time shows on the row, travels to the timetable route,
+   survives process death (it rides `TimeTableRoute` for exactly this reason).
+4. **Dialog-open recreation** — rotate with the Ask KRAIL surface open at each phase (idle,
+   listening stopped, unresolved-with-banner) and assert the phase-appropriate content.
+
+## Deferred
+
+- **`ActivityScenario.recreate()` for a full Bundle round trip.** `createComposeRule()` owns
+  its Activity and does not expose the scenario, and switching to
+  `createAndroidComposeRule<ComponentActivity>()` does not help on its own: content set through
+  the rule belongs to the original Activity instance, so a real recreate leaves nothing
+  composed. Doing it properly needs a test Activity that calls `setContent` in `onCreate`, and
+  therefore a manifest, which every test here avoids with `manifest = Config.NONE`.
+  `StateRestorationTester` already covers the part that breaks in practice (saveable state
+  restoring into a fresh composition), and the back-stack serialisation a Bundle round trip
+  would add is covered by reflection in `NavKeySerializationConfigTest`. Worth revisiting only
+  if a defect escapes both.
+- **Instrumented `androidTest` on an emulator in CI** only if the host-side harness cannot
+  represent window-level behaviour we care about (IME insets, dialog windows). Costly: new CI
+  lane, flake budget, device images. Nothing so far has needed it.
+- **Maestro or similar UI-driver flows** for a tiny smoke set on release candidates.
+  Explicitly out of scope for per-PR CI.
+
+## Ground rules
+
+- Fakes at the edges, real everything else. No mocking frameworks (repo convention).
+- Assert through semantics (what is announced/shown), not through internal state, so the
+  tests survive refactors. Driving a ViewModel with the events its own surface sends is
+  allowed; reading state off it to assert is not.
+- Every flow test documents which shipped defect or checklist item it pins.
+- Every flow test is proved to fail against the defect it pins before it is committed.
+- Keep the suite in `testAndroidHostTest`; a flow test slow enough to need its own lane is a
+  design smell in the harness.
+- When a flow test catches something a unit test could have pinned, add the unit test too and
+  keep the flow test for the seam.
+
+## Definition of done for the first milestone
+
+- [x] The Ask KRAIL handoff replay test exists, fails on the pre-fix commit, passes on the fix.
+- [x] A `FlowTest` base exists with recompose-entry and recreation helpers, documented in this
+      file.
+- [x] `docs/FEATURE_QUALITY_CHECKLIST.md`'s section on re-launched effects points here.

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/AskKrailHandoffFlowTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/AskKrailHandoffFlowTest.kt
@@ -1,0 +1,69 @@
+package xyz.ksharma.krail.trip.planner.ui.flow
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Test
+import xyz.ksharma.krail.core.aitext.TripIntentExtraction
+import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
+import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
+
+private const val SETTLE_BEAT_MILLIS = 2_000L
+
+private const val CENTRAL = "Central Station"
+private const val TOWN_HALL = "Town Hall"
+private const val PARRAMATTA = "Parramatta Station"
+private const val PARRAMATTA_ID = "10103"
+
+/**
+ * Pins the shipped defect fixed by `closeAfterHandoff`'s phase step-down: the Ask KRAIL dialog
+ * handed its resolved stops to the home row through a `LaunchedEffect` keyed on the RESOLVED
+ * phase, kept the phase after the handoff, and so replayed the AI's stops over stops the rider
+ * had since picked by hand the next time the entry recomposed.
+ *
+ * No layer below this one could see it. The ViewModel tests never re-run the collector; the
+ * screen tests never navigate. It needs the entry, the effect and a leave-and-return, which is
+ * what [FlowTest] is for.
+ */
+class AskKrailHandoffFlowTest : FlowTest() {
+
+    @Test
+    fun aiStopsDoNotReplayOverAManualPickAfterLeavingAndReturning() {
+        fakes.aiTextService.extractionResult = TripIntentExtraction(
+            originText = CENTRAL,
+            destinationText = TOWN_HALL,
+            timeIntent = null,
+        )
+        launchHome()
+
+        askKrail("central to town hall")
+        // The settle beat: the dialog closes itself onto the row it just filled, and the phase
+        // steps down in the same emission.
+        letTimePass(SETTLE_BEAT_MILLIS)
+
+        // The handoff itself. Both fields are the AI's at this point.
+        composeRule.onNodeWithText(CENTRAL).assertIsDisplayed()
+        composeRule.onNodeWithText(TOWN_HALL).assertIsDisplayed()
+
+        // The rider disagrees about where they are starting and picks their own From, the way
+        // the stop-search screen reports one back.
+        pickStop(
+            StopSelectedResult(
+                fieldType = SearchStopFieldType.FROM,
+                stopId = PARRAMATTA_ID,
+                stopName = PARRAMATTA,
+            ),
+        )
+        composeRule.onNodeWithText(PARRAMATTA).assertIsDisplayed()
+
+        // Coming back from the stop-search screen re-launches the writing effect. With the
+        // gate still open it wrote the AI's Central Station back over Parramatta here.
+        leaveAndReturn()
+
+        // The defect, stated directly: the AI's origin is gone for good and must not come back.
+        composeRule.onNodeWithText(CENTRAL).assertDoesNotExist()
+        composeRule.onNodeWithText(PARRAMATTA).assertIsDisplayed()
+        // The field the rider did not touch is still the AI's, which is the point of writing
+        // per field rather than per resolve.
+        composeRule.onNodeWithText(TOWN_HALL).assertIsDisplayed()
+    }
+}

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/FlowTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/FlowTest.kt
@@ -1,0 +1,212 @@
+package xyz.ksharma.krail.trip.planner.ui.flow
+
+import android.os.Looper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation3.runtime.NavKey
+import androidx.navigation3.runtime.entryProvider
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import xyz.ksharma.krail.core.navigation.ResultEventBus
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
+import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
+import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
+import xyz.ksharma.krail.trip.planner.ui.navigation.entries.SavedTripsEntry
+import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputEvent
+
+/**
+ * Base for **flow tests**: real ViewModels, real composition, a navigation-shaped lifecycle,
+ * fakes only at the module edges. The layer between a ViewModel unit test (one collector, no
+ * composition) and a screen interaction test (one composable, handed-in state) — the layer
+ * where state observed in one place and written in another crosses a navigation boundary.
+ *
+ * See `docs/INTEGRATION_TESTING_PLAN.md` for the plan this implements and for what composes
+ * cleanly under Robolectric and what does not.
+ *
+ * ## What gets composed
+ *
+ * The real [SavedTripsEntry], built through the real `entryProvider` DSL and rendered by
+ * `NavEntry.Content()`. That is the whole reason this harness exists: the entry owns the
+ * `LaunchedEffect` that writes the Ask KRAIL resolve into the home row, and the `ResultEffect`
+ * that receives stop picks from the search screen. Neither is reachable from a screen test.
+ *
+ * `NavDisplay` and its decorators are deliberately not in the picture, so ViewModels are
+ * scoped to the Activity's store rather than to a nav entry. Both survive the two lifecycle
+ * events below, which is the property the flow tests rely on.
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * class MyFlowTest : FlowTest() {
+ *     @Test
+ *     fun theRowKeepsTheRidersOwnPick() {
+ *         fakes.aiTextService.extractionResult = TripIntentExtraction(...)
+ *         launchHome()
+ *
+ *         askKrail("central to town hall")           // resolve through the real pipeline
+ *         letTimePass(SETTLE_BEAT_MILLIS)            // the dialog closes itself
+ *         pickStop(SearchStopFieldType.FROM, "10103", "Parramatta Station")
+ *
+ *         leaveAndReturn()                           // the effects re-launch here
+ *
+ *         composeRule.onNodeWithText("Parramatta Station").assertIsDisplayed()
+ *     }
+ * }
+ * ```
+ *
+ * ## The two lifecycle events
+ *
+ * - [leaveAndReturn] disposes the entry and composes it again, which is what going to the
+ *   stop-search screen and coming back does. Every `LaunchedEffect` in the entry is cancelled
+ *   and re-launched; ViewModels are not.
+ * - [recreate] is Activity recreation (rotation, theme switch): the composition is saved,
+ *   thrown away and restored from its `rememberSaveable` values. ViewModels are not recreated,
+ *   matching a real configuration change.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [FLOW_TEST_SDK],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+abstract class FlowTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    internal val fakes = HomeFlowFakes()
+
+    internal val navigator = RecordingTripPlannerNavigator()
+
+    private val restorationTester by lazy { StateRestorationTester(composeRule) }
+
+    /** Whether the entry is currently on screen. Flipped by [leaveAndReturn]. */
+    private val hosted = mutableStateOf(true)
+
+    @Before
+    fun startFlowKoin() {
+        startKoin { modules(fakes.koinModule) }
+    }
+
+    @After
+    fun stopFlowKoin() {
+        stopKoin()
+        // The bus is a process singleton. Left alone, a result one test sent but never
+        // collected is delivered to the next test's entry.
+        ResultEventBus.getInstance().removeResult<StopSelectedResult>()
+    }
+
+    /**
+     * Composes the home entry and waits for its first load to settle.
+     *
+     * The wait is not optional. The search row is held off screen until the saved-trips load
+     * has emitted once and then slides in, so a test that asserts straight after composition
+     * finds its node in the tree but not yet displayed.
+     */
+    protected fun launchHome() {
+        restorationTester.setContent {
+            PreviewTheme {
+                if (hosted.value) {
+                    HomeEntry(navigator = navigator)
+                }
+            }
+        }
+        composeRule.waitForIdle()
+        letTimePass(ENTRY_REVEAL_MILLIS)
+    }
+
+    /**
+     * Leave the entry and come back to it, the way a rider does when they open the stop-search
+     * screen and pick something. The entry leaves composition entirely, so its effects are
+     * cancelled and re-launched on return against whatever state the ViewModels now hold.
+     */
+    protected fun leaveAndReturn() {
+        composeRule.runOnIdle { hosted.value = false }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { hosted.value = true }
+        composeRule.waitForIdle()
+        letTimePass(ENTRY_REVEAL_MILLIS)
+    }
+
+    /** Activity recreation: save, discard, restore. ViewModels survive; composition does not. */
+    protected fun recreate() {
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeRule.waitForIdle()
+        letTimePass(ENTRY_REVEAL_MILLIS)
+    }
+
+    /**
+     * Move both clocks forward. Compose animations run on the test frame clock, while
+     * `delay()` inside a ViewModel runs on the main looper's queue, and a flow test usually
+     * needs both: the settle beat that closes the Ask KRAIL dialog is a `delay`, the reveal of
+     * the row it closes onto is an animation.
+     */
+    protected fun letTimePass(millis: Long) {
+        composeRule.mainClock.advanceTimeBy(millis)
+        shadowOf(Looper.getMainLooper()).idleFor(millis, TimeUnit.MILLISECONDS)
+        composeRule.waitForIdle()
+    }
+
+    /**
+     * Ask KRAIL, from opening the surface to sending the sentence. These are the three events
+     * the Ask KRAIL surface itself sends. The open matters because the phase only steps down
+     * again on a surface that was open (`closeAfterHandoff`).
+     *
+     * Each event is composed through before the next one, because the real surface answers
+     * back: `TextField` reports its contents from a `LaunchedEffect` keyed on them, so opening
+     * the dialog echoes an empty `TypedTextChanged` and filling it echoes the sentence. Sent as
+     * one batch, those echoes land *during* the resolve and step the phase back to IDLE, which
+     * silently disables any test that depends on the resolve staying live.
+     */
+    protected fun askKrail(sentence: String) {
+        sendAiEvent(AiSearchInputEvent.OpenInput)
+        sendAiEvent(AiSearchInputEvent.TypedTextChanged(sentence))
+        sendAiEvent(AiSearchInputEvent.Submit)
+    }
+
+    private fun sendAiEvent(event: AiSearchInputEvent) {
+        composeRule.runOnIdle { fakes.aiSearchInputViewModel.onEvent(event) }
+        composeRule.waitForIdle()
+    }
+
+    /**
+     * Play the stop-search screen's part: put a picked stop on the real result bus, which is
+     * exactly what `SearchStopScreen` does before it navigates back. The entry's own
+     * `ResultEffect` is what receives it.
+     */
+    protected fun pickStop(result: StopSelectedResult) {
+        ResultEventBus.getInstance().sendResult(result = result)
+        composeRule.waitForIdle()
+    }
+}
+
+/** Robolectric SDK level shared by every flow test. */
+internal const val FLOW_TEST_SDK = 34
+
+/** Long enough for the bottom search row's slide-in to finish after the first load. */
+private const val ENTRY_REVEAL_MILLIS = 1_000L
+
+/**
+ * The real entry, composed without `NavDisplay`. `entryProvider` is the same builder the app
+ * uses (`collectEntryProviders`), and `Content()` is the same call `NavDisplay` makes for the
+ * top of the back stack.
+ */
+@Composable
+private fun HomeEntry(navigator: TripPlannerNavigator) {
+    val provider = entryProvider<NavKey> { SavedTripsEntry(navigator) }
+    provider(SavedTripsRoute).Content()
+}

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/HomeFlowFakes.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/HomeFlowFakes.kt
@@ -1,0 +1,113 @@
+package xyz.ksharma.krail.trip.planner.ui.flow
+
+import kotlinx.coroutines.Dispatchers
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeInfoTileManager
+import xyz.ksharma.krail.core.testing.fakes.FakeNswParkRideSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideFacilityManager
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideService
+import xyz.ksharma.krail.core.testing.fakes.FakePlatformOps
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.feature.track.TrackingManager
+import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionViewModel
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.SavedTripsViewModel
+import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputViewModel
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.ChainedStopTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelWordGuard
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelledStopLocator
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.RiderOriginLocator
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopLabelTextResolver
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.StopSearchTextResolver
+import xyz.ksharma.krail.trip.planner.ui.searchstop.RealSearchSessionStore
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAiTextService
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeInviteFriendsTileManager
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeNearbyStopsManagerForMap
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeNearbyStopsRepository
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeSpeechToTextService
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
+
+/**
+ * Every collaborator the home entry reaches for, faked at the module edge and nowhere else:
+ * the database, the network services, the on-device AI, the recogniser. Everything between
+ * those edges and the semantics tree is the real thing — the real ViewModels, the real
+ * resolver chain (in the same order [xyz.ksharma.krail.trip.planner.ui.di.viewModelsModule]
+ * builds it), the real screen.
+ *
+ * The three ViewModels are built here rather than by Koin so a flow test can drive them with
+ * the same events the surface sends. Koin hands out these instances, so the ones under test
+ * and the ones on screen are the same objects. Reading state off them is not how a flow test
+ * asserts — that is what the semantics tree is for — but sending them an event is how a rider
+ * gets in.
+ */
+internal class HomeFlowFakes {
+
+    val sandook = FakeSandook()
+    val stopResultsManager = FakeStopResultsManager()
+    val aiTextService = FakeAiTextService()
+    val speechToTextService = FakeSpeechToTextService()
+    val nearbyStopsRepository = FakeNearbyStopsRepository()
+    val flag = FakeFlag()
+
+    val aiSearchInputViewModel = AiSearchInputViewModel(
+        aiTextService = aiTextService,
+        speechToTextService = speechToTextService,
+        stopTextResolver = ChainedStopTextResolver(
+            listOf(
+                StopLabelTextResolver(sandook = sandook),
+                LabelWordGuard(StopSearchTextResolver(stopResultsManager = stopResultsManager)),
+            ),
+        ),
+        riderOriginLocator = RiderOriginLocator(
+            // No GPS in the harness. UserLocationManager only exists as a @Composable
+            // factory, and the real entry supplies this lambda through
+            // koinViewModel(parametersOf(...)); the harness's Koin definition ignores those
+            // params, so a flow that needs a GPS-derived origin has to fake the nearby
+            // repository instead.
+            resolveCurrentLocation = { null },
+            labelledStopLocator = LabelledStopLocator(sandook = sandook),
+            nearbyStopsRepository = nearbyStopsRepository,
+        ),
+        isAiSearchInputEnabled = { true },
+    )
+
+    val savedTripsViewModel = SavedTripsViewModel(
+        sandook = sandook,
+        analytics = FakeAnalytics(),
+        // Unconfined rather than a StandardTestDispatcher: a flow test has no TestScope to
+        // advance, so anything the ViewModel moves off the main dispatcher has to run where
+        // it is launched or it never runs at all.
+        ioDispatcher = Dispatchers.Unconfined,
+        nswParkRideFacilityManager = FakeParkRideFacilityManager(),
+        parkRideService = FakeParkRideService(),
+        parkRideSandook = FakeNswParkRideSandook(),
+        stopResultsManager = stopResultsManager,
+        searchSessionStore = RealSearchSessionStore(),
+        flag = flag,
+        preferences = FakeSandookPreferences(),
+        infoTileManager = FakeInfoTileManager(),
+        platformOps = FakePlatformOps(),
+        inviteFriendsTileManager = FakeInviteFriendsTileManager(),
+        trackingManager = TrackingManager(),
+        appReviewManager = FakeAppReviewManager(),
+    )
+
+    val mapStopSelectionViewModel = MapStopSelectionViewModel(
+        nearbyStopsManager = FakeNearbyStopsManagerForMap(),
+    )
+
+    /**
+     * What the entry resolves through `koinViewModel()`. Only the three ViewModels the home
+     * entry asks for — everything else it needs is already inside them.
+     */
+    val koinModule: Module = module {
+        viewModel<SavedTripsViewModel> { savedTripsViewModel }
+        viewModel<AiSearchInputViewModel> { aiSearchInputViewModel }
+        viewModel<MapStopSelectionViewModel> { mapStopSelectionViewModel }
+    }
+}

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/RecordingTripPlannerNavigator.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/RecordingTripPlannerNavigator.kt
@@ -1,0 +1,55 @@
+package xyz.ksharma.krail.trip.planner.ui.flow
+
+import androidx.navigation3.runtime.NavKey
+import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
+import xyz.ksharma.krail.trip.planner.ui.navigation.TripPlannerNavigator
+
+/**
+ * The navigation edge of the home entry. A flow test only ever needs to know *that* the entry
+ * asked to leave and for which field, because the harness plays the other screen's part by
+ * putting a result back on the real [xyz.ksharma.krail.core.navigation.ResultEventBus]. No
+ * second destination is composed.
+ */
+internal class RecordingTripPlannerNavigator : TripPlannerNavigator {
+
+    /** Every stop-search request the entry made, oldest first. */
+    val searchStopRequests = mutableListOf<SearchStopFieldType>()
+
+    /** Every timetable the entry asked to open, as "fromStopId>toStopId" pairs. */
+    val timeTableRequests = mutableListOf<Pair<String, String>>()
+
+    override fun navigateToSearchStop(
+        fieldType: SearchStopFieldType,
+        labelKey: String?,
+        editTripLeg: Boolean,
+    ) {
+        searchStopRequests += fieldType
+    }
+
+    override fun navigateToTimeTable(
+        fromStopId: String,
+        fromStopName: String,
+        toStopId: String,
+        toStopName: String,
+        dateTimeSelectionJson: String?,
+    ) {
+        timeTableRequests += fromStopId to toStopId
+    }
+
+    override fun navigateToJourneyMap(journeyId: String) = Unit
+    override fun navigateToSettings() = Unit
+    override fun navigateToDiscover() = Unit
+    override fun navigateToManageStopLabels() = Unit
+    override fun navigateToAddParkRide() = Unit
+    override fun navigateToThemeSelection() = Unit
+    override fun navigateToAlerts(journeyId: String) = Unit
+    override fun navigateToDateTimeSelector(json: String?) = Unit
+    override fun navigateToOurStory() = Unit
+    override fun navigateToIntro() = Unit
+    override fun navigateToTrackTrip(encodedData: String?) = Unit
+    override fun navigateToDebugConfig() = Unit
+    override fun navigateToDebugConfigNetwork() = Unit
+    override fun goBack() = Unit
+    override fun updateTheme(hexColorCode: String) = Unit
+    override fun clearBackStackAndNavigate(route: NavKey) = Unit
+}


### PR DESCRIPTION
## What

Adds `FlowTest`, a Robolectric harness that composes the real navigation entry rather than a hand-built approximation of it, and the first flow test on top of it: a regression test for the Ask KRAIL handoff replaying a stale answer onto the search row.

## Changes

- `flow/FlowTest.kt`: builds the SavedTrips entry through the same `entryProvider` the app uses and renders it with `NavEntry.Content()`, real ViewModels wired by constructor with fakes only at the module edges. It exposes the two lifecycle events that break effects:
  - `leaveAndReturn` disposes the entry and composes it again.
  - `recreate` runs a `rememberSaveable` round trip through `StateRestorationTester`.
- `flow/HomeFlowFakes.kt` and `flow/RecordingTripPlannerNavigator.kt`: the edge fakes and a navigator that records instead of navigating.
- `flow/AskKrailHandoffFlowTest.kt`: resolves a trip through Ask KRAIL, lets the surface hand off and close, takes a manual From pick off the real result bus, then leaves and returns. Against the pre-fix ViewModel it fails with the AI's origin back on the row as a Button node reading "Central Station"; with the phase step-down in place it passes.
- `docs/INTEGRATION_TESTING_PLAN.md`: documents the `FlowTest` API with a usage example, the Robolectric findings behind it, and the rule that a flow test is proved to fail against the defect it pins before it is committed.
- `docs/FEATURE_QUALITY_CHECKLIST.md`: the re-launched-effects section gains a line pointing at the harness, since that is the only layer that can re-run a collector.

## What the harness deliberately leaves out

`NavDisplay` and its decorators, which makes ViewModels Activity-scoped rather than entry-scoped. Both survive the two lifecycle events, which is the property these tests need; the cost is written down in the plan rather than papered over.

`askKrail` sends its three events one composition apart on purpose. `TextField` reports its contents from a `LaunchedEffect` keyed on them, so a batched open plus fill echoes `TypedTextChanged` during the resolve and steps the phase back to `IDLE` by itself, which would hide the defect the test exists to catch.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green.
- The Ask KRAIL flow test was run against the pre-fix ViewModel and fails there, so it is proved to pin the defect rather than passing vacuously.
- `./gradlew detekt --continue` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
