### PR TITLE
test(trip-planner): pin the search-stop round trip across a recreation

### DIFF
--- a/docs/INTEGRATION_TESTING_PLAN.md
+++ b/docs/INTEGRATION_TESTING_PLAN.md
@@ -188,8 +188,11 @@ Node found: Node #108 ... Role = 'Button'  Text = '[Central Station]'
 ## Remaining targets, in value order
 
 1. ~~**Ask KRAIL handoff replay**~~ — built: `AskKrailHandoffFlowTest`.
-2. **Search-stop round trip** — pick From, pick To, rotate between the two, assert both land
-   in the row and survive recreation.
+2. ~~**Search-stop round trip**~~ — built: `SearchStopRoundTripFlowTest`. Unlike the replay
+   test there is no shipped defect to fail against, so what stands in for that proof is a
+   positive control on the helper: a `DisposableEffect` probe inside the harness's entry shows
+   `recreate()` really disposing and recomposing it, rather than the test passing because
+   nothing happened. Run that probe again if `recreate()` is ever reworked.
 3. **Time chip journey** — AI-resolved time shows on the row, travels to the timetable route,
    survives process death (it rides `TimeTableRoute` for exactly this reason).
 4. **Dialog-open recreation** — rotate with the Ask KRAIL surface open at each phase (idle,

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/SearchStopRoundTripFlowTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/SearchStopRoundTripFlowTest.kt
@@ -1,0 +1,53 @@
+package xyz.ksharma.krail.trip.planner.ui.flow
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Test
+import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopFieldType
+import xyz.ksharma.krail.trip.planner.ui.navigation.StopSelectedResult
+
+private const val CENTRAL = "Central Station"
+private const val CENTRAL_ID = "10101"
+private const val TOWN_HALL = "Town Hall"
+private const val TOWN_HALL_ID = "10102"
+
+/**
+ * The ordinary two-tap trip: pick a From, pick a To, with the device rotated in between.
+ *
+ * Pins the state-survives-recreation item in `docs/FEATURE_QUALITY_CHECKLIST.md`. Filling the
+ * row takes two separate trips to another screen, so anything that lived only in the entry's
+ * composition would lose the first stop on the way to the second — and rotation is exactly
+ * when a rider changes their mind about a stop.
+ */
+class SearchStopRoundTripFlowTest : FlowTest() {
+
+    @Test
+    fun bothStopsLandOnTheRowWhenTheScreenIsRecreatedBetweenThePicks() {
+        launchHome()
+
+        pickStop(
+            StopSelectedResult(
+                fieldType = SearchStopFieldType.FROM,
+                stopId = CENTRAL_ID,
+                stopName = CENTRAL,
+            ),
+        )
+        composeRule.onNodeWithText(CENTRAL).assertIsDisplayed()
+
+        recreate()
+
+        // The From stop was picked before the recreation and has to still be there after it.
+        composeRule.onNodeWithText(CENTRAL).assertIsDisplayed()
+
+        pickStop(
+            StopSelectedResult(
+                fieldType = SearchStopFieldType.TO,
+                stopId = TOWN_HALL_ID,
+                stopName = TOWN_HALL,
+            ),
+        )
+
+        composeRule.onNodeWithText(CENTRAL).assertIsDisplayed()
+        composeRule.onNodeWithText(TOWN_HALL).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## What

Adds a second flow test on the `FlowTest` harness: pick a From, recreate the screen, pick a To, and assert both stops are on the row afterwards.

Filling the row takes two separate trips to another screen, so a stop held anywhere but the ViewModel would be lost on the way to the second one, and a recreation is exactly when a rider changes their mind about a stop.

## Changes

- `flow/SearchStopRoundTripFlowTest.kt`: the round trip across a `recreate()`. Both picks arrive on the real `ResultEventBus`, so the entry's own `ResultEffect` has to survive being cancelled and re-subscribed on the same channel.
- `docs/INTEGRATION_TESTING_PLAN.md`: records the new test against its milestone.

## Proving the test is not vacuous

There is no shipped defect for this one to fail against. A `DisposableEffect` probe inside the harness's entry stands in for that proof: it shows `recreate()` disposing and recomposing the entry, rather than the test passing because nothing happened.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green.
- `./gradlew detekt --continue` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
