### PR TITLE
feat(testing): add testTag selectors for end-to-end drivers

### DIFF
--- a/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/TestTagResourceIds.android.kt
+++ b/composeApp/src/androidMain/kotlin/xyz/ksharma/krail/TestTagResourceIds.android.kt
@@ -1,0 +1,8 @@
+package xyz.ksharma.krail
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
+
+actual fun Modifier.exposeTestTagsToUiAutomation(): Modifier =
+    semantics { testTagsAsResourceId = true }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/KrailApp.kt
@@ -3,6 +3,7 @@ package xyz.ksharma.krail
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
 import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.request.crossfade
@@ -26,7 +27,7 @@ fun KrailApp() {
         SetupCoilImageLoader()
 
         KrailTheme(themeController = themeController) {
-            KrailNavHost()
+            KrailNavHost(modifier = Modifier.exposeTestTagsToUiAutomation())
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/TestTagResourceIds.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/TestTagResourceIds.kt
@@ -1,0 +1,17 @@
+package xyz.ksharma.krail
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Exposes every descendant's `Modifier.testTag` to the platform's UI-automation layer so
+ * end-to-end drivers (Maestro) can select nodes by a stable id instead of by visible copy.
+ *
+ * Apply once, at the app root. It adds semantics only and never participates in layout or
+ * drawing, so it cannot change a single pixel of output.
+ *
+ * - Android: sets `testTagsAsResourceId`, which surfaces each `testTag` as the
+ *   accessibility node's `resource-id`.
+ * - iOS: a no-op. Compose Multiplatform already publishes `testTag` as the
+ *   `accessibilityIdentifier` of the corresponding element, so nothing extra is needed.
+ */
+expect fun Modifier.exposeTestTagsToUiAutomation(): Modifier

--- a/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/TestTagResourceIds.ios.kt
+++ b/composeApp/src/iosMain/kotlin/xyz/ksharma/krail/TestTagResourceIds.ios.kt
@@ -1,0 +1,9 @@
+package xyz.ksharma.krail
+
+import androidx.compose.ui.Modifier
+
+/**
+ * No-op on iOS: Compose Multiplatform maps `Modifier.testTag` onto the element's
+ * `accessibilityIdentifier` already, which is what XCUITest and Maestro read.
+ */
+actual fun Modifier.exposeTestTagsToUiAutomation(): Modifier = this

--- a/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugConfigScreen.kt
+++ b/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugConfigScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import xyz.ksharma.krail.taj.components.Divider
 import xyz.ksharma.krail.taj.components.Text
@@ -48,6 +49,7 @@ fun DebugConfigScreen(
 ) {
     Box(
         modifier = modifier
+            .testTag(DebugSettingsTestTags.DEBUG_CONFIG_SCREEN)
             .fillMaxSize()
             .background(color = KrailTheme.colors.surface),
     ) {
@@ -58,7 +60,11 @@ fun DebugConfigScreen(
                 title = { Text(text = "Debug Config") },
             )
 
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(DebugSettingsTestTags.DEBUG_CONFIG_LIST),
+            ) {
                 item(key = "header") {
                     DebugConfigHeader()
                 }
@@ -67,6 +73,8 @@ fun DebugConfigScreen(
                         title = "Network",
                         subtitle = "Pick where BFF-eligible calls are routed.",
                         onClick = onNetworkClick,
+                        modifier = Modifier
+                            .testTag(DebugSettingsTestTags.DEBUG_CONFIG_TILE_NETWORK),
                     )
                 }
                 item(key = "tile-trip-tracking") {
@@ -75,6 +83,8 @@ fun DebugConfigScreen(
                         subtitle = "Override TRIP_TRACKING_ENABLED RC flag.",
                         checked = tripTrackingEnabled,
                         onCheckedChange = onTripTrackingToggle,
+                        modifier = Modifier
+                            .testTag(DebugSettingsTestTags.toggleTile("TRIP_TRACKING_ENABLED")),
                     )
                 }
                 item(key = "tile-address-search") {
@@ -83,6 +93,10 @@ fun DebugConfigScreen(
                         subtitle = "Override SEARCH_STOP_ADDRESS_SEARCH_ENABLED RC flag.",
                         checked = addressSearchEnabled,
                         onCheckedChange = onAddressSearchToggle,
+                        modifier = Modifier.testTag(
+                            DebugSettingsTestTags
+                                .toggleTile("SEARCH_STOP_ADDRESS_SEARCH_ENABLED"),
+                        ),
                     )
                 }
                 item(key = "tile-alert-summary") {
@@ -93,6 +107,8 @@ fun DebugConfigScreen(
                         onCheckedChange = onAlertSummaryToggle,
                         enabled = onDeviceAiAvailable,
                         disabledReason = "On-device AI isn't available on this device.",
+                        modifier = Modifier
+                            .testTag(DebugSettingsTestTags.toggleTile("ALERT_SUMMARY_ENABLED")),
                     )
                 }
                 item(key = "tile-ai-search-input") {
@@ -103,6 +119,8 @@ fun DebugConfigScreen(
                         onCheckedChange = onAiSearchInputToggle,
                         enabled = onDeviceAiAvailable,
                         disabledReason = "On-device AI isn't available on this device.",
+                        modifier = Modifier
+                            .testTag(DebugSettingsTestTags.toggleTile("AI_SEARCH_INPUT_ENABLED")),
                     )
                 }
                 item(key = "tile-reset-review") {
@@ -110,6 +128,8 @@ fun DebugConfigScreen(
                         title = "Reset in-app review",
                         subtitle = "Clear the 'already asked' count so it can fire again. Keeps the install date.",
                         onClick = onResetReviewClick,
+                        modifier = Modifier
+                            .testTag(DebugSettingsTestTags.DEBUG_CONFIG_TILE_RESET_REVIEW),
                     )
                 }
             }

--- a/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsTestTags.kt
+++ b/feature/debug-settings/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/debug/settings/ui/DebugSettingsTestTags.kt
@@ -1,0 +1,21 @@
+package xyz.ksharma.krail.feature.debug.settings.ui
+
+/**
+ * Stable selectors for end-to-end drivers (Maestro) on the debug config screen.
+ *
+ * Same contract as `TripPlannerTestTags`: semantics-only, never derived from visible copy, and
+ * public API once a flow in `.maestro/` references one.
+ */
+object DebugSettingsTestTags {
+
+    const val DEBUG_CONFIG_SCREEN = "debugconfig.screen"
+    const val DEBUG_CONFIG_LIST = "debugconfig.list"
+    const val DEBUG_CONFIG_TILE_NETWORK = "debugconfig.tile.network"
+    const val DEBUG_CONFIG_TILE_RESET_REVIEW = "debugconfig.tile.resetreview"
+
+    /**
+     * One feature-flag toggle row. [flagId] is the flag's own identifier, so the tag stays
+     * correct when the row's label is reworded.
+     */
+    fun toggleTile(flagId: String): String = "debugconfig.toggle.$flagId"
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/TripPlannerTestTags.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/TripPlannerTestTags.kt
@@ -1,0 +1,77 @@
+package xyz.ksharma.krail.trip.planner.ui
+
+/**
+ * Stable selectors for end-to-end drivers (Maestro).
+ *
+ * Every tag here is applied with `Modifier.testTag`, which is semantics-only: it never
+ * participates in layout or drawing, so tagging a node cannot move or repaint a pixel.
+ *
+ * Two rules keep these useful:
+ *
+ * 1. **Never derive a tag from visible copy.** A flow that selects on "Saved Trips" breaks the
+ *    day the wording changes. These names describe the node's job, not its label.
+ * 2. **Treat a tag as public API once a flow references it.** Renaming one is a breaking change
+ *    to `.maestro/`; grep there before editing.
+ *
+ * On Android the tags surface as accessibility `resource-id`s because the app root opts in via
+ * `exposeTestTagsToUiAutomation()`. On iOS, Compose Multiplatform publishes them as
+ * `accessibilityIdentifier` with no opt-in needed, so a single tag serves both platforms.
+ *
+ * Per-item tags (one row of a list) are built by the functions at the bottom of this file.
+ */
+object TripPlannerTestTags {
+
+    // First-run intro carousel. Every fresh install lands here, so an E2E run on a clean
+    // device has to get past it before it can test anything else. One button advances the
+    // carousel and finishes it, hence a single action tag rather than one per page.
+    const val INTRO_SCREEN = "intro.screen"
+    const val INTRO_PRIMARY_ACTION = "intro.action.primary"
+
+    // Saved trips (home)
+    const val SAVED_TRIPS_SCREEN = "savedtrips.screen"
+    const val SAVED_TRIPS_LIST = "savedtrips.list"
+    const val SAVED_TRIPS_ACTION_SETTINGS = "savedtrips.action.settings"
+    const val SAVED_TRIPS_ACTION_DISCOVER = "savedtrips.action.discover"
+    const val SAVED_TRIPS_ACTION_DONE = "savedtrips.action.done"
+
+    // Search row (the bottom origin/destination bar on the home screen)
+    const val SEARCH_ROW = "searchrow.root"
+    const val SEARCH_ROW_FROM = "searchrow.from"
+    const val SEARCH_ROW_TO = "searchrow.to"
+    const val SEARCH_ROW_SEARCH = "searchrow.search"
+    const val SEARCH_ROW_ASK_KRAIL = "searchrow.askkrail"
+    const val SEARCH_ROW_COLLAPSED_PILL = "searchrow.collapsedpill"
+
+    // Search stop
+    const val SEARCH_STOP_QUERY_FIELD = "searchstop.query"
+    const val SEARCH_STOP_BACK = "searchstop.back"
+    const val SEARCH_STOP_RESULTS_LIST = "searchstop.results"
+    const val SEARCH_STOP_RECENTS_LIST = "searchstop.recents"
+
+    // Timetable
+    const val TIME_TABLE_SCREEN = "timetable.screen"
+    const val TIME_TABLE_DATE_TIME_SELECTOR = "timetable.action.datetime"
+    const val TIME_TABLE_MODE_FILTER = "timetable.action.modefilter"
+    const val TIME_TABLE_REVERSE = "timetable.action.reverse"
+    const val TIME_TABLE_SAVE_TRIP = "timetable.action.savetrip"
+
+    /** The alerts button inside an expanded journey card. */
+    const val JOURNEY_CARD_ALERTS = "journeycard.alerts"
+
+    // Settings
+    const val SETTINGS_SCREEN = "settings.screen"
+    const val SETTINGS_ITEM_THEME = "settings.item.theme"
+    const val SETTINGS_ITEM_INVITE = "settings.item.invite"
+    const val SETTINGS_ITEM_HOW_TO = "settings.item.howto"
+    const val SETTINGS_ITEM_OUR_STORY = "settings.item.ourstory"
+    const val SETTINGS_ITEM_DEBUG_CONFIG = "settings.item.debugconfig"
+
+    /** One saved trip row. Suffixed so a flow can target a known trip or glob the set. */
+    fun savedTripCard(tripId: String): String = "savedtrips.card.$tripId"
+
+    /** One search result row, keyed by the stop it would select. */
+    fun searchStopResult(stopId: String): String = "searchstop.result.$stopId"
+
+    /** One journey result card. */
+    fun timeTableJourneyCard(journeyId: String): String = "timetable.journey.$journeyId"
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/JourneyCard.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
@@ -62,6 +63,7 @@ import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailDimensions
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.pastDepartureTextStyle
 import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
@@ -259,6 +261,7 @@ fun ExpandedJourneyCardContent(
                 AlertButton(
                     dimensions = ButtonDefaults.smallButtonSize(),
                     onClick = onAlertClick,
+                    modifier = Modifier.testTag(TripPlannerTestTags.JOURNEY_CARD_ALERTS),
                 ) {
                     Text(
                         text = if (totalUniqueServiceAlerts > 1) {

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import krail.feature.trip_planner.ui.generated.resources.Res
@@ -65,6 +66,7 @@ import xyz.ksharma.krail.taj.components.ThemeTextFieldPlaceholderText
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.tokens.AiThemeGradientTokens
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputEvent
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
@@ -131,7 +133,7 @@ fun SearchStopRow(
                     ) + fadeOut(animationSpec = tween(250))
             }
         },
-        modifier = modifier,
+        modifier = modifier.testTag(TripPlannerTestTags.SEARCH_ROW),
         contentAlignment = Alignment.BottomCenter,
         label = "SearchStopRowContent",
     ) { expanded ->
@@ -215,10 +217,12 @@ private fun CollapsedPill(
         Button(
             dimensions = ButtonDefaults.mediumButtonSize(),
             onClick = onClick,
-            modifier = Modifier.graphicsLayer {
-                scaleX = scale.value
-                scaleY = scale.value
-            },
+            modifier = Modifier
+                .testTag(TripPlannerTestTags.SEARCH_ROW_COLLAPSED_PILL)
+                .graphicsLayer {
+                    scaleX = scale.value
+                    scaleY = scale.value
+                },
         ) {
             Text(
                 text = "Plan a trip",
@@ -375,15 +379,17 @@ private fun FromToFields(
     ) {
         TextFieldButton(
             onClick = fromButtonClick,
-            modifier = if (isFromHighlighted) {
-                Modifier.border(
-                    width = dim.strokeRegular,
-                    color = KrailTheme.colors.surface.copy(alpha = borderAlpha),
-                    shape = RoundedCornerShape(50),
-                )
-            } else {
-                Modifier
-            },
+            modifier = Modifier.testTag(TripPlannerTestTags.SEARCH_ROW_FROM).then(
+                if (isFromHighlighted) {
+                    Modifier.border(
+                        width = dim.strokeRegular,
+                        color = KrailTheme.colors.surface.copy(alpha = borderAlpha),
+                        shape = RoundedCornerShape(50),
+                    )
+                } else {
+                    Modifier
+                },
+            ),
         ) {
             StopFieldText(
                 text = fromStopItem?.stopName ?: "Starting from",
@@ -401,7 +407,10 @@ private fun FromToFields(
     }
 
     // To field — always visible when expanded
-    TextFieldButton(onClick = toButtonClick) {
+    TextFieldButton(
+        onClick = toButtonClick,
+        modifier = Modifier.testTag(TripPlannerTestTags.SEARCH_ROW_TO),
+    ) {
         StopFieldText(
             text = toStopItem?.stopName ?: "Destination",
             isActive = toStopItem != null,
@@ -464,6 +473,7 @@ private fun AiSheetEntryButton(
             )
         },
         onClick = { onAiEvent(AiSearchInputEvent.OpenInput) },
+        modifier = Modifier.testTag(TripPlannerTestTags.SEARCH_ROW_ASK_KRAIL),
     )
 }
 
@@ -481,6 +491,7 @@ private fun SearchButton(onSearchButtonClick: () -> Unit) {
             )
         },
         onClick = onSearchButtonClick,
+        modifier = Modifier.testTag(TripPlannerTestTags.SEARCH_ROW_SEARCH),
     )
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/intro/IntroScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -53,6 +54,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.modifier.gradientBorder
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState
 import xyz.ksharma.krail.trip.planner.ui.state.intro.IntroState.IntroPageType
@@ -107,6 +109,7 @@ fun IntroScreen(
     val dim = KrailTheme.dimensions
     Box(
         modifier = modifier
+            .testTag(TripPlannerTestTags.INTRO_SCREEN)
             .fillMaxSize()
             .background(color = KrailTheme.colors.surface)
             .statusBarsPadding()
@@ -222,7 +225,9 @@ fun IntroScreen(
                         customContainerColor = animatedButtonColor,
                         customContentColor = Color.White,
                     ),
-                    modifier = Modifier.padding(horizontal = dim.spacingXXXL, vertical = dim.spacingML),
+                    modifier = Modifier
+                        .testTag(TripPlannerTestTags.INTRO_PRIMARY_ACTION)
+                        .padding(horizontal = dim.spacingXXXL, vertical = dim.spacingML),
                 ) {
                     Text(
                         text = state.pages[startPage].ctaText,

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import app.krail.taj.resources.ic_close
@@ -81,6 +82,7 @@ import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeColor
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.ai.AskKrailScreen
 import xyz.ksharma.krail.trip.planner.ui.components.ai.rememberAiGreeting
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputEvent
@@ -159,7 +161,7 @@ fun SavedTripsScreen(
         }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(modifier = modifier.testTag(TripPlannerTestTags.SAVED_TRIPS_SCREEN).fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -208,6 +210,7 @@ fun SavedTripsScreen(
 
                     LazyColumn(
                         state = lazyListState,
+                        modifier = Modifier.testTag(TripPlannerTestTags.SAVED_TRIPS_LIST),
                         contentPadding = PaddingValues(bottom = LAZY_COLUMN_BOTTOM_PADDING.dp),
                     ) {
                         savedTripsListBody(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreenSections.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
 import kotlinx.collections.immutable.ImmutableList
 import krail.feature.trip_planner.ui.generated.resources.Res
 import krail.feature.trip_planner.ui.generated.resources.ic_settings
@@ -40,6 +41,7 @@ import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.CityCodeText
 import xyz.ksharma.krail.trip.planner.ui.components.ParkRideCard
 import xyz.ksharma.krail.trip.planner.ui.components.SavedTripCard
@@ -236,12 +238,14 @@ internal fun LazyItemScope.SavedTripItem(
                     } else {
                         null
                     },
-                    modifier = Modifier.longPressDraggableHandle(
-                        enabled = editing,
-                        onDragStarted = {
-                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        },
-                    ),
+                    modifier = Modifier
+                        .testTag(TripPlannerTestTags.savedTripCard(trip.tripId))
+                        .longPressDraggableHandle(
+                            enabled = editing,
+                            onDragStarted = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                            },
+                        ),
                 )
 
                 if (editing) {
@@ -272,7 +276,9 @@ internal fun SavedTripsTitleBarActions(
             onClick = onDoneClick,
             colors = ButtonDefaults.monochromeButtonColors(),
             dimensions = ButtonDefaults.chipButtonSize(),
-            modifier = Modifier.padding(horizontal = dim.spacingM),
+            modifier = Modifier
+                .testTag(TripPlannerTestTags.SAVED_TRIPS_ACTION_DONE)
+                .padding(horizontal = dim.spacingM),
         ) {
             Text(text = "Done")
         }
@@ -281,6 +287,7 @@ internal fun SavedTripsTitleBarActions(
             RoundIconButton(
                 showBadge = displayDiscoverBadge,
                 onClick = onDiscoverButtonClick,
+                modifier = Modifier.testTag(TripPlannerTestTags.SAVED_TRIPS_ACTION_DISCOVER),
             ) {
                 CityCodeText("SYD")
             }
@@ -288,6 +295,7 @@ internal fun SavedTripsTitleBarActions(
 
         RoundIconButton(
             onClick = onSettingsButtonClick,
+            modifier = Modifier.testTag(TripPlannerTestTags.SAVED_TRIPS_ACTION_SETTINGS),
         ) {
             Image(
                 painter = painterResource(Res.drawable.ic_settings),

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -81,6 +82,7 @@ import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.themeColor
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.AddressSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.AssignNewLabelSheet
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
@@ -670,7 +672,9 @@ private fun SearchStopListContent(
             // the LazyColumn so the loading state doesn't claim a chunk of vertical space.
             Box(modifier = modifier) {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(TripPlannerTestTags.SEARCH_STOP_RECENTS_LIST),
                     contentPadding = PaddingValues(
                         top = KrailTheme.dimensions.spacingNone,
                         bottom = KrailTheme.dimensions.spacingXXXXL,
@@ -748,7 +752,9 @@ private fun SearchStopListContent(
         is ListState.Results -> {
             Box(modifier = modifier) {
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag(TripPlannerTestTags.SEARCH_STOP_RESULTS_LIST),
                     contentPadding = PaddingValues(
                         top = KrailTheme.dimensions.spacingNone,
                         bottom = KrailTheme.dimensions.spacingXXXXL,
@@ -923,7 +929,9 @@ private fun LazyListScope.searchResultsList(
                     },
                     onLabelPillClick = { label -> onLabelPillClick(stopItem, label) },
                     onNewLabelClick = { onNewLabelClick(stopItem, result.transportModeType) },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(TripPlannerTestTags.searchStopResult(result.stopId)),
                 )
                 Divider(
                     modifier = Modifier.padding(horizontal = KrailTheme.dimensions.pageHorizontalPadding),
@@ -1138,7 +1146,9 @@ private fun LazyListScope.recentSearchStopsList(
                     },
                     onLabelPillClick = { label -> onLabelPillClick(stopItem, label) },
                     onNewLabelClick = { onNewLabelClick(stopItem, stop.transportModeType) },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(TripPlannerTestTags.searchStopResult(stop.stopId)),
                 )
             }
         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchTopBar.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
@@ -42,6 +43,7 @@ import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TextField
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.MapToggleButton
 
 /**
@@ -109,7 +111,8 @@ fun SearchTopBar(
             initialText = initialText.ifEmpty { null },
             modifier = Modifier
                 .weight(1f)
-                .focusRequester(focusRequester),
+                .focusRequester(focusRequester)
+                .testTag(TripPlannerTestTags.SEARCH_STOP_QUERY_FIELD),
             maxLength = 30,
             filter = { input ->
                 input.filter { it.isLetterOrDigit() || it.isWhitespace() || it == ',' }
@@ -118,6 +121,7 @@ fun SearchTopBar(
                 NavActionButton(
                     icon = Icons.AutoMirrored.Filled.ArrowBack,
                     iconContentDescription = "Back",
+                    modifier = Modifier.testTag(TripPlannerTestTags.SEARCH_STOP_BACK),
                     onClick = {
                         keyboard?.hide()
                         focusRequester.freeFocus()

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -42,6 +43,7 @@ import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.AppLogo
 
 @Composable
@@ -59,6 +61,7 @@ fun SettingsScreen(
     val dim = KrailTheme.dimensions
     Box(
         modifier = modifier
+            .testTag(TripPlannerTestTags.SETTINGS_SCREEN)
             .fillMaxSize()
             .background(color = KrailTheme.colors.surface),
     ) {
@@ -78,27 +81,29 @@ fun SettingsScreen(
                 modifier = Modifier,
                 contentPadding = PaddingValues(bottom = CONTENT_BOTTOM_PADDING),
             ) {
-                item {
+                item(key = "settings-change-theme") {
                     SettingsItem(
                         icon = painterResource(Res.drawable.ic_paint),
                         text = "Change Theme",
+                        modifier = Modifier.testTag(TripPlannerTestTags.SETTINGS_ITEM_THEME),
                         onClick = {
                             onChangeThemeClick()
                         },
                     )
                 }
 
-                item {
+                item(key = "settings-invite") {
                     SettingsItem(
                         icon = painterResource(Res.drawable.ic_heart),
                         text = "Invite your friends \uD83D\uDC95",
+                        modifier = Modifier.testTag(TripPlannerTestTags.SETTINGS_ITEM_INVITE),
                         onClick = {
                             onReferFriendClick()
                         },
                     )
                 }
 
-                item {
+                item(key = "settings-about-title") {
                     Text(
                         text = "About",
                         style = KrailTheme.typography.title,
@@ -108,18 +113,20 @@ fun SettingsScreen(
                     )
                 }
 
-                item {
+                item(key = "settings-how-to") {
                     SettingsItem(
                         icon = painterResource(Res.drawable.ic_info),
                         text = "How to KRAIL?",
+                        modifier = Modifier.testTag(TripPlannerTestTags.SETTINGS_ITEM_HOW_TO),
                         onClick = onIntroClick,
                     )
                 }
 
-                item {
+                item(key = "settings-our-story") {
                     SettingsItem(
                         icon = painterResource(Res.drawable.ic_pen),
                         text = "Our story",
+                        modifier = Modifier.testTag(TripPlannerTestTags.SETTINGS_ITEM_OUR_STORY),
                         onClick = { onAboutUsClick() },
                     )
                 }
@@ -129,12 +136,14 @@ fun SettingsScreen(
                         SettingsItem(
                             icon = painterResource(Res.drawable.ic_paint),
                             text = "Debug Config",
+                            modifier = Modifier
+                                .testTag(TripPlannerTestTags.SETTINGS_ITEM_DEBUG_CONFIG),
                             onClick = onDebugConfigClick,
                         )
                     }
                 }
 
-                item {
+                item(key = "settings-footer-spacer") {
                     Spacer(modifier = Modifier.fillMaxWidth().height(FOOTER_SPACER_HEIGHT))
                 }
             }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -81,6 +82,7 @@ import xyz.ksharma.krail.taj.preview.PreviewScreen
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.theme.getForegroundColor
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.ActionData
 import xyz.ksharma.krail.trip.planner.ui.components.DepartureBoardStopCard
 import xyz.ksharma.krail.trip.planner.ui.components.ErrorMessage
@@ -140,6 +142,7 @@ fun TimeTableScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
+                .testTag(TripPlannerTestTags.TIME_TABLE_SCREEN)
                 .statusBarsPadding()
                 .windowInsetsPadding(WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)),
             contentPadding = PaddingValues(bottom = dim.spacingXL),
@@ -176,6 +179,7 @@ fun TimeTableScreen(
                         )
                         ActionButton(
                             modifier = Modifier
+                                .testTag(TripPlannerTestTags.TIME_TABLE_REVERSE)
                                 .graphicsLayer {
                                     rotationZ = rotation
                                 },
@@ -197,6 +201,7 @@ fun TimeTableScreen(
                             celebrate = celebrateSaveStar,
                             onCelebrateEnd = { celebrateSaveStar = false },
                             onClick = { onEvent(TimeTableUiEvent.SaveTripButtonClicked) },
+                            modifier = Modifier.testTag(TripPlannerTestTags.TIME_TABLE_SAVE_TRIP),
                         )
                     },
                 )
@@ -266,6 +271,8 @@ fun TimeTableScreen(
                     SubtleButton(
                         onClick = dateTimeSelectorClicked,
                         dimensions = ButtonDefaults.mediumButtonSize(),
+                        modifier = Modifier
+                            .testTag(TripPlannerTestTags.TIME_TABLE_DATE_TIME_SELECTOR),
                     ) {
                         Text(
                             text = dateTimeSelectionItem?.toDateTimeText() ?: "Plan your trip",
@@ -278,6 +285,7 @@ fun TimeTableScreen(
                             onModeClick(displayModeSelectionRow)
                         },
                         dimensions = ButtonDefaults.mediumButtonSize(),
+                        modifier = Modifier.testTag(TripPlannerTestTags.TIME_TABLE_MODE_FILTER),
                     ) {
                         Row(
                             // todo -  handle in Button
@@ -618,7 +626,10 @@ private fun LazyListScope.journeyCardItems(
                     ),
                 )
             },
-            modifier = Modifier.padding(vertical = KrailTheme.dimensions.spacingM).animateItem(),
+            modifier = Modifier
+                .testTag(TripPlannerTestTags.timeTableJourneyCard(journey.journeyId))
+                .padding(vertical = KrailTheme.dimensions.spacingM)
+                .animateItem(),
             departureDeviation = journey.departureDeviation,
             scheduledOriginTime = journey.scheduledOriginTime,
             deepLinkUrl = state.deepLinkUrls[journey.journeyId],


### PR DESCRIPTION
## What

Adds a stable selector layer for end-to-end drivers. Flows had nothing to select on except visible copy, which makes a flow break on a wording change rather than on a regression.

## Changes

- `exposeTestTagsToUiAutomation()` at the app root, as an expect/actual:
  - Android sets `testTagsAsResourceId`, so each `testTag` surfaces as the accessibility node's `resource-id`.
  - iOS is a no-op, because Compose Multiplatform already publishes `testTag` as `accessibilityIdentifier`.
  - One tag therefore serves both platforms with no per-platform selector table.
- Two constants files, `TripPlannerTestTags` and `DebugSettingsTestTags`, hold the 37 tags so a name cannot drift between the screen that declares it and the flow that uses it. Names describe a node's job, never its label.
- Tags rolled out across saved trips, the search row, search stop, timetable, settings and debug config.
- `SettingsScreen`: gives the six unkeyed `item {}` calls explicit keys, which the repo already requires everywhere else.

## Testing

- `Modifier.testTag` is semantics-only, so none of this participates in layout or drawing. `./gradlew :taj:verifyRoborazziAndroidHostTest :feature:trip-planner:ui:verifyRoborazziAndroidHostTest` is green on both golden-owning modules with the tags in place.
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest :feature:debug-settings:ui:testAndroidHostTest :composeApp:testAndroidHostTest --continue` green.
- `./gradlew detekt --continue` green, no autocorrects left uncommitted.

## Snapshots

Screens are touched, but only with semantics-only modifiers and LazyColumn keys, so there is no rendering change. The snapshot verification job added earlier holds that claim: it compares every golden in both modules against a fresh render and passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
