### PR TITLE
test(e2e): add Maestro smoke and nightly flows

### DIFF
--- a/.maestro/README.md
+++ b/.maestro/README.md
@@ -1,0 +1,121 @@
+# End-to-end flows
+
+[Maestro](https://maestro.mobile.dev) flows that drive the real app on a real device or
+simulator. They cover the things unit tests and detekt structurally cannot: whether the app
+launches, whether a rider can actually plan a trip, and whether a screen survives having its
+Activity destroyed underneath it.
+
+Verified against **Maestro 2.8.0**. `setOrientation` needs 2.x; on 1.x the rotation sweep will
+not parse.
+
+```sh
+curl -fsSL "https://get.maestro.mobile.dev" | bash
+export PATH="$PATH:$HOME/.maestro/bin"
+maestro --version   # expect 2.x
+```
+
+## Two lanes
+
+| Lane | Runs | Contents |
+|---|---|---|
+| `smoke/` | Every PR | Launch, plan a trip, rotation sweep. Fast enough to gate a merge. |
+| `nightly/` | Nightly cron, `prod/**`, manual dispatch | Process lifecycle and permission-denial cases. Slower, and not worth blocking a PR on. |
+
+`shared/` holds helper flows called via `runFlow`. It is deliberately outside both lanes so a
+directory run never picks it up as a test.
+
+## Running locally
+
+The app id is a parameter, so one set of flows serves both platforms. It **must** be passed
+with `-e`; a shell variable alone will not reach the flow, and an in-file `env:` default would
+silently win over `-e` and make the parameter unoverridable.
+
+```sh
+# Android (note the .debug suffix on the debug build)
+./gradlew :androidApp:installDebug
+maestro test -e APP_ID=xyz.ksharma.krail.debug .maestro/smoke/
+
+# iOS simulator
+maestro test -e APP_ID=xyz.ksharma.krail .maestro/smoke/
+
+# One flow, on a chosen device
+maestro --device emulator-5554 test -e APP_ID=xyz.ksharma.krail.debug .maestro/smoke/02-plan-trip.yaml
+```
+
+| Target | `APP_ID` |
+|---|---|
+| Android debug | `xyz.ksharma.krail.debug` |
+| Android release | `xyz.ksharma.krail` |
+| iOS | `xyz.ksharma.krail` |
+
+## What each flow pins
+
+| Flow | Pins |
+|---|---|
+| `smoke/01-launch-home.yaml` | Cold launch reaches home, the saved-trips list and the search row render, the title bar has its actions. |
+| `smoke/02-plan-trip.yaml` | The core journey: pick an origin, pick a destination, get real journey results back from the API. |
+| `smoke/03-rotation-sweep.yaml` | Home, search stop and the timetable each survive rotation, including with results and journey data loaded. |
+| `nightly/04-background-foreground.yaml` | Backgrounding and returning lands the rider on the screen they left, not on home. |
+| `nightly/05-kill-relaunch.yaml` | After a force-stop the app recovers to home and navigation still works. |
+| `nightly/06-permissions-denied.yaml` | With location denied the app still runs and a trip can still be planned by typing. |
+| `shared/dismiss-intro.yaml` | Not a test. Walks the first-run carousel so a clean device can reach the app. |
+
+## Selectors
+
+Flows select on `testTag` ids, never on visible copy, so a wording change cannot break a flow
+and a flow failure always means behaviour changed. The tags are declared in
+`TripPlannerTestTags` and `DebugSettingsTestTags` and are **public API** to this directory:
+grep here before renaming one.
+
+On Android the tags reach the accessibility tree as `resource-id` because the app root opts in
+via `exposeTestTagsToUiAutomation()`. On iOS, Compose Multiplatform publishes them as
+`accessibilityIdentifier` already. Same tag, same `id:` selector, both platforms.
+
+Per-item tags carry their domain id (`timetable.journey.<journeyId>`), so a flow matches the
+set with a regex and picks by index:
+
+```yaml
+- tapOn:
+    id: "searchstop.result..*"
+    index: 0
+```
+
+## Conventions worth keeping
+
+These are all fixes for failures this suite actually hit, not style preferences.
+
+- **Wait, do not assert, after anything asynchronous.** Rotation, navigation and network all
+  have a window where a node is legitimately missing. `extendedWaitUntil` passes on a warm
+  device *and* a cold one; `assertVisible` in the same spot is green locally and red on CI's
+  first run.
+- **Scroll to list items rather than asserting them in place.** Maestro only matches what is on
+  screen. A "Save this trip?" prompt above the results pushes every journey card below the fold
+  on a short viewport, so an in-place assert measures device height, not behaviour.
+- **Restore device state in `onFlowComplete`.** A flow that fails mid-rotation leaves the device
+  in landscape, where the search row collapses to a single pill, and every later flow in the run
+  fails looking for fields that are not on screen. One failure becomes three.
+- **Guard the intro dismissal, do not inline it.** Only a clean device sees the carousel, so
+  `runFlow` is conditioned on `intro.screen` and costs nothing everywhere else.
+
+## Permission prep
+
+`06-permissions-denied.yaml` sets the permission itself via `launchApp: permissions:`. It
+deliberately does **not** use `clearState: true`, which would also wipe the "intro seen" flag
+and spend the flow walking the carousel instead of testing a denial.
+
+If a device already granted location and you want to be certain the denial is real:
+
+```sh
+adb shell pm revoke xyz.ksharma.krail.debug android.permission.ACCESS_FINE_LOCATION
+adb shell pm revoke xyz.ksharma.krail.debug android.permission.ACCESS_COARSE_LOCATION
+```
+
+## Debugging a failure
+
+Maestro writes the hierarchy, logs and screenshots for every run to `~/.maestro/tests/<timestamp>/`.
+CI uploads that directory as an artifact when a job fails. To see what the driver sees on a live
+device:
+
+```sh
+maestro --device emulator-5554 hierarchy | grep '"resource-id"' | sort -u
+```

--- a/.maestro/nightly/04-background-foreground.yaml
+++ b/.maestro/nightly/04-background-foreground.yaml
@@ -1,0 +1,49 @@
+# Backgrounding is not a relaunch. Coming back must land the rider exactly where
+# they left, not on home.
+#
+# Settings is used as the marker screen because it is one tap from home, is not
+# the start destination, and has a tag of its own, so "we came back to the right
+# place" is a single unambiguous assertion.
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: false
+    stopApp: true
+
+
+# A clean device (every CI emulator) starts on the first-run carousel. Guarded,
+# so this is skipped entirely on a device that has already been through it.
+- runFlow:
+    when:
+      visible:
+        id: "intro.screen"
+    file: ../shared/dismiss-intro.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 30000
+
+- tapOn:
+    id: "savedtrips.action.settings"
+- extendedWaitUntil:
+    visible:
+      id: "settings.screen"
+    timeout: 15000
+
+- pressKey: Home
+- assertNotVisible:
+    id: "settings.screen"
+
+# stopApp:false is the whole test. With stopApp:true this would be flow 05.
+- launchApp:
+    stopApp: false
+
+- extendedWaitUntil:
+    visible:
+      id: "settings.screen"
+    timeout: 20000
+
+# And the screen has to be usable, not just present.
+- assertVisible:
+    id: "settings.item.theme"

--- a/.maestro/nightly/05-kill-relaunch.yaml
+++ b/.maestro/nightly/05-kill-relaunch.yaml
@@ -1,0 +1,59 @@
+# Process death, the hard kind. `killApp` force-stops, which discards the task,
+# so the app must come back on home and be usable rather than crash on a
+# half-restored back stack.
+#
+# The opposite expectation to flow 04, and that contrast is deliberate: 04 pins
+# "resume where you were", this pins "recover cleanly when there is nothing to
+# resume".
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: false
+    stopApp: true
+
+
+# A clean device (every CI emulator) starts on the first-run carousel. Guarded,
+# so this is skipped entirely on a device that has already been through it.
+- runFlow:
+    when:
+      visible:
+        id: "intro.screen"
+    file: ../shared/dismiss-intro.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 30000
+
+# Get off the start destination first, so landing on home afterwards is a real
+# result and not just where we already were.
+- tapOn:
+    id: "savedtrips.action.settings"
+- extendedWaitUntil:
+    visible:
+      id: "settings.screen"
+    timeout: 15000
+
+- killApp
+
+- launchApp:
+    clearState: false
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 30000
+
+- assertNotVisible:
+    id: "settings.screen"
+
+# Recovered, and still works: navigation out of home has to function after the
+# restart, not just render.
+- assertVisible:
+    id: "searchrow.root"
+- tapOn:
+    id: "searchrow.to"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 15000

--- a/.maestro/nightly/06-permissions-denied.yaml
+++ b/.maestro/nightly/06-permissions-denied.yaml
@@ -1,0 +1,65 @@
+# Location denied is a supported state, not an error state. The app uses GPS to
+# offer a nearby origin; without it every other path must still work.
+#
+# `clearState: true` would be the obvious way to guarantee a clean permission
+# state, and it is wrong here: it also wipes the "intro seen" flag, so the flow
+# would spend its time walking the first-run carousel instead of testing a
+# denial. Maestro's `permissions:` map revokes without touching app data, which
+# is what this needs.
+#
+# On a device where location was previously granted, revoke it out of band
+# before the run so the denial is real rather than assumed:
+#
+#   adb shell pm revoke xyz.ksharma.krail.debug android.permission.ACCESS_FINE_LOCATION
+#   adb shell pm revoke xyz.ksharma.krail.debug android.permission.ACCESS_COARSE_LOCATION
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: false
+    stopApp: true
+    permissions:
+      location: deny
+
+- runFlow:
+    when:
+      visible:
+        id: "intro.screen"
+    file: ../shared/dismiss-intro.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 45000
+
+# Home renders and the primary action is reachable with no location fix.
+- assertVisible:
+    id: "searchrow.root"
+- assertVisible:
+    id: "searchrow.to"
+
+# Planning a trip by typing must not depend on GPS at all.
+- tapOn:
+    id: "searchrow.to"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 20000
+- tapOn:
+    id: "searchstop.query"
+- inputText: "Central"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.result..*"
+    timeout: 30000
+- tapOn:
+    id: "searchstop.result..*"
+    index: 0
+
+# Back on home, still alive. If the denial had crashed a background coroutine
+# this assertion is where it surfaces.
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.root"
+    timeout: 20000
+- assertVisible:
+    id: "savedtrips.screen"

--- a/.maestro/shared/dismiss-intro.yaml
+++ b/.maestro/shared/dismiss-intro.yaml
@@ -1,0 +1,33 @@
+# Gets past the first-run intro carousel.
+#
+# Every clean device lands here, so a CI emulator hits this on the first flow of
+# a run and never again. Callers guard the `runFlow` on `intro.screen` being
+# visible, so on a device that has already been through it this file never
+# executes and costs nothing.
+#
+# The carousel is driven by a single button whose label changes per page
+# ("Next", then "Let's KRAIL" on the last one). `intro.action.primary` is the
+# same node throughout, so looping on the tag walks the whole thing without this
+# flow knowing how many pages there are or what any of them say. Adding a page
+# does not require touching this file.
+#
+# `times` is a safety net, not the exit condition: `while` is what ends the
+# loop. Without the cap a button that stops responding would hang the run
+# instead of failing it.
+#
+# Not a test. It has no assertions, and a directory run does not pick it up
+# because `.maestro/shared/` sits outside both `smoke/` and `nightly/`.
+appId: ${APP_ID}
+---
+- repeat:
+    times: 12
+    while:
+      visible:
+        id: "intro.action.primary"
+    commands:
+      - tapOn:
+          id: "intro.action.primary"
+      # The pager animates between pages. Tapping through that animation lands
+      # the second tap on the page that is still sliding in.
+      - waitForAnimationToEnd:
+          timeout: 5000

--- a/.maestro/smoke/01-launch-home.yaml
+++ b/.maestro/smoke/01-launch-home.yaml
@@ -1,0 +1,52 @@
+# Cold launch. Pins that the app starts, the home screen composes, and the two
+# controls every other flow depends on are present.
+#
+# Deliberately asserts the saved-trips *list container*, never its contents: a
+# fresh install has no saved trips, and a flow that needs seeded data is not a
+# smoke test.
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: false
+    stopApp: true
+
+
+# A clean device (every CI emulator) starts on the first-run carousel. Guarded,
+# so this is skipped entirely on a device that has already been through it.
+- runFlow:
+    when:
+      visible:
+        id: "intro.screen"
+    file: ../shared/dismiss-intro.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 30000
+
+- assertVisible:
+    id: "savedtrips.list"
+
+# The bottom search row is the app's primary action. If it is missing, the home
+# screen rendered but is useless.
+#
+# The row's own root appears with the screen, but its fields animate in and are
+# briefly replaced by a collapsed "Plan a trip" pill, so they are waited for
+# rather than asserted. Asserting them in place passes on a warm device and
+# fails on a cold one, which is the worst kind of flake: green locally, red in
+# CI, and only on the first run.
+- assertVisible:
+    id: "searchrow.root"
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.to"
+    timeout: 20000
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.search"
+    timeout: 20000
+
+# Settings is the only always-present title-bar action (Discover is flagged off
+# by default), so it stands in for "the title bar rendered".
+- assertVisible:
+    id: "savedtrips.action.settings"

--- a/.maestro/smoke/02-plan-trip.yaml
+++ b/.maestro/smoke/02-plan-trip.yaml
@@ -1,0 +1,109 @@
+# The core journey: pick an origin, pick a destination, get a timetable.
+#
+# Every selector is a testTag, and results are chosen by index rather than by
+# name, so the flow does not break when NSW renames a stop or reorders results.
+# The stop names typed in are inputs, not assertions.
+appId: ${APP_ID}
+---
+- launchApp:
+    clearState: false
+    stopApp: true
+
+
+# A clean device (every CI emulator) starts on the first-run carousel. Guarded,
+# so this is skipped entirely on a device that has already been through it.
+- runFlow:
+    when:
+      visible:
+        id: "intro.screen"
+    file: ../shared/dismiss-intro.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 30000
+
+# --- Origin ---
+- tapOn:
+    id: "searchrow.from"
+
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 15000
+
+- tapOn:
+    id: "searchstop.query"
+- inputText: "Central"
+
+# Search is a network call, so give it real time rather than a fixed sleep.
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.result..*"
+    timeout: 30000
+
+- tapOn:
+    id: "searchstop.result..*"
+    index: 0
+
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.root"
+    timeout: 15000
+
+# --- Destination ---
+- tapOn:
+    id: "searchrow.to"
+
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 15000
+
+- tapOn:
+    id: "searchstop.query"
+- inputText: "Town Hall"
+
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.result..*"
+    timeout: 30000
+
+- tapOn:
+    id: "searchstop.result..*"
+    index: 0
+
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.root"
+    timeout: 15000
+
+# --- Timetable ---
+- tapOn:
+    id: "searchrow.search"
+
+- extendedWaitUntil:
+    visible:
+      id: "timetable.screen"
+    timeout: 30000
+
+# Controls on the timetable that other flows and riders depend on. Asserted
+# before the scroll below, while the top of the list is still on screen.
+- assertVisible:
+    id: "timetable.action.datetime"
+- assertVisible:
+    id: "timetable.action.reverse"
+
+# The screen scaffold renders while the request is still in flight, so the
+# journey cards are checked separately. This is what actually proves a trip was
+# planned.
+#
+# Scrolled to rather than asserted in place: a "Save this trip?" prompt sits
+# above the results, and on a short viewport it pushes every card below the
+# fold. Maestro only matches what is on screen, so asserting in place would make
+# this flow's result depend on device height.
+- scrollUntilVisible:
+    element:
+      id: "timetable.journey..*"
+    direction: DOWN
+    timeout: 45000

--- a/.maestro/smoke/03-rotation-sweep.yaml
+++ b/.maestro/smoke/03-rotation-sweep.yaml
@@ -1,0 +1,159 @@
+# Rotation destroys and recreates the Activity. This repo treats a screen that
+# dies on rotation as a broken screen, and neither detekt nor unit tests can see
+# that class of bug: a missing NavKey serializer, or state held in `remember`
+# instead of `rememberSaveable`, compiles perfectly and crashes only here.
+#
+# Each of the three main screens is rotated to landscape, re-asserted, and
+# rotated back. The re-assertion after each rotation is the whole point: the
+# screen must still be *there*, not merely have survived the rotate call.
+#
+# Every post-rotation check is an `extendedWaitUntil`, never a bare
+# `assertVisible`. Recreation re-runs the composition and can re-issue a
+# request, so a node is legitimately absent for a moment; asserting instantly
+# tests the timing of the rotate call rather than whether the screen came back.
+#
+# `onFlowComplete` restores portrait even when the flow fails. Without it a
+# failure here leaves the device in landscape, where the search row collapses to
+# a single pill, and every later flow in the run fails looking for fields that
+# are not on screen. That is exactly how this file was first written, and the
+# two cascading failures it caused are the reason for the hook.
+appId: ${APP_ID}
+onFlowComplete:
+  - setOrientation: PORTRAIT
+---
+- launchApp:
+    clearState: false
+    stopApp: true
+
+- runFlow:
+    when:
+      visible:
+        id: "intro.screen"
+    file: ../shared/dismiss-intro.yaml
+
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 30000
+
+# --- Home ---
+- setOrientation: LANDSCAPE_LEFT
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 20000
+# In landscape the search row collapses to a pill, so assert the row's root,
+# which is present in both layouts, rather than the portrait-only fields.
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.root"
+    timeout: 20000
+
+- setOrientation: PORTRAIT
+- extendedWaitUntil:
+    visible:
+      id: "savedtrips.screen"
+    timeout: 20000
+
+# --- Search stop ---
+- tapOn:
+    id: "searchrow.from"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 15000
+- tapOn:
+    id: "searchstop.query"
+- inputText: "Central"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.result..*"
+    timeout: 30000
+
+# Rotating with results on screen exercises a different path than rotating an
+# empty list: the results have to survive recreation too.
+- setOrientation: LANDSCAPE_LEFT
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 20000
+
+- setOrientation: PORTRAIT
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 20000
+
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.result..*"
+    timeout: 30000
+- tapOn:
+    id: "searchstop.result..*"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.root"
+    timeout: 15000
+
+# --- Timetable ---
+- tapOn:
+    id: "searchrow.to"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.query"
+    timeout: 15000
+- tapOn:
+    id: "searchstop.query"
+- inputText: "Town Hall"
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.result..*"
+    timeout: 30000
+- tapOn:
+    id: "searchstop.result..*"
+    index: 0
+- extendedWaitUntil:
+    visible:
+      id: "searchrow.root"
+    timeout: 15000
+
+- tapOn:
+    id: "searchrow.search"
+- extendedWaitUntil:
+    visible:
+      id: "timetable.journey..*"
+    timeout: 45000
+
+# Rotating with journey data loaded is the case that has historically broken:
+# the list, its expanded state and the polling all have to come back. Landscape
+# also switches this screen to a dual-pane layout, so this is a layout change as
+# well as a recreation.
+#
+# The journey cards are reached with `scrollUntilVisible` rather than asserted
+# in place. Landscape is short enough that the title bar, the origin/destination
+# header, the actions row and the "Save this trip?" prompt fill the viewport on
+# their own, pushing every card below the fold — and Maestro only matches what
+# is actually on screen. Asserting in place here does not test whether the list
+# survived rotation, it tests how tall the device is.
+- setOrientation: LANDSCAPE_LEFT
+- extendedWaitUntil:
+    visible:
+      id: "timetable.screen"
+    timeout: 20000
+- scrollUntilVisible:
+    element:
+      id: "timetable.journey..*"
+    direction: DOWN
+    timeout: 45000
+
+- setOrientation: PORTRAIT
+- extendedWaitUntil:
+    visible:
+      id: "timetable.screen"
+    timeout: 20000
+- scrollUntilVisible:
+    element:
+      id: "timetable.journey..*"
+    direction: DOWN
+    timeout: 45000


### PR DESCRIPTION
## What

Adds a checked-in Maestro flow suite: six flows split into two lanes, plus a shared step and a README.

`smoke/` is fast enough to gate a pull request; `nightly/` covers process lifecycle and permission denial, where a slow run is fine.

## Changes

- `.maestro/smoke/`: cold launch, the full plan-a-trip journey against the real API, and a rotation sweep across home, search stop and the timetable. Rotation is the one worth having, because it destroys and recreates the Activity, which is this repo's top crash class and is invisible to detekt and unit tests.
- `.maestro/nightly/`: the longer flows, including permissions-denied.
- `.maestro/shared/dismiss-intro.yaml`: the first-run carousel dismissal, kept outside both lanes so a directory run never treats it as a test.
- `.maestro/README.md`: the conventions below, written at each one.
- Selectors are `testTag` ids throughout, so a wording change cannot break a flow and a failure always means behaviour changed. The app id is a parameter passed with `-e`, so one set of flows serves Android debug, Android release and iOS.

## Four conventions, each a fix for a failure this suite hit while being written

- **Wait rather than assert after anything async.** The search row animates in, so asserting it in place passes warm and fails cold: green locally, red on CI's first run only.
- **Scroll to list items instead of asserting in place.** Maestro matches only what is on screen, and the "Save this trip?" prompt pushes journey cards below the fold on a short viewport, so an in-place assert measures device height rather than behaviour.
- **Restore orientation in `onFlowComplete`.** A rotation flow that fails leaves the device in landscape, where the search row collapses to a pill, so one failure cascaded into three.
- **Guard the carousel dismissal on `intro.screen`.** Otherwise it fails on every run after the first.

## Testing

- All six flows verified against an Android emulator and an iOS simulator.
- No production source touched, so unit tests and snapshot verification are unaffected; both lanes still run on this PR.
- `./gradlew detekt --continue` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
