### PR TITLE
ci(ios): run the shared tests on the iOS simulator

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,6 +47,7 @@ jobs:
         run: >-
           ./gradlew
           verifyTestWiring verifyTestingModuleUsage verifyNoAdHocBoundaryFakes
+          verifyIosTestClassification
           --continue -PciQuality=true
 
       # -PciQuality=true tells core/network/build.gradle.kts to skip the

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -1,0 +1,105 @@
+name: iOS Unit Tests
+
+# Runs the shared `commonTest` suites on the iOS simulator via Kotlin/Native
+# (`iosSimulatorArm64Test`). code-quality.yml already runs the same sources on the JVM host
+# through `testAndroidHostTest`; this lane is what catches the differences between the two
+# runtimes — freezing, memory model, `Char`/date/number formatting, `kotlin.time` behaviour.
+#
+# Only the modules in `IOS_TEST_MODULES` (build-logic → IosUnitTests.kt) participate. The
+# `verifyIosTestClassification` task that `iosUnitTest` depends on fails the build if a module
+# grows shared tests without being classified, so this lane cannot silently shrink.
+# See TESTING.md → "Running the shared tests on iOS".
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, prod/* ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+    paths:
+      - '**/src/commonMain/**'
+      - '**/src/commonTest/**'
+      - '**/src/iosMain/**'
+      - '**/src/iosTest/**'
+      - '**/build.gradle.kts'
+      - 'gradle/build-logic/**'
+      - 'gradle/libs.versions.toml'
+      - 'gradle.properties'
+      - '.github/workflows/ios-unit-tests.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ios-unit-tests:
+    # Same reasoning as build-ios.yml: Dependabot pull requests cannot read `secrets.*`, so
+    # Gradle configuration fails on the missing NSW transport API key.
+    if: github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: macos-latest
+    environment: Firebase
+    # Measured locally: ~31s for the 5-module lane with a warm build cache, and ~6m40s for a
+    # whole-repo iosSimulatorArm64Test sweep with the Kotlin/Native toolchain already on disk.
+    # A cold CI run adds the ~1GB konan download and full Kotlin/Native compilation of every
+    # dependency, so 45min is generous head-room while still capping a hung simulator well
+    # short of the 6h default.
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      # Requires Xcode 26+ for the iOS 26 SDK, matching build-ios.yml.
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '~26'
+
+      - name: Setup environment variables
+        run: |
+          echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-disabled: false
+
+      # The Kotlin/Native compiler and its platform libs are a ~1GB download that is stable
+      # across runs — caching it separately from the Gradle caches keeps a cold run bearable.
+      - name: Cache Kotlin/Native toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: konan-${{ runner.os }}-
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      # -PciQuality=true tells core/network/build.gradle.kts to use placeholder API keys —
+      # none of these tests hit the network.
+      - name: Run iOS unit tests
+        id: tests
+        env:
+          CI: true
+          GITHUB_ACTIONS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew iosUnitTest --continue -PciQuality=true
+
+      - name: Upload iOS test reports
+        if: always() && steps.tests.conclusion != 'skipped'
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-test-reports-${{ github.run_id }}
+          path: |
+            **/build/reports/tests/iosSimulatorArm64Test/**
+            **/build/test-results/iosSimulatorArm64Test/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/TESTING.md
+++ b/TESTING.md
@@ -260,6 +260,26 @@ wall, so renaming alone would not get them running.
 **Robolectric, Roborazzi and Compose UI tests** stay host-only by construction — they live in
 `androidHostTest`, which the iOS compilation never sees.
 
+### Shared Compose UI tests (`runComposeUiTest`) — parked, not rejected
+
+Spiked in `:taj` with `compose.uiTest` and an `@OptIn(ExperimentalTestApi)` test driving a real
+`Button` through `setContent` / `onNodeWithText` / `performClick`. Findings:
+
+- On **iOS it works**. The test ran green under `iosSimulatorArm64Test` with no extra setup.
+- In **`commonTest` it cannot stay**, because the same source also expands into
+  `androidHostTest`, and Android's `runComposeUiTest` needs a Robolectric runner and
+  `@Config`, which `commonTest` has no way to express. The Android run dies with
+  `NullPointerException: … "android.os.Build.FINGERPRINT" is null` from
+  `RobolectricIdlingStrategy`.
+- Moving it to **`iosTest` works on both** (iOS runs it, the host ignores it) — but then it is
+  an iOS-only test, not a shared one.
+
+**Parked.** An `iosTest`-only Compose test duplicates coverage `:taj` already has via
+Robolectric and Roborazzi, and the modules where a shared UI test would genuinely pay off
+(`:feature:trip-planner:ui`, `:feature:departures:ui`) are all behind the Firebase link wall,
+so they could not run it anyway. Worth revisiting the day that wall comes down — the API
+itself is not the obstacle.
+
 ---
 
 ## Snapshot testing

--- a/TESTING.md
+++ b/TESTING.md
@@ -195,6 +195,73 @@ before pushing.
 
 ---
 
+## Running the shared tests on iOS
+
+`commonTest` has always *compiled* for iOS. Until the `iosUnitTest` lane it never **ran**
+there, so every Kotlin/Native behaviour difference — freezing, date and number formatting,
+`kotlin.time`, `Char` handling — was invisible.
+
+```
+./gradlew iosUnitTest          # macOS + Xcode only
+```
+
+That aggregate runs `iosSimulatorArm64Test` for each module in the lane and first runs
+`verifyIosTestClassification`, which fails if a module has shared test sources but is in
+neither the include nor the exclude list. Both lists, and the reason for every exclusion,
+live in one place:
+[`gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt`](gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt).
+`verifyIosTestClassification` also runs on the cheap Ubuntu runner in `code-quality.yml`, so
+drift is caught on every PR rather than only on the macOS lane.
+
+CI: [`.github/workflows/ios-unit-tests.yml`](.github/workflows/ios-unit-tests.yml) on
+`macos-latest`, for pushes to `main` and PRs touching shared sources or build config.
+
+### What runs on iOS
+
+| Module | Tests |
+|---|---|
+| `:core:date-time` | 27 |
+| `:core:deeplink` | 18 |
+| `:core:transport` | 15 |
+| `:taj` | 8 |
+| `:feature:debug-settings:store` | 6 |
+
+### What is host-only, and why
+
+**Firebase iOS frameworks — 19 of the 24 modules with shared tests.** `:core:analytics` and
+`:core:remote-config` depend on the GitLive Firebase Kotlin SDK, whose iOS klibs declare
+`-framework FirebaseCore`. Those frameworks are supplied by the Xcode project's SPM
+integration, so when Gradle links a standalone `.kexe` test binary the linker cannot find
+them:
+
+```
+ld: framework 'FirebaseCore' not found
+> Task :core:analytics:linkDebugTestIosSimulatorArm64 FAILED
+```
+
+`:core:testing` depends on both, so **every module that consumes the shared fakes inherits
+the wall** — that is what keeps the lane small, not anything wrong with the tests. Widening
+it means giving Gradle its own copy of the Firebase iOS frameworks (the repo already drives
+SPM from Gradle for MapLibre, via `krail.maplibre`), or splitting the Firebase-backed
+implementations out from the interfaces the fakes need. Both are real work, neither is a
+test-code change.
+
+**Backtick test names containing `,`.** Kotlin/Native rejects them where the JVM accepts
+them:
+
+```
+e: ThemeContrastTest.kt:35:9 Name contains illegal characters: ",".
+```
+
+Cheap to fix — rename the test. `:taj` joined the lane this way. `:feature:track:network`
+and `:feature:trip-planner:ui` still carry such names, but both also sit behind the Firebase
+wall, so renaming alone would not get them running.
+
+**Robolectric, Roborazzi and Compose UI tests** stay host-only by construction — they live in
+`androidHostTest`, which the iOS compilation never sees.
+
+---
+
 ## Snapshot testing
 
 The annotation-driven generation flow is preserved: any `@PreviewComponent` /

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt
@@ -1,0 +1,192 @@
+package xyz.ksharma.krail.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * The iOS unit-test execution lane.
+ *
+ * `commonTest` has always *compiled* for iOS; until this plugin nothing ever *ran* it. The
+ * Kotlin/Native test task is `iosSimulatorArm64Test`, and running it repo-wide fails, so the
+ * lane is an explicit allowlist ([IOS_TEST_MODULES]) rather than a wildcard.
+ *
+ * Two things stop the other modules, and neither is a property of the test code:
+ *
+ *  1. **Firebase iOS frameworks.** `:core:analytics` and `:core:remote-config` pull the
+ *     GitLive Firebase Kotlin SDK, whose iOS klibs carry `-framework FirebaseCore` linker
+ *     options. Those frameworks are supplied by the Xcode project's SPM integration, so a
+ *     Gradle-linked `.kexe` test binary cannot find them and `linkDebugTestIosSimulatorArm64`
+ *     dies with `ld: framework 'FirebaseCore' not found`. `:core:testing` depends on both, so
+ *     every module that consumes the shared fakes inherits the wall.
+ *
+ *  2. **Backtick test names containing `,`.** Kotlin/Native rejects them outright
+ *     (`Name contains illegal characters: ","`) where the JVM accepts them. This one is
+ *     cheap to fix per module — rename the test — and is called out separately below so it
+ *     is not mistaken for the structural blocker.
+ *
+ * The allowlist is deliberately verified rather than trusted: [VerifyIosTestClassificationTask]
+ * fails when a module grows shared test sources without being placed in either list, so a new
+ * module cannot quietly opt out of the lane.
+ *
+ * Registration happens on the *root* project, driven from [KotlinMultiplatformConventionPlugin]
+ * rather than from a root plugin of its own: applying any build-logic plugin to the root puts
+ * build-logic on the root classpath with an unknown version, after which every subproject's
+ * `alias(libs.plugins.krail.*)` request (catalog version `unspecified`) fails to resolve.
+ */
+fun Project.configureIosUnitTestLane() {
+    rootProject.registerIosUnitTestLane()
+}
+
+private const val IOS_TEST_TASK = "iosSimulatorArm64Test"
+private const val IOS_LANE_TASK = "iosUnitTest"
+
+/** Shared-test source roots that make a module a candidate for the iOS lane. */
+private val SHARED_TEST_SOURCE_DIRS = listOf("commonTest", "iosTest")
+
+/**
+ * Modules whose shared tests run on the iOS simulator. CI runs exactly these, and they are
+ * expected to stay green — a failure here is a real Kotlin/Native behaviour difference.
+ */
+val IOS_TEST_MODULES: List<String> = listOf(
+    ":core:date-time",
+    ":core:deeplink",
+    ":core:transport",
+    ":feature:debug-settings:store",
+    ":taj",
+)
+
+private const val FIREBASE_WALL =
+    "links the GitLive Firebase Kotlin SDK (directly or via :core:testing); its iOS klibs " +
+        "declare -framework FirebaseCore, which only the Xcode/SPM build supplies, so the " +
+        "Kotlin/Native test binary cannot be linked."
+
+private const val FIREBASE_WALL_AND_TEST_NAMES =
+    "$FIREBASE_WALL Its shared tests additionally use ',' inside backtick names, which " +
+        "Kotlin/Native rejects — both have to go before this module can join the lane."
+
+/**
+ * Every other module with shared test sources, and why it is host-only. Entries leave this
+ * map by being fixed and added to [IOS_TEST_MODULES], never by being deleted.
+ */
+val IOS_TEST_EXCLUSIONS: Map<String, String> = mapOf(
+    ":composeApp" to FIREBASE_WALL,
+    ":core:analytics" to FIREBASE_WALL,
+    ":core:app-version" to FIREBASE_WALL,
+    ":core:festival" to FIREBASE_WALL,
+    ":core:network" to FIREBASE_WALL,
+    ":core:remote-config" to FIREBASE_WALL,
+    ":core:testing" to FIREBASE_WALL,
+    ":discover:network:real" to FIREBASE_WALL,
+    ":feature:debug-settings:ui" to FIREBASE_WALL,
+    ":feature:departures:network" to FIREBASE_WALL,
+    ":feature:departures:ui" to FIREBASE_WALL,
+    ":feature:park-ride:network" to FIREBASE_WALL,
+    ":feature:track:network" to FIREBASE_WALL_AND_TEST_NAMES,
+    ":feature:track:state" to FIREBASE_WALL,
+    ":feature:track:ui" to FIREBASE_WALL,
+    ":feature:trip-planner:network" to FIREBASE_WALL,
+    ":feature:trip-planner:ui" to FIREBASE_WALL_AND_TEST_NAMES,
+    ":info-tile:network:api" to FIREBASE_WALL,
+    ":info-tile:network:real" to FIREBASE_WALL,
+)
+
+private fun Project.registerIosUnitTestLane() {
+    // Every KMP module calls in; the root only needs the tasks once.
+    if (tasks.findByName(IOS_LANE_TASK) != null) return
+
+    val classified = IOS_TEST_MODULES.toSet() + IOS_TEST_EXCLUSIONS.keys
+    val withSharedTests = subprojects
+        .filter { it.hasSharedTestSources() }
+        .map { it.path }
+        .sorted()
+
+    val verify = tasks.register(
+        VerifyIosTestClassificationTask.NAME,
+        VerifyIosTestClassificationTask::class.java,
+    ) {
+        group = "verification"
+        description = "Fails if a module has shared test sources but no iOS lane classification."
+        modulesWithSharedTests.set(withSharedTests)
+        classifiedModules.set(classified.sorted())
+    }
+
+    tasks.register(IOS_LANE_TASK) {
+        group = "verification"
+        description = "Runs $IOS_TEST_TASK for every module in the iOS lane (macOS only)."
+        dependsOn(verify)
+        if (isMacOs()) {
+            dependsOn(IOS_TEST_MODULES.map { "$it:$IOS_TEST_TASK" })
+        } else {
+            doFirst {
+                throw IllegalStateException(
+                    "iosUnitTest needs macOS with Xcode — Kotlin/Native cannot link or boot " +
+                        "an iOS simulator binary on this host. Run testAndroidHostTest instead.",
+                )
+            }
+        }
+    }
+}
+
+private fun isMacOs(): Boolean = System.getProperty("os.name").orEmpty().startsWith("Mac")
+
+private fun Project.hasSharedTestSources(): Boolean = SHARED_TEST_SOURCE_DIRS.any { dir ->
+    File(projectDir, "src/$dir").hasKotlinSourcesIn()
+}
+
+private fun File.hasKotlinSourcesIn(): Boolean =
+    isDirectory && walkTopDown().any { it.isFile && it.extension == "kt" }
+
+/**
+ * Keeps [IOS_TEST_MODULES] + [IOS_TEST_EXCLUSIONS] honest. A new module with `commonTest`
+ * sources is neither silently run on iOS nor silently skipped — the contributor has to state
+ * which it is, and record why if it is skipped.
+ */
+abstract class VerifyIosTestClassificationTask : DefaultTask() {
+
+    @get:Input
+    abstract val modulesWithSharedTests: ListProperty<String>
+
+    @get:Input
+    abstract val classifiedModules: ListProperty<String>
+
+    @TaskAction
+    fun verify() {
+        val classified = classifiedModules.get().toSet()
+        val actual = modulesWithSharedTests.get()
+
+        val unclassified = actual.filterNot { it in classified }
+        val stale = classified.filterNot { it in actual }.sorted()
+
+        if (unclassified.isEmpty() && stale.isEmpty()) return
+
+        throw IllegalStateException(
+            buildString {
+                appendLine("iOS test lane classification is out of date.")
+                if (unclassified.isNotEmpty()) {
+                    appendLine()
+                    appendLine("These modules have shared test sources but are in neither list:")
+                    unclassified.forEach { appendLine("  $it") }
+                    appendLine("Add each to IOS_TEST_MODULES (if `./gradlew <module>:$IOS_TEST_TASK`")
+                    appendLine("passes) or to IOS_TEST_EXCLUSIONS with the reason it cannot run.")
+                }
+                if (stale.isNotEmpty()) {
+                    appendLine()
+                    appendLine("These are listed but no longer have shared test sources:")
+                    stale.forEach { appendLine("  $it") }
+                    appendLine("Remove them from IosUnitTests.kt.")
+                }
+                appendLine()
+                appendLine("Both lists live in gradle/build-logic/convention/src/main/kotlin/")
+                appendLine("xyz/ksharma/krail/gradle/IosUnitTests.kt")
+            },
+        )
+    }
+
+    companion object {
+        const val NAME = "verifyIosTestClassification"
+    }
+}

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/KotlinMultiplatformConventionPlugin.kt
@@ -39,5 +39,10 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
         // Test-infrastructure guardrails. Idempotent — if AndroidKmpLibrary already
         // registered these (modules applying both plugins), this is a no-op.
         configureTestWiringVerification()
+
+        // Root-level `iosUnitTest` aggregate + its classification guard. Registered from here
+        // (idempotently) because the root project cannot apply a build-logic plugin itself —
+        // see the KDoc on configureIosUnitTestLane.
+        configureIosUnitTestLane()
     }
 }

--- a/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/ThemeContrastTest.kt
+++ b/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/ThemeContrastTest.kt
@@ -32,7 +32,7 @@ class ThemeContrastTest {
     }
 
     @Test
-    fun `a low-contrast preferred foreground is replaced, not passed through`() {
+    fun `a low-contrast preferred foreground is replaced rather than passed through`() {
         // The toggle passes LocalThemeContentColor as the preferred glyph colour. When that
         // local is unset (previews default it to opaque black) it can collide with a dark
         // theme colour, so the helper has to override it rather than honour the preference.


### PR DESCRIPTION
## What

Runs the shared `commonTest` sources on an iOS simulator for the first time. They compiled for iOS but never executed there, so Kotlin/Native behaviour differences went unseen.

## Changes

- `IosUnitTests.kt` (convention plugin): adds an `iosUnitTest` aggregate that runs `iosSimulatorArm64Test` for the modules where it works, plus a `verifyIosTestClassification` guard so a module cannot grow shared tests without being placed in either the include or the exclude list.
- `.github/workflows/ios-unit-tests.yml`: the CI lane, `./gradlew iosUnitTest --continue -PciQuality=true` on a macOS runner with a cached Kotlin/Native toolchain.
- `code-quality.yml`: one line wiring the lane in.
- Renames one `:taj` test: Kotlin/Native rejects `,` inside a backtick name, which is all that kept that module out of the lane.
- TESTING.md documents the lane, the allowlist and why each excluded module is excluded.
- Records the `runComposeUiTest` spike verdict: it runs fine under `iosSimulatorArm64Test`, but a shared Compose UI test cannot live in `commonTest`, because the same source expands into `androidHostTest` where Android's implementation needs a Robolectric runner and `@Config` that `commonTest` cannot express. Parked with the evidence and the condition for revisiting.

## Why the lane is an allowlist rather than everything

Most modules cannot link a Kotlin/Native test binary. `:core:analytics` and `:core:remote-config` pull the GitLive Firebase Kotlin SDK, whose iOS klibs declare `-framework FirebaseCore`, supplied only by the Xcode/SPM build. `:core:testing` depends on both, so every consumer of the shared fakes inherits `ld: framework 'FirebaseCore' not found`. Each exclusion records its reason next to it, and the classification guard fails the build if a module is in neither list.

## Testing

- `./gradlew iosUnitTest --continue -PciQuality=true` green: 74 tests execute on the simulator across `:core:date-time`, `:core:deeplink`, `:core:transport`, `:taj` and `:feature:debug-settings:store`.
- `./gradlew detekt --continue` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
