### PR TITLE
feat(coverage): merged Kover report and Codecov upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
   code-quality:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     uses: ./.github/workflows/code-quality.yml
+    # Deliberately passes no secrets. Everything code-quality.yml needs — including
+    # CODECOV_TOKEN — comes from the `Firebase` environment its job declares. See the
+    # Codecov step there.
 
   # Runs in parallel with code-quality rather than after it: it is the one job on a macOS
   # runner and the slowest of the two, so gating it on detekt would add its wait to the

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -91,6 +91,45 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew -p gradle/build-logic :detekt-rules:test
 
+      # Kover's report tasks depend on the very testAndroidHostTest tasks the step above just
+      # ran, so those are UP-TO-DATE here and this only does the merge — coverage costs a
+      # report, not a second test run. Skipped when tests failed: partial coverage from a
+      # broken run is worse than none.
+      - name: Generate coverage report
+        id: coverage
+        if: steps.tests.outcome == 'success'
+        env:
+          ANDROID_NSW_TRANSPORT_API_KEY: ${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}
+          IOS_NSW_TRANSPORT_API_KEY: ${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}
+          CI: true
+          GITHUB_ACTIONS: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew :koverXmlReport :koverHtmlReport -PciQuality=true
+
+      - name: Upload coverage report (HTML)
+        if: always() && steps.coverage.conclusion == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report-${{ github.run_id }}
+          path: build/reports/kover/html/**
+          if-no-files-found: warn
+          retention-days: 7
+
+      # CODECOV_TOKEN must live in the `Firebase` environment, alongside the API keys above.
+      # A reusable workflow cannot see repository secrets, and the alternatives are both
+      # worse: `secrets: inherit` would hand this workflow the signing keystores and store
+      # credentials to deliver one upload token, and declaring `workflow_call.secrets` closes
+      # the secrets context, so the environment-only API keys above stop resolving.
+      # Upload is best-effort — a missing token or a Codecov outage must not fail a PR.
+      - name: Upload coverage to Codecov
+        if: always() && steps.coverage.conclusion == 'success'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/kover/report.xml
+          flags: host-tests
+          fail_ci_if_error: false
+
       - name: Upload Detekt reports
         if: always() && steps.detekt.conclusion != 'skipped'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-2-deploy-rc.yml
+++ b/.github/workflows/release-2-deploy-rc.yml
@@ -26,6 +26,7 @@ jobs:
   # ── 1. Quality gate ─────────────────────────────────────────────────────────
   code-quality:
     uses: ./.github/workflows/code-quality.yml
+    # See build.yml — passes no secrets; the `Firebase` environment supplies them.
 
   # ── 2. Build signed release AAB ─────────────────────────────────────────────
   build-android-release:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ real-time public transport information, personalised features like trip-saving a
 modular architecture for maintainability.
 
 [![Krail App CI](https://github.com/ksharma-xyz/Krail/actions/workflows/build.yml/badge.svg)](https://github.com/ksharma-xyz/Krail/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/ksharma-xyz/Krail/branch/main/graph/badge.svg)](https://codecov.io/gh/ksharma-xyz/Krail)
 
 ## Table of Contents
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -282,6 +282,51 @@ itself is not the obstacle.
 
 ---
 
+## Coverage
+
+```
+./gradlew koverHtmlReport      # build/reports/kover/html/index.html
+./gradlew koverXmlReport       # build/reports/kover/report.xml — the Codecov upload
+./gradlew koverLog             # one line, straight to the console
+```
+
+One merged report for the whole repo, not 31 per-module ones. Kover's report tasks depend on
+the `testAndroidHostTest` tasks, so a report task runs the suites it measures — there is no
+"stale coverage" state to get caught by.
+
+Modules opt in automatically: `configureCoverage()` in
+[`Coverage.kt`](gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Coverage.kt)
+applies Kover and registers the module into the root aggregate **if it has test sources**. A
+module with no tests is left out rather than reported as 0% — that would bury the signal from
+modules that do have suites, and `verifyTestWiring` is what stops a module having none. Two
+things are excluded on purpose: `:core:testing`, whose production code *is* test
+infrastructure, and codegen (`ComposableSingletons*`, SQLDelight, BuildKonfig, Compose
+Resources) — filters live in the root `build.gradle.kts`.
+
+CI generates the report inside `code-quality.yml`, right after the host-test step, so the
+suites run once. The HTML goes up as a build artifact and the XML to Codecov.
+
+> **`CODECOV_TOKEN` has to live in the `Firebase` environment**, next to the NSW API keys.
+> It currently exists only as a *repository* secret, and a reusable workflow cannot see
+> those — so until it is added there, coverage generates and uploads as a build artifact but
+> does not reach Codecov. Nothing else breaks: the step is `fail_ci_if_error: false`.
+>
+> Neither alternative is acceptable. `secrets: inherit` on the callers would hand
+> `code-quality.yml` every repository secret — signing keystores, App Store keys, service
+> accounts — to deliver one upload token. Declaring `workflow_call.secrets` instead *closes*
+> the secrets context, at which point the environment-only `ANDROID_NSW_TRANSPORT_API_KEY`
+> and `IOS_NSW_TRANSPORT_API_KEY` references stop resolving and `actionlint` fails the
+> `lint-workflows` job. The environment is the one place that is both narrow and consistent
+> with how this workflow already gets every other secret.
+
+### There are no iOS coverage numbers
+
+Kover instruments JVM bytecode. Kotlin/Native is not supported upstream and cannot be worked
+around here, so coverage measures the host-test run only. A module in the iOS lane still shows
+its host coverage — iOS execution is a correctness signal, not a coverage one.
+
+---
+
 ## Snapshot testing
 
 The annotation-driven generation flow is preserved: any `@PreviewComponent` /

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,4 +15,25 @@ plugins {
     alias(libs.plugins.wire) apply false
     alias(libs.plugins.detekt) apply false
     alias(libs.plugins.roborazzi) apply false
+    // Applied (not `apply false`) so the root project owns the merged coverage report. The
+    // per-module side is wired from KotlinMultiplatformConventionPlugin — see Coverage.kt.
+    alias(libs.plugins.kover)
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                // Compose compiler emits one of these per file holding `@Composable` lambdas.
+                // Never written by hand, never meaningfully "covered".
+                classes("*.ComposableSingletons*")
+                // SQLDelight codegen. The hand-written repositories above it are measured.
+                packages("xyz.ksharma.krail.sandook.sandook")
+                // BuildKonfig codegen.
+                classes("*.BuildKonfig")
+                // Compose Resources accessors (`Res.drawable.*`), also codegen.
+                packages("*.generated.resources")
+            }
+        }
+    }
 }

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Coverage.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Coverage.kt
@@ -1,0 +1,47 @@
+package xyz.ksharma.krail.gradle
+
+import org.gradle.api.Project
+import java.io.File
+
+/**
+ * Kover coverage wiring.
+ *
+ * Every module that has test sources gets the Kover plugin and is added to the root project's
+ * `kover` configuration, so `./gradlew koverHtmlReport` at the root produces one merged report
+ * across the whole repo rather than 31 per-module ones nobody reads. Applying it from here
+ * rather than from each `build.gradle.kts` keeps the list of measured modules derived from
+ * "does this module actually have tests" instead of hand-maintained.
+ *
+ * Modules with no test sources are deliberately left out. Adding them would report their
+ * production code as 0% covered, which is true but drowns the signal from the modules that do
+ * have suites; `verifyTestWiring` is what stops a module from quietly having none.
+ *
+ * Coverage is **host-only**. Kover instruments JVM bytecode, so it measures
+ * `testAndroidHostTest` and has nothing to say about `iosSimulatorArm64Test` — Kotlin/Native
+ * is not supported upstream and cannot be made to work from here.
+ */
+private const val KOVER_PLUGIN_ID = "org.jetbrains.kotlinx.kover"
+
+/** Source-set roots whose Kotlin files mean this module produces coverage worth merging. */
+private val COVERAGE_TEST_SOURCE_DIRS = listOf("commonTest", "androidHostTest", "androidUnitTest")
+
+fun Project.configureCoverage() {
+    // :core:testing is the fakes module. Its production code *is* test infrastructure, so a
+    // coverage number for it says nothing about the app.
+    if (path == TESTING_MODULE_PATH) return
+    if (!hasTestSources()) return
+    if (pluginManager.hasPlugin(KOVER_PLUGIN_ID)) return
+
+    pluginManager.apply(KOVER_PLUGIN_ID)
+
+    // Register into the root aggregate. The root applies Kover in its own build file, so the
+    // `kover` configuration already exists by the time subprojects are configured.
+    rootProject.dependencies.add("kover", this)
+}
+
+private fun Project.hasTestSources(): Boolean = COVERAGE_TEST_SOURCE_DIRS.any { dir ->
+    File(projectDir, "src/$dir").containsKotlinFile()
+}
+
+private fun File.containsKotlinFile(): Boolean =
+    isDirectory && walkTopDown().any { it.isFile && it.extension == "kt" }

--- a/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/KotlinMultiplatformConventionPlugin.kt
@@ -44,5 +44,8 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
         // (idempotently) because the root project cannot apply a build-logic plugin itself —
         // see the KDoc on configureIosUnitTestLane.
         configureIosUnitTestLane()
+
+        // Kover, for modules that have tests, feeding the root's merged report.
+        configureCoverage()
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,9 @@ foundationLayoutAndroid = "1.10.6"
 ui-tooling = "1.10.6"
 detekt = "1.23.8"
 detektCompose = "0.5.8"
+# 0.9.7+ is required: earlier Kover releases do not understand the KMP
+# `androidLibrary { withHostTest {} }` target this repo's modules use.
+kover = "0.9.9"
 coil3 = "3.4.0"
 appcompat = "1.7.1"
 roborazzi = "1.59.0"
@@ -218,6 +221,7 @@ firebase-crashlyticsPlugin = { id = "com.google.firebase.crashlytics", version =
 firebase-performancePlugin = { id = "com.google.firebase.firebase-perf", version = "2.0.2" }
 wire = { id = "com.squareup.wire", version = "6.2.0" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }
 spmForKmp = { id = "io.github.frankois944.spmForKmp", version.ref = "spmForKmp" }
 


### PR DESCRIPTION
## What

Adds Kover 0.9.9 with a single merged coverage report for the whole repo instead of per-module ones, uploads the XML to Codecov, and puts a badge in the README.

## Changes

- `Coverage.kt` (convention plugin): modules opt in from `KotlinMultiplatformConventionPlugin` when they have test sources, so the measured set is derived rather than hand-maintained. `koverHtmlReport` / `koverXmlReport` run the host suites they measure.
- Left out on purpose: `:core:testing`, whose production code is test infrastructure, and codegen (`ComposableSingletons`, SQLDelight, BuildKonfig, Compose Resources).
- `code-quality.yml`: generates the report right after the existing host-test step, so the suites still run exactly once. Kover's report tasks depend on the very `testAndroidHostTest` tasks that step just ran, so those are UP-TO-DATE and coverage costs a report rather than a second test run. Skipped when tests failed, because partial coverage from a broken run is worse than none. HTML uploads as an artifact; XML goes to Codecov.
- `README.md`: coverage badge.
- TESTING.md: documents the report, what it measures and what it does not.

## Secrets note

The callers of that reusable workflow pass no secrets. `CODECOV_TOKEN` has to be added to the `Firebase` environment, where the NSW API keys already live, because a reusable workflow cannot see repository secrets. The two alternatives are both worse: `secrets: inherit` would hand `code-quality.yml` every repository secret to deliver one upload token, and declaring `workflow_call.secrets` closes the secrets context, breaking the environment-only API-key references and failing actionlint. Until the token is in place, coverage still builds and uploads as an artifact; the Codecov step is `fail_ci_if_error: false`, so a missing token or a Codecov outage cannot fail a pull request.

## Scope

Coverage is host-only. Kover instruments JVM bytecode and has no Kotlin/Native support, so `iosSimulatorArm64Test` from the previous PR in this stack contributes nothing to the number.

## Testing

- `./gradlew koverXmlReport -PciQuality=true` green, report produced at `build/reports/kover/report.xml`.
- `./gradlew detekt --continue` green.
- Merged line coverage at this commit: 46.1%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
