### PR TITLE
test(quality): guard search-text egress, learning-log claims, and dual-pane compositing

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Setup environment variables
         run: |
-          echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
-          echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> $GITHUB_ENV
+          echo "ANDROID_NSW_TRANSPORT_API_KEY=${{ secrets.ANDROID_NSW_TRANSPORT_API_KEY }}" >> "$GITHUB_ENV"
+          echo "IOS_NSW_TRANSPORT_API_KEY=${{ secrets.IOS_NSW_TRANSPORT_API_KEY }}" >> "$GITHUB_ENV"
 
       - name: set up JDK
         uses: actions/setup-java@v5
@@ -33,6 +33,18 @@ jobs:
 
       - name: Make Gradle executable
         run: chmod +x ./gradlew
+
+      # The same two scripts scripts/fullQualityChecks.sh runs first, promoted to CI so the
+      # invariants they hold are enforced on every PR rather than only for whoever remembers to
+      # run the local script. check_layout_invariants.py exits non-zero on a violation (manifest
+      # losing adjustResize, or a file applying two inset authorities at once) and so fails this
+      # step. check_stale_assumptions.py warns only: an assumption falling due is not a reason to
+      # block an unrelated PR, and a scheduled job runs it with --strict to raise an issue.
+      - name: Layout invariants and analytics assumptions
+        id: prose-invariants
+        run: |
+          python3 scripts/check_layout_invariants.py
+          python3 scripts/check_stale_assumptions.py
 
       # Test-infrastructure guardrails — run BEFORE detekt/tests so a misconfigured
       # module (missing withHostTest{}, test code leaking into production, ad-hoc

--- a/composeApp/src/androidHostTest/kotlin/xyz/ksharma/krail/quality/DualPaneCompositingGuardTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/xyz/ksharma/krail/quality/DualPaneCompositingGuardTest.kt
@@ -1,0 +1,159 @@
+package xyz.ksharma.krail.quality
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Keeps a `DualPaneScaffold` out from under an offscreen-compositing ancestor.
+ *
+ * On iOS a `UIKitView` (MapLibre's `MLNMapView`) cannot composite into an offscreen GPU buffer.
+ * Put the dual-pane split inside `CloudGradientBackground` — which applies
+ * `graphicsLayer { compositingStrategy = Offscreen }` to its whole subtree — and the right-pane
+ * map renders **blank**, at the correct size, in the correct window position, with no error
+ * anywhere. Android is unaffected, so the Android build, the tests and detekt are all green
+ * while the iOS screen is empty. That combination cost a long debugging saga once already; see
+ * `DualPaneScaffold`'s KDoc and `docs/MAPLIBRE_IOS_PITFALLS.md` §1.
+ *
+ * The rule: any gradient or render-effect wrapper goes **inside** the `listPane` lambda. The
+ * scaffold call itself must have no such ancestor.
+ *
+ * ## What this scan can see
+ *
+ * A forward pass over each file tracking brace depth. A line naming a wrapper
+ * ([COMPOSITING_WRAPPERS]) arms a marker; the next content lambda opened by a `) {` within
+ * [ARM_WINDOW] lines pushes that wrapper onto a stack until its block closes. A
+ * `DualPaneScaffold(` reached with a non-empty stack is a violation. This catches the real
+ * shapes: `CloudGradientBackground(...) { … DualPaneScaffold(…) }` and
+ * `Box(modifier = Modifier.blur(x)) { … DualPaneScaffold(…) }`.
+ *
+ * ## What it cannot see
+ *
+ *  - A wrapper applied in a **different function** — `Screen()` wrapping `ScreenDualPane()`
+ *    which calls the scaffold. It is lexical only; it does not follow composable calls.
+ *  - A wrapper reached through a hoisted `@Composable` lambda variable.
+ *  - `CompositingStrategy.Offscreen` set through a modifier built elsewhere and passed in.
+ *  - A wrapper whose `) {` is more than [ARM_WINDOW] lines after the modifier that names it.
+ *  - Braces inside string literals, which are counted as real braces.
+ *
+ * So it is a tripwire on the shape that broke before, not a proof of correctness. The iOS
+ * checklist in `docs/MAPLIBRE_IOS_PITFALLS.md` is still the thing to work through for a new map
+ * screen.
+ */
+class DualPaneCompositingGuardTest {
+
+    @Test
+    fun `no DualPaneScaffold sits under an offscreen compositing ancestor`() {
+        val violations =
+            productionSources().flatMap { file -> scaffoldsUnderWrappers(file) }.toList()
+
+        if (violations.isNotEmpty()) {
+            fail(
+                "A DualPaneScaffold is nested inside a compositing wrapper. On iOS the " +
+                    "right-pane UIKitView map cannot composite into an offscreen buffer and " +
+                    "renders blank, while Android, detekt and every test stay green:\n" +
+                    violations.joinToString("\n") { "  - ${it.where} is inside ${it.wrappers}" } +
+                    "\n\nMove the wrapper INSIDE the listPane lambda so the right pane stays a " +
+                    "sibling. See DualPaneScaffold's KDoc and docs/MAPLIBRE_IOS_PITFALLS.md §1; " +
+                    "docs/TABLET_FOLDABLE_UX.md §4b has the per-screen rules.",
+            )
+        }
+    }
+
+    private data class Violation(val where: String, val wrappers: String)
+
+    private fun scaffoldsUnderWrappers(file: File): List<Violation> {
+        val wrapperStack = WrapperStack()
+        return file.readLines().mapIndexedNotNull { index, line ->
+            val code = line.substringBefore("//")
+            wrapperStack.advance(index, code)
+            val wrappers = wrapperStack.openWrappers().filterNot { it.isExcepted(file) }
+            violationOrNull(file, index, code, wrappers)
+        }
+    }
+
+    private fun violationOrNull(
+        file: File,
+        index: Int,
+        code: String,
+        wrappers: List<String>,
+    ): Violation? {
+        if (!code.contains(SCAFFOLD) || wrappers.isEmpty()) return null
+        return Violation(
+            where = "${file.relativeTo(repoRoot).path}:${index + 1}",
+            wrappers = wrappers.joinToString(" > "),
+        )
+    }
+
+    /**
+     * Brace-depth tracker. A wrapper name arms a marker; the next `) {` within [ARM_WINDOW]
+     * lines pushes it, and it pops when its block closes.
+     */
+    private class WrapperStack {
+        private val open = ArrayDeque<Pair<Int, String>>()
+        private var armed: String? = null
+        private var armedAt = 0
+        private var depth = 0
+
+        fun openWrappers(): List<String> = open.map { it.second }
+
+        fun advance(index: Int, code: String) {
+            if (armed != null && index - armedAt > ARM_WINDOW) armed = null
+            COMPOSITING_WRAPPERS.firstOrNull { code.contains(it) }?.let { wrapper ->
+                armed = wrapper
+                armedAt = index
+            }
+
+            val opens = code.count { it == '{' }
+            val armedWrapper = armed
+            if (opens > 0 && armedWrapper != null && CONTENT_LAMBDA.containsMatchIn(code)) {
+                open.addLast(depth + 1 to armedWrapper)
+                armed = null
+            }
+
+            depth += opens - code.count { it == '}' }
+            while (open.isNotEmpty() && open.last().first > depth) open.removeLast()
+        }
+    }
+
+    /**
+     * `SavedTripsScreen` blurs everything behind the Ask KRAIL dialog, and the scaffold is under
+     * that Box. The radius is 0.dp whenever the dialog is closed, and `Modifier.blur` installs no
+     * render effect at radius 0, so there is no offscreen layer in the state a rider spends the
+     * screen in; while the dialog is up it covers the map anyway. Narrow on purpose: adding a
+     * `CloudGradientBackground` to the same file still fails.
+     */
+    private fun String.isExcepted(file: File): Boolean =
+        this == BLUR && file.name == BLUR_EXCEPTED_FILE
+
+    private fun productionSources(): Sequence<File> =
+        repoRoot.walkTopDown()
+            .onEnter { it.name != "build" && it.name != ".git" }
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { file ->
+                val path = file.path.replace('\\', '/')
+                PRODUCTION_SOURCE_SETS.any { path.contains(it) }
+            }
+
+    private companion object {
+
+        const val SCAFFOLD = "DualPaneScaffold("
+        const val BLUR = ".blur("
+        const val BLUR_EXCEPTED_FILE = "SavedTripsScreen.kt"
+
+        /** How far a wrapper's name may sit above the `) {` that opens its content lambda. */
+        const val ARM_WINDOW = 25
+
+        val COMPOSITING_WRAPPERS = listOf("CloudGradientBackground(", ".graphicsLayer", BLUR)
+
+        /** A call's trailing content lambda, as opposed to a `graphicsLayer { }` scope lambda. */
+        val CONTENT_LAMBDA = Regex("\\)\\s*\\{")
+
+        val PRODUCTION_SOURCE_SETS =
+            listOf("/src/commonMain/", "/src/androidMain/", "/src/iosMain/")
+
+        val repoRoot: File = generateSequence(File(".").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate the repo root from ${File(".").absolutePath}")
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/xyz/ksharma/krail/quality/LearningLogActionsTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/xyz/ksharma/krail/quality/LearningLogActionsTest.kt
@@ -1,0 +1,142 @@
+package xyz.ksharma.krail.quality
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * Every ticked box in `docs/learning/` claims a check exists. This proves the claim.
+ *
+ * A learning entry whose check has been deleted is worse than no entry: it tells the next reader
+ * that a class of bug is covered when nothing is watching it any more, so nobody looks. The
+ * entries are the repo's memory of expensive bugs and they are only worth reading if their
+ * ticked boxes are true.
+ *
+ * ## What it checks
+ *
+ * For each `- [x]` line (and its indented continuation lines), every backticked identifier that
+ * is either
+ *
+ *  - a file path (has a known extension) — must exist on disk, or
+ *  - a test class, optionally `.withAMethod` (matches [TEST_IDENTIFIER]) — a Kotlin file under a
+ *    test source set must declare that class, and must contain the method name if one is given.
+ *
+ * Everything else in backticks is prose or a framework symbol and is ignored.
+ *
+ * ## What it cannot check
+ *
+ *  - That the test still asserts what the entry says it asserts. Names are cheap; a test can be
+ *    hollowed out and keep its name. Mutation-check when you write the entry, as the entries
+ *    themselves recommend.
+ *  - Claims with no backticked identifier at all, e.g. "the content description is named in the
+ *    test's companion". Write the identifier in backticks and it becomes checkable.
+ *  - Unticked `- [ ]` boxes, which are open work and are meant to be unresolved.
+ */
+class LearningLogActionsTest {
+
+    @Test
+    fun `every ticked learning-log action still resolves on disk`() {
+        val entries = File(repoRoot, LEARNING_DIR).listFiles()
+            .orEmpty()
+            .filter { it.extension == "md" && it.name != "README.md" }
+            .sortedBy { it.name }
+
+        if (entries.isEmpty()) fail("No learning entries found under $LEARNING_DIR")
+
+        val broken = entries.flatMap { entry ->
+            tickedClaims(entry).flatMap { claim ->
+                BACKTICKED.findAll(claim)
+                    .map { it.groupValues[1] }
+                    .mapNotNull { identifier -> unresolved(identifier)?.let { entry.name to it } }
+            }
+        }.distinct()
+
+        if (broken.isNotEmpty()) {
+            fail(
+                "A learning entry whose check has been deleted is worse than no entry: it says " +
+                    "a class of bug is covered when nothing is watching it. These ticked boxes " +
+                    "name something that no longer exists:\n" +
+                    broken.joinToString("\n") { (file, problem) -> "  - $LEARNING_DIR$file: $problem" } +
+                    "\n\nEither restore the check, or downgrade the box to '- [ ]' with a one-" +
+                    "line note saying what happened to it. Do not delete the line: the record " +
+                    "of what was once covered is the point.",
+            )
+        }
+    }
+
+    /** A `- [x]` line plus the indented lines that continue it. */
+    private fun tickedClaims(entry: File): List<String> {
+        val claims = mutableListOf<StringBuilder>()
+        var current: StringBuilder? = null
+
+        entry.readLines().forEach { line ->
+            when {
+                line.trimStart().startsWith(TICKED_PREFIX) ->
+                    current = StringBuilder(line).also { claims += it }
+
+                current != null && line.startsWith(" ") && line.isNotBlank() ->
+                    current?.append(' ')?.append(line.trim())
+
+                else -> current = null
+            }
+        }
+        return claims.map { it.toString() }
+    }
+
+    /** Null when the identifier resolves or is not the kind of thing this test judges. */
+    private fun unresolved(identifier: String): String? = when {
+        identifier.looksLikeAPath() ->
+            "`$identifier` does not exist".takeIf { !File(repoRoot, identifier).exists() }
+
+        TEST_IDENTIFIER.matches(identifier) -> unresolvedTest(identifier)
+
+        else -> null
+    }
+
+    private fun unresolvedTest(identifier: String): String? {
+        val className = identifier.substringBefore('.')
+        val methodName = identifier.substringAfter('.', missingDelimiterValue = "")
+        val declaring = testSources().firstOrNull {
+            it.readText().contains(Regex("\\bclass\\s+$className\\b"))
+        } ?: return "`$identifier` names a test class that no source file declares"
+
+        return "`$identifier` names a test that ${declaring.name} does not contain"
+            .takeIf { methodName.isNotEmpty() && !declaring.readText().contains(methodName) }
+    }
+
+    private fun String.looksLikeAPath(): Boolean =
+        none { it.isWhitespace() || it == '(' } &&
+            PATH_EXTENSIONS.any { endsWith(it) }
+
+    private fun testSources(): Sequence<File> =
+        repoRoot.walkTopDown()
+            .onEnter { it.name != "build" && it.name != ".git" }
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { file ->
+                val path = file.path.replace('\\', '/')
+                TEST_SOURCE_SETS.any { path.contains(it) }
+            }
+
+    private companion object {
+
+        const val LEARNING_DIR = "docs/learning/"
+        const val TICKED_PREFIX = "- [x]"
+
+        val BACKTICKED = Regex("`([^`]+)`")
+        val TEST_IDENTIFIER = Regex("[A-Z][A-Za-z0-9_]*Test(?:\\.[A-Za-z0-9_]+)?")
+        val PATH_EXTENSIONS = listOf(".md", ".py", ".sh", ".kt", ".kts", ".xml", ".yml", ".yaml")
+
+        val TEST_SOURCE_SETS = listOf(
+            "/src/commonTest/",
+            "/src/androidHostTest/",
+            "/src/androidUnitTest/",
+            "/src/androidInstrumentedTest/",
+            "/src/iosTest/",
+            "/src/test/",
+        )
+
+        val repoRoot: File = generateSequence(File(".").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate the repo root from ${File(".").absolutePath}")
+    }
+}

--- a/docs/LAYOUT_AND_INSETS.md
+++ b/docs/LAYOUT_AND_INSETS.md
@@ -54,7 +54,10 @@ so Compose handles the IME itself. Without this attribute the mode defaults to
 the same keyboard: the layout shrinks by the keyboard height and the system then slides the
 whole window up by it again.
 
-`scripts/check_layout_invariants.py` fails the build if the attribute goes missing.
+`scripts/check_layout_invariants.py` fails if the attribute goes missing. It runs in CI on every
+PR, in the "Layout invariants and analytics assumptions" step of
+`.github/workflows/code-quality.yml`, and locally as the first step of
+`scripts/fullQualityChecks.sh`.
 
 ### 1.3 Unbounded constraints: know which parents actually do it
 

--- a/docs/learning/2026-08-16-clipped-inside-its-own-parent.md
+++ b/docs/learning/2026-08-16-clipped-inside-its-own-parent.md
@@ -92,9 +92,10 @@ directions.
 
 - [x] `AiInputBar`'s `TextField` takes `weight(1f, fill = false)`, with the reasoning in a
       comment at the call site pointing here.
-- [x] `AiResultCardTest.shortHost_theBarsActionsStayInsideIt` renders the surface at the height
+- [ ] `AiResultCardTest.shortHost_theBarsActionsStayInsideIt` renders the surface at the height
       a keyboard leaves, with six lines of text, and asserts both controls with
       `assertIsDisplayed()`. Mutation-checked: removing the weight fails it, restoring it passes.
+      Check deleted with AiResultCard; restore tracked in the blind-spot audit.
 - [x] The send button's real content description is named in the test's companion, with why it
       is worth naming.
 - [x] Rule added to `docs/LAYOUT_AND_INSETS.md`: measurement order inside a `Column`, and

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryRedactionCallSiteTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryRedactionCallSiteTest.kt
@@ -1,0 +1,98 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * The other half of `SearchQueryTextEgressTest`, which can only prove that the call sites that
+ * exist today behave. This proves no new one appears that skips the redaction.
+ *
+ * `AnalyticsEvent.SearchStopQuery.zeroResultQuery` is the single parameter allowed to carry a
+ * rider's typed text, and only when `SearchQueryAnalyticsRedaction.zeroResultQueryOrNull` says
+ * so. Passing the raw query straight into it compiles, type-checks and reads plausibly, so the
+ * only thing standing between that and shipping addresses is a reviewer noticing.
+ *
+ * Lives in androidHostTest rather than commonTest because it reads source files off disk, which
+ * commonTest cannot do.
+ *
+ * ## What it can see
+ *
+ * Every `zeroResultQuery =` argument in production Kotlin, and whether a sanctioned redaction
+ * function is named within the following few lines.
+ *
+ * ## What it cannot see
+ *
+ *  - An assignment whose redaction call is further away than [WINDOW] lines.
+ *  - A wrapper function that itself returns the raw query. It checks the name at the call site,
+ *    not what that name does; `resolveLocalZeroResultQuery` is trusted by name and pinned
+ *    separately by its own tests.
+ */
+class SearchQueryRedactionCallSiteTest {
+
+    @Test
+    fun `zeroResultQuery is only ever assigned from the redaction functions`() {
+        val offenders = mutableListOf<String>()
+
+        productionSources().forEach { file ->
+            val lines = file.readLines()
+            lines.forEachIndexed { index, line ->
+                if (!line.isAssignmentToZeroResultQuery()) return@forEachIndexed
+                val window = lines.subList(index, minOf(index + WINDOW, lines.size))
+                    .joinToString("\n")
+                if (SANCTIONED.none { window.contains(it) }) {
+                    offenders += "${file.relativeTo(repoRoot).path}:${index + 1}: ${line.trim()}"
+                }
+            }
+        }
+
+        if (offenders.isNotEmpty()) {
+            fail(
+                "zeroResultQuery is the one analytics parameter allowed to carry a rider's " +
+                    "typed text, and only through the redaction carve-out. These assignments " +
+                    "do not go through ${SANCTIONED.joinToString(" or ")}:\n" +
+                    offenders.joinToString("\n") { "  - $it" } +
+                    "\n\nSee docs/SEARCH_QUERY_TELEMETRY_SPEC.md. A query that found results is " +
+                    "never sent, whatever else is true of it.",
+            )
+        }
+    }
+
+    /** The parameter's own declaration (`val zeroResultQuery: String? = null`) is not one. */
+    private fun String.isAssignmentToZeroResultQuery(): Boolean {
+        val trimmed = trimStart()
+        val isComment = trimmed.startsWith("//") || trimmed.startsWith("*")
+        return !isComment &&
+            !DECLARATION.containsMatchIn(this) &&
+            ASSIGNMENT.containsMatchIn(this)
+    }
+
+    private fun productionSources(): Sequence<File> =
+        repoRoot.walkTopDown()
+            .onEnter { it.name != "build" && it.name != ".git" }
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { file ->
+                val path = file.path.replace('\\', '/')
+                PRODUCTION_SOURCE_SETS.any { path.contains(it) }
+            }
+
+    private companion object {
+
+        const val WINDOW = 8
+
+        val SANCTIONED = listOf(
+            "SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(",
+            "resolveLocalZeroResultQuery(",
+        )
+
+        val ASSIGNMENT = Regex("\\bzeroResultQuery\\s*=")
+        val DECLARATION = Regex("\\b(?:val|var)\\s+zeroResultQuery\\b")
+
+        val PRODUCTION_SOURCE_SETS =
+            listOf("/src/commonMain/", "/src/androidMain/", "/src/iosMain/")
+
+        val repoRoot: File = generateSequence(File(".").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: error("Could not locate the repo root from ${File(".").absolutePath}")
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryTextEgressTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryTextEgressTest.kt
@@ -1,0 +1,138 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.trip.planner.ui.searchstop.address.AddressSearchGate
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * A typed search query can be a street address, and a street address is a home. The rule in
+ * `docs/SEARCH_QUERY_TELEMETRY_SPEC.md` is that raw text leaves the device only under the
+ * zero-result carve-out: nothing found anywhere, no digits, short.
+ *
+ * `SearchQueryAnalyticsRedactionTest` already pins the carve-out predicate. This test guards the
+ * step after it — the event that actually goes out. It drives the production track helpers and
+ * reads the built property map, because that map is what ships, and a leak could arrive through
+ * a parameter nobody thought of rather than through a wrong carve-out decision.
+ *
+ * The assertion deliberately checks **every** property value rather than just the `query` key,
+ * and checks the query's individual words as well as the whole string, because the spec calls
+ * out that "a first token, a normalised query or a hash of the text are all the text".
+ *
+ * What it cannot see: a hash or an encoding of the query, which by construction does not
+ * contain the query as a substring. That would have to be caught in review.
+ */
+class SearchQueryTextEgressTest {
+
+    @Test
+    fun `a local query that found results never leaves as text`() {
+        val analytics = FakeAnalytics()
+
+        analytics.trackLocalSearchResolved(
+            query = QUERY,
+            searchSessionId = SESSION_ID,
+            localResultsCount = 4,
+            addressSearchGate = AddressSearchGate.DISABLED,
+        )
+
+        assertNoRawQuery(analytics.searchEvent())
+    }
+
+    @Test
+    fun `an address query that found results never leaves as text`() {
+        val analytics = FakeAnalytics()
+
+        analytics.trackAddressSearchResolved(
+            normalizedQuery = QUERY,
+            searchSessionId = SESSION_ID,
+            localResultsCount = 0,
+            addressResults = listOf(
+                SearchStopState.SearchResult.Address(
+                    addressId = "addr-1",
+                    displayName = "Wynyard Station, Sydney NSW",
+                    addressType = "poi",
+                ),
+            ),
+        )
+
+        assertNoRawQuery(analytics.searchEvent())
+    }
+
+    @Test
+    fun `a failed local search never leaves as text`() {
+        val analytics = FakeAnalytics()
+
+        analytics.trackLocalSearchFailed(query = QUERY, searchSessionId = SESSION_ID)
+
+        assertNoRawQuery(analytics.searchEvent())
+    }
+
+    @Test
+    fun `an address-eligible query defers rather than leaking on the local event`() {
+        // The local site does not know the address count yet, so it must not decide.
+        val analytics = FakeAnalytics()
+
+        analytics.trackLocalSearchResolved(
+            query = QUERY,
+            searchSessionId = SESSION_ID,
+            localResultsCount = 0,
+            addressSearchGate = AddressSearchGate.ELIGIBLE,
+        )
+
+        assertNoRawQuery(analytics.searchEvent())
+    }
+
+    @Test
+    fun `the carve-out itself still works`() {
+        // Control. Without this, every assertion above would also pass if the event stopped
+        // carrying any query at all, and the guard would be measuring nothing.
+        val analytics = FakeAnalytics()
+
+        analytics.trackLocalSearchResolved(
+            query = QUERY,
+            searchSessionId = SESSION_ID,
+            localResultsCount = 0,
+            addressSearchGate = AddressSearchGate.DISABLED,
+        )
+
+        assertEquals(QUERY, analytics.searchEvent().properties?.get("query"))
+    }
+
+    private fun FakeAnalytics.searchEvent(): AnalyticsEvent.SearchStopQuery {
+        val event = getTrackedEvent(EVENT_NAME)
+        assertIs<AnalyticsEvent.SearchStopQuery>(event)
+        return event
+    }
+
+    private fun assertNoRawQuery(event: AnalyticsEvent.SearchStopQuery) {
+        val needles = listOf(QUERY) + QUERY.split(" ").filter { it.length >= MIN_TOKEN_LENGTH }
+        val values = event.properties.orEmpty().entries
+
+        needles.forEach { needle ->
+            val leaking = values.filter { it.value.toString().contains(needle, ignoreCase = true) }
+            if (leaking.isNotEmpty()) {
+                fail(
+                    "search_stop_query carried the rider's typed text for a query that found " +
+                        "results. Raw text may only ship under the zero-result carve-out in " +
+                        "SearchQueryAnalyticsRedaction.zeroResultQueryOrNull; see " +
+                        "docs/SEARCH_QUERY_TELEMETRY_SPEC.md.\n" +
+                        "  leaked '$needle' via " +
+                        leaking.joinToString { "${it.key}=${it.value}" },
+                )
+            }
+        }
+        assertTrue(event.properties.orEmpty().isNotEmpty(), "event carried no properties at all")
+    }
+
+    private companion object {
+        const val QUERY = "wynyard quaybridge"
+        const val SESSION_ID = "session-egress"
+        const val EVENT_NAME = "search_stop_query"
+        const val MIN_TOKEN_LENGTH = 4
+    }
+}


### PR DESCRIPTION
## What

Three more guards that hold written conventions to the actual source, plus the CI wiring that
runs the two existing prose-invariant scripts on every PR instead of only for whoever remembers
to run `scripts/fullQualityChecks.sh` locally.

## Changes

### Search-text egress

- `SearchQueryTextEgressTest.kt` drives the production track helpers and reads the built
  analytics property map, asserting a rider's typed text only ever leaves under the zero-result
  carve-out in `docs/SEARCH_QUERY_TELEMETRY_SPEC.md`. The existing redaction test pins the
  carve-out predicate; this pins the event that actually ships, because a leak could arrive
  through a parameter nobody thought about rather than a wrong carve-out decision.
- `SearchQueryRedactionCallSiteTest.kt` is the other half: it scans production Kotlin for every
  `zeroResultQuery =` argument and fails unless a sanctioned redaction function is named nearby.
  Passing the raw query straight in compiles and reads plausibly, so nothing but a reviewer
  currently stands between that and shipping typed addresses.

### Learning-log verifier

- `LearningLogActionsTest.kt` walks `docs/learning/`, and for every ticked `- [x]` box resolves
  the backticked identifiers: file paths must exist on disk, test-class references (optionally
  `.withAMethod`) must be declared in a test source set. An entry whose check was deleted is
  worse than no entry, because it tells the next reader a class of bug is covered when nothing
  is watching it.
- Fixes one entry in `2026-08-16-clipped-inside-its-own-parent.md` whose reference did not
  resolve.

### Dual-pane compositing guard

- `DualPaneCompositingGuardTest.kt` fails when a `DualPaneScaffold` sits under an
  offscreen-compositing ancestor such as `CloudGradientBackground` or a `Modifier.blur`. On iOS a
  `UIKitView` cannot composite into an offscreen GPU buffer, so the map pane renders blank at the
  correct size and position with no error anywhere, while Android, detekt and the tests stay
  green. Gradient and render-effect wrappers belong inside the `listPane` lambda.

### CI wiring

- `code-quality.yml` runs `check_layout_invariants.py` (fails the job on a violation: manifest
  losing `adjustResize`, or a file applying two inset authorities at once) and
  `check_stale_assumptions.py` (warning only, since an assumption falling due should not block an
  unrelated PR).
- Quotes `$GITHUB_ENV` in the two existing key-export lines.
- `docs/LAYOUT_AND_INSETS.md` notes the checks now run in CI.

## Testing

- `./gradlew :composeApp:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green
- Both python scripts run clean against the current tree
- No production behaviour changed, so no device QA applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
