### PR TITLE
refactor(core): one injectable clock seam for time-dependent code

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
             implementation(projects.core.appStart)
             implementation(projects.core.appVersion)
             implementation(projects.core.coroutinesExt)
+            implementation(projects.core.dateTime)
             implementation(projects.core.deeplink)
             implementation(projects.core.di)
             implementation(projects.core.festival)

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/di/KoinApp.kt
@@ -13,6 +13,7 @@ import xyz.ksharma.krail.core.appinfo.di.appInfoModule
 import xyz.ksharma.krail.core.appreview.di.appReviewModule
 import xyz.ksharma.krail.core.appstart.di.appStartModule
 import xyz.ksharma.krail.core.appversion.di.appVersionModule
+import xyz.ksharma.krail.core.datetime.di.dateTimeModule
 import xyz.ksharma.krail.core.deeplink.di.deepLinkModule
 import xyz.ksharma.krail.core.di.DispatchersComponent.Companion.IODispatcher
 import xyz.ksharma.krail.core.di.coroutineDispatchersModule
@@ -48,6 +49,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
         includes(config)
         modules(
             coroutineDispatchersModule,
+            dateTimeModule,
             coreNetworkModule,
             // Permission + location are now provided by aagya/dhruva via Composable
             // factories (rememberPermissionController, rememberLocationTracker), so

--- a/config/clock-system-baseline.txt
+++ b/config/clock-system-baseline.txt
@@ -21,21 +21,16 @@
 # binding in a `di` package. Test source sets are exempt entirely.
 
 core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt|1
-core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt|4
 core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimePickerInfo.kt|2
 discover/network/real/src/commonMain/kotlin/xyz/ksharma/krail/discover/network/real/db/RealDiscoverCardOrderingEngine.kt|1
 feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DepartureBoardRepository.kt|3
 feature/departures/ui/src/commonMain/kotlin/xyz/ksharma/krail/departures/ui/DeparturesViewModel.kt|1
 feature/track/network/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/network/RealGtfsRealtimeRepository.kt|1
-feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt|7
-feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt|2
 feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt|1
 feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/datetimeselector/DateTimeSelectorScreen.kt|3
 feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/parkride/ParkRideAvailabilityLoader.kt|1
 feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideMapper.kt|1
 feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt|1
-feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManager.kt|2
-feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt|5
 io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswbusroutes/NswBusRoutesManager.kt|10
 io/gtfs/src/commonMain/kotlin/xyz/ksharma/krail/io/gtfs/nswstops/NswStopsManager.kt|8
 sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealUserLifecycleStore.kt|1

--- a/core/date-time/build.gradle.kts
+++ b/core/date-time/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             dependencies {
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.compose.runtime)
+                implementation(projects.core.di)
                 implementation(projects.core.log)
             }
         }

--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelper.kt
@@ -172,11 +172,14 @@ object DateTimeHelper {
 
     /**
      * Returns true if the given date is in the future, false otherwise.
+     *
+     * @param now the instant "today" is derived from. Defaults to the system clock;
+     *            tests pass their own so the answer is not tied to the wall clock.
      */
     @OptIn(ExperimentalTime::class)
-    fun LocalDate?.isFuture(): Boolean {
+    fun LocalDate?.isFuture(now: Instant = Clock.System.now()): Boolean {
         return this?.let {
-            it > Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+            it > now.toLocalDateTime(TimeZone.currentSystemDefault()).date
         } ?: false
     }
 
@@ -230,14 +233,14 @@ object DateTimeHelper {
      * The string should be in ISO-8601 format (e.g., "2023-12-31").
      *
      * @receiver String The date string to check.
+     * @param now The instant "today" is derived from. Defaults to the system clock.
      * @return Boolean true if the date is in the future, false otherwise.
      */
     @OptIn(ExperimentalTime::class)
-    fun String.isDateInFuture(): Boolean {
+    fun String.isDateInFuture(now: Instant = Clock.System.now()): Boolean {
         return runCatching {
             val localDate = LocalDate.parse(this)
-            val today = Clock.System.now()
-                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
             localDate > today
         }.onFailure { e ->
             logError("$ERROR_MESSAGE: $this", e)
@@ -250,14 +253,14 @@ object DateTimeHelper {
      * Returns true if the date is today or in the future, false if it's in the past.
      *
      * @receiver String The date string to check.
+     * @param now The instant "today" is derived from. Defaults to the system clock.
      * @return Boolean true if the date is today or in the future, false otherwise.
      */
     @OptIn(ExperimentalTime::class)
-    fun String.isDateTodayOrInFuture(): Boolean {
+    fun String.isDateTodayOrInFuture(now: Instant = Clock.System.now()): Boolean {
         return runCatching {
             val localDate = LocalDate.parse(this)
-            val today = Clock.System.now()
-                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
             localDate >= today
         }.onFailure { e ->
             logError("$ERROR_MESSAGE: $this", e)
@@ -301,14 +304,14 @@ object DateTimeHelper {
      * Returns true if the date is today or in the past, false if it's in the future.
      *
      * @receiver String The date string to check.
+     * @param now The instant "today" is derived from. Defaults to the system clock.
      * @return Boolean true if the date is today or in the past, false otherwise.
      */
     @OptIn(ExperimentalTime::class)
-    fun String.isDateTodayOrInPast(): Boolean {
+    fun String.isDateTodayOrInPast(now: Instant = Clock.System.now()): Boolean {
         return runCatching {
             val localDate = LocalDate.parse(this)
-            val today = Clock.System.now()
-                .toLocalDateTime(TimeZone.currentSystemDefault()).date
+            val today = now.toLocalDateTime(TimeZone.currentSystemDefault()).date
             localDate <= today
         }.onFailure { e ->
             logError("$ERROR_MESSAGE $this", e)

--- a/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/di/DateTimeModule.kt
+++ b/core/date-time/src/commonMain/kotlin/xyz/ksharma/krail/core/datetime/di/DateTimeModule.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.krail.core.datetime.di
+
+import org.koin.dsl.module
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * The single place wall-clock time enters the object graph.
+ *
+ * Anything that asks "what time is it?" takes a [Clock] instead of calling
+ * `Clock.System.now()` inline, so a test can hand it a clock it controls. The
+ * seam has two shapes, and which one to use follows from how long the caller
+ * lives:
+ *
+ *  - **Long-lived collaborators** (ViewModels, pollers, cache managers) take a
+ *    `clock: Clock` constructor parameter, defaulting to [Clock.System]. They read
+ *    the time repeatedly, at moments the test wants to control, so they need the
+ *    clock itself rather than one reading of it.
+ *  - **Pure helpers** (`DateTimeHelper`, `ParkRideRefreshHelper`) take
+ *    `now: Instant = Clock.System.now()`. They answer one question about one
+ *    instant, so passing the instant keeps them free of any dependency.
+ *
+ * Production resolves the same [Clock.System] either way — the default parameter
+ * and this Koin binding are the same object — so nothing changes at runtime.
+ */
+@OptIn(ExperimentalTime::class)
+val dateTimeModule = module {
+    single<Clock> { Clock.System }
+}

--- a/core/date-time/src/commonTest/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelperClockSeamTest.kt
+++ b/core/date-time/src/commonTest/kotlin/xyz/ksharma/krail/core/datetime/DateTimeHelperClockSeamTest.kt
@@ -1,0 +1,70 @@
+package xyz.ksharma.krail.core.datetime
+
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateInFuture
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateTodayOrInFuture
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isDateTodayOrInPast
+import xyz.ksharma.krail.core.datetime.DateTimeHelper.isFuture
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Demonstrates the clock seam on [DateTimeHelper]: the same date answers differently
+ * purely because the caller moved `now`. Before the seam these four functions read
+ * `Clock.System.now()` directly and could only be tested against the day the suite
+ * happened to run on.
+ *
+ * "Today" is derived from the injected instant in the system default zone rather
+ * than hard-coded, so the assertions hold in every timezone CI might run in.
+ */
+@OptIn(ExperimentalTime::class)
+class DateTimeHelperClockSeamTest {
+
+    private val t0 = Instant.parse("2026-04-09T12:00:00Z")
+
+    private fun todayAt(now: Instant): LocalDate =
+        now.toLocalDateTime(TimeZone.currentSystemDefault()).date
+
+    @Test
+    fun `Given a fixed date When now moves past it Then isFuture flips to false`() {
+        val date = todayAt(t0).plus(1, DateTimeUnit.DAY)
+
+        assertTrue(date.isFuture(t0), "one day ahead of t0 is future")
+        assertFalse(date.isFuture(t0 + 2.days), "the same date is not future once now passes it")
+    }
+
+    @Test
+    fun `Given a fixed date string When now moves past it Then isDateInFuture flips to false`() {
+        val date = todayAt(t0).plus(3, DateTimeUnit.DAY).toString()
+
+        assertTrue(date.isDateInFuture(t0))
+        assertFalse(date.isDateInFuture(t0 + 5.days))
+    }
+
+    @Test
+    fun `Given a fixed date string When now crosses it Then today-or-future and today-or-past swap`() {
+        val date = todayAt(t0).plus(2, DateTimeUnit.DAY).toString()
+
+        // Two days ahead of t0.
+        assertTrue(date.isDateTodayOrInFuture(t0))
+        assertFalse(date.isDateTodayOrInPast(t0))
+
+        // Now is that day: both are true.
+        val onTheDay = t0 + 2.days
+        assertTrue(date.isDateTodayOrInFuture(onTheDay))
+        assertTrue(date.isDateTodayOrInPast(onTheDay))
+
+        // Now is past it.
+        val after = t0 + 4.days
+        assertFalse(date.isDateTodayOrInFuture(after))
+        assertTrue(date.isDateTodayOrInPast(after))
+    }
+}

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/KrailTestScope.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/KrailTestScope.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
+import kotlin.time.Clock
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * The single shared coroutine/scheduler harness for the entire KRAIL test suite.
@@ -61,6 +65,22 @@ class KrailTestScope internal constructor(
     val mainDispatcher: CoroutineDispatcher = StandardTestDispatcher(scheduler, name = "krail-main")
 
     /**
+     * A [Clock] wired to the scheduler's virtual time.
+     *
+     * Inject it into any production `clock: Clock` seam and wall-clock reads become
+     * a function of virtual time: [pumpOnce] moves the clock by exactly the interval
+     * it advances, so "30 seconds later" means the same thing to a `delay(30.seconds)`
+     * and to a `clock.now()` comparison. Without this the two drift apart — virtual
+     * time jumps while `Clock.System.now()` stays where the test started.
+     *
+     * The epoch offset is a fixed instant so a test never depends on the day it runs.
+     */
+    @OptIn(ExperimentalTime::class)
+    val clock: Clock = object : Clock {
+        override fun now(): Instant = VIRTUAL_EPOCH + scheduler.currentTime.milliseconds
+    }
+
+    /**
      * Drain all coroutines whose dispatch time is the *current* virtual instant.
      * Does NOT advance virtual time, so it's safe against infinite pollers (unlike
      * `advanceUntilIdle()`, which is deliberately NOT exposed here — see [pumpOnce]).
@@ -88,5 +108,11 @@ class KrailTestScope internal constructor(
     fun pumpOnce(intervalMs: Long) {
         scheduler.advanceTimeBy(intervalMs)
         scheduler.runCurrent()
+    }
+
+    companion object {
+        /** Virtual time zero, as a wall-clock instant. A Thursday, midday UTC. */
+        @OptIn(ExperimentalTime::class)
+        val VIRTUAL_EPOCH: Instant = Instant.parse("2026-04-09T12:00:00Z")
     }
 }

--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeClock.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/fakes/FakeClock.kt
@@ -1,0 +1,39 @@
+package xyz.ksharma.krail.core.testing.fakes
+
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * A [Clock] the test moves by hand.
+ *
+ * Use it where the code under test reads the wall clock but does not otherwise
+ * depend on coroutine virtual time — cache-expiry checks, "has this departed yet?"
+ * comparisons, peak/off-peak windows. Where the code *does* live on a scheduler,
+ * prefer `KrailTestScope.clock`, which is already tied to virtual time so
+ * `pumpOnce(...)` moves it.
+ *
+ * [DEFAULT_NOW] is a fixed instant rather than the real clock so a test never
+ * depends on the day it runs on.
+ */
+@OptIn(ExperimentalTime::class)
+class FakeClock(private var current: Instant = DEFAULT_NOW) : Clock {
+
+    override fun now(): Instant = current
+
+    /** Moves the clock forward (or back, for a negative [duration]). */
+    fun advanceBy(duration: Duration) {
+        current += duration
+    }
+
+    /** Jumps the clock to an absolute [instant]. */
+    fun setTo(instant: Instant) {
+        current = instant
+    }
+
+    companion object {
+        /** A Thursday, midday UTC — no month/DST/weekend edge to trip over. */
+        val DEFAULT_NOW: Instant = Instant.parse("2026-04-09T12:00:00Z")
+    }
+}

--- a/feature/track/ui/build.gradle.kts
+++ b/feature/track/ui/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
     sourceSets {
         commonTest {
             dependencies {
+                implementation(projects.core.testing)
                 implementation(libs.test.kotlin)
                 implementation(libs.test.kotlinxCoroutineTest)
                 implementation(libs.test.turbine)

--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
@@ -77,9 +77,14 @@ internal class TripPoller(
     private val gtfsRealtimeRepository: GtfsRealtimeRepository,
     private val sandook: Sandook,
     private val state: MutableStateFlow<TrackTripState>,
+    /**
+     * Wall-clock seam. The smart-delay anchor, the expiry check and the 1 Hz tick all
+     * read time from here, so a test decides what "now" is. See `dateTimeModule`.
+     */
+    private val timeSource: Clock = Clock.System,
 ) {
 
-    private val _clock = MutableStateFlow(Clock.System.now())
+    private val _clock = MutableStateFlow(timeSource.now())
 
     /** Current time, ticking every second while polling is active. */
     val clock: StateFlow<Instant> = _clock
@@ -160,7 +165,7 @@ internal class TripPoller(
     fun isTripExpired(deepLink: TripDeepLink): Boolean {
         val depInstant = runCatching { Instant.parse(deepLink.departureUtcDateTime) }.getOrNull()
             ?: return false
-        return Clock.System.now() > depInstant + TrackingConfig.DEPARTURE_EXPIRED_HOURS.hours
+        return timeSource.now() > depInstant + TrackingConfig.DEPARTURE_EXPIRED_HOURS.hours
     }
 
     /**
@@ -216,7 +221,7 @@ internal class TripPoller(
                 // wait out the remaining interval instead of hitting the API immediately.
                 // lastPollInstant == null means first poll — go straight through.
                 val elapsedMs =
-                    lastPollInstant?.let { (Clock.System.now() - it).inWholeMilliseconds }
+                    lastPollInstant?.let { (timeSource.now() - it).inWholeMilliseconds }
                         ?: Long.MAX_VALUE
                 val remainingWaitMs =
                     (TrackingConfig.POLL_INTERVAL_MS - elapsedMs).coerceAtLeast(0L)
@@ -228,7 +233,7 @@ internal class TripPoller(
 
                 setRefreshing(true)
                 fetchAndUpdate(deepLink)
-                lastPollInstant = Clock.System.now()
+                lastPollInstant = timeSource.now()
                 setRefreshing(false)
                 val current = state.value
                 when {
@@ -306,7 +311,7 @@ internal class TripPoller(
         clockJob?.cancel()
         clockJob = scope.launch {
             while (isActive) {
-                _clock.value = Clock.System.now()
+                _clock.value = timeSource.now()
                 delay(1.seconds)
             }
         }
@@ -364,7 +369,7 @@ internal class TripPoller(
             trackingManager.update(display)
             fetchStopCoordinatesIfNeeded(display)
 
-            val now = Clock.System.now()
+            val now = timeSource.now()
             val arrivalInstant = Instant.parse(display.destinationUtcDateTime)
             val arrivalFinishedAt = arrivalInstant + TrackingConfig.ARRIVAL_FINISHED_MINUTES.minutes
             when {
@@ -483,7 +488,7 @@ internal class TripPoller(
     private fun scheduleAutoRemoval(arrivalInstant: Instant) {
         scope.launch {
             val removeAt = arrivalInstant + TrackingConfig.ARRIVAL_FINISHED_MINUTES.minutes
-            val delayMs = (removeAt - Clock.System.now()).inWholeMilliseconds.coerceAtLeast(0)
+            val delayMs = (removeAt - timeSource.now()).inWholeMilliseconds.coerceAtLeast(0)
             log("TrackTrip: scheduleAutoRemoval — ArrivedAndFinished in ${delayMs}ms")
             delay(delayMs)
             transitionToArrivedAndFinished()

--- a/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TripPollerTest.kt
+++ b/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TripPollerTest.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.core.testing.fakes.FakeClock
 import xyz.ksharma.krail.feature.track.GtfsRealtimeRepository
 import xyz.ksharma.krail.feature.track.LegTrackingInfo
 import xyz.ksharma.krail.feature.track.LiveTrackingOverlay
 import xyz.ksharma.krail.feature.track.TrackTripState
+import xyz.ksharma.krail.feature.track.TrackingConfig
 import xyz.ksharma.krail.feature.track.TrackingManager
 import xyz.ksharma.krail.feature.track.TripDeepLink
 import xyz.ksharma.krail.sandook.RecentSearchLocation
@@ -211,6 +213,29 @@ class TripPollerTest {
         assertFalse(poller.isTripExpired(fresh))
     }
 
+    /**
+     * Demonstrates the clock seam: the same deep link is fresh, then expired, because
+     * the injected clock moved. Before the seam this could only be tested by picking a
+     * departure time relative to the real wall clock.
+     */
+    @Test
+    fun `GIVEN a fixed departure WHEN the injected clock passes the expiry window THEN the trip expires`() = runTest {
+        val fakeClock = FakeClock()
+        val deepLink = makeDeepLink(
+            departureUtcDateTime = (fakeClock.now() - 1.hours).toString(),
+        )
+        val poller = makePoller(timeSource = fakeClock)
+
+        assertFalse(
+            poller.isTripExpired(deepLink),
+            "one hour past departure is inside the ${TrackingConfig.DEPARTURE_EXPIRED_HOURS}h window",
+        )
+
+        fakeClock.advanceBy(2.hours)
+
+        assertTrue(poller.isTripExpired(deepLink), "three hours past departure is outside the window")
+    }
+
     @Test
     fun `GIVEN startPolling WHEN successful THEN polling job is active`() = runTest {
         val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
@@ -235,6 +260,7 @@ class TripPollerTest {
         tripService: TripPlanningService = ConfigurableTripService(),
         state: MutableStateFlow<TrackTripState> = MutableStateFlow(TrackTripState.Loading()),
         trackingManager: TrackingManager = TrackingManager(),
+        timeSource: Clock = Clock.System,
     ): TripPoller = TripPoller(
         scope = backgroundScope,
         // Share the test scheduler so withContext(ioDispatcher) advances under the
@@ -245,6 +271,7 @@ class TripPollerTest {
         gtfsRealtimeRepository = NoopGtfsRealtimeRepository,
         sandook = NoopSandook,
         state = state,
+        timeSource = timeSource,
     )
 
     private fun futureIso(duration: kotlin.time.Duration) =

--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/timetable/TimeTableState.kt
@@ -121,15 +121,21 @@ data class TimeTableState(
 
         /**
          * If the origin time is in the past.
+         *
+         * Takes [now] rather than reading the system clock so a caller that already
+         * knows "now" (and a test that controls it) decides which instant the journey
+         * is compared against. Defaults to the system clock, so untouched call sites
+         * behave exactly as before.
          */
-        val hasJourneyStarted: Boolean
-            get() = Instant.parse(originUtcDateTime) < Clock.System.now()
+        fun hasJourneyStarted(now: Instant = Clock.System.now()): Boolean =
+            Instant.parse(originUtcDateTime) < now
 
         /**
-         * If the destination time is in the past.
+         * If the destination time is in the past. See [hasJourneyStarted] for why this
+         * takes [now].
          */
-        val hasJourneyEnded: Boolean
-            get() = Instant.parse(destinationUtcDateTime) < Clock.System.now()
+        fun hasJourneyEnded(now: Instant = Clock.System.now()): Boolean =
+            Instant.parse(destinationUtcDateTime) < now
 
         /**
          * A sealed type describing the departure deviation status.

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/di/ViewModelModule.kt
@@ -194,6 +194,7 @@ val viewModelsModule = module {
             shareManager = get(),
             appReviewManager = get(),
             tripTrackingDebugOverride = tripTrackingDebugOverride,
+            clock = get(),
         )
     }
 
@@ -241,6 +242,7 @@ val viewModelsModule = module {
         createNearbyStopsManager(
             repository = get(),
             ioDispatcher = get(named(IODispatcher)),
+            clock = get(),
         )
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideRefreshHelper.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/ParkRideRefreshHelper.kt
@@ -40,12 +40,16 @@ internal fun isNotPeakTime(now: Instant = Clock.System.now()): Boolean {
  *
  * Shared by every surface that can trigger a Park & Ride fetch, so the map sheet and the home
  * card cannot end up with different rate limits for the same facility.
+ *
+ * [now] is the wall-clock seam: it decides which side of the peak window we are on.
+ * Defaults to the system clock so production call sites are unchanged.
  */
 @OptIn(ExperimentalTime::class)
 internal fun parkRideApiCooldown(
     peakTimeCooldownSeconds: Long,
     nonPeakTimeCooldownSeconds: Long,
-): Duration = if (isNotPeakTime()) {
+    now: Instant = Clock.System.now(),
+): Duration = if (isNotPeakTime(now)) {
     nonPeakTimeCooldownSeconds.seconds
 } else {
     peakTimeCooldownSeconds.seconds

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManager.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManager.kt
@@ -48,11 +48,16 @@ interface NearbyStopsManager {
 
 /**
  * Factory function to create a [NearbyStopsManager] instance.
+ *
+ * [clock] is the wall-clock seam used for cache expiry; production passes the Koin
+ * singleton (`Clock.System`), tests pass one they control. See `dateTimeModule`.
  */
+@OptIn(ExperimentalTime::class)
 fun createNearbyStopsManager(
     repository: NearbyStopsRepository,
     ioDispatcher: CoroutineDispatcher,
-): NearbyStopsManager = RealNearbyStopsManager(repository, ioDispatcher)
+    clock: Clock = Clock.System,
+): NearbyStopsManager = RealNearbyStopsManager(repository, ioDispatcher, clock)
 
 /**
  * Real implementation of [NearbyStopsManager].
@@ -62,6 +67,7 @@ fun createNearbyStopsManager(
 internal class RealNearbyStopsManager(
     private val repository: NearbyStopsRepository,
     private val ioDispatcher: CoroutineDispatcher,
+    private val clock: Clock = Clock.System,
 ) : NearbyStopsManager {
     private var nearbyStopsJob: Job? = null
     private var lastQueryCenter: LatLng? = null
@@ -156,7 +162,7 @@ internal class RealNearbyStopsManager(
     }
 
     private fun isCacheExpired(): Boolean {
-        val cacheAge = Clock.System.now().toEpochMilliseconds() - lastQueryTime
+        val cacheAge = clock.now().toEpochMilliseconds() - lastQueryTime
         return cacheAge > NearbyStopsConfig.CACHE_EXPIRY_MS
     }
 
@@ -173,7 +179,7 @@ internal class RealNearbyStopsManager(
 
     private fun updateCache(center: LatLng) {
         lastQueryCenter = center
-        lastQueryTime = Clock.System.now().toEpochMilliseconds()
+        lastQueryTime = clock.now().toEpochMilliseconds()
     }
 
     private fun handleError(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModel.kt
@@ -82,6 +82,12 @@ class TimeTableViewModel(
     val flag: Flag,
     private val appReviewManager: AppReviewManager,
     private val tripTrackingDebugOverride: Boolean = true,
+    /**
+     * Wall-clock seam. Everything on this screen that asks "has this departed yet?",
+     * "is this selection in the future?" or "how far away is this?" reads it from
+     * here, so a test can decide what time it is. See `dateTimeModule`.
+     */
+    private val clock: Clock = Clock.System,
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<TimeTableState> = MutableStateFlow(TimeTableState())
@@ -130,7 +136,7 @@ class TimeTableViewModel(
         while (true) {
             val hasJourneys = _uiState.value.journeyList.isEmpty().not()
             val hasError = _uiState.value.isError
-            val isFutureDate = dateTimeSelectionItem?.date.isFuture()
+            val isFutureDate = dateTimeSelectionItem?.date.isFuture(clock.now())
 
             if ((hasJourneys || hasError) && !isFutureDate) {
                 rateLimiter.triggerEvent()
@@ -462,9 +468,9 @@ class TimeTableViewModel(
 
             analytics.track(
                 AnalyticsEvent.DateTimeSelectEvent(
-                    dayOfWeek = item?.date?.dayOfWeek?.name ?: Clock.System.now()
+                    dayOfWeek = item?.date?.dayOfWeek?.name ?: clock.now()
                         .toLocalDateTime(currentSystemDefault()).dayOfWeek.name,
-                    time = item?.toHHMM() ?: Clock.System.now()
+                    time = item?.toHHMM() ?: clock.now()
                         .toLocalDateTime(currentSystemDefault()).toHHMM(),
                     journeyOption = item?.option?.name ?: JourneyTimeOptions.LEAVE.name,
                     isReset = item == null,
@@ -528,16 +534,17 @@ class TimeTableViewModel(
         // Update raw journey data map
         rawJourneyDataByJourneyId.putAll(newRawDataMap)
 
+        val now = clock.now()
         val startedJourneyList = journeys.values
             .filter {
                 // Find list of journeys that have started.
-                it.hasJourneyStarted
+                it.hasJourneyStarted(now)
             }
             .filterNot {
                 // If a journey has ended then remove it from the cache.
                 // This is to avoid displaying ended journeys.
                 // The threshold time is set to 10 minutes.
-                val thresholdTime = Clock.System.now().minus(JOURNEY_ENDED_CACHE_THRESHOLD_TIME)
+                val thresholdTime = now.minus(JOURNEY_ENDED_CACHE_THRESHOLD_TIME)
                 Instant.parse(it.destinationUtcDateTime).isBefore(thresholdTime)
             }
             .filterNot {
@@ -899,7 +906,7 @@ class TimeTableViewModel(
     private fun trackLoadMoreClick() {
         val info = tripInfo ?: return
         val visibleList = _uiState.value.journeyList
-        val now = Clock.System.now()
+        val now = clock.now()
         val latestMinutes = visibleList
             .mapNotNull { runCatching { Instant.parse(it.originUtcDateTime) }.getOrNull() }
             .maxOrNull()
@@ -921,7 +928,7 @@ class TimeTableViewModel(
     private fun trackLoadPreviousClick() {
         val info = tripInfo ?: return
         val visibleList = _uiState.value.journeyList
-        val now = Clock.System.now()
+        val now = clock.now()
         val earliestMinutes = visibleList
             .mapNotNull { runCatching { Instant.parse(it.originUtcDateTime) }.getOrNull() }
             .minOrNull()
@@ -1004,7 +1011,7 @@ class TimeTableViewModel(
 
     private fun onJourneyCardClicked(journeyId: String) {
         val journey = journeys[journeyId]
-        val hasJourneyStarted = journey?.hasJourneyStarted ?: false
+        val hasJourneyStarted = journey?.hasJourneyStarted(clock.now()) ?: false
         val legCount = journey?.legs?.size ?: 0
         val transportModes = journey?.transportModeLines
             ?.map { it.transportMode.productClass }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManagerCacheTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/NearbyStopsManagerCacheTest.kt
@@ -12,6 +12,8 @@ import kotlinx.coroutines.test.setMain
 import xyz.ksharma.krail.core.maps.data.model.NearbyStop
 import xyz.ksharma.krail.core.maps.data.repository.NearbyStopsRepository
 import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.maps.state.NearbyStopsConfig
+import xyz.ksharma.krail.core.testing.fakes.FakeClock
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapDisplay
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.NearbyStopFeature
@@ -19,6 +21,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Tests the cache-bypass rule: when the caller's MapUiState has no stops yet,
@@ -33,15 +36,18 @@ class NearbyStopsManagerCacheTest {
 
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var fakeRepository: FakeNearbyStopsRepository
+    private lateinit var fakeClock: FakeClock
     private lateinit var manager: NearbyStopsManager
 
     @BeforeTest
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         fakeRepository = FakeNearbyStopsRepository()
+        fakeClock = FakeClock()
         manager = createNearbyStopsManager(
             repository = fakeRepository,
             ioDispatcher = testDispatcher,
+            clock = fakeClock,
         )
     }
 
@@ -120,6 +126,62 @@ class NearbyStopsManagerCacheTest {
         )
         advanceUntilIdle()
         assertEquals(1, fakeRepository.callCount, "caller with stops should reuse warm cache")
+    }
+
+    /**
+     * Demonstrates the clock seam: cache expiry is now decided by the injected clock,
+     * so the test moves time instead of sleeping for [NearbyStopsConfig.CACHE_EXPIRY_MS].
+     */
+    @Test
+    fun `reloads once the injected clock passes the cache expiry window`() = runTest {
+        val center = LatLng(-33.87, 151.21)
+        val scope = CoroutineScope(testDispatcher)
+        val existingStop = NearbyStopFeature(
+            stopId = "stop-1",
+            stopName = "Town Hall",
+            position = center,
+            transportModes = persistentListOf(),
+        )
+        val warmState = MapUiState.Ready(
+            mapDisplay = MapDisplay(nearbyStops = persistentListOf(existingStop), mapCenter = center),
+        )
+
+        manager.loadNearbyStops(
+            mapState = MapUiState.Ready(mapDisplay = MapDisplay(mapCenter = center)),
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(1, fakeRepository.callCount)
+
+        // Still inside the window — cache holds.
+        fakeClock.advanceBy((NearbyStopsConfig.CACHE_EXPIRY_MS - 1).milliseconds)
+        manager.loadNearbyStops(
+            mapState = warmState,
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(1, fakeRepository.callCount, "cache must still be warm one millisecond early")
+
+        // Past the window — cache expires and the manager fetches again.
+        fakeClock.advanceBy(2.milliseconds)
+        manager.loadNearbyStops(
+            mapState = warmState,
+            center = center,
+            scope = scope,
+            onLoadingStateChanged = {},
+            onStopsLoaded = {},
+            onError = {},
+        )
+        advanceUntilIdle()
+        assertEquals(2, fakeRepository.callCount, "expired cache must trigger a fresh query")
     }
 }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/ClockSeamTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/ClockSeamTest.kt
@@ -1,0 +1,88 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.core.transport.nsw.NswTransportMode
+import xyz.ksharma.krail.trip.planner.ui.savedtrips.parkRideApiCooldown
+import xyz.ksharma.krail.trip.planner.ui.state.TransportModeLine
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+
+/**
+ * Demonstrates the clock seam on the two trip-planner pieces that used to read
+ * `Clock.System.now()` inline: [TimeTableState.JourneyCardInfo]'s departure checks and
+ * `parkRideApiCooldown`'s peak window.
+ *
+ * The journey test drives the seam from `KrailTestScope.clock`, which is wired to the
+ * coroutine scheduler — so `pumpOnce` moves virtual time AND the wall clock together,
+ * and a journey crosses its departure because the test advanced time, not because the
+ * suite ran at the right moment.
+ */
+@OptIn(ExperimentalTime::class)
+class ClockSeamTest {
+
+    @Test
+    fun `Given an upcoming journey When virtual time crosses departure Then it has started`() = krailRunTest {
+        val departure = clock.now() + 5.minutes
+        val journey = journeyDepartingAt(departure)
+
+        assertFalse(journey.hasJourneyStarted(clock.now()), "5 minutes out, the journey has not started")
+        assertFalse(journey.hasJourneyEnded(clock.now()))
+
+        pumpOnce(6.minutes)
+
+        assertTrue(journey.hasJourneyStarted(clock.now()), "virtual time crossed departure — journey has started")
+        assertFalse(journey.hasJourneyEnded(clock.now()), "arrival is still 20 minutes out")
+
+        pumpOnce(25.minutes)
+
+        assertTrue(journey.hasJourneyEnded(clock.now()), "virtual time crossed arrival — journey has ended")
+    }
+
+    @Test
+    fun `Given a peak-hour instant Then the park-ride cooldown is the peak one`() {
+        val zone = TimeZone.currentSystemDefault()
+        val inPeak = LocalDateTime(2026, 4, 9, PEAK_HOUR, 0).toInstant(zone)
+        val outsidePeak = LocalDateTime(2026, 4, 9, OFF_PEAK_HOUR, 0).toInstant(zone)
+
+        assertEquals(
+            PEAK_COOLDOWN_SECONDS.seconds,
+            parkRideApiCooldown(PEAK_COOLDOWN_SECONDS, OFF_PEAK_COOLDOWN_SECONDS, inPeak),
+        )
+        assertEquals(
+            OFF_PEAK_COOLDOWN_SECONDS.seconds,
+            parkRideApiCooldown(PEAK_COOLDOWN_SECONDS, OFF_PEAK_COOLDOWN_SECONDS, outsidePeak),
+        )
+    }
+
+    private fun journeyDepartingAt(departure: kotlin.time.Instant) = TimeTableState.JourneyCardInfo(
+        timeText = "in 5 mins",
+        originTime = "8:10 AM",
+        originUtcDateTime = departure.toString(),
+        destinationTime = "8:30 AM",
+        destinationUtcDateTime = (departure + JOURNEY_LENGTH).toString(),
+        travelTime = "20 mins",
+        transportModeLines = persistentListOf(
+            TransportModeLine(transportMode = NswTransportMode.Train, lineName = "T1"),
+        ),
+        legs = persistentListOf(),
+        totalUniqueServiceAlerts = 0,
+    )
+
+    private companion object {
+        val JOURNEY_LENGTH = 20.minutes
+        const val PEAK_HOUR = 7
+        const val OFF_PEAK_HOUR = 14
+        const val PEAK_COOLDOWN_SECONDS = 60L
+        const val OFF_PEAK_COOLDOWN_SECONDS = 600L
+    }
+}


### PR DESCRIPTION
## What

Introduces one injectable `Clock` seam so time-dependent code can be tested at a chosen instant
instead of whenever the suite happens to run, and moves the first batch of callers onto it.

## Changes

- `dateTimeModule` (`core/date-time`) binds `single<Clock> { Clock.System }`: the single place
  wall-clock time enters the object graph. Registered in `KoinApp`.
- Two shapes, chosen by how long the caller lives, documented on the module:
  - long-lived collaborators (ViewModels, pollers, cache managers) take a `clock: Clock`
    constructor parameter defaulting to `Clock.System`, because they read the time repeatedly at
    moments a test wants to control;
  - pure helpers take `now: Instant = Clock.System.now()`, because they answer one question about
    one instant and need no dependency at all.
- Production resolves the same `Clock.System` through either shape, so runtime behaviour is
  unchanged.
- Migrated: `TripPoller`, `TimeTableState`, `TimeTableViewModel`, `NearbyStopsManager`,
  `ParkRideRefreshHelper`, `DateTimeHelper`.
- `FakeClock` added to `core/testing` so tests can set and advance an instant directly.
- `config/clock-system-baseline.txt` counts lowered for every migrated file, per that file's
  shrink-only rule.

## Testing

- `./gradlew :feature:track:ui:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest :feature:trip-planner:state:testAndroidHostTest --continue` green
- New: `ClockSeamTest`, `NearbyStopsManagerCacheTest`, plus `TripPollerTest` cases that pin
  behaviour at a fixed instant
- `./gradlew detekt --continue` green, with `ClockSystemBan` reading the reduced baseline
- No user-visible behaviour changed, so no device QA applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
