### PR TITLE
fix(trip-planner): give each consumer its own rate limiter

### DIFF
--- a/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/KrailRunTest.kt
+++ b/core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/KrailRunTest.kt
@@ -2,6 +2,7 @@ package xyz.ksharma.krail.core.testing.coroutines
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -18,12 +19,18 @@ import kotlinx.coroutines.test.setMain
 @OptIn(ExperimentalCoroutinesApi::class)
 fun krailRunTest(
     body: suspend KrailTestScope.() -> Unit,
-) = runTest {
-    val scope = KrailTestScope(this)
-    Dispatchers.setMain(scope.mainDispatcher)
-    try {
+): TestResult = try {
+    runTest {
+        val scope = KrailTestScope(this)
+        Dispatchers.setMain(scope.mainDispatcher)
         scope.body()
-    } finally {
-        Dispatchers.resetMain()
     }
+} finally {
+    // Reset AFTER runTest returns, not inside it. `runTest` drains the scheduler once
+    // more on the way out, and anything still parked on a scope that is not a child of
+    // the test scope — a `viewModelScope`, most often — dispatches onto Dispatchers.Main
+    // during that drain. Resetting inside the test body leaves those dispatches with no
+    // Main delegate, and the test dies with a DispatchException that has nothing to do
+    // with what it was asserting.
+    Dispatchers.resetMain()
 }

--- a/feature/trip-planner/network/build.gradle.kts
+++ b/feature/trip-planner/network/build.gradle.kts
@@ -65,6 +65,7 @@ kotlin {
 
         commonTest {
             dependencies {
+                implementation(projects.core.testing)
                 implementation(libs.test.kotlin)
                 implementation(libs.test.turbine)
                 implementation(libs.test.kotlinxCoroutineTest)

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/TripPlannerNetworkModule.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/di/TripPlannerNetworkModule.kt
@@ -1,7 +1,7 @@
 package xyz.ksharma.krail.trip.planner.network.api.di
 
 import org.koin.core.module.dsl.bind
-import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.factoryOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -13,7 +13,10 @@ import xyz.ksharma.krail.trip.planner.network.api.service.TripPlanningService
 import xyz.ksharma.krail.trip.planner.network.api.service.tripPlannerHttpClient
 
 val tripPlannerNetworkModule = module {
-    singleOf(::NetworkRateLimiter) { bind<RateLimiter>() }
+    // factory, NOT single: a limiter's trigger channel is a broadcast, so every consumer
+    // sharing one instance fetches whenever any of them refreshes. See NetworkRateLimiter's
+    // KDoc and RateLimiterScopeTest.
+    factoryOf(::NetworkRateLimiter) { bind<RateLimiter>() }
 
     single {
         RealTripPlanningService(

--- a/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/NetworkRateLimiter.kt
+++ b/feature/trip-planner/network/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/NetworkRateLimiter.kt
@@ -16,7 +16,22 @@ import kotlin.time.Duration.Companion.seconds
  * Implements rate limiting for API calls using Kotlin Flows.
  * This class ensures that API calls are made at a controlled rate to avoid hitting rate limits.
  *
- * Note: This class should not be Singleton. It should be created per use-case.
+ * ## One instance per consumer
+ *
+ * [triggerEvent] is a broadcast to every flow built from this instance. Two consumers sharing
+ * one limiter therefore both fetch whenever either of them refreshes. The DI binding is a
+ * `factory` for exactly that reason — see `tripPlannerNetworkModule`.
+ *
+ * ## Trigger semantics: at most one pending trigger, delivered exactly once
+ *
+ * A trigger fired while nothing is collecting is **held** and delivered to the next collector.
+ * The screen relies on this: `onLoadTimeTable` triggers before `fetchTrip`'s collector has
+ * attached, and losing that trigger would mean the timetable never loads.
+ *
+ * `replay = 1` on the trigger channel is what holds that trigger. Once delivered, the pending
+ * trigger is **cleared** by [rateLimitFlow]. Without the clear, the same trigger re-ran for
+ * every later collection — so returning to the screen, or any code path that rebuilds the
+ * flow, fired a fetch nobody asked for on top of the one it was starting.
  */
 internal class NetworkRateLimiter : RateLimiter {
 
@@ -41,6 +56,10 @@ internal class NetworkRateLimiter : RateLimiter {
             .flatMapLatest {
                 // log(("flatmapLatest: Triggered")
                 isFirstTime.update { true } // Mark the first trigger
+                // The trigger has been served — drop it so a later collection does not
+                // replay it as a second, unrequested fetch. Only affects collectors that
+                // attach after this point; this one has already received it.
+                triggerFlow.resetReplayCache()
                 flow {
                     //   log(("Inside flow -emitting block")
                     emit(block())

--- a/feature/trip-planner/network/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/RateLimiterScopeTest.kt
+++ b/feature/trip-planner/network/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/network/api/ratelimit/RateLimiterScopeTest.kt
@@ -1,0 +1,88 @@
+package xyz.ksharma.krail.trip.planner.network.api.ratelimit
+
+import kotlinx.coroutines.launch
+import org.koin.dsl.koinApplication
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.trip.planner.network.api.di.tripPlannerNetworkModule
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Holds the two rules [NetworkRateLimiter]'s own KDoc states but the graph did not enforce.
+ *
+ * 1. **One limiter per consumer.** The trigger channel is a broadcast: every flow built from
+ *    the same limiter runs its block when *anyone* calls `triggerEvent()`. Bound as a Koin
+ *    `single`, two timetable screens shared one channel, so one screen's refresh fetched
+ *    for both.
+ * 2. **A trigger is consumed once.** A trigger fired while nothing is collecting must reach
+ *    the next collector — that is how the screen fetches on entry — but must not be replayed
+ *    to every collector after that.
+ */
+class RateLimiterScopeTest {
+
+    @Test
+    fun `Given the DI graph When RateLimiter is resolved twice Then each consumer gets its own`() {
+        val koin = koinApplication { modules(tripPlannerNetworkModule) }.koin
+        try {
+            assertNotSame(
+                koin.get<RateLimiter>(),
+                koin.get<RateLimiter>(),
+                "each consumer must own its rate limiter — a shared one broadcasts triggers",
+            )
+        } finally {
+            koin.close()
+        }
+    }
+
+    @Test
+    fun `Given two DI-resolved limiters When one is triggered Then only its own block runs`() = krailRunTest {
+        val koin = koinApplication { modules(tripPlannerNetworkModule) }.koin
+        val limiterA = koin.get<RateLimiter>()
+        val limiterB = koin.get<RateLimiter>()
+        var aCalls = 0
+        var bCalls = 0
+
+        val collectA = launch { limiterA.rateLimitFlow { aCalls++ }.collect {} }
+        val collectB = launch { limiterB.rateLimitFlow { bCalls++ }.collect {} }
+        runCurrent()
+
+        limiterA.triggerEvent()
+        pumpOnce(SETTLE)
+
+        assertEquals(1, aCalls, "the limiter that was triggered must run its block")
+        assertEquals(0, bCalls, "a second consumer must not fetch off another consumer's trigger")
+
+        collectA.cancel()
+        collectB.cancel()
+        koin.close()
+    }
+
+    @Test
+    fun `Given a trigger fired with no collector When collected later Then it runs once, not on every collection`() =
+        krailRunTest {
+            val limiter = NetworkRateLimiter()
+            var calls = 0
+
+            // The screen triggers before its collector attaches — that trigger must not be lost.
+            limiter.triggerEvent()
+
+            val first = launch { limiter.rateLimitFlow { calls++ }.collect {} }
+            pumpOnce(SETTLE)
+            assertEquals(1, calls, "a pending trigger must reach the first collector")
+            first.cancel()
+
+            // A later collection (screen re-entry, a new fetchTrip job) must not re-run the
+            // trigger that has already been served.
+            val second = launch { limiter.rateLimitFlow { calls++ }.collect {} }
+            pumpOnce(SETTLE)
+            assertEquals(1, calls, "an already-consumed trigger must not be replayed to a new collector")
+            second.cancel()
+        }
+
+    private companion object {
+        /** Longer than the limiter's own rate-limit interval, so nothing is left mid-debounce. */
+        val SETTLE = 2.seconds
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAutoRefreshTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableAutoRefreshTest.kt
@@ -1,0 +1,130 @@
+package xyz.ksharma.krail.trip.planner.ui.timetable
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.testing.coroutines.KrailTestScope
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFestivalManager
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeRateLimiter
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.core.testing.fakes.FakeShareManager
+import xyz.ksharma.krail.core.testing.fakes.FakeTripPlanningService
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.TimeTableUiEvent
+import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+
+/**
+ * The auto-refresh cadence, tested against the clock instead of against "some time passed".
+ *
+ * The previous version of this asserted `triggerCount > 0` after advancing past the interval,
+ * which the loop satisfies before any time passes at all — the `onStart` body runs one
+ * iteration the moment a subscriber attaches. It could not have caught a wrong interval, a
+ * missing delay, or a double fire. These pin the actual contract: one trigger on subscribe,
+ * nothing until the interval elapses, then exactly one more.
+ */
+@OptIn(ExperimentalTime::class)
+class TimeTableAutoRefreshTest {
+
+    private val sandook = FakeSandook()
+    private val preferences = FakeSandookPreferences()
+    private val analytics = FakeAnalytics()
+    private val shareManager = FakeShareManager()
+    private val tripPlanningService = FakeTripPlanningService()
+    private val rateLimiter = FakeRateLimiter()
+    private val festivalManager = FakeFestivalManager()
+    private val flag = FakeFlag()
+
+    @BeforeTest
+    fun setUp() {
+        TimeTableViewModel.resetSavePromptSessionFlagForTest()
+    }
+
+    @Test
+    fun `GIVEN journeys on screen WHEN the interval has not elapsed THEN nothing refreshes, then exactly one does`() =
+        krailRunTest {
+            val viewModel = buildViewModel()
+            loadJourneys(viewModel)
+            assertTrue(viewModel.uiState.value.journeyList.isNotEmpty(), "journeys must be on screen")
+            rateLimiter.reset()
+
+            val collectJob = collectAutoRefresh(viewModel)
+            // The loop's first iteration runs on subscribe — that is the refresh-on-entry.
+            val onSubscribe = rateLimiter.triggerCount
+            assertEquals(1, onSubscribe, "subscribing refreshes once, immediately")
+
+            pumpOnce(AUTO_REFRESH - 1.seconds)
+            assertEquals(onSubscribe, rateLimiter.triggerCount, "no refresh before the interval elapses")
+
+            pumpOnce(2.seconds)
+            assertEquals(onSubscribe + 1, rateLimiter.triggerCount, "exactly one refresh once it elapses")
+
+            collectJob.cancel()
+        }
+
+    @Test
+    fun `GIVEN an empty journey list WHEN intervals elapse THEN nothing is ever refreshed`() = krailRunTest {
+        val viewModel = buildViewModel()
+        rateLimiter.reset()
+
+        val collectJob = collectAutoRefresh(viewModel)
+        assertEquals(0, rateLimiter.triggerCount, "nothing on screen — nothing to refresh")
+
+        repeat(INTERVALS_TO_PUMP) { pumpOnce(AUTO_REFRESH + 1.seconds) }
+
+        assertEquals(0, rateLimiter.triggerCount, "an empty screen must never auto-refresh")
+        collectJob.cancel()
+    }
+
+    // region helpers
+
+    private fun KrailTestScope.buildViewModel() = TimeTableViewModel(
+        tripPlanningService = tripPlanningService,
+        rateLimiter = rateLimiter,
+        sandook = sandook,
+        preferences = preferences,
+        analytics = analytics,
+        shareManager = shareManager,
+        ioDispatcher = ioDispatcher,
+        festivalManager = festivalManager,
+        flag = flag,
+        appReviewManager = FakeAppReviewManager(),
+        clock = clock,
+    )
+
+    private fun KrailTestScope.loadJourneys(viewModel: TimeTableViewModel) {
+        tripPlanningService.isSuccess = true
+        viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(TRIP))
+        viewModel.fetchTrip()
+        pumpOnce(SETTLE)
+    }
+
+    /** Subscribes to the auto-refresh flow and lets its first loop iteration run. */
+    private fun KrailTestScope.collectAutoRefresh(viewModel: TimeTableViewModel): Job {
+        val job = launch { viewModel.autoRefreshTimeTable.collect {} }
+        runCurrent()
+        return job
+    }
+
+    // endregion
+
+    private companion object {
+        val AUTO_REFRESH = TimeTableViewModel.AUTO_REFRESH_TIME_TABLE_DURATION
+        val SETTLE = 1.seconds
+        const val INTERVALS_TO_PUMP = 10
+        val TRIP = Trip(
+            fromStopId = "stop1",
+            fromStopName = "S1",
+            toStopId = "stop2",
+            toStopName = "S2",
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableViewModelTest.kt
@@ -56,7 +56,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -1248,56 +1247,8 @@ class TimeTableViewModelTest {
 
     // endregion
 
-    // region Test for autoRefreshTimeTable
-
-    @Test
-    fun `GIVEN non-empty journey list WHEN AUTO_REFRESH_TIME_TABLE_DURATION passes THEN rate limiter is triggered`() =
-        runTest {
-            val trip = Trip(fromStopId = "stop1", fromStopName = "S1", toStopId = "stop2", toStopName = "S2")
-            tripPlanningService.isSuccess = true
-
-            viewModel.onEvent(TimeTableUiEvent.LoadTimeTable(trip))
-            viewModel.fetchTrip()
-            advanceUntilIdle()
-            assertTrue(viewModel.uiState.value.journeyList.isNotEmpty())
-
-            rateLimiter.reset()
-
-            viewModel.autoRefreshTimeTable.test {
-                skipItems(1) // initial value
-
-                advanceTimeBy(
-                    TimeTableViewModel.AUTO_REFRESH_TIME_TABLE_DURATION.inWholeMilliseconds + 1.seconds.inWholeMilliseconds,
-                )
-                assertTrue(rateLimiter.triggerCount > 0, "Rate limiter should be triggered after auto-refresh interval")
-
-                cancelAndConsumeRemainingEvents()
-            }
-        }
-
-    @Test
-    fun `GIVEN empty journey list WHEN AUTO_REFRESH_TIME_TABLE_DURATION passes THEN rate limiter is NOT triggered`() =
-        runTest {
-            // GIVEN empty journey list (no trips loaded)
-            rateLimiter.reset()
-
-            viewModel.autoRefreshTimeTable.test {
-                skipItems(1)
-
-                advanceTimeBy(
-                    TimeTableViewModel.AUTO_REFRESH_TIME_TABLE_DURATION.inWholeMilliseconds + 1.seconds.inWholeMilliseconds,
-                )
-                assertEquals(
-                    0,
-                    rateLimiter.triggerCount,
-                    "Rate limiter should not be triggered when journey list is empty",
-                )
-
-                cancelAndConsumeRemainingEvents()
-            }
-        }
-
-    // endregion
+    // Auto-refresh cadence lives in TimeTableAutoRefreshTest — it needs the shared
+    // scheduler from krailRunTest so `pumpOnce` can pin the interval to the millisecond.
 
     // region Test for isActive (time text updates)
 


### PR DESCRIPTION
## What

Gives each consumer its own `NetworkRateLimiter` and stops a served trigger from replaying on
every later collection.

## Changes

- `tripPlannerNetworkModule` binds `NetworkRateLimiter` as a `factory`, not a `single`. The
  limiter's `triggerEvent` is a broadcast to every flow built from the instance, so consumers
  sharing one limiter all fetch whenever any one of them refreshes. The class KDoc already said
  it should not be a singleton; the binding did not match.
- `rateLimitFlow` calls `triggerFlow.resetReplayCache()` once a trigger has been delivered. The
  channel keeps `replay = 1` so a trigger fired before a collector attaches is still held and
  delivered (`onLoadTimeTable` triggers before `fetchTrip`'s collector attaches, and losing that
  would mean the timetable never loads). Without the clear, the same trigger re-ran for every
  later collection, so returning to the screen fired a fetch nobody asked for on top of the one
  it was starting.
- KDoc now states both properties explicitly: one instance per consumer, and at most one pending
  trigger delivered exactly once.
- `KrailRunTest` gains the plumbing the new tests need.

## Testing

- New `RateLimiterScopeTest` covers the two properties directly: two consumers do not fetch on
  each other's trigger, and a held trigger is delivered once rather than on every collection.
- New `TimeTableAutoRefreshTest` asserts the refresh interval with a non-vacuous test: it fails
  if the flow stops emitting as well as if it emits too often, so it cannot pass by doing
  nothing.
- `TimeTableViewModelTest` trimmed of the cases now covered properly by the two above.
- `./gradlew :feature:trip-planner:network:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
