### PR TITLE
fix(track): back off when the trip API produces no journey to track

### DIFF
--- a/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
+++ b/feature/track/ui/src/commonMain/kotlin/xyz/ksharma/krail/feature/track/ui/TripPoller.kt
@@ -161,6 +161,14 @@ internal class TripPoller(
     val isLivePositionPollingActive: Boolean
         get() = livePositionJob?.isActive == true
 
+    /**
+     * Consecutive times the GTFS-RT loop has woken to find the trip API has still not
+     * produced a journey display. Reset to zero the moment one arrives. Exposed so a test
+     * can assert the retry schedule is bounded rather than inferring it from timing.
+     */
+    var displayWaitAttempts: Int = 0
+        private set
+
     /** True when [TrackingConfig.DEPARTURE_EXPIRED_HOURS] have elapsed since the scheduled departure. */
     fun isTripExpired(deepLink: TripDeepLink): Boolean {
         val depInstant = runCatching { Instant.parse(deepLink.departureUtcDateTime) }.getOrNull()
@@ -285,12 +293,24 @@ internal class TripPoller(
                 }
                 val display = tracked.display
                 if (display == null) {
-                    // Trip API hasn't returned yet — retry quickly so the first GTFS-RT poll
-                    // fires immediately after trip data lands rather than waiting a full 30s cycle.
-                    log("[LIVETRACK] tracked.display=null (trip API not yet returned), retrying in 2s")
-                    delay(GTFS_RT_RETRY_DELAY_MS)
+                    if (displayWaitAttempts >= MAX_DISPLAY_WAIT_ATTEMPTS) {
+                        log(
+                            "[LIVETRACK] no display after $MAX_DISPLAY_WAIT_ATTEMPTS attempts — " +
+                                "giving up on live positions; re-subscribing restarts the loop",
+                        )
+                        break
+                    }
+                    // The first retry stays fast on purpose: in the normal case the trip API
+                    // returns within a second or two, and live positions should appear then
+                    // rather than after a full 30s cycle. Each further wait doubles, because a
+                    // display that has not arrived by now is not one second away.
+                    val waitMs = displayWaitRetryDelayMs(displayWaitAttempts)
+                    displayWaitAttempts++
+                    log("[LIVETRACK] tracked.display=null (trip API not yet returned), retrying in ${waitMs}ms")
+                    delay(waitMs)
                     continue
                 }
+                displayWaitAttempts = 0
                 val transportLegCount = display.legs.filterIsInstance<TrackedLeg.Transport>().size
                 log("[LIVETRACK] pollLivePositions — legs=${display.legs.size}, transport legs=$transportLegCount")
                 pollLivePositions(display)
@@ -558,5 +578,27 @@ internal class TripPoller(
         private const val LABEL_DEPARTING_IN = "Departing in"
         private const val GTFS_RT_RETRY_DELAY_MS = 2_000L
         private const val WHILE_SUBSCRIBED_TIMEOUT_MS = 5_000L
+
+        // Doubling past this point is pointless — the delay is already at the ceiling.
+        private const val MAX_BACKOFF_SHIFT = 4
+
+        // Attempts to wait for a journey display before giving up. With the backoff schedule
+        // that is a little over two minutes. A display still missing by then means the trip
+        // API is failing or the journey was never matched, and neither is fixed by waiting.
+        // Re-subscribing to liveOverlay (re-opening the map panel) starts a fresh loop.
+        private const val MAX_DISPLAY_WAIT_ATTEMPTS = 8
+
+        /**
+         * Wait before the [attempt]-th retry for a journey display, in milliseconds.
+         *
+         * `2s, 4s, 8s, 16s, 30s, 30s, …` — doubling from the fast first retry up to the same
+         * ceiling as a normal GTFS-RT poll. A fixed 2 s retry costs thirty wakeups a minute
+         * for as long as the map panel is open, and every one of them is wasted if the trip
+         * API is not going to answer.
+         */
+        internal fun displayWaitRetryDelayMs(attempt: Int): Long {
+            val doubled = GTFS_RT_RETRY_DELAY_MS shl attempt.coerceAtMost(MAX_BACKOFF_SHIFT)
+            return doubled.coerceAtMost(TrackingConfig.GTFS_RT_POLL_INTERVAL_MS)
+        }
     }
 }

--- a/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TripPollerTest.kt
+++ b/feature/track/ui/src/commonTest/kotlin/xyz/ksharma/krail/feature/track/ui/TripPollerTest.kt
@@ -254,6 +254,81 @@ class TripPollerTest {
         assertIs<TrackTripState.Tracking>(state.value)
     }
 
+    // region GTFS-RT retry while the trip API has produced nothing
+
+    /**
+     * The live-positions loop cannot start until the trip API has produced a journey display.
+     * It waits for one on a fast retry, which is right for the normal case — the display lands
+     * within a second or two and live positions appear immediately rather than after a full
+     * 30 s cycle. When the display never lands (the trip API is failing, or the journey was
+     * not matched), that same fast retry became a fixed 2 s spin for as long as the map panel
+     * stayed open: thirty wakeups a minute, forever, achieving nothing.
+     */
+    @Test
+    fun `GIVEN the trip API never returns a display WHEN a minute passes THEN retries back off`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val trackingManager = TrackingManager().apply { start(deepLink) }
+        val poller = makePoller(trackingManager = trackingManager)
+
+        poller.startLivePositionPolling()
+        runCurrent()
+
+        testScheduler.advanceTimeBy(ALMOST_A_MINUTE_MS)
+        runCurrent()
+
+        // 2s, 4s, 8s, 16s, then capped at 30s: attempts at t = 0, 2, 6, 14, 30.
+        assertEquals(
+            EXPECTED_ATTEMPTS_IN_A_MINUTE,
+            poller.displayWaitAttempts,
+            "the wait for a display must back off, not spin at a fixed 2s",
+        )
+
+        poller.stopLivePositionPolling()
+    }
+
+    @Test
+    fun `GIVEN no display ever arrives WHEN the attempt cap is reached THEN the loop stops`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val trackingManager = TrackingManager().apply { start(deepLink) }
+        val poller = makePoller(trackingManager = trackingManager)
+
+        poller.startLivePositionPolling()
+        runCurrent()
+
+        testScheduler.advanceTimeBy(WELL_PAST_THE_CAP_MS)
+        runCurrent()
+
+        assertFalse(
+            poller.isLivePositionPollingActive,
+            "waiting forever for a display that is not coming is not a live map — give up",
+        )
+
+        poller.stopLivePositionPolling()
+    }
+
+    @Test
+    fun `GIVEN the display arrives WHEN the loop wakes THEN the wait counter resets`() = runTest {
+        val deepLink = makeDeepLink(departureUtcDateTime = futureIso(30.minutes))
+        val trackingManager = TrackingManager().apply { start(deepLink) }
+        val poller = makePoller(trackingManager = trackingManager)
+
+        poller.startLivePositionPolling()
+        runCurrent()
+        testScheduler.advanceTimeBy(TWO_RETRIES_MS)
+        runCurrent()
+        assertTrue(poller.displayWaitAttempts > 0, "the loop should be waiting for a display")
+
+        trackingManager.update(makeDisplay(deepLink, arrivalUtcDateTime = futureIso(1.hours)))
+        testScheduler.advanceTimeBy(TWO_RETRIES_MS)
+        runCurrent()
+
+        assertEquals(0, poller.displayWaitAttempts, "a display that lands resets the backoff")
+
+        poller.stopLivePositionPolling()
+    }
+
+    // endregion
+
     // region helpers
 
     private fun TestScope.makePoller(
@@ -347,6 +422,15 @@ class TripPollerTest {
 
     companion object {
         private const val SECONDS_PER_HALF_HOUR = 1800L
+
+        // Stops just short of the 60 s boundary so the assertion is not on a tie.
+        private const val ALMOST_A_MINUTE_MS = 59_000L
+
+        // Attempts at t = 0, 2 s, 6 s, 14 s, 30 s — the 2/4/8/16/30 backoff.
+        private const val EXPECTED_ATTEMPTS_IN_A_MINUTE = 5
+
+        private const val WELL_PAST_THE_CAP_MS = 10 * 60_000L
+        private const val TWO_RETRIES_MS = 7_000L
     }
 }
 


### PR DESCRIPTION
## What

Bounds the GTFS-RT loop's wait for a journey display. It previously retried every 2 seconds
forever when the trip API produced nothing to track.

## Changes

- `TripPoller` backs off while waiting for a journey display: `2s, 4s, 8s, 16s, 30s, 30s, …`,
  doubling from the fast first retry up to the same ceiling as a normal GTFS-RT poll. The first
  retry stays fast on purpose, because in the normal case the trip API returns within a second or
  two and live positions should appear then rather than after a full 30 second cycle.
- Gives up after `MAX_DISPLAY_WAIT_ATTEMPTS` (8, a little over two minutes on that schedule). A
  display still missing by then means the trip API is failing or the journey was never matched,
  and neither is fixed by waiting. Re-subscribing to `liveOverlay` (re-opening the map panel)
  starts a fresh loop.
- `displayWaitAttempts` resets to zero as soon as a display arrives, and is exposed read-only so
  a test can assert the retry schedule is bounded rather than inferring it from timing.

## Testing

- `TripPollerTest` extended: the backoff schedule, the reset on a display arriving, and the loop
  terminating at the attempt cap
- `./gradlew :feature:track:ui:testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
