### PR TITLE
fix(saved-trips): drop the park-ride review moment if the rider has left

### DIFF
--- a/docs/POLLING_LIFECYCLE.md
+++ b/docs/POLLING_LIFECYCLE.md
@@ -78,6 +78,11 @@ plain `LaunchedEffect` keeps it running behind the lock screen.
 `WhileSubscribed` here only releases upstream collectors; nothing repeats, so there is no
 background-work hazard. They are listed so that a new flow cannot land unclassified.
 
+`SavedTripsViewModel.whileScreenSubscribed` is a `SharingStarted` strategy rather than a flow:
+it is `WhileSubscribed` with the screen's real subscriber count mirrored out on its way past, so
+the review moment can tell whether the rider is still on Saved Trips. It starts no work of its
+own, so it is classified here with the state it shares.
+
 | Flow |
 |---|
 | `AddParkRideViewModel.uiState` |
@@ -87,6 +92,7 @@ background-work hazard. They are listed so that a new flow cannot land unclassif
 | `IntroViewModel.uiState` |
 | `MapStopSelectionViewModel.mapUiState` |
 | `SavedTripsViewModel.uiState` |
+| `SavedTripsViewModel.whileScreenSubscribed` |
 | `SearchStopViewModel.uiState` |
 | `ServiceAlertsViewModel.uiState` |
 | `SettingsViewModel.uiState` |

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsViewModel.kt
@@ -11,16 +11,19 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingCommand
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.analytics.Analytics
@@ -118,6 +121,25 @@ class SavedTripsViewModel(
 
     val trackedJourney: StateFlow<TrackedJourney?> = trackingManager.tracked
 
+    // How many collectors uiState has RIGHT NOW, with no grace period.
+    //
+    // stateIn keeps its own subscriber count to itself, and the count that is reachable —
+    // _uiState.subscriptionCount — reads 1 for a further SUBSCRIPTION_GRACE_MS after the last
+    // collector has gone. That padding is deliberate and correct for keeping the database
+    // observation warm across a rotation; it is the wrong answer for "is the rider looking at
+    // Saved Trips", which is what the review moment below has to know.
+    private val screenCollectors = MutableStateFlow(0)
+
+    // WhileSubscribed with the real subscriber count mirrored into screenCollectors on its way
+    // past. The counting stream never emits a command of its own; merging it just keeps it
+    // collected for as long as the sharing coroutine lives.
+    private val whileScreenSubscribed = SharingStarted { subscriptionCount ->
+        merge(
+            SharingStarted.WhileSubscribed(SUBSCRIPTION_GRACE_MS).command(subscriptionCount),
+            subscriptionCount.transform<Int, SharingCommand> { screenCollectors.value = it },
+        )
+    }
+
     private val _uiState: MutableStateFlow<SavedTripsState> = MutableStateFlow(SavedTripsState())
     val uiState: StateFlow<SavedTripsState> = _uiState
         .onStart {
@@ -137,7 +159,7 @@ class SavedTripsViewModel(
         .onCompletion {
             cleanupJobs()
         }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), SavedTripsState())
+        .stateIn(viewModelScope, whileScreenSubscribed, SavedTripsState())
 
     private suspend fun updateSelectedStops() {
         updateUiState {
@@ -221,6 +243,15 @@ class SavedTripsViewModel(
     private fun armParkRideCardReviewMoment() {
         viewModelScope.launchWithExceptionHandler<SavedTripsViewModel>(ioDispatcher) {
             delay(PARK_RIDE_CARD_REVIEW_DELAY_MS)
+            // Those few seconds are long enough for the rider to open a timetable, settings or
+            // the stop search, and the review sheet is a system dialog that will open over any
+            // of them — the one thing the calm-screen rule above exists to prevent. If they
+            // have left, the moment is simply dropped: it is not worth holding onto, since
+            // expanding a card again is all it takes to earn another one.
+            if (screenCollectors.value == 0) {
+                log("Park & Ride review moment dropped — Saved Trips is no longer on screen")
+                return@launchWithExceptionHandler
+            }
             appReviewManager.onDelightMoment(DelightMoment.PARK_RIDE_CARD_TAPPED)
             appReviewManager.onSavedTripsScreenShown()
         }
@@ -823,6 +854,10 @@ class SavedTripsViewModel(
 // Delay before requesting review after a Park and Ride card tap, so it never fires in the
 // same frame as the tap.
 private const val PARK_RIDE_CARD_REVIEW_DELAY_MS = 3_000L
+
+// How long the screen's data keeps loading after the last collector leaves, so a rotation or
+// a brief detach does not restart it.
+private const val SUBSCRIPTION_GRACE_MS = 5_000L
 
 private fun SavedTrip.toTrip(): Trip = Trip(
     fromStopId = fromStopId,

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsReviewMomentTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsReviewMomentTest.kt
@@ -1,0 +1,135 @@
+package xyz.ksharma.krail.trip.planner.ui.savedtrips
+
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import xyz.ksharma.krail.core.appreview.DelightMoment
+import xyz.ksharma.krail.core.testing.coroutines.KrailTestScope
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeFlag
+import xyz.ksharma.krail.core.testing.fakes.FakeInfoTileManager
+import xyz.ksharma.krail.core.testing.fakes.FakeNswParkRideSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideFacilityManager
+import xyz.ksharma.krail.core.testing.fakes.FakeParkRideService
+import xyz.ksharma.krail.core.testing.fakes.FakePlatformOps
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import xyz.ksharma.krail.core.testing.fakes.FakeSandookPreferences
+import xyz.ksharma.krail.feature.track.TrackingManager
+import xyz.ksharma.krail.trip.planner.ui.searchstop.RealSearchSessionStore
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.ParkRideUiState
+import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAppReviewManager
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeInviteFriendsTileManager
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeStopResultsManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Saved Trips is the one calm screen the store review sheet is allowed to land on.
+ *
+ * Tapping a Park & Ride card is a delight moment that happens *on* that screen, so it arms and
+ * fires in one place after a short delay rather than waiting for the next visit. The delay is
+ * the whole risk: three seconds is long enough for the rider to open a timetable, the settings
+ * screen or the stop search, and the review sheet is a system dialog that will happily open
+ * over any of them. A sheet on the wrong screen is exactly what the calm-screen rule exists to
+ * prevent, and it is invisible to a test that only checks the moment eventually fires.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SavedTripsReviewMomentTest {
+
+    private val appReviewManager = FakeAppReviewManager()
+
+    private val parkRideCard = ParkRideUiState(
+        stopId = "STOP_1",
+        stopName = "Bella Vista",
+        facilities = persistentSetOf(),
+        isLoading = false,
+    )
+
+    @Test
+    fun `the review moment fires while the rider is still on saved trips`() = krailRunTest {
+        val viewModel = buildViewModel()
+        val screen = watchSavedTrips(viewModel)
+
+        viewModel.onEvent(SavedTripUiEvent.ParkRideCardClick(parkRideCard, isExpanded = true))
+        pumpOnce(REVIEW_DELAY_MS + BEAT_MS)
+
+        assertEquals(
+            listOf(DelightMoment.PARK_RIDE_CARD_TAPPED),
+            appReviewManager.armedMoments,
+            "Expanding a card on the calm screen is a delight moment and should still fire",
+        )
+        leaveSavedTrips(screen)
+    }
+
+    @Test
+    fun `the review moment is dropped when the rider leaves before the delay elapses`() =
+        krailRunTest {
+            val viewModel = buildViewModel()
+            val screen = watchSavedTrips(viewModel)
+
+            viewModel.onEvent(SavedTripUiEvent.ParkRideCardClick(parkRideCard, isExpanded = true))
+
+            // The rider taps into a timetable a beat later — well inside the review delay.
+            pumpOnce(BEAT_MS)
+            screen.cancel()
+            pumpOnce(REVIEW_DELAY_MS + SUBSCRIPTION_GRACE_MS + BEAT_MS)
+
+            assertTrue(
+                appReviewManager.armedMoments.isEmpty(),
+                "The review sheet was requested after the rider had already left Saved Trips, " +
+                    "so it would have opened over whatever they opened instead",
+            )
+        }
+
+    /** Stands in for the screen collecting `uiState` with `collectAsStateWithLifecycle`. */
+    private fun KrailTestScope.watchSavedTrips(viewModel: SavedTripsViewModel): Job {
+        val job = launch { viewModel.uiState.collect {} }
+        pumpOnce(SCREEN_SETTLE_MS)
+        return job
+    }
+
+    /**
+     * Drop the screen's subscription and let `WhileSubscribed`'s grace expire, so the
+     * ViewModel's own coroutines are finished before the test scope tears the main dispatcher
+     * back down underneath them.
+     */
+    private fun KrailTestScope.leaveSavedTrips(screen: Job) {
+        screen.cancel()
+        pumpOnce(SUBSCRIPTION_GRACE_MS + BEAT_MS)
+    }
+
+    private fun KrailTestScope.buildViewModel() = SavedTripsViewModel(
+        sandook = FakeSandook(),
+        analytics = FakeAnalytics(),
+        ioDispatcher = ioDispatcher,
+        nswParkRideFacilityManager = FakeParkRideFacilityManager(),
+        parkRideService = FakeParkRideService(),
+        parkRideSandook = FakeNswParkRideSandook(),
+        stopResultsManager = FakeStopResultsManager(),
+        searchSessionStore = RealSearchSessionStore(),
+        flag = FakeFlag(),
+        preferences = FakeSandookPreferences(),
+        infoTileManager = FakeInfoTileManager(),
+        platformOps = FakePlatformOps(),
+        inviteFriendsTileManager = FakeInviteFriendsTileManager(),
+        trackingManager = TrackingManager(),
+        appReviewManager = appReviewManager,
+    )
+
+    private companion object {
+        /** Mirrors `PARK_RIDE_CARD_REVIEW_DELAY_MS`, which is private to the ViewModel. */
+        const val REVIEW_DELAY_MS = 3_000L
+
+        /** Long enough for the `onStart` bootstrap, including its own settle delay. */
+        const val SCREEN_SETTLE_MS = 1_000L
+
+        const val BEAT_MS = 500L
+
+        /** Mirrors the `WhileSubscribed` grace `uiState` is shared with. */
+        const val SUBSCRIPTION_GRACE_MS = 5_000L
+    }
+}


### PR DESCRIPTION
## What

Drops the park-ride review moment when the rider is no longer on Saved Trips, so the review
sheet cannot open over a different screen.

## Changes

- `SavedTripsViewModel` gains `screenCollectors`, the number of `uiState` collectors right now
  with no grace period. `stateIn` keeps its own subscriber count private, and the reachable
  count (`_uiState.subscriptionCount`) still reads 1 for `SUBSCRIPTION_GRACE_MS` after the last
  collector leaves. That padding is deliberate and right for keeping the database observation
  warm across a rotation, but it is the wrong answer to "is the rider looking at Saved Trips",
  which is what the review moment has to know.
- `whileScreenSubscribed` is `WhileSubscribed(SUBSCRIPTION_GRACE_MS)` with the real subscriber
  count mirrored into `screenCollectors` on its way past. The counting stream emits no command of
  its own; merging it only keeps it collected for as long as the sharing coroutine lives.
- The delight moment is skipped when `screenCollectors` is zero. The moment is dropped rather
  than deferred: expanding a card again is all it takes to earn another one.
- `SUBSCRIPTION_GRACE_MS` extracted as a named constant with a comment on what the grace is for.

## Testing

- New `SavedTripsReviewMomentTest` covers the moment firing while the screen is collected and
  being dropped once the last collector has gone, including within the grace window
- `./gradlew :feature:trip-planner:ui:testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
