### PR TITLE
ci: stop each main push from cancelling the previous one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,12 @@ permissions:
   actions: write  # allows build-android.yml to write back ANDROID_VERSION_CODE
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # Fall back to the ref on push: pull_request.number is empty there, so every main push
+  # otherwise shared one group and each merge cancelled the previous push's run. Cancelling is
+  # right for a PR (a new commit supersedes the old one) and wrong for main, where every commit
+  # needs its own result and its Codecov upload.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # The Dependabot gate lives inside build-android.yml and build-ios.yml, not here. The
 # branch ruleset for `main` requires the contexts "build-android-debug / build",

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -28,8 +28,10 @@ on:
       - '.github/workflows/ios-unit-tests.yml'
 
 concurrency:
+  # Same rule as build.yml: main pushes all share refs/heads/main, so cancelling in progress
+  # would let each merge kill the previous commit's run.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   ios-unit-tests:

--- a/.github/workflows/maestro-pr-smoke.yml
+++ b/.github/workflows/maestro-pr-smoke.yml
@@ -14,8 +14,11 @@ on:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  # This lane is pull-request-only, so the fallback and the condition are both inert today.
+  # They are here so that adding a push trigger cannot reintroduce build.yml's bug, where an
+  # empty pull_request.number put every push in one group and each merge cancelled the last.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   smoke:


### PR DESCRIPTION
## What

Stops a push to `main` from cancelling the CI run of the push before it.

`build.yml` keyed its concurrency group on `github.event.pull_request.number`, which is empty
on a `push` event. Every push to main therefore landed in the same group (`Krail App CI-`), and
with `cancel-in-progress: true` each merge cancelled the run for the commit before it. Two
consecutive main runs were cancelled that way today. Reruns and the main-branch Codecov uploads
that PR deltas are compared against go with them.

## Changes

- `build.yml`: group falls back to `github.ref` when there is no pull request, so each branch
  gets its own group. `cancel-in-progress` becomes
  `${{ github.event_name == 'pull_request' }}`.
  The fallback alone is not enough: every push to main shares `refs/heads/main`, so an
  unconditional `cancel-in-progress` would still let each merge kill the previous commit's run.
  Making it conditional keeps the "a new commit supersedes the old one" behaviour where it is
  correct (pull requests) and turns it off where it is not (main, where every commit needs its
  own result).
- `ios-unit-tests.yml`: already had the ref fallback but cancelled unconditionally, so it had
  the second half of the same bug. Same conditional applied.
- `maestro-pr-smoke.yml`: pull-request-only, so neither the fallback nor the condition changes
  its behaviour today. Given the same shape so that adding a push trigger later cannot
  reintroduce the bug.
- `maestro-nightly.yml` left alone: it already keys on `github.ref` and sets no
  `cancel-in-progress`.

One comment on each block records why the condition is there, since "cancel in progress" reads
as unconditionally desirable until you hit this.

## Testing

- All three files parse, and `actionlint` reports nothing new (the SC2086 notes it prints are
  pre-existing findings in `run:` blocks this change does not touch)
- Behaviour is verifiable after merge: consecutive pushes to main should each keep their own
  run instead of the newer one cancelling the older

🤖 Generated with [Claude Code](https://claude.com/claude-code)
