### PR TITLE
docs(testing): split TESTING.md into doctrine plus three reference pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,12 +38,24 @@ file" section for the exact row format before adding one.
 
 Modules use KMP `androidLibrary { withHostTest {} }` — this creates `testAndroidHostTest`, not the standard AGP task name.
 
-Modules that have `withHostTest {}` enabled:
-- `feature/trip-planner/ui`
-- `feature/track/ui`
-- `feature/track/state`
+**Most modules have `withHostTest {}` now** — roughly half the build files in the repo, and every
+module that owns a test suite. Do not keep a list here; it goes stale. Check the module's own
+`build.gradle.kts`, or:
 
-If a module is missing `testAndroidHostTest`, add `withHostTest {}` inside its `androidLibrary {}` block in `build.gradle.kts`.
+```sh
+grep -rl "withHostTest" --include=build.gradle.kts .
+```
+
+If a module is missing `testAndroidHostTest`, add `withHostTest {}` inside its `androidLibrary {}`
+block in `build.gradle.kts`. You will not have to notice this yourself: `verifyTestWiring` fails
+the build when a module has test sources but no host-test task, which is exactly the bug that
+once hid seven modules' suites.
+
+Full testing doctrine lives in [`TESTING.md`](TESTING.md), with the detail split across
+[`docs/testing/LAYERS.md`](docs/testing/LAYERS.md) (what each test layer is for),
+[`docs/testing/GUARDS.md`](docs/testing/GUARDS.md) (every custom detekt rule and guard test) and
+[`docs/testing/COVERAGE.md`](docs/testing/COVERAGE.md) (what the coverage number does and does not
+mean).
 
 ## Detekt
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,13 @@
 # Testing KRAIL
 
-A short guide. Read this before adding tests or onboarding a new module.
+The doctrine. Read this before adding tests or onboarding a module; the detail lives in three
+sub-pages.
+
+| Page | Answers |
+|---|---|
+| [`docs/testing/LAYERS.md`](docs/testing/LAYERS.md) | Which kind of test should I write? What does each layer catch, and what can it structurally never catch? |
+| [`docs/testing/GUARDS.md`](docs/testing/GUARDS.md) | What is that failure telling me? Every custom detekt rule and guard test, its baseline, and the ratchet contract. |
+| [`docs/testing/COVERAGE.md`](docs/testing/COVERAGE.md) | What does the coverage number mean, and what is it not allowed to claim? |
 
 ---
 
@@ -22,7 +29,7 @@ production class.
 > Rule of thumb: if you'd hit network, disk, the system clock, or a platform service in
 > production, that's a fake. Everything else is the real class.
 
-**PR checklist before merging a test:**
+**Checklist before merging a test:**
 
 - [ ] Class under test is the **real production class**.
 - [ ] Only seam interfaces from the table above are replaced with `:core:testing` fakes.
@@ -31,11 +38,25 @@ production class.
 - [ ] Koin is not started; collaborators are passed via constructor.
 - [ ] No `object : SomeBoundary { error(...) }` anonymous stub.
 
+### A test must be able to fail
+
+The rule that outranks everything else on this page:
+
+> **A test that cannot fail is worse than no test, because it reads as coverage.**
+
+Before committing a test that pins a fix, revert the fix, watch the test fail, and read the
+failure message to confirm it fails *for the reason you think*. When there is no shipped defect
+to revert against, prove it another way — instrument the harness and show the thing you assume
+is happening is actually happening. The full procedure, with a worked example, is under
+"[the discriminating-test rule](docs/testing/LAYERS.md#the-discriminating-test-rule)".
+
+Coverage percentages cannot see this distinction. Nothing in CI can. It is on the author.
+
 ---
 
 ## The harness — `krailRunTest`
 
-Single coroutine/scheduler harness for the whole codebase. Lives in
+One coroutine/scheduler harness for the whole codebase, in
 [`:core:testing`](core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/).
 
 ```kotlin
@@ -54,29 +75,18 @@ Single coroutine/scheduler harness for the whole codebase. Lives in
 }
 ```
 
-What you get:
-
-- One shared `TestCoroutineScheduler` for `runTest`, `ioDispatcher`, `mainDispatcher` — no
+- One shared `TestCoroutineScheduler` for `runTest`, `ioDispatcher` and `mainDispatcher` — no
   more *"Detected use of different schedulers"*.
-- `runCurrent()` drains coroutines at the current virtual instant; doesn't advance time.
-- `pumpOnce(interval)` = bounded `advanceTimeBy + runCurrent`. The **only** safe way to
-  drive a `channelFlow { while (true) { delay(); fetch() } }` poller.
-- `advanceUntilIdle()` is **deliberately not exposed** on `KrailTestScope`. Calling it
-  against an infinite poller spins forever — that's how `DepartureBoardRepositoryTest`
-  previously produced a 98 GB Gradle log (#1601).
+- `runCurrent()` drains coroutines at the current virtual instant without advancing time;
+  `pumpOnce(interval)` is a bounded `advanceTimeBy + runCurrent`.
+- **`advanceUntilIdle()` is deliberately not exposed.** Against an infinite poller it spins
+  forever — that is how `DepartureBoardRepositoryTest` once produced a 98 GB Gradle log (#1601).
 
-**Forbidden** when testing infinite pollers:
-- `advanceUntilIdle()` (won't terminate).
-- Forgetting `cancelAndIgnoreRemainingEvents()` on the Turbine block (leaks the flow into
-  the next test).
+Forbidden when testing infinite pollers: `advanceUntilIdle()`, and forgetting
+`cancelAndIgnoreRemainingEvents()` on the Turbine block. `TurbineHygieneTest` enforces the
+second; see [GUARDS.md](docs/testing/GUARDS.md).
 
-`TurbineHygieneTest` (in `:core:testing`) enforces the second one. It scans every test source
-for a `.test { }` block whose subject names itself a poller, ticker, auto-refresh or
-`isActive` gate, and fails if the block never cancels. It accepts
-`cancelAndConsumeRemainingEvents()` and a bare `cancel()` as well — all three end the
-collection, and they differ only in what they hand back. A genuinely finite flow that trips
-the name match goes in `config/turbine-hygiene-allowlist.txt` with the reason it is finite;
-a stale entry there fails the same test.
+Full API and the virtual-clock details: [LAYERS.md](docs/testing/LAYERS.md#unit-tests).
 
 ---
 
@@ -87,206 +97,110 @@ a stale entry there fails the same test.
 | Fake of a cross-cutting boundary interface (`Sandook`, `Analytics`, `*Service`, `Flag`, `RemoteConfig`, …) | `:core:testing/fakes/` — one canonical configurable impl, consumed via `testImplementation(projects.core.testing)`. |
 | Reused DTO / response builder | `:core:testing/builders/` |
 | Helper used across modules (e.g. analytics-assertion sugar) | `:core:testing/helpers/` |
-| Single-feature-only double (an interface defined *inside* one feature module) | Feature-local: `feature/<x>/src/commonTest/.../testfakes/` (e.g. `FakeStopResultsManager` in `trip-planner/ui`). Promote to `:core:testing` the moment a 2nd module needs it. |
+| Single-feature-only double (an interface defined *inside* one feature module) | Feature-local: `feature/<x>/src/commonTest/.../testfakes/`. Promote to `:core:testing` the moment a 2nd module needs it. |
 
 **Never:**
-- An anonymous `object : Boundary { error("x") }` stub. The CI guardrail
-  (`verifyNoAdHocBoundaryFakes`) rejects new ones.
-- A re-declared `private class Fake<Boundary>` in a test file. Same rule.
+- An anonymous `object : Boundary { error("x") }` stub.
+- A re-declared `private class Fake<Boundary>` in a test file.
 
-The few pre-existing offenders are listed in [`config/test-wiring-baseline.txt`](config/test-wiring-baseline.txt).
-The baseline file shrinks every time a migration replaces one with the canonical fake; it
-never grows.
+`verifyNoAdHocBoundaryFakes` rejects both. Pre-existing offenders sit in
+[`config/test-wiring-baseline.txt`](config/test-wiring-baseline.txt), which is **at its enforced
+cap** — a new ad-hoc fake cannot be grandfathered by adding a line.
 
----
-
-## CI guardrails
-
-Three verification tasks run on every PR via `.github/workflows/code-quality.yml` and are
-also wired into `check`:
-
-| Task | Fails when |
-|---|---|
-| `verifyTestWiring` | A module has Kotlin files under `src/commonTest`/`src/androidHostTest`/`src/androidUnitTest` but no `testAndroidHostTest` task — i.e. someone forgot `withHostTest {}` so CI was silently skipping the suite. |
-| `verifyTestingModuleUsage` | Any `commonMain` / `androidMain` / `iosMain` configuration resolves `:core:testing`. Stops fakes from shipping in the app and breaks any `:core:testing → feature → :core:testing` cycle. |
-| `verifyNoAdHocBoundaryFakes` | New `object : Boundary { … }` stub or `private class Fake<Boundary>` appears in any test source set. Existing offenders are grandfathered via the baseline file above. |
-
-The same workflow also runs the custom detekt rules' own suite:
-
-```
-./gradlew -p gradle/build-logic :detekt-rules:test
-```
-
-`:detekt-rules` lives in the `gradle/build-logic` included build. `./gradlew detekt` compiles
-it but never runs its tests, and a root-build `test` invocation cannot reach across the
-composite boundary — so `PublicImplementationClassTest` had never executed in CI. A rule could
-have quietly stopped flagging anything with CI still green. `-p` runs the task inside the
-included build directly.
-
-Note on the bare `test` task: it is not a way to run anything here. `./gradlew test` resolves
-to exactly one task, `:androidApp:test`, and `:androidApp` has no test source set, so it runs
-zero tests. `testAndroidHostTest` is the only host-test task name that matches KMP modules.
-
-Snapshot verification is a separate job, `.github/workflows/snapshot-verify.yml`, called
-from `build.yml` in parallel with `code-quality`. It runs one step per golden-owning module:
-
-| Step | Task | Blocking |
-|---|---|---|
-| `verify-taj` | `:taj:verifyRoborazziAndroidHostTest` | yes |
-| `verify-trip-planner` | `:feature:trip-planner:ui:verifyRoborazziAndroidHostTest` | yes |
-
-Four things about that job are load-bearing:
-
-- **It is a separate job, not a step in `code-quality`.** It runs on `macos-latest`, because
-  the goldens are recorded on a Mac and Robolectric's native rendering is not byte-identical
-  across operating systems. On `ubuntu-latest` it fails on files that are correct.
-- **The checkout sets `lfs: true`.** Goldens are Git LFS objects; without it the runner has
-  pointer files on disk and every comparison fails on an undecodable PNG.
-- **The modules are named explicitly**, one step each. Onboarding a third module means adding
-  a step — the cost of a macOS runner should not grow by accident.
-- **Both steps block.** The theme-transition race that kept trip-planner on
-  `continue-on-error` is fixed. See below.
-
-The reason the job has to exist at all: `testAndroidHostTest` on its own captures in
-Roborazzi's default mode, which silently records a missing or changed golden and still
-passes. Explicit verify is what turns a pixel change into a failure. When either step
-reports a diff the job uploads the reference/diff/new composites from
-`**/build/outputs/roborazzi/**` as an artifact.
-
-### The theme-transition race, and how it was fixed
-
-`KrailTheme` animates `colors.surface` with `animateColorAsState` against a multi-stage target
-(`taj/animations/ThemeTransitionAnimations.kt`). The harness used to shoot a preview as soon as
-the view was attached, mid-transition, so a golden recorded a background one shade off and
-which files that hit changed from run to run — which is why trip-planner ran with
-`continue-on-error` for as long as it did.
-
-`BaseSnapshotTest.captureScreenshot` now settles the animation clock before every capture:
-pause the Robolectric choreographer, then idle the main looper for a fixed 2 s, which is longer
-than the transition's worst case (80 ms + 100 ms of staged delay plus a 1500 ms surface tween).
-Two details are the whole fix:
-
-- **The advance is a fixed duration, not a wait for quiescence.** Several previews animate
-  forever, so an idle-wait would hang on them.
-- **The choreographer has to be paused first.** Left running, Robolectric answers
-  `nativeScheduleVsync` immediately without moving the clock, so an endless animation re-arms a
-  frame inside the same idle window and `idleFor` never returns — one preview sat at 100% CPU
-  through 170 000+ frames. Paused, each vsync is posted at the next frame boundary, so the
-  window is capped at 125 frames and an endless animation lands on a fixed frame.
-
-Re-recording under the settled clock rewrote every golden in both modules: the committed
-images had been captured during the transition's 80 ms glow stage (`#E8ECF0`) rather than on
-the settled surface (`#FFFFFF`). Two consecutive record runs then produced byte-identical sets,
-and the step blocks.
-
-One preview is excluded outright rather than relying on that settle:
-`PreviewMapStopSelectionPane_Loading` renders an indeterminate `CircularProgressIndicator`, so
-its captured frame is decided by the animation clock no matter how well the theme settles. It
-is listed in `TripPlannerUiSnapshotTest.excludedPreviewNames`, the same treatment taj gives
-`PreviewLoadingDotsPill_Visible`.
+The fakes live in `commonMain`, not `commonTest`, because KMP has no `java-test-fixtures`
+equivalent. `verifyTestingModuleUsage` is what stops them shipping in the app.
 
 ---
 
 ## Test commands
 
-The KMP Android plugin's host test task is `testAndroidHostTest` — **not** `jvmTest` or
-`testDebugUnitTest`.
+The KMP Android plugin's host test task is `testAndroidHostTest` — **not** `jvmTest`,
+`testDebugUnitTest` or `allTests`.
 
 | Scope | Command |
 |---|---|
 | Single module | `./gradlew :feature:track:ui:testAndroidHostTest` |
 | Multiple modules | `./gradlew :a:testAndroidHostTest :b:testAndroidHostTest --continue` |
 | All modules | `./gradlew testAndroidHostTest --continue` |
+| Static analysis | `./gradlew detekt --continue` |
+| The custom detekt rules' own suite | `./gradlew -p gradle/build-logic :detekt-rules:test` |
+| Shared tests on iOS (macOS only) | `./gradlew iosUnitTest` |
+| Snapshots | `./gradlew :module:recordRoborazziAndroidHostTest` / `verifyRoborazziAndroidHostTest` |
+| Coverage | `./gradlew koverHtmlReport` / `koverVerify` |
+| Everything static, both platforms | `./scripts/fullQualityChecks.sh` |
 
-`./gradlew detekt --continue` rounds out the pre-push gate. Both must be green locally
-before pushing.
+> The bare `test` task is not a way to run anything here. `./gradlew test` resolves to exactly
+> one task, `:androidApp:test`, and `:androidApp` has no test source set — so it runs zero tests
+> and reports success.
 
 ---
 
-## Running the shared tests on iOS
+## The layers
 
-`commonTest` has always *compiled* for iOS. Until the `iosUnitTest` lane it never **ran**
-there, so every Kotlin/Native behaviour difference — freezing, date and number formatting,
-`kotlin.time`, `Char` handling — was invisible.
+Six of them. Pick the cheapest layer that can actually fail for the reason you care about.
+Full detail in [LAYERS.md](docs/testing/LAYERS.md).
 
-```
-./gradlew iosUnitTest          # macOS + Xcode only
-```
+| Layer | Catches | Where |
+|---|---|---|
+| Unit (`krailRunTest`) | logic, state reduction, mapping, time | every module |
+| Compose interaction (Robolectric + `createComposeRule`) | what a screen renders, what a tap does, what survives recreation | `:feature:trip-planner:ui` |
+| Flow (`FlowTest`) | real screens + real ViewModels wired together, across recreation | `:feature:trip-planner:ui` |
+| Snapshot (Roborazzi) | pixels — contrast, clipping, font scale, dark mode | `:taj`, `:feature:trip-planner:ui` |
+| iOS (`iosUnitTest`) | Kotlin/Native behaviour differences | 6 modules |
+| E2E (Maestro) | does the app launch, can a rider finish a trip | `.maestro/` |
 
-That aggregate runs `iosSimulatorArm64Test` for each module in the lane and first runs
-`verifyIosTestClassification`, which fails if a module has shared test sources but is in
-neither the include nor the exclude list. Both lists, and the reason for every exclusion,
-live in one place:
-[`gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt`](gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt).
-`verifyIosTestClassification` also runs on the cheap Ubuntu runner in `code-quality.yml`, so
-drift is caught on every PR rather than only on the macOS lane.
+Everything is **host-side**. There are no instrumented `androidTest` targets, and the only
+emulator jobs in CI are the Maestro lanes.
 
-CI: [`.github/workflows/ios-unit-tests.yml`](.github/workflows/ios-unit-tests.yml) on
-`macos-latest`, for pushes to `main` and PRs touching shared sources or build config.
+Two limits worth knowing before you plan work around them:
 
-### What runs on iOS
+- **The iOS lane is small because of a linker wall, not because of the tests.** `:core:testing`
+  pulls in the GitLive Firebase SDK, whose iOS klibs need frameworks only the Xcode/SPM build
+  supplies — so every module consuming the shared fakes is excluded. 21 modules sit behind it.
+- **Snapshot goldens must be recorded on macOS.** Robolectric's native rendering is not
+  byte-identical across operating systems, and nothing in the code enforces this — it is a
+  property of where the CI job runs.
 
-| Module | Tests |
+---
+
+## Guards
+
+Beyond ordinary tests, the repo carries checks that hold **repo-wide invariants**: seven custom
+detekt rules, fifteen guard tests, four Gradle verification tasks and one Python
+script. Each exists because the mistake it catches actually shipped, is invisible in review, and
+is not catchable by a normal unit test.
+
+Full inventory, with every baseline file and where each check runs:
+[GUARDS.md](docs/testing/GUARDS.md).
+
+The contract shared by all of their allowlists:
+
+1. The list only ever **shrinks**. Fixing an offender means deleting its line in the same change.
+2. Every entry carries its reason.
+3. At zero entries, delete the file — the guard becomes an unconditional gate.
+4. **A stale entry is a failure.** An allowlist that excuses something which no longer exists
+   has rotted into a list of things that were once true.
+
+Adding a line to make a **new** violation pass is not a use of these files.
+
+### CI
+
+Guards run across four places, which is worth knowing when something fails locally but not in CI
+or the reverse:
+
+| Check | Runs in |
 |---|---|
-| `:core:date-time` | 27 |
-| `:core:deeplink` | 18 |
-| `:core:transport` | 15 |
-| `:taj` | 8 |
-| `:feature:debug-settings:store` | 6 |
+| `verifyTestWiring`, `verifyTestingModuleUsage`, `verifyNoAdHocBoundaryFakes`, `verifyIosTestClassification` | `code-quality.yml`, step **Verify test wiring** (before detekt, so a misconfigured module fails fast); also every local `check` |
+| The 7 custom detekt rules | `code-quality.yml`, step **Run Detekt** |
+| The rules' own unit tests | `code-quality.yml`, step **Run build-logic tests** — `./gradlew detekt` cannot run them, see below |
+| The guard tests | `code-quality.yml`, step **Run host tests** |
+| `check_layout_invariants.py` | `code-quality.yml`, step **Layout invariants**, and `fullQualityChecks.sh` |
+| Snapshot verify | `snapshot-verify.yml`, a separate **macOS** job called from `build.yml` |
 
-### What is host-only, and why
-
-**Firebase iOS frameworks — 19 of the 24 modules with shared tests.** `:core:analytics` and
-`:core:remote-config` depend on the GitLive Firebase Kotlin SDK, whose iOS klibs declare
-`-framework FirebaseCore`. Those frameworks are supplied by the Xcode project's SPM
-integration, so when Gradle links a standalone `.kexe` test binary the linker cannot find
-them:
-
-```
-ld: framework 'FirebaseCore' not found
-> Task :core:analytics:linkDebugTestIosSimulatorArm64 FAILED
-```
-
-`:core:testing` depends on both, so **every module that consumes the shared fakes inherits
-the wall** — that is what keeps the lane small, not anything wrong with the tests. Widening
-it means giving Gradle its own copy of the Firebase iOS frameworks (the repo already drives
-SPM from Gradle for MapLibre, via `krail.maplibre`), or splitting the Firebase-backed
-implementations out from the interfaces the fakes need. Both are real work, neither is a
-test-code change.
-
-**Backtick test names containing `,`.** Kotlin/Native rejects them where the JVM accepts
-them:
-
-```
-e: ThemeContrastTest.kt:35:9 Name contains illegal characters: ",".
-```
-
-Cheap to fix — rename the test. `:taj` joined the lane this way. `:feature:track:network`
-and `:feature:trip-planner:ui` still carry such names, but both also sit behind the Firebase
-wall, so renaming alone would not get them running.
-
-**Robolectric, Roborazzi and Compose UI tests** stay host-only by construction — they live in
-`androidHostTest`, which the iOS compilation never sees.
-
-### Shared Compose UI tests (`runComposeUiTest`) — parked, not rejected
-
-Spiked in `:taj` with `compose.uiTest` and an `@OptIn(ExperimentalTestApi)` test driving a real
-`Button` through `setContent` / `onNodeWithText` / `performClick`. Findings:
-
-- On **iOS it works**. The test ran green under `iosSimulatorArm64Test` with no extra setup.
-- In **`commonTest` it cannot stay**, because the same source also expands into
-  `androidHostTest`, and Android's `runComposeUiTest` needs a Robolectric runner and
-  `@Config`, which `commonTest` has no way to express. The Android run dies with
-  `NullPointerException: … "android.os.Build.FINGERPRINT" is null` from
-  `RobolectricIdlingStrategy`.
-- Moving it to **`iosTest` works on both** (iOS runs it, the host ignores it) — but then it is
-  an iOS-only test, not a shared one.
-
-**Parked.** An `iosTest`-only Compose test duplicates coverage `:taj` already has via
-Robolectric and Roborazzi, and the modules where a shared UI test would genuinely pay off
-(`:feature:trip-planner:ui`, `:feature:departures:ui`) are all behind the Firebase link wall,
-so they could not run it anyway. Worth revisiting the day that wall comes down — the API
-itself is not the obstacle.
+`:detekt-rules` lives in the `gradle/build-logic` included build. `./gradlew detekt` resolves its
+*jar*, so `test` is never in the task graph, and a root-build `test` invocation cannot reach
+across the composite boundary. A rule could quietly stop flagging anything with CI still green —
+hence the separate step. `fullQualityChecks.sh` does not run them either.
 
 ---
 
@@ -296,166 +210,19 @@ itself is not the obstacle.
 ./gradlew koverHtmlReport      # build/reports/kover/html/index.html
 ./gradlew koverXmlReport       # build/reports/kover/report.xml — the Codecov upload
 ./gradlew koverLog             # one line, straight to the console
+./gradlew koverVerify          # the floors
 ```
 
-One merged report for the whole repo, not 31 per-module ones. Kover's report tasks depend on
-the `testAndroidHostTest` tasks, so a report task runs the suites it measures — there is no
-"stale coverage" state to get caught by.
+One merged report for the repo rather than one per module. Kover's report tasks depend on the
+`testAndroidHostTest` tasks they measure, so there is no "stale coverage" state to get caught by.
 
-Modules opt in automatically: `configureCoverage()` in
-[`Coverage.kt`](gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Coverage.kt)
-applies Kover and registers the module into the root aggregate **if it has test sources**. A
-module with no tests is left out rather than reported as 0% — that would bury the signal from
-modules that do have suites, and `verifyTestWiring` is what stops a module having none. Two
-things are excluded on purpose: `:core:testing`, whose production code *is* test
-infrastructure, and codegen (`ComposableSingletons*`, SQLDelight, BuildKonfig, Compose
-Resources) — filters live in the root `build.gradle.kts`.
+Three things the number does not mean, spelled out in [COVERAGE.md](docs/testing/COVERAGE.md):
 
-CI generates the report inside `code-quality.yml`, right after the host-test step, so the
-suites run once. The HTML goes up as a build artifact and the XML to Codecov.
-
-> **`CODECOV_TOKEN` has to live in the `Firebase` environment**, next to the NSW API keys.
-> It currently exists only as a *repository* secret, and a reusable workflow cannot see
-> those — so until it is added there, coverage generates and uploads as a build artifact but
-> does not reach Codecov. Nothing else breaks: the step is `fail_ci_if_error: false`.
->
-> Neither alternative is acceptable. `secrets: inherit` on the callers would hand
-> `code-quality.yml` every repository secret — signing keystores, App Store keys, service
-> accounts — to deliver one upload token. Declaring `workflow_call.secrets` instead *closes*
-> the secrets context, at which point the environment-only `ANDROID_NSW_TRANSPORT_API_KEY`
-> and `IOS_NSW_TRANSPORT_API_KEY` references stop resolving and `actionlint` fails the
-> `lint-workflows` job. The environment is the one place that is both narrow and consistent
-> with how this workflow already gets every other secret.
-
-### There are no iOS coverage numbers
-
-Kover instruments JVM bytecode. Kotlin/Native is not supported upstream and cannot be worked
-around here, so coverage measures the host-test run only. A module in the iOS lane still shows
-its host coverage — iOS execution is a correctness signal, not a coverage one.
-
----
-
-## End-to-end tests
-
-Host tests prove logic; snapshots prove pixels. Neither can tell you whether the app
-launches, whether a rider can actually reach a timetable, or whether a screen survives
-having its Activity destroyed underneath it. [Maestro](https://maestro.mobile.dev) flows in
-[`.maestro/`](.maestro/) drive the real app on a real device to cover exactly that gap.
-
-Full detail lives in [`.maestro/README.md`](.maestro/README.md). The essentials:
-
-### Two lanes
-
-| Lane | Runs | Workflow |
-|---|---|---|
-| `.maestro/smoke/` | Every non-draft pull request | `.github/workflows/maestro-pr-smoke.yml` |
-| `.maestro/nightly/` | 03:00 AEST cron, `prod/**`, manual dispatch | `.github/workflows/maestro-nightly.yml` |
-
-Smoke is three flows and finishes in about four minutes: cold launch, plan a trip against
-the real API, and a rotation sweep across home, search stop and the timetable. Nightly adds
-process lifecycle and permission denial, and runs the whole suite on Android **and** an iOS
-simulator.
-
-`.maestro/shared/` holds helper flows called via `runFlow`. It sits outside both lanes so a
-directory run never treats one as a test.
-
-### Running locally
-
-Requires Maestro 2.x — `setOrientation` does not exist on 1.x.
-
-```sh
-curl -fsSL "https://get.maestro.mobile.dev" | bash
-export PATH="$PATH:$HOME/.maestro/bin"
-
-./gradlew :androidApp:installDebug
-maestro test -e APP_ID=xyz.ksharma.krail.debug .maestro/smoke/
-```
-
-### The `APP_ID` convention
-
-One set of flows serves both platforms, so the app id is a parameter rather than a literal.
-It **must** be passed with `-e`: a plain shell variable never reaches the flow, and an
-in-file `env:` default would silently take precedence over `-e` and make the parameter
-impossible to override.
-
-| Target | `APP_ID` |
-|---|---|
-| Android debug | `xyz.ksharma.krail.debug` (note the suffix) |
-| Android release | `xyz.ksharma.krail` |
-| iOS | `xyz.ksharma.krail` |
-
-### Selectors
-
-Flows select on `testTag` ids, never on visible copy, so a wording change cannot break a
-flow and a failure always means behaviour changed. Tags are declared in
-`TripPlannerTestTags` and `DebugSettingsTestTags`, and are **public API** to `.maestro/` —
-grep there before renaming one.
-
-Android surfaces them as accessibility `resource-id`s via `exposeTestTagsToUiAutomation()`
-at the app root; on iOS, Compose Multiplatform publishes them as `accessibilityIdentifier`
-with no opt-in. The same `id:` selector works on both, verified on an iPhone 17 simulator
-with the flows unchanged.
-
-### Flake policy
-
-**The PR lane never retries.** A flake that can block a merge gets fixed, not re-run. The
-flows are built for that: they wait rather than assert after anything asynchronous, and
-scroll to list items instead of asserting them in place, because Maestro matches only what
-is on screen.
-
-**The iOS nightly leg retries once.** Simulator runs are meaningfully flakier than emulator
-runs (boot races, window-server hiccups) and that lane reports rather than gates, so one
-retry buys signal without hiding a real break — a genuine regression fails twice. The
-Android nightly leg does not retry.
-
-Neither nightly job merges, tags or publishes anything. A red nightly is a signal for a
-human.
-
----
-
-## Snapshot testing
-
-The annotation-driven generation flow is preserved: any `@PreviewComponent` /
-`@PreviewScreen` annotated `@ScreenshotTest` gets shot by the next
-`recordRoborazziAndroidHostTest` run.
-
-Onboarding a new UI module is one line plus a small test class:
-
-```kotlin
-// In module's build.gradle.kts
-plugins {
-    alias(libs.plugins.krail.snapshot.testing)   // adds roborazzi + both core/snapshot* deps
-    // …other plugins
-}
-
-androidLibrary {
-    withHostTest {
-        isIncludeAndroidResources = true         // Roborazzi needs Android resources
-    }
-    androidResources {
-        enable = true                            // MANDATORY for AGP 9
-    }
-}
-```
-
-Then a 10-line `<Module>SnapshotTest.kt` extending [`BaseSnapshotTest`](core/snapshot-testing/src/androidMain/kotlin/xyz/ksharma/krail/core/snapshot/BaseSnapshotTest.kt):
-
-```kotlin
-@RunWith(RobolectricTestRunner::class)
-@GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(sdk = [34], qualifiers = RobolectricDeviceQualifiers.Pixel6, manifest = Config.NONE)
-class MyUiSnapshotTest : BaseSnapshotTest() {
-    override val packageToScan = "xyz.ksharma.krail.my.ui"
-
-    // Skip previews Robolectric hangs on (infinite shimmer, indeterminate loading).
-    override val excludedPreviewNames = setOf("PreviewLoadingDotsPill_Visible")
-
-    @Test fun `generate snapshots`() = generateSnapshots()
-}
-```
-
-Then `./gradlew :my:module:recordRoborazziAndroidHostTest` captures the goldens (PNGs go to
-`<module>/screenshots/`, tracked by Git LFS).
+- **It measures execution, not assertion.** A test with no assertions covers every line it runs.
+- **On a Compose module it is mostly previews.** A snapshot test renders the composable tree and
+  marks it covered without checking anything beyond "did not crash".
+- **It says nothing about iOS.** Kover instruments JVM bytecode; Kotlin/Native is unsupported
+  upstream. `commonMain` *is* counted — via the Android host run — but `iosMain` is invisible.
 
 ---
 
@@ -463,33 +230,36 @@ Then `./gradlew :my:module:recordRoborazziAndroidHostTest` captures the goldens 
 
 Concrete bug classes the current setup makes hard or impossible:
 
-- **"Detected use of different schedulers."** Eliminated by `krailRunTest` owning one
-  shared `TestCoroutineScheduler`.
-- **Infinite-poller virtual-time hangs** (the 98 GB log). `advanceUntilIdle()` isn't on
-  the surface area; only bounded `runCurrent` / `pumpOnce`. Mandatory
-  `cancelAndIgnoreRemainingEvents()` in every Turbine block.
-- **Silent dead tests.** `verifyTestWiring` fails the build when a module has test sources
-  but no `testAndroidHostTest` — exactly the bug that hid 7 modules' suites for months.
+- **"Detected use of different schedulers."** Eliminated by `krailRunTest` owning one shared
+  `TestCoroutineScheduler`.
+- **Infinite-poller virtual-time hangs** (the 98 GB log). `advanceUntilIdle()` is not on the
+  surface area; `TurbineHygieneTest` requires the cancel.
+- **Silent dead tests.** `verifyTestWiring` fails the build when a module has test sources but no
+  `testAndroidHostTest` — exactly the bug that hid seven modules' suites for months.
 - **Test code leaking into production.** `verifyTestingModuleUsage` forbids any non-test
   configuration from resolving `:core:testing`.
-- **Boundary fake drift** (the `FakeFlag` × 6 problem). The canonical fakes are the
-  shared source of truth; new ad-hoc copies fail
-  `verifyNoAdHocBoundaryFakes`; pre-existing ones are in a shrinking baseline.
-- **Snapshot drift shipping silently.** The `snapshot-verify` job runs
-  `verifyRoborazziAndroidHostTest` explicitly, on macOS, with LFS goldens checked out, so a
-  pixel change without a re-record fails the build for both golden-owning modules. Nineteen
-  `:taj` goldens had already drifted by the time that job existed, which is what an unrun
-  check costs.
-- **Boilerplate per test.** `krailRunTest { }` replaces ~10 lines of dispatcher
-  setup/teardown ceremony. New module snapshot adoption is one-line plugin alias instead
-  of three duplicated build-config blocks.
+- **Boundary fake drift** (the `FakeFlag` × 6 problem). Canonical fakes are the source of truth;
+  new ad-hoc copies fail `verifyNoAdHocBoundaryFakes` against a capped, shrinking baseline.
+- **Snapshot drift shipping silently.** Plain `testAndroidHostTest` *records* rather than
+  verifies, so a changed golden passes. The explicit `verifyRoborazzi` job is what makes a pixel
+  change a failure. Nineteen `:taj` goldens had already drifted by the time that job existed,
+  which is what an unrun check costs.
+- **Rotation crashes.** `NavKeySerializationConfigTest` catches an unregistered route at test
+  time instead of the first time a user rotates; `ViewModelStateDurabilityTest` makes skipping
+  `SavedStateHandle` a decision someone writes down.
+- **A screen that renders blank on one platform.** `DualPaneCompositingGuardTest` holds the
+  iOS map/gradient compositing rule that no compiler can see.
+- **Boilerplate per test.** `krailRunTest { }` replaces ~10 lines of dispatcher ceremony; module
+  snapshot adoption is a one-line plugin alias.
 
 ---
 
 ## Pointers
 
-- Plan that drove this work: [`.claude/plans/on-a-worktee-look-expressive-cat.md`](.claude/plans/on-a-worktee-look-expressive-cat.md) (in the parent checkout).
-- Canonical harness: [`core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/`](core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/)
-- Convention plugin source: [`gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/`](gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/)
+- Canonical harness: [`core/testing/`](core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/)
+- Convention plugins: [`gradle/build-logic/convention/`](gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/)
+- Custom detekt rules: [`gradle/build-logic/detekt-rules/`](gradle/build-logic/detekt-rules/)
 - Snapshot infra: [`core/snapshot-testing/`](core/snapshot-testing/) and [`core/snapshot-testing-annotations/`](core/snapshot-testing-annotations/)
+- E2E flows: [`.maestro/README.md`](.maestro/README.md)
+- Integration-testing rationale and the discriminating-test procedure: [`docs/INTEGRATION_TESTING_PLAN.md`](docs/INTEGRATION_TESTING_PLAN.md)
 - Per-feature UX invariants worth keeping tests in sync with: e.g. [`feature/trip-planner/ui/SEARCH_STOP_UX.md`](feature/trip-planner/ui/SEARCH_STOP_UX.md)

--- a/docs/testing/COVERAGE.md
+++ b/docs/testing/COVERAGE.md
@@ -1,0 +1,219 @@
+# Coverage — what the number means
+
+Part of [TESTING.md](../../TESTING.md). Read this before quoting a coverage percentage at
+anyone, and before changing a Kover filter.
+
+A coverage percentage is a **measurement of what the suite executed**, not a measurement of
+what the suite checked. Everything below exists to keep the number from claiming more than
+that.
+
+---
+
+## Commands
+
+```
+./gradlew koverHtmlReport      # build/reports/kover/html/index.html
+./gradlew koverXmlReport       # build/reports/kover/report.xml — the Codecov upload
+./gradlew koverLog             # one line, straight to the console
+./gradlew koverVerify          # the floors; fails the build when coverage drops through one
+```
+
+One merged report for the whole repo rather than a per-module one nobody reads. Kover's
+report tasks depend on the `testAndroidHostTest` tasks they measure, so a report task runs
+the suites first — there is no "stale coverage" state to get caught by, and running a report
+after the test step in CI costs a merge, not a second test run.
+
+Kover is pinned at **0.9.9** in `gradle/libs.versions.toml`. Anything below 0.9.7 does not
+understand the KMP Android host-test variant and silently measures nothing.
+
+---
+
+## What is measured
+
+Kover instruments **JVM bytecode produced by the Android host-test run**. That is the whole
+mechanism, and every property below follows from it.
+
+| Source set | Counted? | How |
+|---|---|---|
+| `commonMain` | **yes** | It compiles into the Android host-test classpath, so the Android run measures it |
+| `androidMain` | yes | Same run |
+| `iosMain` | **no** | Never compiled to JVM bytecode |
+| `commonTest` / `androidHostTest` | n/a — test code, not a coverage subject | |
+
+### There is no such thing as an iOS coverage number here
+
+Kover instruments JVM bytecode. Kotlin/Native is **not supported upstream** and cannot be
+worked around from this repo. That is a real limit, but it is narrower than it sounds:
+`commonMain` is where nearly all shared logic lives, and `commonMain` *is* counted — through
+the Android host run. What is invisible is `iosMain`, which is thin platform wiring.
+
+A module in the `iosUnitTest` lane still shows only its host coverage. Running the shared
+tests on iOS is a **correctness** signal (see [LAYERS.md](LAYERS.md)), not a coverage one.
+Do not read a module's coverage number as evidence about its iOS behaviour.
+
+---
+
+## What is deliberately excluded, and why
+
+Excluding code from coverage is a claim that measuring it would make the number *less*
+truthful. Each exclusion below carries that argument. Nothing gets excluded because it is
+merely inconvenient to test.
+
+### `:core:testing` — the fakes module
+
+Its production code **is** test infrastructure. The fakes are exercised constantly by every
+other module's suite, so including the module reports a very high number for code that ships
+to nobody. It inflates the aggregate and tells you nothing about the app.
+
+Enforced in `configureCoverage()`
+([`Coverage.kt`](../../gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Coverage.kt)):
+the module returns early and is never registered into the aggregate.
+
+### Codegen
+
+Generated code is never written by hand and never meaningfully "covered" — a generated
+`equals`/`hashCode` that no test calls is not a gap anyone should fix.
+
+| Excluded | Generator |
+|---|---|
+| `*.ComposableSingletons*` | Compose compiler — one per file holding `@Composable` lambdas |
+| `*.BuildKonfig` | BuildKonfig |
+| `*.generated.resources` packages | Compose Resources (`Res.drawable.*`) |
+| SQLDelight query and table classes | SQLDelight |
+
+> **Known gap as of this document.** The SQLDelight filter is written as
+> `packages("xyz.ksharma.krail.sandook.sandook")`, which matches exactly one generated file
+> (`KrailSandookImpl`). The other 36 generated query and table classes are emitted into
+> `xyz.ksharma.krail.sandook` — **the same package the hand-written repositories live in** —
+> so no package filter can separate them and they are all currently counted as covered
+> production code. Separating them needs the generated package moved, not a better glob.
+
+### Where the filters live
+
+Today the filter block sits in the **root `build.gradle.kts`**. That means it applies to the
+merged report and **not** to a per-module report: `./gradlew :taj:koverLog` and the taj slice
+of the merged report do not filter identically. Treat a per-module number as the rougher of
+the two.
+
+---
+
+## Which modules are in the aggregate
+
+`configureCoverage()` applies the Kover plugin and registers a module into the root aggregate
+**if the module has test sources** (`commonTest`, `androidHostTest` or `androidUnitTest`
+containing at least one `.kt` file).
+
+The stated reason for the "has tests" condition: a module with no tests would report 0%, which
+is true but drowns the signal from modules that do have suites, and `verifyTestWiring` is what
+stops a module quietly having none.
+
+That argument is load-bearing in one direction and misleading in the other. It is right that
+a wall of 0% rows makes the report harder to read. It is wrong that the aggregate should
+therefore *exclude* them — a module with no tests is precisely the thing an honest number
+should show. Excluding it means the headline percentage is computed over the friendly half of
+the repo. **See the roadmap below.**
+
+---
+
+## Where the reports go
+
+| Destination | What | Retention |
+|---|---|---|
+| `build/reports/kover/html/index.html` | Local browsable report | until the next build |
+| CI build artifact `coverage-report-<run_id>` | The same HTML, per run | 7 days |
+| Codecov | `report.xml`, flag `host-tests` | dashboard, PR comments, badge |
+
+Both CI destinations are produced by the `Generate coverage report` step in
+[`code-quality.yml`](../../.github/workflows/code-quality.yml), which runs **only if the host
+test step succeeded** — partial coverage from a broken run is worse than none.
+
+### The `CODECOV_TOKEN` placement rule
+
+`CODECOV_TOKEN` must live in the **`Firebase` environment**, next to the NSW API keys — not as
+a repository secret. `code-quality.yml` is a reusable workflow, and a reusable workflow cannot
+see repository secrets.
+
+Both alternatives are worse, and this is why neither was taken:
+
+- `secrets: inherit` on the callers hands `code-quality.yml` **every** repository secret —
+  signing keystores, App Store keys, service accounts — to deliver one upload token.
+- Declaring `workflow_call.secrets` instead *closes* the secrets context, at which point the
+  environment-only `ANDROID_NSW_TRANSPORT_API_KEY` and `IOS_NSW_TRANSPORT_API_KEY` references
+  stop resolving and `actionlint` fails the `lint-workflows` job.
+
+The upload is `fail_ci_if_error: false` throughout. A missing token or a Codecov outage must
+never fail a pull request; coverage is a signal, not a gate at that layer.
+
+---
+
+## Policy: what coverage is allowed to gate
+
+**Today: raw line coverage, with floors that sit under the current number.**
+
+`koverVerify` enforces a minimum. The floors are set a couple of points below the measured
+baseline, so they catch a *regression* — someone deleting a suite, or landing a large
+untested surface — and never block ordinary work. They are not aspirational targets, and they
+are not `warningInsteadOfFailure`: a floor that only warns is a comment.
+
+Raising a floor is a deliberate act that goes in its own commit with the new measurement
+quoted. Lowering one requires saying what was given up.
+
+### Raw line coverage overstates a Compose codebase
+
+This is the honest caveat on every number in this document. In a Compose Multiplatform app a
+large share of the lines are `@Composable` declarations, and a **snapshot test executes almost
+all of them**. Roborazzi renders every `@PreviewComponent` / `@PreviewScreen`, which walks the
+composable tree and marks those lines covered — without asserting a single behaviour beyond
+"it did not crash and the pixels match".
+
+So a rise in the number can mean a new preview was added, not that anything new is checked.
+
+### Roadmap: the logic-only gate
+
+The direction is to gate on **logic coverage** and report raw line coverage alongside it as
+context.
+
+1. Add `annotatedBy("androidx.compose.runtime.Composable")` to the Kover exclusion filters.
+   Kover supports annotation-based filtering directly, so this needs no new tooling. What
+   remains measured is the code where a wrong branch is a bug you can write an assertion
+   about: reducers, mappers, repositories, ranking, date handling.
+2. Move the filters out of the root build file into `configureCoverage()`, so a per-module
+   report and the merged report filter identically.
+3. Register **every module with production code** into the aggregate, not only the ones that
+   already have tests, so the headline is computed over the whole app.
+4. Re-measure, and set the floors under the new honest baseline.
+
+Each of those makes the reported number **go down**. That is the point. A number that fell
+because the measurement got more honest is worth more than a number that stayed high because
+the measurement was flattering.
+
+### The golden-coverage companion metric
+
+Line coverage cannot see the difference between a preview that is rendered and a preview whose
+rendering is *checked*. The companion metric that can: **what fraction of `@PreviewComponent` /
+`@PreviewScreen` previews own a committed golden image.**
+
+That fraction is a direct measure of assertion, not execution — a preview with a golden fails
+when its pixels change, a preview without one cannot fail at all. Tracked next to the line
+number, it answers the question line coverage silently dodges: of the UI this suite touches,
+how much of it is actually pinned?
+
+It is a concept here, not yet a task. The inputs already exist —
+`BaseSnapshotTest.packageToScan` enumerates the annotated previews, and the golden PNGs are
+committed per module — so computing it is a matter of comparing two lists.
+
+---
+
+## Reading a coverage report without fooling yourself
+
+- **A high number on a UI module is mostly previews.** Check whether the covered lines are
+  `@Composable` before believing it.
+- **A low number on a module full of `expect`/`actual` platform wiring is expected.** The
+  `actual` side that matters on iOS is not measured at all (see above).
+- **Coverage never says a test asserts anything.** `krailRunTest { subject.doThing() }` with no
+  assertion covers every line it touches. The guards in [GUARDS.md](GUARDS.md) and the
+  discriminating-test rule in [LAYERS.md](LAYERS.md) are what push back on that; the
+  percentage cannot.
+- **Diff coverage is more useful than total coverage.** Codecov's patch status answers "is the
+  code this PR added tested", which is the question a reviewer actually has. Total coverage
+  answers a question about the past.

--- a/docs/testing/GUARDS.md
+++ b/docs/testing/GUARDS.md
@@ -1,0 +1,326 @@
+# Guards — the checks that hold invariants nobody remembers
+
+Part of [TESTING.md](../../TESTING.md).
+
+An ordinary test checks one class. A **guard** checks the whole repo for a mistake that is
+cheap to make, invisible in review, and expensive to find later. Every guard here exists
+because the mistake it catches actually shipped.
+
+Two mechanisms:
+
+- **Custom detekt rules** — syntax-tree checks, run by `./gradlew detekt`.
+- **Guard tests** — ordinary JVM tests that walk the source tree, run by `testAndroidHostTest`.
+
+Plus two Gradle-level and one Python-level check that fit neither box.
+
+---
+
+## The ratchet contract
+
+Almost every guard has an escape hatch: a baseline or allowlist of pre-existing offenders. The
+contract on all of them is the same, and it is the reason they are worth having:
+
+1. **The list only ever shrinks.** Fixing an offender means deleting its line in the same
+   change. Adding a line to make a *new* violation pass is not a use of the file.
+2. **Every entry carries its reason**, in a comment on the line or beside it.
+3. **When the list reaches zero, delete the file.** The guard then becomes an unconditional
+   gate, which is the destination.
+4. **A stale entry is a failure.** The better guards fail when an allowlist excuses something
+   that no longer exists — otherwise the list rots into a list of things that were once true.
+
+Point 4 is the one that separates a live ratchet from a graveyard, so the tables below say for
+each guard whether it enforces it.
+
+One mechanical detail that makes the whole thing work: `Detekt.kt` registers
+`config/*-baseline.txt` as a **task input** on every detekt task. Without that, deleting a
+baseline entry would leave every detekt task `UP-TO-DATE` and the newly un-grandfathered
+violation would never be reported.
+
+---
+
+## Custom detekt rules
+
+Ruleset id `krail`, in the `gradle/build-logic` included build:
+[`gradle/build-logic/detekt-rules/`](../../gradle/build-logic/detekt-rules/). Registered in
+`KrailRuleSetProvider.kt`, wired onto every module by `configureDetekt()` in
+[`Detekt.kt`](../../gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/Detekt.kt)
+as `detektPlugins "xyz.ksharma.krail.gradle:detekt-rules:unspecified"` — a coordinate, not a
+project reference, because composite-build substitution resolves it.
+
+All seven run in `./gradlew detekt`. Config lives in the `krail:` block of
+[`config/detekt.yml`](../../config/detekt.yml).
+
+### `ClockSystemBan`
+
+Flags `Clock.System` read inline, including the fully-qualified form and the
+`import kotlin.time.Clock.System` alias evasion. Inline time reads are untestable: nothing can
+move them.
+
+**Instead:** read time from the injected `Clock` — a constructor parameter, or a `now:`
+parameter.
+
+Exempt: parameter default values (walking *up*, so `Clock.System.now().plus(1.minutes)` as a
+default is exempt whole), Koin binding files (a `di` package segment plus an `org.koin`
+import), and every test source set — matched by **source-set directory, never by file name**.
+
+| | |
+|---|---|
+| Baseline | [`config/clock-system-baseline.txt`](../../config/clock-system-baseline.txt) — 14 rows, `path\|count` |
+| Ratchet | The count is an **allowance**: offenders beyond it report, so a listed file cannot grow a new read. Shrink-only by header rule, not machine-enforced. |
+| Note | Counts, not line numbers — line numbers churn on every unrelated edit, and a stale baseline is worse than none. Cost: in a baselined file the reported location is the *last* read in the file, not the new one. |
+
+### `CollectAsStateBan`
+
+Flags `collectAsState(` calls and its import. `collectAsState()` keeps collecting while the
+screen is backgrounded, so polling never pauses and a `WhileSubscribed` upstream never sees
+its subscriber count drop.
+
+**Instead:** `collectAsStateWithLifecycle()`. See [`docs/POLLING_LIFECYCLE.md`](../POLLING_LIFECYCLE.md).
+
+No baseline — zero offenders, unconditional gate. Matched exactly, so
+`collectAsStateWithLifecycle` does not trip it.
+
+### `CyclomaticSuppressBan`
+
+Two routes, both banned:
+
+1. `@Suppress("CyclomaticComplexMethod")` on a declaration or as `@file:Suppress`.
+2. A `CyclomaticComplexMethod:` entry in a module's `baseline.xml` — **baselining is
+   suppression**, and this route has no escape hatch at all.
+
+**Instead:** refactor. Extract cohesive blocks to *top-level private functions* — a local `fun`
+does not reduce the count, because detekt attributes its branches to the enclosing function.
+Or replace the branch ladder with a `when` or a lookup map.
+
+> `config/cyclomatic-suppress-baseline.txt` **does not exist**. `RatchetBaseline` finds the
+> repo root by looking for that file, so with it absent nothing is grandfathered and the rule
+> is a hard zero-tolerance gate today — stricter than its own KDoc and the `detekt.yml`
+> comment describe. That is the intended destination, reached early. Do not create the file to
+> get out of a refactor.
+
+### `LazyItemKeyRule`
+
+Flags an `item { }` call with an empty argument list inside a lazy container (`LazyColumn`,
+`LazyRow`, the four grid variants) or a `LazyListScope` / `LazyGridScope` /
+`LazyStaggeredGridScope` extension function. Without a key, Compose identifies the item by
+position, so inserting or reordering hands one row's remembered state — scroll, expanded flags,
+running animations — to a different row.
+
+**Instead:** a descriptive string literal for a static item, a domain id for a dynamic one. See
+CLAUDE.md, "LazyColumn / LazyRow item keys".
+
+`items(...)` is **deliberately out of scope**: its keyed and unkeyed forms are told apart by
+named arguments across several lines and it has count/list/array overloads, so a syntactic
+check false-positives. Extending it means matching named arguments on the resolved call.
+
+| | |
+|---|---|
+| Baseline | [`config/lazy-item-key-baseline.txt`](../../config/lazy-item-key-baseline.txt) — 2 rows, `path\|function\|count` |
+| Ratchet | Shrink-only by header rule: decrement the count in the same change, delete the line at zero. |
+
+### `PublicImplementationClass`
+
+Flags a public top-level class that implements an interface (`: Foo` or `: Foo by delegate`,
+never `: Foo(args)` — that is always a superclass constructor call like `ViewModel()`).
+
+**Instead:** make it `internal`, and depend on the interface everywhere else. Or add the
+supertype to `excludeSuperTypes` in `detekt.yml` if it genuinely must stay public.
+
+24 supertypes are excluded by default (`Parcelable`, `Comparable`, `CoroutineScope`, `NavKey`,
+`KoinComponent`, the Compose `*ModifierNode` family, …). `:core:testing` is excluded wholesale —
+its `Fake*` classes are deliberately public shared test doubles.
+
+Notably it does **not** use type resolution. The `@RequiresTypeResolution` version was written
+and verified to produce **zero** findings against a deliberately broken sample on both
+`detektAndroidMain` and `detektMetadataCommonMain`, while the same logic worked in a unit-test
+harness with resolution set up by hand. Hence raw supertype-name matching.
+
+### `ScreenshotPreviewAnnotation`
+
+Flags a `@ScreenshotTest` function annotated with neither `@PreviewComponent` nor
+`@PreviewScreen`.
+
+A bare `@Preview` records **one** light-mode phone baseline. The project annotations expand to
+light, dark and 2× font scale, plus tablet for `@PreviewScreen`. So with a bare `@Preview`, a
+dark-mode contrast regression or a 2×-font clipping bug lands green.
+
+| | |
+|---|---|
+| Baseline | [`config/screenshot-annotation-baseline.txt`](../../config/screenshot-annotation-baseline.txt) — 33 rows, `path\|function` |
+| Ratchet | Shrink-only by header rule. Fixing one means swapping the annotation, **re-recording the goldens**, and deleting the line in the same change. |
+
+### `SnackbarBan`
+
+Flags any callee or import whose name contains `snackbar`, case-insensitively — so `Snackbar`,
+`SnackbarHost`, `SnackbarHostState` and `showSnackbar` all trip it.
+
+A snackbar puts undo on a timer, somewhere other than the thing being undone, on top of the
+bottom-anchored controls.
+
+**Instead:** long-press to enter edit mode with an in-place action, or a `ModalBottomSheet` when
+a decision needs confirming.
+
+No baseline — zero offenders, unconditional gate. It exists because
+`Scaffold { snackbarHost = … }` is the default answer in every Compose sample, so it arrives by
+copy-paste rather than by decision.
+
+### Running the rules' own tests
+
+```
+./gradlew -p gradle/build-logic :detekt-rules:test
+```
+
+**`./gradlew detekt` does not run these.** `detektPlugins` resolves the rules' *jar*, and Gradle
+builds only the producing task chain (`compileKotlin`, then `jar`); `test` is never in that graph,
+and a root-build task name cannot address tasks in an included build. So a rule could quietly
+stop flagging anything with CI still green — which is why `code-quality.yml` has a separate
+`Run build-logic tests` step. `fullQualityChecks.sh` does not run them either.
+
+Each rule has a unit test asserting both what it flags and what it must not, and
+`RatchetBaselineTest` covers the shared baseline mechanism against a real temp-dir fake repo.
+
+---
+
+## Guard tests
+
+Ordinary tests that walk the source tree. They find the repo root by walking up to
+`settings.gradle.kts`, and skip `build/` and `.git/`.
+
+### In `:composeApp` — `./gradlew :composeApp:testAndroidHostTest`
+
+| Guard | Enforces | Allowlist | Stale check |
+|---|---|---|---|
+| `PollingLifecycleGuardTest` | (a) every `SharingStarted.WhileSubscribed(` in production source is registered as `` `Owner.flowName` `` in [`docs/POLLING_LIFECYCLE.md`](../POLLING_LIFECYCLE.md); (b) no `collectAsState(` anywhere | the doc itself is the register | **no** — a doc row for a deleted flow can rot |
+| `DualPaneCompositingGuardTest` | no `DualPaneScaffold(` nested inside a compositing wrapper (`CloudGradientBackground(`, `.graphicsLayer`, `.blur(`) | in-file: `.blur(` in `SavedTripsScreen.kt` | no |
+| `LearningLogActionsTest` | every backticked identifier inside a ticked `- [x]` action in `docs/learning/*.md` resolves — a path exists on disk, a `*Test` name is declared in a test source set and the named method is in that file | none | n/a |
+| `ViewModelStateDurabilityTest` | every ViewModel registered in a Koin module takes a `SavedStateHandle` in some constructor, or is listed with a reason | [`config/no-saved-state-allowlist.txt`](../../config/no-saved-state-allowlist.txt) — 19 entries | **yes** |
+| `RoutePaneMetadataTest` | the pane-metadata table in [`docs/TABLET_FOLDABLE_UX.md`](../TABLET_FOLDABLE_UX.md) exactly equals the `entry<Route>(metadata = …)` declarations in source | the doc table is the register | **yes**, both directions |
+| `NavKeySerializationConfigTest` | every concrete subclass of every sealed route hierarchy is registered in the polymorphic `SerializersModule` | none | no |
+
+`DualPaneCompositingGuardTest` and `NavKeySerializationConfigTest` both hold crash classes that
+**only appear at runtime**: an iOS map that renders blank under a gradient, and a
+`SerializationException` thrown the first time a user rotates. Neither is visible to the
+compiler.
+
+`ViewModelStateDurabilityTest` also fails hard if it finds **zero** ViewModel registrations —
+a scan-broke detector, so a refactor that defeats the regex fails loudly instead of passing
+vacuously. Several guards here carry that pattern; copy it into any new one.
+
+### Elsewhere
+
+| Guard | Module | Enforces | Allowlist | Stale check |
+|---|---|---|---|---|
+| `TurbineHygieneTest` | `:core:testing` | a `.test { }` block whose subject names itself a poller/ticker/auto-refresh or an `isActive` gate must cancel: `cancelAndIgnoreRemainingEvents()`, `cancelAndConsumeRemainingEvents()` or a bare `cancel()` | [`config/turbine-hygiene-allowlist.txt`](../../config/turbine-hygiene-allowlist.txt) — **0 entries**, empty on purpose | **yes** |
+| `SearchQueryTextEgressTest` | `:feature:trip-planner:ui` | drives the real analytics helpers and asserts no property of the built `search_stop_query` event contains the query or any ≥4-char token of it; a control test asserts the zero-result carve-out still does emit it | none | n/a |
+| `SearchQueryRedactionCallSiteTest` | `:feature:trip-planner:ui` | every `zeroResultQuery =` assignment has a redaction call within 8 lines | none | n/a |
+| `BrandHexUniquenessTest` | `:feature:trip-planner:ui` | no production `.kt` outside `core/transport/` contains a `TransportMode.*.colorCode` hex literal | in-file, 13 entries | **yes** |
+| `KrailColorsParityTest` | `:taj` | (a) no `KrailColors` constructor parameter has a default — a default lets a scheme silently omit a token; (b) every token differs between light and dark unless declared invariant | in-file `INTENTIONALLY_MODE_INVARIANT`, 6 entries | **yes** |
+| `KrailColorTokenContrastTest` | `:taj` | 14 foreground/background pairings clear WCAG AA in both schemes, foreground composited over background first; **and** every `KrailColors` property is classified as either a pairing or explicitly not-a-contrast-pair | in-file: 6 known failures, 13 not-a-pair | **yes**, both directions |
+| `ThemeContrastTest` | `:taj` | every `KrailThemeStyle` yields an AA-passing foreground, and overrides a low-contrast foreground handed to it rather than honouring it | none | self-healing over the enum |
+| `TransportModeContrastTest` | `:feature:trip-planner:ui` | every transport-mode colour clears AA for UI components against both surfaces | in-file, 5 entries with measured ratios | **yes** |
+| `NswTransportLineContrastTest` | `:feature:trip-planner:ui` | every NSW line colour passes on at least one surface and is never failing on both; plus a **surface-token drift guard** asserting the light surface stays near-white and the dark one near-black | in-file `officialNswExceptions`, 5 entries | no — and the set is duplicated across two test methods |
+
+The contrast guards share their thresholds from
+[`ContrastAnalyzer.kt`](../../taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/contrast/ContrastAnalyzer.kt)
+(`TEXT_CONTRAST_AA` 4.5, `UI_COMPONENT_CONTRAST_AA` 3.0). Several are **self-healing**: they
+enumerate an enum or parse the token list out of `toString()`, so a new token cannot be added
+without being classified. That is the pattern to copy — a guard that iterates a hand-written
+list stops covering anything the moment someone forgets to extend the list.
+
+---
+
+## Gradle verification tasks
+
+Registered by the convention plugins, `dependsOn`'d by every module's `check`, and run in CI by
+the **Verify test wiring** step of `code-quality.yml`:
+
+```
+./gradlew verifyTestWiring verifyTestingModuleUsage verifyNoAdHocBoundaryFakes \
+          verifyIosTestClassification --continue -PciQuality=true
+```
+
+They run **before** detekt and the tests on purpose, so a misconfigured module fails fast with
+a clear message instead of silently skipping its suite.
+
+| Task | Fails when | Baseline |
+|---|---|---|
+| `verifyTestWiring` | a module has `.kt` under `commonTest` / `androidHostTest` / `androidUnitTest` but no `testAndroidHostTest` task — someone forgot `withHostTest {}`, so CI was silently skipping the suite | none |
+| `verifyTestingModuleUsage` | any configuration whose name does not contain `test` declares a dependency on `:core:testing` — stops fakes shipping in the app and breaks the `:core:testing` / feature / `:core:testing` dependency cycle | none |
+| `verifyNoAdHocBoundaryFakes` | a new `object : Boundary { … }` stub or `private class Fake<Boundary>` appears in a test source set | [`config/test-wiring-baseline.txt`](../../config/test-wiring-baseline.txt) |
+| `verifyIosTestClassification` | a module has shared test sources but is in neither the include nor the exclude list in [`IosUnitTests.kt`](../../gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt) | the two Kotlin lists themselves |
+
+`verifyNoAdHocBoundaryFakes` carries the **strongest ratchet in the repo**: a hard count cap.
+`MAX_BASELINE_ENTRIES = 8` in `TestWiringVerification.kt`, and the baseline currently holds
+**exactly 8 entries**. Adding a ninth line fails the build. A new ad-hoc boundary fake is not
+grandfathered by adding a line here — the number only ever moves down.
+
+`verifyIosTestClassification` is bidirectional: a module listed in either list that no longer
+has shared test sources fails. It also runs on the cheap Ubuntu runner, so classification drift
+is caught on every PR rather than only on the macOS lane.
+
+---
+
+## `scripts/check_layout_invariants.py`
+
+Runs as step 0 of `fullQualityChecks.sh` and as the **Layout invariants and analytics
+assumptions** CI step. Exits non-zero on a violation. Enforces the mechanical parts of
+[`docs/LAYOUT_AND_INSETS.md`](../LAYOUT_AND_INSETS.md):
+
+1. `MainActivity` keeps `android:windowSoftInputMode="adjustResize"` in the manifest — without
+   it the system pans the window on top of Compose's IME insets, drawing an input above the
+   keyboard and clipping content off the top.
+2. No file applies two inset authorities at once (`safeDrawingPadding()` **and** `imePadding()`).
+   In-file allowlist: `SavedTripsScreen.kt`, `AskKrailScreen.kt`.
+3. No `*LayoutTest.kt` uses `getUnclippedBoundsInRoot()` — it reports where a node was laid out,
+   not where it was drawn, which is exactly the distinction those tests exist to make. Kotlin
+   comments are stripped first, so a KDoc explaining the ban is fine.
+
+The sibling `check_stale_assumptions.py` in the same CI step is **warning-only**: an analytics
+assumption falling due is not a reason to block an unrelated PR. A scheduled job runs it
+`--strict`.
+
+---
+
+## Where each `config/` file is consumed
+
+| File | Entries | Consumer |
+|---|---:|---|
+| `clock-system-baseline.txt` | 14 | `ClockSystemBan` (detekt) |
+| `lazy-item-key-baseline.txt` | 2 | `LazyItemKeyRule` (detekt) |
+| `screenshot-annotation-baseline.txt` | 33 | `ScreenshotPreviewAnnotation` (detekt) |
+| `test-wiring-baseline.txt` | 8 — **at its cap** | `verifyNoAdHocBoundaryFakes` (Gradle) |
+| `no-saved-state-allowlist.txt` | 19 | `ViewModelStateDurabilityTest` (`:composeApp`) |
+| `turbine-hygiene-allowlist.txt` | 0 | `TurbineHygieneTest` (`:core:testing`) |
+| `detekt.yml` | — | every detekt task |
+| `baseline.xml` | 22 IDs | **nothing** — see below |
+
+Two loose ends worth knowing about before you trust a file in here:
+
+- **`config/baseline.xml` is dead.** `Detekt.kt` points each module's baseline at its own
+  `projectDir`, and the root project applies detekt with `apply false`, so no task reads it.
+  Its contents duplicate `composeApp/baseline.xml`. [`docs/lint.md`](../lint.md) still describes
+  it as the global baseline; that claim is stale.
+- **`config/cyclomatic-suppress-baseline.txt` is absent** while `CyclomaticSuppressBan` and the
+  `detekt.yml` comment both name it. The effect is stricter, not looser (see above).
+
+---
+
+## Adding a guard
+
+Before writing one, check it earns its place: a guard is justified by a mistake that is
+**invisible in review** and **not caught by an ordinary test**. If a normal unit test would
+catch it, write the unit test.
+
+Then:
+
+1. **Prefer a detekt rule to a guard test** when the check is syntactic. It reports at the
+   exact offending line, runs on every module, and has somewhere obvious for its own unit test
+   to live.
+2. **Make it self-healing.** Enumerate the enum, reflect over the class, parse the register —
+   never iterate a hand-written list that someone must remember to extend.
+3. **Add a scan-broke detector.** Assert the scan found a non-zero number of candidates, so a
+   refactor that defeats your matching fails loudly instead of passing vacuously.
+4. **If it needs an allowlist**, give it the ratchet contract above — including the stale-entry
+   check, which is the part people skip.
+5. **Put the reason in the failure message**, not only in a doc. The person who trips it is
+   mid-task and will read exactly one thing.

--- a/docs/testing/LAYERS.md
+++ b/docs/testing/LAYERS.md
@@ -1,0 +1,480 @@
+# Layers — what each kind of test is for
+
+Part of [TESTING.md](../../TESTING.md). Read the doctrine there first; this page is the detail.
+
+Six layers. Each one catches a class of bug the layer below it structurally cannot see, and
+costs more to run. Pick the cheapest layer that can actually fail for the reason you care
+about.
+
+| Layer | Catches | Cost | Where |
+|---|---|---|---|
+| [Unit](#unit-tests) | logic, state reduction, mapping, time | milliseconds | every module |
+| [Compose interaction](#compose-interaction-tests) | what a screen renders and what a tap does | ~1 s per class | `:feature:trip-planner:ui` |
+| [Flow](#flow-tests) | several real screens and ViewModels wired together, across recreation | seconds | `:feature:trip-planner:ui` |
+| [Snapshot](#snapshot-tests) | pixels — contrast, clipping, font scale, dark mode | seconds, macOS to record | `:taj`, `:feature:trip-planner:ui` |
+| [iOS](#ios-tests) | Kotlin/Native behaviour differences | a macOS runner | 6 modules |
+| [E2E](#end-to-end-maestro) | does the app launch, can a rider finish a trip | minutes, real device | `.maestro/` |
+
+Everything here is **host-side**. There are no instrumented `androidTest` targets and no
+emulator jobs in CI other than the Maestro lanes.
+
+---
+
+## Unit tests
+
+The default. If a bug can be expressed as "this function returned the wrong thing", it belongs
+here and nowhere else.
+
+### `krailRunTest` — the one coroutine harness
+
+Lives in
+[`core/testing/.../coroutines/`](../../core/testing/src/commonMain/kotlin/xyz/ksharma/krail/core/testing/coroutines/).
+
+```kotlin
+@Test fun `loads data`() = krailRunTest {
+    val repo = MyRepository(
+        service = FakeMyService(),
+        ioDispatcher = ioDispatcher,        // same scheduler as runTest
+    )
+    repo.observe().test {                   // Turbine
+        runCurrent()
+        assertEquals(Initial, awaitItem())
+        pumpOnce(refreshIntervalMs)         // ONE poll cycle for an infinite-poller flow
+        assertEquals(Refreshed, awaitItem())
+        cancelAndIgnoreRemainingEvents()    // never let an infinite flow spin
+    }
+}
+```
+
+`krailRunTest` wraps `runTest`, builds a `KrailTestScope`, sets `Dispatchers.setMain`, and
+resets it in a `finally` **after** `runTest` returns — resetting inside the body kills
+`viewModelScope` dispatches during `runTest`'s final drain with an unrelated
+`DispatchException`. There is no JUnit `@Rule`, so it works on every KMP target.
+
+The whole `KrailTestScope` surface:
+
+| Member | What it is |
+|---|---|
+| `scheduler` | the single `TestCoroutineScheduler` |
+| `ioDispatcher` | `StandardTestDispatcher(scheduler, name = "krail-io")` |
+| `mainDispatcher` | `StandardTestDispatcher(scheduler, name = "krail-main")` |
+| `clock` | a virtual `Clock` driven by the same scheduler |
+| `runCurrent()` | drains work at the current virtual instant; does not advance time |
+| `pumpOnce(Duration)` / `pumpOnce(Long)` | `advanceTimeBy` + `runCurrent` — bounded |
+
+`VIRTUAL_EPOCH` is `2026-04-09T12:00:00Z` — a Thursday, midday UTC. Picked so a test never
+lands on a weekend or a day boundary by accident.
+
+**`advanceUntilIdle()` is deliberately not on the scope.** Against an infinite poller it never
+terminates: that is how `DepartureBoardRepositoryTest` once produced a 98 GB Gradle log (#1601).
+`pumpOnce` is the only sanctioned way to drive a `channelFlow { while (true) { delay(); fetch() } }`.
+
+Forbidden when testing infinite pollers:
+
+- `advanceUntilIdle()` — will not terminate.
+- Forgetting `cancelAndIgnoreRemainingEvents()` on the Turbine block — leaks the flow into the
+  next test. `TurbineHygieneTest` enforces this one; see [GUARDS.md](GUARDS.md).
+
+### Fakes at the edges
+
+The fake seam is a fixed list (see TESTING.md). Above it, the class under test is the real
+production class. `:core:testing` holds the canonical fakes — 23 of them — plus builders and
+assertion helpers.
+
+They live in **`commonMain`, not `commonTest`**, because KMP has no `java-test-fixtures`
+equivalent. That would let test doubles ship in the app, so `verifyTestingModuleUsage` forbids
+any non-test configuration from resolving `:core:testing`.
+
+`:core:testing` depends only on **interface** modules, never on a `Real*` implementation. That
+is what keeps it from dragging half the app into every test classpath — and it is why the
+module's own coverage number is meaningless (see [COVERAGE.md](COVERAGE.md)).
+
+---
+
+## Compose interaction tests
+
+Robolectric plus `createComposeRule`. They answer "given this state, what is on screen, and
+what does a tap do" — questions a ViewModel test cannot ask and a snapshot cannot answer
+either, because a snapshot cannot click.
+
+Today they live only in **`:feature:trip-planner:ui`**, under `src/androidHostTest/`: 9 test
+classes, around 56 tests. (`:sandook`, `:core:speech-to-text` and `:core:text-recognition` use
+Robolectric without Compose, for SQLDelight migrations and Android service wrappers.)
+
+The boilerplate is identical in every class and is currently copy-pasted rather than shared:
+
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(sdk = [34], qualifiers = RobolectricDeviceQualifiers.Pixel6, manifest = Config.NONE)
+class MyScreenInteractionTest {
+    @get:Rule val composeRule = createComposeRule()
+```
+
+Content is always wrapped in `PreviewTheme`. `RobolectricDeviceQualifiers` comes from
+Roborazzi, not Robolectric.
+
+Representative cases, each showing a different reason to reach for this layer:
+
+| Test | Why it exists |
+|---|---|
+| `SearchStopScreenInteractionTest` | pill-row visibility across `SearchStopState` shapes, and Home's protection-from-deletion invariant. Its KDoc names what it does **not** cover — drag-to-reorder, sheet flows — which is the right habit |
+| `SavedTripsParkRideRestoreTest` | an open Park & Ride card is still open after rotation, via `StateRestorationTester` |
+| `TimeTableStopSheetRestoreTest` | the stop-details sheet survives rotation — a `rememberSaveable` vs `remember` bug, invisible to every static check |
+| `AiInputBarLayoutTest` | a layout-invariant probe pinning the fix in [`docs/learning/2026-08-16-clipped-inside-its-own-parent.md`](../learning/2026-08-16-clipped-inside-its-own-parent.md) |
+| `AskKrailStatusLineTest` | a precedence contract: resolved beats busy, busy beats hint |
+
+The two restore tests are the cheap host-side answer to "does this screen survive rotation".
+They are why the rotation E2E flow does not need to run on every PR.
+
+---
+
+## Flow tests
+
+One level above interaction tests: several **real** screens, **real** ViewModels and the real
+navigation entry wired together, driven the way a rider would drive them, across process
+recreation.
+
+Harness:
+[`feature/trip-planner/ui/src/androidHostTest/.../flow/`](../../feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/)
+
+| File | Role |
+|---|---|
+| `FlowTest.kt` | `abstract class FlowTest` — annotations, compose rule, Koin lifecycle, helpers |
+| `HomeFlowFakes.kt` | edge fakes plus the three real ViewModels and the Koin module |
+| `RecordingTripPlannerNavigator.kt` | records navigation requests instead of navigating |
+
+### What it actually composes
+
+The **real `SavedTripsEntry`**, through the real `entryProvider` DSL:
+
+```kotlin
+val provider = entryProvider<NavKey> { SavedTripsEntry(navigator) }
+provider(SavedTripsRoute).Content()
+```
+
+`NavDisplay` and its decorators are deliberately cut, so ViewModels scope to the Activity store
+rather than the nav entry. The ViewModels are real — `AiSearchInputViewModel` with its real
+resolver chain and real `RiderOriginLocator`, `SavedTripsViewModel`, `MapStopSelectionViewModel`.
+Only module edges are faked: `FakeSandook`, `FakeAiTextService`, `FakeSpeechToTextService`,
+`FakeStopResultsManager`, `FakeNearbyStopsRepository`, `FakeFlag`.
+
+Koin is started in `@Before` with the fakes module. `@After` calls `stopKoin()` **and** clears
+`ResultEventBus`'s `StopSelectedResult` — a process singleton that otherwise leaks between
+tests.
+
+### Helpers
+
+| Helper | Does |
+|---|---|
+| `launchHome()` | composes the entry and settles it |
+| `leaveAndReturn()` | navigates away and back |
+| `recreate()` | drives `StateRestorationTester` — the rotation/process-death path |
+| `letTimePass(millis)` | advances **both** clocks |
+| `askKrail(sentence)` | drives the Ask KRAIL input end to end |
+| `pickStop(StopSelectedResult)` | delivers a stop selection through the result bus |
+
+Two details in there are hard-won and easy to undo:
+
+- **`letTimePass` advances two clocks**, `composeRule.mainClock.advanceTimeBy` *and*
+  `shadowOf(Looper.getMainLooper()).idleFor`, because Compose animations and ViewModel `delay()`
+  run on different clocks. Advancing one leaves the other where it was.
+- **`askKrail` sends its three events one composition apart.** taj's `TextField` echoes its
+  contents from a `LaunchedEffect`; a batched send steps the phase back to IDLE mid-resolve and
+  the test measures the wrong thing.
+
+### When to write one
+
+A flow test is the right layer when the bug **lives between** components: state that survives
+one screen but not the handoff to the next, a result bus delivering to a recreated ViewModel, a
+value that is correct until the Activity is rebuilt. If the bug fits inside one screen, use an
+interaction test — it is faster and its failure message points at one place.
+
+There are **two** flow tests today. That is deliberate: they are the most expensive tests here
+to write and the easiest to write badly.
+
+### The discriminating-test rule
+
+From [`docs/INTEGRATION_TESTING_PLAN.md`](../INTEGRATION_TESTING_PLAN.md), "Prove the test
+discriminates" — the single most important rule on this page:
+
+> A flow test that cannot fail is worse than no test, because it reads as coverage.
+
+Before committing one: revert the fix it pins (`git revert --no-commit <fix>`), **watch it
+fail**, read the failure message to confirm it fails *for the reason you think*, then restore.
+For the Ask KRAIL replay test the pre-fix run fails with the AI's origin back on the row:
+
+```
+Failed: assertDoesNotExist.
+Reason: Did not expect any node but found '1' node that satisfies:
+  (Text + InputText + EditableText contains 'Central Station')
+```
+
+When there is no shipped defect to revert against, prove it another way. `SearchStopRoundTripFlowTest`
+used a `DisposableEffect` probe in the harness entry to show that `recreate()` really disposes
+and recomposes, rather than quietly doing nothing.
+
+This rule is not flow-test-specific in principle. It is stated here because this is the layer
+where a vacuously-passing test is most likely and least visible.
+
+---
+
+## Snapshot tests
+
+Roborazzi. Infrastructure in [`core/snapshot-testing/`](../../core/snapshot-testing/),
+annotations in `core/snapshot-testing-annotations/`.
+
+Any `@PreviewComponent` / `@PreviewScreen` function also annotated `@ScreenshotTest` gets shot
+by the next record run. Two modules own goldens: **`:taj`** (114 PNGs) and
+**`:feature:trip-planner:ui`** (279 PNGs), committed under `<module>/screenshots/` and tracked
+by Git LFS.
+
+### Tasks
+
+| Action | Task |
+|---|---|
+| Record | `./gradlew :module:recordRoborazziAndroidHostTest` |
+| Verify | `./gradlew :module:verifyRoborazziAndroidHostTest` |
+| Compare (writes diff PNGs) | `./gradlew :module:compareRoborazziAndroidHostTest` |
+
+The `*Debug`-suffixed task names do **not** exist on KMP `androidLibrary` modules.
+
+Plain `testAndroidHostTest` captures in Roborazzi's default mode, which silently records a
+missing or changed golden and still passes. **Explicit verify is what turns a pixel change into
+a failure** — which is the entire reason the CI job below exists.
+
+Each preview yields three images: light at 1× and 2× font scale, dark at 1×. Previews are
+deduped by `declaringClass#methodName`, because the project preview annotations expand to
+several `@Preview` variants that render identically under this harness.
+
+### Onboarding a module
+
+```kotlin
+plugins { alias(libs.plugins.krail.snapshot.testing) }   // roborazzi + both snapshot deps
+
+androidLibrary {
+    withHostTest { isIncludeAndroidResources = true }    // Roborazzi needs Android resources
+    androidResources { enable = true }                   // MANDATORY for AGP 9
+}
+```
+
+Plus a ~10-line test class extending `BaseSnapshotTest` with `packageToScan` set, then
+`recordRoborazziAndroidHostTest`.
+
+### macOS only, and why
+
+`snapshot-verify.yml` runs on `macos-latest`, called from `build.yml` in parallel with
+`code-quality`. The goldens are recorded on a Mac and Robolectric's native rendering is **not
+byte-identical across operating systems** — font rasterisation and the bundled Skia both differ.
+On `ubuntu-latest` it fails on files that are correct.
+
+The rule is enforced by **job placement, not by code**: nothing inside `BaseSnapshotTest`
+checks the host. Recording on Linux produces goldens that fail everywhere.
+
+Three other things about that job are load-bearing:
+
+- **`lfs: true` on the checkout.** Without it the runner has 130-byte pointer files and every
+  comparison fails on an undecodable PNG.
+- **One step per golden-owning module, named explicitly.** Onboarding a third module means
+  adding a step — the cost of a macOS runner should not grow by accident.
+- **Both steps block.** The theme-transition race that kept trip-planner on `continue-on-error`
+  is fixed.
+
+### The theme-transition race, and how it was fixed
+
+`KrailTheme` animates `colors.surface` against a multi-stage target
+(`taj/animations/ThemeTransitionAnimations.kt`). The harness used to shoot a preview as soon as
+the view attached, mid-transition, so a golden recorded a background one shade off — and *which*
+files that hit changed from run to run.
+
+`settleAnimations()` now runs before every capture: pause the Robolectric choreographer, then
+idle the main looper for a fixed 2 s, longer than the transition's worst case. Two details are
+the whole fix:
+
+- **The advance is a fixed duration, not a wait for quiescence.** Several previews animate
+  forever, so an idle-wait hangs on them.
+- **The choreographer must be paused first.** Left running, Robolectric answers
+  `nativeScheduleVsync` immediately without moving the clock, so an endless animation re-arms a
+  frame inside the same idle window and `idleFor` never returns — one preview sat at 100% CPU
+  through 170 000+ frames. Paused, each vsync lands at the next frame boundary, the window is
+  capped at 125 frames, and an endless animation lands on a fixed frame.
+
+Re-recording under the settled clock rewrote every golden in both modules: the committed images
+had been captured during the transition's 80 ms glow stage rather than on the settled surface.
+Two consecutive record runs then produced byte-identical sets.
+
+### Two ways to skip a preview — do not confuse them
+
+| Mechanism | Effect | Used by |
+|---|---|---|
+| `excludedPreviewNames` in the module's test class | the preview is enumerated but not shot | `:feature:trip-planner:ui`, for `PreviewMapStopSelectionPane_Loading` |
+| Simply not annotating it `@ScreenshotTest` | the preview is never a snapshot subject at all | `:taj`, for `PreviewLoadingDotsPill_Visible` and two others |
+
+`:taj` overrides `excludedPreviewNames` with **nothing** — its infinite-animation previews carry
+a bare `@Preview` and a comment saying why. Both mechanisms are legitimate; pick the second when
+the preview should never be a snapshot, and the first when it is one you are temporarily
+skipping.
+
+`PreviewMapStopSelectionPane_Loading` renders an indeterminate `CircularProgressIndicator`, so
+its captured frame is decided by the animation clock no matter how well the theme settles.
+
+---
+
+## iOS tests
+
+`commonTest` has always *compiled* for iOS. Until the `iosUnitTest` lane it never **ran** there,
+so every Kotlin/Native behaviour difference — freezing, date and number formatting, `kotlin.time`,
+`Char` handling — was invisible.
+
+```
+./gradlew iosUnitTest          # macOS + Xcode only
+```
+
+Registered on the root project by `configureIosUnitTestLane()` in
+[`IosUnitTests.kt`](../../gradle/build-logic/convention/src/main/kotlin/xyz/ksharma/krail/gradle/IosUnitTests.kt).
+It first runs `verifyIosTestClassification`, then `iosSimulatorArm64Test` for every module in
+the lane. Off macOS it fails in `doFirst` with an explicit message rather than pretending to
+pass.
+
+CI: [`.github/workflows/ios-unit-tests.yml`](../../.github/workflows/ios-unit-tests.yml) on
+`macos-latest`, for pushes to `main` and PRs touching shared sources or build config.
+
+### What runs on iOS
+
+Six modules: `:core:date-time`, `:core:deeplink`, `:core:navigation`, `:core:transport`,
+`:feature:debug-settings:store`, `:taj`.
+
+### The Firebase linking wall
+
+**21 modules are excluded, and all but one for the same single reason.** `:core:analytics` and
+`:core:remote-config` depend on the GitLive Firebase Kotlin SDK, whose iOS klibs declare
+`-framework FirebaseCore`. Those frameworks come from the Xcode project's SPM integration, so
+when Gradle links a standalone `.kexe` test binary the linker cannot find them:
+
+```
+ld: framework 'FirebaseCore' not found
+> Task :core:analytics:linkDebugTestIosSimulatorArm64 FAILED
+```
+
+`:core:testing` depends on both, so **every module that consumes the shared fakes inherits the
+wall.** That is what keeps the lane small — not anything wrong with the tests, and not a
+judgement about those modules. The include list is exactly the set of modules that do not touch
+the shared fakes.
+
+Widening it means either giving Gradle its own copy of the Firebase iOS frameworks (the repo
+already drives SPM from Gradle for MapLibre) or splitting the Firebase-backed implementations
+out from the interfaces the fakes need. Both are real work; neither is a test-code change.
+
+A second, cheaper blocker affects two modules on top of the wall: **backtick test names
+containing `,`**, which Kotlin/Native rejects where the JVM accepts them
+(`Name contains illegal characters: ","`). `:feature:track:network` and
+`:feature:trip-planner:ui` carry such names. Renaming is trivial but pointless on its own,
+since both also sit behind the wall. `:taj` joined the lane by fixing exactly this.
+
+Entries leave the exclusion map **by being fixed and moved to the include list, never by being
+deleted.** `verifyIosTestClassification` enforces both directions.
+
+Robolectric, Roborazzi and Compose UI tests stay host-only by construction: they live in
+`androidHostTest`, which the iOS compilation never sees.
+
+### Shared `runComposeUiTest` — parked, not rejected
+
+Spiked in `:taj` with `compose.uiTest` driving a real `Button` through `setContent` /
+`onNodeWithText` / `performClick`:
+
+- On **iOS it works** — green under `iosSimulatorArm64Test`, no extra setup.
+- In **`commonTest` it cannot stay**: the same source also expands into `androidHostTest`, and
+  Android's `runComposeUiTest` needs a Robolectric runner and `@Config`, which `commonTest` has
+  no way to express. The Android run dies with `NullPointerException: … "android.os.Build.FINGERPRINT" is null`.
+- Moving it to **`iosTest` works on both** (iOS runs it, the host ignores it) — but then it is an
+  iOS-only test, not a shared one.
+
+**Parked.** An `iosTest`-only Compose test duplicates coverage `:taj` already has via Robolectric
+and Roborazzi, and the modules where a shared UI test would genuinely pay off
+(`:feature:trip-planner:ui`, `:feature:departures:ui`) are behind the Firebase wall anyway. Worth
+revisiting the day that wall comes down — the API is not the obstacle.
+
+---
+
+## End-to-end (Maestro)
+
+Host tests prove logic; snapshots prove pixels. Neither can say whether the app launches, whether
+a rider can reach a timetable, or whether a screen survives having its Activity destroyed under
+it. [Maestro](https://maestro.mobile.dev) flows in [`.maestro/`](../../.maestro/) drive the real
+app on a real device to cover exactly that gap. Full detail in
+[`.maestro/README.md`](../../.maestro/README.md).
+
+Verified against **Maestro 2.8.0**; `setOrientation` needs 2.x.
+
+### Lanes
+
+| Lane | Runs | Workflow |
+|---|---|---|
+| `.maestro/smoke/` | every non-draft PR to `main` / `prod/*` | `maestro-pr-smoke.yml` |
+| `.maestro/nightly/` | 03:00 AEST cron, `prod/**`, manual dispatch | `maestro-nightly.yml` |
+
+`.maestro/shared/` holds helper flows called via `runFlow`. It sits outside both lanes so a
+directory run never treats one as a test.
+
+Smoke gates a merge and must stay fast. Nightly runs the **whole** tree on Android and, in a
+separate `macos-15` job, on an iPhone simulator — and gates nothing. Neither nightly job merges,
+tags or publishes anything; a red nightly is a signal for a human.
+
+### The `APP_ID` convention
+
+One set of flows serves both platforms, so the app id is a parameter, not a literal. It **must**
+be passed with `-e`: a plain shell variable never reaches the flow, and an in-file `env:` default
+would silently take precedence over `-e` and make the parameter impossible to override.
+
+| Target | `APP_ID` |
+|---|---|
+| Android debug | `xyz.ksharma.krail.debug` (note the suffix) |
+| Android release | `xyz.ksharma.krail` |
+| iOS | `xyz.ksharma.krail` |
+
+```sh
+./gradlew :androidApp:installDebug
+maestro test -e APP_ID=xyz.ksharma.krail.debug .maestro/smoke/
+```
+
+### `ci/run-flows.sh`
+
+```
+Usage: run-flows.sh <app-id> <flows-path> <logcat-file> [device-serial]
+```
+
+Four positional arguments, no flags. It runs the lane, then — **while the emulator is still
+alive** — dumps logcat, copies `~/.maestro/tests` into the workspace, and fails the step if
+`FATAL EXCEPTION` appears in the log, separately from the flow result (a crash in a background
+coroutine does not necessarily fail a flow).
+
+It is a file rather than inline YAML for one specific reason:
+`reactivecircus/android-emulator-runner` executes its `script:` **one line at a time**, each in
+its own `sh -c`. Shell state does not carry across those invocations, so `set +e` on one line
+cannot protect the next, and the step aborts the instant any line exits non-zero — which is how
+the first two runs of this lane finished with no artifact at all. One line in the workflow, one
+shell in the script, all the control flow intact.
+
+Pass a device serial when reproducing locally: with more than one device attached Maestro shards
+the flows across all of them, which fails in ways that look like app bugs and are not.
+
+### Selectors
+
+Flows select on `testTag` ids, never on visible copy, so a wording change cannot break a flow and
+a failure always means behaviour changed. Tags are declared in `TripPlannerTestTags` and
+`DebugSettingsTestTags` and are **public API** to `.maestro/` — grep there before renaming one.
+
+Android surfaces them as accessibility `resource-id`s via `exposeTestTagsToUiAutomation()` at the
+app root; on iOS, Compose Multiplatform publishes them as `accessibilityIdentifier` with no
+opt-in. The same `id:` selector works on both.
+
+### Flake policy
+
+**The PR lane never retries.** A flake that can block a merge gets fixed, not re-run. The flows
+are built for that: they wait rather than assert after anything asynchronous, and scroll to list
+items instead of asserting them in place, because Maestro matches only what is on screen.
+
+**The iOS nightly leg retries once**, hand-rolled in bash: on failure it terminates the app,
+warns, and runs the suite a second time. Simulator runs are meaningfully flakier than emulator
+runs (boot races, window-server hiccups) and that lane reports rather than gates, so one retry
+buys signal without hiding a real break — a genuine regression fails twice.


### PR DESCRIPTION
## What

Splits `TESTING.md` into an entry point plus three reference pages, and fixes the places where
the testing docs had drifted away from what the build actually does.

Docs only: no production or test code changes.

## Changes

- `TESTING.md` keeps the doctrine and becomes the entry point; the detail moves to three pages
  under `docs/testing/`:
  - `LAYERS.md` — what each test layer is for: unit, Compose interaction, flow, snapshot, iOS,
    and end-to-end.
  - `GUARDS.md` — every custom detekt rule and guard test, the ratchet contract they share, the
    Gradle verification tasks, `scripts/check_layout_invariants.py`, and where each `config/`
    file is consumed. There was no single place that listed these, so the usual way to discover a
    guard was to have it fail.
  - `COVERAGE.md` — what the number measures, what is excluded and why, which modules are in the
    aggregate, and what coverage is allowed to gate.
- Drift fixed:
  - `CLAUDE.md` listed three modules as having `withHostTest {}`. It is now most of them, so the
    list is replaced with the `grep` that answers the question, plus a note that `verifyTestWiring`
    fails the build for a module with test sources and no host-test task. A stale list here is
    worse than no list, because it reads as exhaustive.
  - The iOS lane tables described tasks that no longer match the build.
  - The snapshot-mechanism description no longer claimed behaviour the current setup does not have.

## Why this is over 500 lines

It is a restructure: `TESTING.md` loses 373 lines and the three new pages absorb them plus the
material that was previously nowhere. Splitting the split across PRs would mean landing a
`TESTING.md` that points at pages that do not exist yet, or pages nothing links to. The diff is
large but almost entirely moved and reorganised prose.

## Testing

- `./gradlew :composeApp:testAndroidHostTest --continue` green, which is what runs
  `LearningLogActionsTest` over `docs/`
- `python3 scripts/check_layout_invariants.py` and `check_stale_assumptions.py` both clean
- `./gradlew detekt --continue` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
