### PR TITLE
build(deps): move aagya and dhruva to xyz.ksharma, iOS floor 17

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,16 +62,16 @@ mlkitTextRecognition = "16.0.1"
 reorderable = "2.5.1"
 
 # KRAIL-extracted libraries (published as separate KMP libs)
-aagya = "0.2.0"
-dhruva = "0.1.1"
+aagya = "0.3.0"
+dhruva = "0.2.0"
 krail-api-proto = "0.4.2"
 
 [libraries]
 # KRAIL-extracted libraries
-aagya-state = { module = "io.github.ksharma-xyz:aagya-state", version.ref = "aagya" }
-aagya-data = { module = "io.github.ksharma-xyz:aagya-data", version.ref = "aagya" }
-dhruva-state = { module = "io.github.ksharma-xyz:dhruva-state", version.ref = "dhruva" }
-dhruva-data = { module = "io.github.ksharma-xyz:dhruva-data", version.ref = "dhruva" }
+aagya-state = { module = "xyz.ksharma:aagya-state", version.ref = "aagya" }
+aagya-data = { module = "xyz.ksharma:aagya-data", version.ref = "aagya" }
+dhruva-state = { module = "xyz.ksharma:dhruva-state", version.ref = "dhruva" }
+dhruva-data = { module = "xyz.ksharma:dhruva-data", version.ref = "dhruva" }
 krail-api-proto = { module = "xyz.ksharma.krail:api-proto", version.ref = "krail-api-proto" }
 
 androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -314,7 +314,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				NEW_SETTING = "";
@@ -374,7 +374,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				NEW_SETTING = "";
@@ -403,7 +403,7 @@
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Krail App";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -437,7 +437,7 @@
 				INFOPLIST_FILE = iosApp/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Krail App";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.travel";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## What

Retargets the aagya and dhruva dependencies to their new Maven group `xyz.ksharma` and raises the iOS deployment target to 17.0, which aagya 0.3.0 requires.

## Changes

- `gradle/libs.versions.toml`: `io.github.ksharma-xyz` becomes `xyz.ksharma` for `aagya-state`, `aagya-data`, `dhruva-state`, `dhruva-data`; versions bump to aagya 0.3.0 and dhruva 0.2.0 (the first releases under the new group).
- `iosApp/iosApp.xcodeproj/project.pbxproj`: `IPHONEOS_DEPLOYMENT_TARGET` 15.3 becomes 17.0. aagya 0.3.0 moved microphone permission handling to the `AVAudioApplication` APIs and Kotlin/Native links those symbols unconditionally, so iOS 15/16 would trap at runtime in the speech-to-text permission path.
- No source changes: the Kotlin package names were always `xyz.ksharma.*`, and neither release changes the public API of the consumed modules.
- dhruva 0.2.0 also includes the fix that auto-requests iOS location authorization on first use instead of only inspecting the status.

## Testing

- `./scripts/fullQualityChecks.sh` green: `compileDebugSources`, `compileKotlinIosSimulatorArm64`, detekt.
- `./gradlew :core:speech-to-text:testAndroidHostTest :composeApp:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest --continue` green. `core/maps/ui` and `core/maps/data` also consume these libraries but have no host-test suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CtZiJyHCYoNgULXRfPH9W