### PR TITLE
refactor(speech-to-text): let aagya own the iOS mic permission ask

### DIFF
--- a/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/MicPermissionOutcome.kt
+++ b/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/MicPermissionOutcome.kt
@@ -26,10 +26,12 @@ sealed interface MicPermissionOutcome {
  * Requests the microphone permission, suspending until the rider answers, and reports how it
  * ended.
  *
- * Asking has to happen at the Compose layer rather than inside the service:
+ * Asking happens at the Compose layer, never inside the services:
  * [AndroidSpeechToTextService][xyz.ksharma.krail.core.speechtotext.AndroidSpeechToTextService]
- * is a plain singleton with no Activity to show the system dialog from, so on its own it can
- * only read the current status.
+ * is a plain singleton with no Activity to show the system dialog from, and
+ * [IosSpeechToTextService][xyz.ksharma.krail.core.speechtotext.IosSpeechToTextService]
+ * matches that contract so the microphone has exactly one asking path on both platforms.
+ * Both services only read the current status.
  *
  * Backed by aagya's [PermissionController][xyz.ksharma.aagya.permission.PermissionController],
  * the same one `UserLocationManager` uses for location, so both permissions ask the same way

--- a/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/IosSpeechToTextService.kt
+++ b/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/IosSpeechToTextService.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.AVFAudio.AVAudioApplication
+import platform.AVFAudio.AVAudioApplicationRecordPermissionGranted
 import platform.AVFAudio.AVAudioEngine
 import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionCategoryRecord
@@ -19,14 +21,16 @@ import kotlin.coroutines.resume
  * Swift-only surface like Foundation Models), so this is a direct Kotlin/Native cinterop
  * call with no Swift shim needed — see `IosAiTextService` for the contrasting case.
  *
- * Deployment target is iOS 15.3 (see `iosApp` build settings), so this deliberately uses
- * the older `AVAudioSession.requestRecordPermission` (deprecated in favour of
- * `AVAudioApplication` on iOS 17+, but still functional) rather than branching on OS
- * version for a still-working API.
+ * Microphone permission is owned by aagya at the Compose layer
+ * ([rememberRequestMicrophonePermission]), so this service only reads the current status,
+ * mirroring [AndroidSpeechToTextService] which likewise never shows the system dialog
+ * itself. `AVAudioApplication.recordPermission` is an iOS 17+ API, which the deployment
+ * target satisfies (see `iosApp` build settings).
  *
- * Per this project's `ios_permission_must_request.md` lesson: [checkAvailability] actively
- * calls `requestAuthorization`/`requestRecordPermission` when status is not yet determined,
- * it does not just inspect `authorizationStatus()` — otherwise the app never appears in
+ * Speech-recognizer authorization has no aagya family, so it is still requested here. Per
+ * this project's `ios_permission_must_request.md` lesson: [checkAvailability] actively
+ * calls `SFSpeechRecognizer.requestAuthorization` when status is not yet determined, it
+ * does not just inspect `authorizationStatus()` — otherwise the app never appears in
  * Settings for the rider to grant the permission from.
  */
 @OptIn(ExperimentalForeignApi::class)
@@ -38,10 +42,10 @@ internal class IosSpeechToTextService : SpeechToTextService {
 
     override suspend fun checkAvailability(): SpeechToTextAvailability {
         val speechAuthorized = requestSpeechAuthorizationIfNeeded()
-        val micAuthorized = requestMicAuthorizationIfNeeded()
+        val micAuthorized = microphoneAuthorized()
         val result = when {
             !speechAuthorized || !micAuthorized ->
-                SpeechToTextAvailability.Unavailable(reason = "permission_denied")
+                SpeechToTextAvailability.Unavailable(reason = SpeechUnavailableReasons.PERMISSION_REQUIRED)
 
             recognizer.available.not() ->
                 SpeechToTextAvailability.Unavailable(reason = SpeechUnavailableReasons.NOT_AVAILABLE)
@@ -132,10 +136,11 @@ internal class IosSpeechToTextService : SpeechToTextService {
         }
     }
 
-    private suspend fun requestMicAuthorizationIfNeeded(): Boolean =
-        suspendCancellableCoroutine { continuation ->
-            AVAudioSession.sharedInstance().requestRecordPermission { granted ->
-                continuation.resume(granted)
-            }
-        }
+    // Status read only. By the time this runs, aagya's controller has already raised the
+    // system dialog from the mic button (see rememberRequestMicrophonePermission), and only
+    // a granted answer starts listening. Anything but granted here means a caller skipped
+    // that flow, and the answer is the same one AndroidSpeechToTextService gives: report
+    // PERMISSION_REQUIRED rather than ask a second time from a layer that should not own it.
+    private fun microphoneAuthorized(): Boolean =
+        AVAudioApplication.sharedInstance().recordPermission == AVAudioApplicationRecordPermissionGranted
 }


### PR DESCRIPTION
## What

Removes the service-side iOS microphone permission request so aagya's `PermissionController` is the only thing that asks for the mic, on both platforms.

## Changes

- `IosSpeechToTextService.kt`: `requestMicAuthorizationIfNeeded()` (a direct `AVAudioSession.requestRecordPermission` call) is replaced with a status-only read via `AVAudioApplication.recordPermission` (iOS 17+, satisfied by the deployment target after #1917). The Compose-layer mic button already requests through aagya's `rememberRequestMicrophonePermission` before listening starts, so the service asking again was a duplicate path.
- The missing-permission reason changes from the untyped `"permission_denied"` literal to the shared `SpeechUnavailableReasons.PERMISSION_REQUIRED` constant, matching `AndroidSpeechToTextService`. Callers treated both strings as an unknown failure, so no behaviour change.
- Speech-recognizer authorization is intentionally left in the service: aagya has no `SFSpeechRecognizer` permission family, and that request must stay active (request when not determined, not just inspect) or the app never appears in the Settings permission list.
- `MicPermissionOutcome.kt`: doc updated to state that both services are status-read only.

## Testing

- `./scripts/fullQualityChecks.sh` green: `compileDebugSources`, `compileKotlinIosSimulatorArm64` (covers the `AVAudioApplication` cinterop), detekt.
- `./gradlew :core:speech-to-text:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest --continue` green.
- iOS runtime not exercised (iOS tests are not run in this repo); the mic-button flow is unchanged and the removed request was unreachable on the granted path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CtZiJyHCYoNgULXRfPH9W