### PR TITLE
refactor(navigation): delete ServiceAlertRoute and DateTimeSelectorRoute

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/xyz/ksharma/krail/navigation/RoutePaneMetadataTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/xyz/ksharma/krail/navigation/RoutePaneMetadataTest.kt
@@ -18,9 +18,9 @@ import kotlin.test.fail
  * screenshot can see it.
  *
  * The doc was the only place the intent was written down, and it had already drifted — two
- * routes were missing from it entirely, and two more exist with no `entry` at all. A table
- * that describes the code is a comment; a table the build compares against the code is a
- * contract, and this makes it the second.
+ * routes were missing from it entirely, and two more had no `entry` at all (those two were
+ * dead and have since been deleted, #1916). A table that describes the code is a comment; a
+ * table the build compares against the code is a contract, and this makes it the second.
  *
  * Bidirectional on purpose. A route missing from the table fails, because that is the new
  * route nobody made a pane decision for. A row naming a route that no longer exists fails too,

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/analytics/RouteAnalyticsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/analytics/RouteAnalyticsScreen.kt
@@ -10,7 +10,6 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.ManageStopLabelsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.OurStoryRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopRoute
-import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SettingsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
@@ -23,7 +22,7 @@ const val UNMAPPED_SCREEN_NAME = "Unmapped"
  * `view_screen`, so window transitions can be joined to screen views without a second set
  * of screen names to reconcile.
  *
- * Routes with no [AnalyticsScreen] (Splash, Discover, DateTimeSelector, TrackTrip) report
+ * Routes with no [AnalyticsScreen] (Splash, Discover, TrackTrip) report
  * [UNMAPPED_SCREEN_NAME]. Minting names here instead would put strings into the analytics
  * vocabulary that no other event uses, which is worse than one honest bucket.
  */
@@ -38,7 +37,6 @@ fun NavKey.toAnalyticsScreenName(): String = when (this) {
     is IntroRoute -> AnalyticsScreen.Intro.name
     is ManageStopLabelsRoute -> AnalyticsScreen.ManageStopLabels.name
     is AddParkRideRoute -> AnalyticsScreen.AddParkRide.name
-    is ServiceAlertRoute -> AnalyticsScreen.ServiceAlerts.name
     else -> {
         // Logged, not sent: a route reaching this branch is either genuinely screenless
         // (Splash) or a gap in the mapping, and the two are indistinguishable in the data.

--- a/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/SerializationConfig.kt
+++ b/composeApp/src/commonMain/kotlin/xyz/ksharma/krail/navigation/SerializationConfig.kt
@@ -10,7 +10,6 @@ import xyz.ksharma.krail.feature.debug.settings.ui.navigation.DebugConfigHomeRou
 import xyz.ksharma.krail.feature.debug.settings.ui.navigation.DebugConfigNetworkRoute
 import xyz.ksharma.krail.feature.track.ui.navigation.TrackTripRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.AddParkRideRoute
-import xyz.ksharma.krail.trip.planner.ui.navigation.DateTimeSelectorRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.DiscoverRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.IntroRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.JourneyMapRoute
@@ -18,7 +17,6 @@ import xyz.ksharma.krail.trip.planner.ui.navigation.ManageStopLabelsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.OurStoryRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SavedTripsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SearchStopRoute
-import xyz.ksharma.krail.trip.planner.ui.navigation.ServiceAlertRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.SettingsRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.ThemeSelectionRoute
 import xyz.ksharma.krail.trip.planner.ui.navigation.TimeTableRoute
@@ -41,9 +39,7 @@ val krailNavSerializationConfig = SavedStateConfiguration {
             subclass(TimeTableRoute::class, TimeTableRoute.serializer())
             subclass(JourneyMapRoute::class, JourneyMapRoute.serializer())
             subclass(ThemeSelectionRoute::class, ThemeSelectionRoute.serializer())
-            subclass(ServiceAlertRoute::class, ServiceAlertRoute.serializer())
             subclass(SettingsRoute::class, SettingsRoute.serializer())
-            subclass(DateTimeSelectorRoute::class, DateTimeSelectorRoute.serializer())
             subclass(OurStoryRoute::class, OurStoryRoute.serializer())
             subclass(IntroRoute::class, IntroRoute.serializer())
             subclass(DiscoverRoute::class, DiscoverRoute.serializer())

--- a/docs/TABLET_FOLDABLE_UX.md
+++ b/docs/TABLET_FOLDABLE_UX.md
@@ -224,22 +224,22 @@ code does not declare. The `Metadata` column is parsed, so it takes exactly one 
 | `AddParkRideRoute`       | none           | owns its own list+map split internally (`DualPaneScaffold`) |
 | `DebugConfigHomeRoute`   | `detailPane()` | debug builds only                                 |
 | `DebugConfigNetworkRoute`| `detailPane()` | debug builds only                                 |
-| `ServiceAlertRoute`      | no entry       | see below                                         |
-| `DateTimeSelectorRoute`  | no entry       | see below                                         |
 
-### Two routes with no entry
+### Surfaces that are sheets, not routes
 
-`ServiceAlertRoute` and `DateTimeSelectorRoute` are declared, serialised and reachable from
-`TripPlannerNavigatorImpl` (`navigateToServiceAlert`, `navigateToDateTimeSelector`), but
-neither has an `entry<…>` in any entry provider. Both surfaces are rendered as a
-`ModalBottomSheet` from inside `TimeTableEntry` instead, and nothing calls either navigate
-method today.
+Service alerts and the date/time selector are **not** routes. Both render as a
+`ModalBottomSheet` from inside `TimeTableEntry`, over the timetable that owns their state, so
+neither needs a pane decision and neither appears in the table above.
 
-That is safe only for as long as nothing calls them: pushing a key the entry provider has no
-entry for fails at navigation time, on a screen that compiles and reads correctly. If either
-surface ever becomes a real destination, it needs an entry and a metadata decision here in
-the same change. Until then the pair are kept in this table rather than deleted from it, so
-the guard keeps naming them.
+They used to be routes: `ServiceAlertRoute` and `DateTimeSelectorRoute` were declared,
+registered for serialisation and pushed by two `TripPlannerNavigator` methods, but no
+`entry<…>` anywhere rendered either of them, so calling those methods would have failed at
+navigation time on code that compiled and read correctly. Nothing called them, and they were
+deleted (#1916) rather than wired up, because the sheets are the intended shape.
+
+If either surface ever does become a real destination, it needs a route, an `entry<…>`, a
+`subclass(...)` line in `SerializationConfig.kt` and a row in the table above, all in the
+same change.
 
 Screens themselves detect their dual-pane mode via
 `rememberAdaptiveLayoutInfo()` / `AdaptiveScreenContent` — route

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -82,8 +82,9 @@ that does not need the prompt to have worked.
 
 ### Still to do on the time path
 
-- The chip clears on tap. It should open the existing date/time picker, which wants
-  `DateTimeSelectorRoute` reachable from the home screen.
+- The chip clears on tap. It should open the existing date/time picker, which today is a
+  `ModalBottomSheet` owned by `TimeTableEntry` and has no way to be opened from the home
+  screen.
 - A day on its own still resolves to nothing. A date with no time is not a departure, and
   picking an hour for it would be a guess.
 - Vague day-parts stay unresolved on purpose. "morning = 9am" is invented precision. If they

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/RecordingTripPlannerNavigator.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/flow/RecordingTripPlannerNavigator.kt
@@ -42,8 +42,6 @@ internal class RecordingTripPlannerNavigator : TripPlannerNavigator {
     override fun navigateToManageStopLabels() = Unit
     override fun navigateToAddParkRide() = Unit
     override fun navigateToThemeSelection() = Unit
-    override fun navigateToAlerts(journeyId: String) = Unit
-    override fun navigateToDateTimeSelector(json: String?) = Unit
     override fun navigateToOurStory() = Unit
     override fun navigateToIntro() = Unit
     override fun navigateToTrackTrip(encodedData: String?) = Unit

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigator.kt
@@ -37,8 +37,6 @@ interface TripPlannerNavigator {
 
     fun navigateToAddParkRide()
     fun navigateToThemeSelection()
-    fun navigateToAlerts(journeyId: String)
-    fun navigateToDateTimeSelector(json: String?)
     fun navigateToOurStory()
     fun navigateToIntro()
     fun navigateToTrackTrip(encodedData: String? = null)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerNavigatorImpl.kt
@@ -76,14 +76,6 @@ internal class TripPlannerNavigatorImpl(
         baseNavigator.goTo(ThemeSelectionRoute)
     }
 
-    override fun navigateToAlerts(journeyId: String) {
-        baseNavigator.goTo(ServiceAlertRoute(journeyId))
-    }
-
-    override fun navigateToDateTimeSelector(json: String?) {
-        baseNavigator.goTo(DateTimeSelectorRoute(json))
-    }
-
     override fun navigateToOurStory() {
         baseNavigator.goTo(OurStoryRoute)
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/TripPlannerRoutes.kt
@@ -73,11 +73,6 @@ data class JourneyMapRoute(
 data object ThemeSelectionRoute : TripPlannerRoute
 
 @Serializable
-data class ServiceAlertRoute(
-    val journeyId: String,
-) : TripPlannerRoute
-
-@Serializable
 data object SettingsRoute : TripPlannerRoute
 
 @Serializable
@@ -86,14 +81,12 @@ data object OurStoryRoute : TripPlannerRoute
 @Serializable
 data object IntroRoute : TripPlannerRoute
 
-@Serializable
-data class DateTimeSelectorRoute(
-    val dateTimeSelectionItemJson: String? = null,
-) : TripPlannerRoute {
-    companion object {
-        const val DATE_TIME_TEXT_KEY = "DateTimeSelectionKey"
-    }
-}
+/*
+ * Service alerts and the date/time selector are deliberately not routes. Both render as a
+ * `ModalBottomSheet` from inside `TimeTableEntry`, over the timetable that owns their state.
+ * Route declarations for them existed with no `entry<…>` to render them, so navigating to
+ * either would have failed at runtime; they were deleted rather than wired up (#1916).
+ */
 
 @Serializable
 data object DiscoverRoute : TripPlannerRoute


### PR DESCRIPTION
## What

Deletes `ServiceAlertRoute` and `DateTimeSelectorRoute`. Both were registered NavKey routes with no `entry<>` rendering them and no caller pushing them, so navigating to either would have failed at runtime. Both surfaces render as sheets owned by `TimeTableEntry`, which is why nothing ever pushed the routes.

## Changes

- `TripPlannerRoutes.kt`: removed both routes and `DATE_TIME_TEXT_KEY`, which had no references. Left a comment recording that both surfaces are sheets.
- `TripPlannerNavigator` / `TripPlannerNavigatorImpl`: removed `navigateToAlerts(journeyId)` and `navigateToDateTimeSelector(json)` and their overrides.
- `RecordingTripPlannerNavigator` (test fake): removed the two orphaned overrides.
- `SerializationConfig.kt`: removed both `subclass(...)` registrations.
- `RouteAnalyticsScreen.kt`: removed the unreachable `is ServiceAlertRoute ->` branch and corrected the KDoc list.
- `RoutePaneMetadataTest`: KDoc only. No expectation weakened; the guard still fails on an entry-less route.
- `docs/TABLET_FOLDABLE_UX.md`, `feature/trip-planner/ui/AI_SEARCH_UX.md`: dropped the rows and open items naming the deleted routes; recorded what promoting either surface to a real destination would need.

Left in place on purpose:

- `RoutePaneMetadataTest`'s `NO_ENTRY` value, now unused by any row. Removing it would stop the guard describing the exact bug it exists to catch.
- `AnalyticsScreen.ServiceAlerts`: `ServiceAlertsViewModel` still reports that screen view from inside the sheet. Only the route-to-name mapping went.
- The sheets themselves are functionally untouched.

## Testing

- `./gradlew compileDebugSources` green
- `./gradlew :composeApp:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest --continue` green; confirmed from the result XML that `RoutePaneMetadataTest` and `NavKeySerializationConfigTest` both ran and passed
- `./gradlew detekt --continue` green, nothing auto-corrected

No device QA: this deletes unreachable declarations and touches no rendered screen.

Closes #1916

🤖 Generated with [Claude Code](https://claude.com/claude-code)
