### PR TITLE
fix(trip-planner): keep map stop sheets and pending map options across recreation

### DIFF
--- a/docs/learning/2026-08-21-sheet-closed-by-a-text-callback.md
+++ b/docs/learning/2026-08-21-sheet-closed-by-a-text-callback.md
@@ -1,0 +1,75 @@
+# A bottom sheet that "the dialog dismissed itself" was closed by a text field
+
+**2026-08-21** · Search-stop map, journey map, map options · ~4 builds, 3 install cycles, one evening
+
+## Symptom
+
+Open a stop's details sheet on the search-stop map, switch the device to dark mode (or change
+font size), and the sheet is gone. The screen behind it is gone too: the map has been replaced
+by the recents list, as if the rider had never tapped "Select on map".
+
+## Root cause
+
+Three separate faults, none of them the one that had been written down.
+
+1. `SearchStopMap` and `JourneyMap` held which stop's sheet is open in a plain `remember`, so
+   Activity recreation dropped it. `MapOptionsBottomSheet` did the same with the rider's
+   unsaved radius/mode/toggle edits, on a sheet that itself stays open — so the edits reverted
+   under an unchanged-looking sheet.
+2. `SearchStopScreen` switched from map back to list on any text-field callback. The field
+   re-emits its restored value when the Activity is recreated, and that read as typing. The
+   comment right above it already recorded the same trap for focus callbacks; the value
+   callback had the same problem and was not covered.
+3. Phone portrait and landscape are different layouts (single pane vs dual pane) and use two
+   different map composables, so no `rememberSaveable` inside either can carry state across a
+   rotation. That one is still open — see the gap below.
+
+## Why it took so long
+
+The starting theory, written into the issue and into `TimeTableStopSheetRestoreTest`'s KDoc,
+was that `ModalBottomSheet` fires `onDismissRequest` while its dialog is disposed during
+recreation, so the caller's dismiss handler clears the state. That is a good story: it explains
+the symptom, it matches how M3 hosts a sheet in a real `Dialog`, and it also explains why
+`StateRestorationTester` cannot see the bug.
+
+It is not what happens. A probe build that logged every `onDismissRequest` with the lifecycle
+state and a stack trace showed:
+
+- rotating with a sheet open logged **nothing** — no dismiss request at all, and the
+  date-time sheet (whose visibility flag is already saveable) came back on screen;
+- the only `onDismissRequest` in the whole session came from `ModalBottomSheet.kt:157`
+  (`animateToDismiss`) at lifecycle `RESUMED` — a scrim tap, not a disposal.
+
+The dismissal theory had blocked the obvious question, which is whether the state was saveable
+at all. It was not.
+
+A second trap was self-inflicted: `adb shell input tap` opens a sheet and instantly closes it
+again, because the `ACTION_UP` lands on the dialog window that the `ACTION_DOWN` just created,
+and M3 treats a touch outside the sheet as a dismiss. That looks exactly like the bug under
+investigation. Splitting the tap into `input motionevent DOWN` / `input motionevent UP` leaves
+the sheet open.
+
+## What would have caught it sooner
+
+- **Log the callback you are accusing.** One probe build settled a theory that three rounds of
+  reading library source could not. `Throwable().stackTraceToString()` inside the suspect
+  lambda names the exact library line that called it.
+- **Check whether the state can survive before explaining why it does not.** `remember` vs
+  `rememberSaveable` is a one-line question, and it outranks any mechanism story.
+- **Drive sheets with split motion events.** `adb shell input tap` is not a usable way to open
+  a bottom sheet.
+- **Read the screen's own recomposition log.** `[SEARCH_STOP_SINGLE_PANE] recomposed: showMap=false`
+  after a dark-mode switch was the whole of fault 2, sitting in logcat the entire time.
+
+## Actions taken
+
+- [x] Sheet-visibility state on both maps is now a saveable stop id, re-resolved from the map
+      state the ViewModel still holds (the same lookup the map layer does for a tap).
+- [x] `MapOptionsBottomSheet`'s pending edits are saveable, pinned by
+      `MapOptionsSheetRestoreTest` — verified to fail when the fix is reverted.
+- [x] The map/list switch ignores a text callback that carries unchanged text.
+- [x] `TimeTableStopSheetRestoreTest`'s KDoc no longer states the dismissal theory as fact.
+- [ ] **Open gap:** on a phone, rotating crosses single pane and dual pane, which are two
+      different map composables, so an open stop sheet is still lost. Fixing it means hoisting
+      the selection above `AdaptiveScreenContent` and giving both panes the same sheet, the way
+      `showMap` is already hoisted. Tracked in issue #1915.

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsSheetRestoreTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsSheetRestoreTest.kt
@@ -1,0 +1,121 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.map
+
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.isOff
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val MAP_OPTIONS_RESTORE_TEST_SDK = 34
+
+/**
+ * Map options a rider has picked but not yet saved have to survive Activity recreation.
+ *
+ * The sheet stays open across a rotation — its visibility flag is already saveable — so the
+ * only way a rider can tell the pending edits were dropped is by saving and getting the old
+ * values back. Held in a plain `remember`, every chip and toggle silently reverted to what
+ * was already committed, on a sheet that looked untouched.
+ *
+ * The assertion is what Save commits rather than which chip draws selected: the committed
+ * value is the thing the rider loses, and it does not depend on how selection is painted.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [MAP_OPTIONS_RESTORE_TEST_SDK],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+class MapOptionsSheetRestoreTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val restorationTester by lazy { StateRestorationTester(composeRule) }
+
+    private val events = mutableListOf<SearchStopUiEvent>()
+
+    @Test
+    fun `a radius picked before recreation is the one Save commits after it`() {
+        setSheetContent()
+
+        composeRule.onNodeWithText(FIVE_KM_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(SAVE_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        val radiusChanges = events.filterIsInstance<SearchStopUiEvent.SearchRadiusChanged>()
+        assertEquals(
+            listOf(FIVE_KM),
+            radiusChanges.map { it.radiusKm },
+            "Save committed ${radiusChanges.map { it.radiusKm }} instead of the picked ${FIVE_KM}km",
+        )
+    }
+
+    @Test
+    fun `a toggle flipped before recreation is still flipped after it`() {
+        setSheetContent()
+
+        // Only the switch is clickable, and the distance scale is the one that starts off:
+        // the compass starts on, so "the off switch" identifies it without a test tag.
+        composeRule.onAllNodes(isToggleable() and isOff()).onFirst().performClick()
+        composeRule.waitForIdle()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodes(isToggleable()).onFirst().assertIsOn()
+
+        composeRule.onNodeWithText(SAVE_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        val toggles = events.filterIsInstance<SearchStopUiEvent.ShowDistanceScaleToggled>()
+        assertTrue(
+            toggles.singleOrNull()?.enabled == true,
+            "Save committed $toggles instead of the distance scale the rider switched on",
+        )
+    }
+
+    private fun setSheetContent() {
+        restorationTester.setContent {
+            PreviewTheme {
+                MapOptionsBottomSheet(
+                    searchRadiusKm = ONE_KM,
+                    selectedTransportModes = persistentSetOf(TRAIN_PRODUCT_CLASS),
+                    showDistanceScale = false,
+                    showCompass = true,
+                    onDismiss = {},
+                    onEvent = { event -> events += event },
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    private companion object {
+        const val ONE_KM = 1.0
+        const val FIVE_KM = 5.0
+        const val FIVE_KM_LABEL = "5km"
+        const val SAVE_LABEL = "Save"
+        const val TRAIN_PRODUCT_CLASS = 1
+    }
+}

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableStopSheetRestoreTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/timetable/TimeTableStopSheetRestoreTest.kt
@@ -41,15 +41,22 @@ private const val TIMETABLE_RESTORE_TEST_SDK = 34
  *
  * ## What this test cannot see
  *
- * On a device the sheet still closes, for a second and separate reason: `ModalBottomSheet`
- * hosts its content in a real `Dialog`, and that dialog fires `onDismissRequest` as it is
- * disposed during recreation — which runs the caller's dismiss handler and clears the state
- * this test is about. `StateRestorationTester` saves and restores the composition without ever
- * building that dialog window, so it does not reproduce it. Confirmed by hand: after a theme
- * switch the sheet is gone and one tap on the same stop reopens it, which it would not do if
- * the state had survived. Every sheet in the app is wired the same way, so the fix belongs
- * with the sheet rather than here. Saving the state is still required either way — without it
- * there would be nothing left to restore once that is fixed.
+ * It composes the screen, not the window around it, so anything that only happens to a real
+ * Activity is out of its reach: which pane the layout picks, and what other callbacks fire
+ * while the window is being rebuilt.
+ *
+ * An earlier version of this note claimed the sheet also closes on device because
+ * `ModalBottomSheet`'s dialog fires `onDismissRequest` as it is disposed during recreation.
+ * Measured on an emulator, that does not happen: a probe logging every `onDismissRequest`
+ * with its lifecycle state recorded none at all across a rotation, and the sheets whose
+ * visibility is saveable came back on screen. The dismissals it did record were scrim taps at
+ * `RESUMED`. What actually closed sheets was ordinary lost state, and on the search-stop map a
+ * text callback that re-fired with restored text and switched the screen back to the list.
+ * See `docs/learning/2026-08-21-sheet-closed-by-a-text-callback.md`.
+ *
+ * One case remains, and this test cannot reach it either: on a phone, rotating swaps single
+ * pane for dual pane, which are different composables, so a sheet open in one does not carry
+ * into the other.
  */
 @RunWith(RobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/JourneyMap.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,7 +40,6 @@ import xyz.ksharma.krail.core.maps.ui.utils.MapCameraUtils
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.trip.planner.ui.searchstop.map.TrackUserLocation
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyMapUiState
-import xyz.ksharma.krail.trip.planner.ui.state.journeymap.JourneyStopFeature
 import xyz.ksharma.krail.trip.planner.ui.state.journeymap.StopType
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -90,9 +90,17 @@ private fun JourneyMapContent(
     onPermissionSettingsClick: () -> Unit = {},
     extraMapContent: @Composable () -> Unit = {},
 ) {
-    // Track selected stop for details bottom sheet
-    // Keyed to mapState so it resets when viewing a different journey
-    var selectedStop by remember(mapState) { mutableStateOf<JourneyStopFeature?>(null) }
+    // Which stop's details sheet is open, held as the stop id so it survives Activity
+    // recreation (rotation, theme switch, font-size change). The feature itself comes back
+    // from the journey the ViewModel still holds, which is also how the map layer resolves a
+    // tap, so a stop that is no longer on the displayed journey leaves the sheet closed —
+    // the same reset the old `remember(mapState)` key gave, without losing it on rotation.
+    var selectedStopId by rememberSaveable { mutableStateOf<String?>(null) }
+    val selectedStop = remember(selectedStopId, mapState.mapDisplay.stops) {
+        selectedStopId?.let { stopId ->
+            mapState.mapDisplay.stops.firstOrNull { it.stopId == stopId }
+        }
+    }
 
     // User location state
     var userLocation by remember { mutableStateOf<LatLng?>(null) }
@@ -174,7 +182,7 @@ private fun JourneyMapContent(
                 JourneyMapLayers(
                     mapState = mapState,
                     userLocation = userLocation,
-                    onStopSelect = { selectedStop = it },
+                    onStopSelect = { selectedStopId = it.stopId },
                 )
                 extraMapContent()
             }
@@ -223,7 +231,7 @@ private fun JourneyMapContent(
         selectedStop?.let { stop ->
             JourneyStopDetailsBottomSheet(
                 stop = stop,
-                onDismiss = { selectedStop = null },
+                onDismiss = { selectedStopId = null },
             )
         }
     }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -514,15 +514,12 @@ private fun SearchStopScreenSinglePane(
                 }
             },
             onBackClick = onBackClick,
-            onTextChange = { value ->
-                // Typing while map is visible switches back to list.
-                // onFocusGained was removed — focus events fire on pane transitions and
-                // dark/light mode changes too, which would spuriously reset map mode.
-                if (showMap) {
-                    onShowMapChange(false)
-                }
-                onTextChange(value)
-            },
+            onTextChange = searchTextChangeHandler(
+                showMap = showMap,
+                currentText = initialText,
+                onShowMapChange = onShowMapChange,
+                onTextChange = onTextChange,
+            ),
             // The top bar floats at the TOP of the screen; the keyboard is at the BOTTOM.
             // They never overlap, so IME padding on the bar is wrong: it inflates topBarHeightDp
             // by the keyboard height, which pushes SearchStopListContent down by the same amount
@@ -637,6 +634,27 @@ private fun SearchStopScreenDualPane(
             }
         },
     )
+}
+
+/**
+ * The search field's value callback, wired so that typing over the map returns to the list.
+ *
+ * Only a real text change counts. `onFocusGained` was removed from this path because focus
+ * events fire on pane transitions and dark/light switches; the value callback needed the same
+ * treatment, because the field re-emits its restored text when the Activity is recreated. Taken
+ * for typing, that put the rider back on the list on every configuration change and took any
+ * open stop sheet with it.
+ */
+private fun searchTextChangeHandler(
+    showMap: Boolean,
+    currentText: String,
+    onShowMapChange: (Boolean) -> Unit,
+    onTextChange: (String) -> Unit,
+): (String) -> Unit = { value ->
+    if (showMap && value != currentText) {
+        onShowMapChange(false)
+    }
+    onTextChange(value)
 }
 
 /**

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
@@ -20,9 +20,10 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +47,11 @@ import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.trip.planner.ui.components.TransportModeChip
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 
+private val transportModeSetSaver: Saver<MutableSet<Int>, List<Int>> = Saver(
+    save = { modes -> modes.toList() },
+    restore = { ids -> ids.toMutableSet() },
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapOptionsBottomSheet(
@@ -57,13 +63,16 @@ fun MapOptionsBottomSheet(
     onEvent: (SearchStopUiEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Local state to track pending changes
-    var pendingRadiusKm by remember { mutableDoubleStateOf(searchRadiusKm) }
-    var pendingTransportModes by remember {
+    // Pending changes, held until the rider taps Done. Saveable because the sheet itself
+    // already survives Activity recreation: in a plain `remember`, a rotation or theme switch
+    // mid-edit silently reverted every choice made since the sheet opened, on a sheet that
+    // stayed open as if nothing had happened.
+    var pendingRadiusKm by rememberSaveable { mutableStateOf(searchRadiusKm) }
+    var pendingTransportModes by rememberSaveable(stateSaver = transportModeSetSaver) {
         mutableStateOf(selectedTransportModes.toMutableSet())
     }
-    var pendingShowDistanceScale by remember { mutableStateOf(showDistanceScale) }
-    var pendingShowCompass by remember { mutableStateOf(showCompass) }
+    var pendingShowDistanceScale by rememberSaveable { mutableStateOf(showDistanceScale) }
+    var pendingShowCompass by rememberSaveable { mutableStateOf(showCompass) }
 
     val dim = KrailTheme.dimensions
     ModalBottomSheet(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/SearchStopMap.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.FlowPreview
@@ -122,6 +123,17 @@ private fun ErrorMessage(
     )
 }
 
+// Resolves the open sheet's stop id back to the stop the map is drawing, which is where the
+// tap that opened it came from in the first place. A stop that has since left the nearby set
+// leaves the sheet closed.
+@Composable
+private fun rememberStopForSheet(
+    selectedStopId: String?,
+    nearbyStops: ImmutableList<NearbyStopFeature>,
+): NearbyStopFeature? = remember(selectedStopId, nearbyStops) {
+    selectedStopId?.let { stopId -> nearbyStops.firstOrNull { it.stopId == stopId } }
+}
+
 @Composable
 private fun MapContent(
     mapState: MapUiState.Ready,
@@ -149,7 +161,13 @@ private fun MapContent(
             onShowOptionsSheet()
         }
     }
-    var selectedStop by remember { mutableStateOf<NearbyStopFeature?>(null) }
+    // Which stop's details sheet is open, held as the stop id because that is the part worth
+    // saving: the feature itself is map-rendering data the ViewModel still holds after the
+    // Activity is recreated, so it can be looked up again rather than serialised. Held in a
+    // plain `remember` this closed the sheet on every rotation, theme switch and font-size
+    // change (see SearchStopMapSheetRestoreTest).
+    var selectedStopId by rememberSaveable { mutableStateOf<String?>(null) }
+    val selectedStop = rememberStopForSheet(selectedStopId, mapState.mapDisplay.nearbyStops)
 
     // User location state
     var permissionStatus by remember { mutableStateOf<PermissionStatus>(PermissionStatus.NotDetermined) }
@@ -261,7 +279,7 @@ private fun MapContent(
                 cameraState = cameraState,
                 ornamentTopPadding = ornamentTopPadding,
                 onStopSelected = { stop ->
-                    selectedStop = stop
+                    selectedStopId = stop.stopId
                     onEvent(SearchStopUiEvent.NearbyStopClicked(stop))
                 },
             )
@@ -345,7 +363,7 @@ private fun MapContent(
             selectedStop?.let { stop ->
                 StopDetailsBottomSheet(
                     stop = stop,
-                    onDismiss = { selectedStop = null },
+                    onDismiss = { selectedStopId = null },
                     actionContent = {
                         StopActionButton(
                             text = "Select Stop",
@@ -377,7 +395,7 @@ private fun MapContent(
                                     ),
                                 )
 
-                                selectedStop = null
+                                selectedStopId = null
                             },
                         )
                     },


### PR DESCRIPTION
## What

Keeps the map stop-details sheets and the map options sheet's unsaved edits alive when the Activity is recreated, and stops the search screen dropping the rider back to the list on a configuration change.

## Changes

- `SearchStopMap.kt` and `JourneyMap.kt`: which stop's sheet is open is now a `rememberSaveable` stop id, resolved back to the feature from the map state the ViewModel still holds. That is the same lookup the map layer already does for a tap, so a stop that has left the displayed set leaves the sheet closed, which is the reset the old `remember(mapState)` key gave. Held in a plain `remember`, the sheet closed itself on every dark/light switch and font-size change.
- `MapOptionsBottomSheet.kt`: pending radius, mode set and toggles are saveable, with a `Saver` storing the mode set as its list of product-class ids. The sheet already stayed open across recreation, so the rider's unsaved edits reverted under a sheet that looked untouched.
- `SearchStopScreen.kt`: the map-to-list switch now ignores a text callback carrying unchanged text. The field re-emits its restored value when the Activity is recreated, and taking that for typing put the rider on the list on every configuration change, taking any open sheet with it. The comment above this call already recorded the same trap for focus callbacks. Extracted as `searchTextChangeHandler` so `SearchStopScreenSinglePane` stays under the cyclomatic limit; `rememberStopForSheet` extracted from `MapContent` for the same reason.
- `MapOptionsSheetRestoreTest`: new. Asserts what Save commits after recreation rather than which chip draws selected, since the committed value is what the rider loses. Verified to fail when the fix is reverted.
- `TimeTableStopSheetRestoreTest`: KDoc corrected. It stated as fact that `ModalBottomSheet` fires `onDismissRequest` while its dialog is disposed during recreation. A probe build logging every `onDismissRequest` with its lifecycle state recorded none at all across a rotation, and the sheets whose visibility flag was already saveable came back on screen. The only dismissals recorded were scrim taps at `RESUMED`.
- `docs/learning/2026-08-21-sheet-closed-by-a-text-callback.md`: new entry covering the wrong theory, the probe that settled it, and the `adb shell input tap` artefact where the injected `ACTION_UP` lands on the dialog window the `ACTION_DOWN` created and dismisses the sheet as an outside touch.

Left open, tracked in #1915: on a phone, rotating swaps single pane for dual pane, which use different map composables, so no state inside either can carry an open sheet across that switch. Closing it means hoisting the selection above `AdaptiveScreenContent` and giving both panes the same sheet, the way `showMap` already is.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` and `:taj:testAndroidHostTest` green
- `./gradlew detekt --continue` green, nothing left auto-corrected
- Emulator (Pixel-class, API 36), on the final build: stop sheet on the search map, stop sheet on the journey map and the options sheet with an unsaved 5km pick all survive a dark-mode recreation; journey map also rotated portrait to landscape and back with the sheet open; `adb logcat` shows no `FATAL EXCEPTION`
- Before the fix, the same steps closed the sheet and returned the search screen to the recents list

## Snapshots

No visual change: this PR changes which state survives recreation, not what any screen draws. No goldens moved.

Part of #1915

🤖 Generated with [Claude Code](https://claude.com/claude-code)
