### PR TITLE
test(trip-planner): exercise Discover chips and link routing

### DIFF
--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapperTest.kt
@@ -1,0 +1,50 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.social.state.SocialType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The two Discover analytics mappers translate domain enums into the labels the dashboard groups
+ * by. A wrong pairing does not fail anything at runtime — it silently files clicks under the wrong
+ * category, and the mistake is only visible months later in a chart.
+ *
+ * Both tests assert the whole mapping at once, so adding a domain enum entry without an analytics
+ * label fails here rather than compiling into a mis-labelled default.
+ */
+class DiscoverAnalyticsMapperTest {
+
+    @Test
+    fun `GIVEN every discover card type WHEN mapped THEN each gets its own analytics label`() {
+        val expected = mapOf(
+            DiscoverCardType.Travel to DiscoverCardClick.CardType.TRAVEL,
+            DiscoverCardType.Events to DiscoverCardClick.CardType.EVENTS,
+            DiscoverCardType.Food to DiscoverCardClick.CardType.FOOD,
+            DiscoverCardType.Sports to DiscoverCardClick.CardType.SPORTS,
+            DiscoverCardType.Unknown to DiscoverCardClick.CardType.UNKNOWN,
+        )
+
+        assertEquals(
+            expected,
+            DiscoverCardType.entries.associateWith { it.toAnalyticsCardType() },
+        )
+    }
+
+    @Test
+    fun `GIVEN every social platform WHEN mapped THEN each gets its own analytics platform`() {
+        val expected = mapOf(
+            SocialType.LinkedIn to SocialConnectionLinkClickEvent.SocialPlatformType.LINKEDIN,
+            SocialType.Reddit to SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT,
+            SocialType.Instagram to SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM,
+            SocialType.Facebook to SocialConnectionLinkClickEvent.SocialPlatformType.FACEBOOK,
+        )
+
+        assertEquals(
+            expected,
+            SocialType.entries.associateWith { it.toAnalyticsSocialType() },
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModelTest.kt
@@ -1,0 +1,358 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import app.cash.turbine.test
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
+import xyz.ksharma.krail.core.testing.coroutines.KrailTestScope
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeAppInfo
+import xyz.ksharma.krail.core.testing.fakes.FakeAppInfoProvider
+import xyz.ksharma.krail.core.testing.fakes.FakePlatformOps
+import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
+import xyz.ksharma.krail.discover.state.Button
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.discover.state.DiscoverEvent
+import xyz.ksharma.krail.social.state.KrailSocialType
+import xyz.ksharma.krail.social.state.SocialType
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeDiscoverSydneyManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `DiscoverViewModel` owns the card list, the filter chip row and every analytics call the Discover
+ * surface makes. None of it was covered.
+ *
+ * The fetch is triggered by the first subscriber (`onStart` on a `WhileSubscribed` state flow), so
+ * every test collects `uiState` rather than reading `.value` — reading the value alone never starts
+ * the fetch, which is exactly the bug this shape can hide.
+ */
+class DiscoverViewModelTest {
+
+    private val discoverManager = FakeDiscoverSydneyManager()
+    private val analytics = FakeAnalytics()
+    private val platformOps = FakePlatformOps()
+    private val appInfoProvider = FakeAppInfoProvider()
+
+    @Test
+    fun `GIVEN cards WHEN first collected THEN they are fetched and mapped into the ui list`() = krailRunTest {
+        discoverManager.cards = listOf(card(cardId = "a", title = "Vivid", type = DiscoverCardType.Events))
+
+        viewModel().uiState.test {
+            assertTrue(awaitItem().discoverCardsList.isEmpty())
+            runCurrent()
+
+            val card = expectMostRecentItem().discoverCardsList.single()
+            assertEquals("a", card.cardId)
+            assertEquals("Vivid", card.title)
+            assertEquals(DiscoverCardType.Events, card.type)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN mixed card types WHEN collected THEN the chip row is deduplicated and sort-ordered`() =
+        krailRunTest {
+            discoverManager.cards = listOf(
+                card(cardId = "a", type = DiscoverCardType.Sports),
+                card(cardId = "b", type = DiscoverCardType.Travel),
+                card(cardId = "c", type = DiscoverCardType.Sports),
+                card(cardId = "d", type = DiscoverCardType.Events),
+            )
+
+            viewModel().uiState.test {
+                awaitItem()
+                runCurrent()
+
+                val state = expectMostRecentItem()
+                assertEquals(
+                    listOf(DiscoverCardType.Travel, DiscoverCardType.Events, DiscoverCardType.Sports),
+                    state.sortedDiscoverCardTypes,
+                )
+                assertEquals(DiscoverCardType.Unknown, state.selectedType)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a chip tap WHEN filtering THEN only that type is listed and the choice is tracked`() =
+        krailRunTest {
+            discoverManager.cards = listOf(
+                card(cardId = "sport", type = DiscoverCardType.Sports),
+                card(cardId = "food", type = DiscoverCardType.Food),
+            )
+            val viewModel = viewModel()
+
+            viewModel.uiState.test {
+                awaitItem()
+                runCurrent()
+                expectMostRecentItem()
+
+                viewModel.onEvent(DiscoverEvent.FilterChipClicked(DiscoverCardType.Food))
+                runCurrent()
+
+                val filtered = expectMostRecentItem()
+                assertEquals(listOf("food"), filtered.discoverCardsList.map { it.cardId })
+                assertEquals(DiscoverCardType.Food, filtered.selectedType)
+                // The chip row still offers every type — filtering must not shrink the row it
+                // lives in.
+                assertEquals(
+                    listOf(DiscoverCardType.Food, DiscoverCardType.Sports),
+                    filtered.sortedDiscoverCardTypes,
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            val event = assertIs<AnalyticsEvent.DiscoverFilterChipSelected>(
+                analytics.getTrackedEvent("discover_filter_chip_selected"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.CardType.FOOD, event.cardType)
+        }
+
+    @Test
+    fun `GIVEN an active filter WHEN the same chip is tapped again THEN the filter clears`() = krailRunTest {
+        discoverManager.cards = listOf(
+            card(cardId = "sport", type = DiscoverCardType.Sports),
+            card(cardId = "food", type = DiscoverCardType.Food),
+        )
+        val viewModel = viewModel()
+
+        viewModel.uiState.test {
+            awaitItem()
+            runCurrent()
+            expectMostRecentItem()
+
+            viewModel.onEvent(DiscoverEvent.FilterChipClicked(DiscoverCardType.Food))
+            runCurrent()
+            expectMostRecentItem()
+
+            viewModel.onEvent(DiscoverEvent.FilterChipClicked(DiscoverCardType.Food))
+            runCurrent()
+
+            val cleared = expectMostRecentItem()
+            assertEquals(listOf("sport", "food"), cleared.discoverCardsList.map { it.cardId })
+            assertEquals(DiscoverCardType.Unknown, cleared.selectedType)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN a CTA tap WHEN handled THEN the link opens and the click is attributed to the cta`() =
+        krailRunTest {
+            val viewModel = viewModel()
+
+            viewModel.onEvent(
+                DiscoverEvent.CtaButtonClicked(
+                    url = "https://example.com/vivid",
+                    cardId = "a",
+                    cardType = DiscoverCardType.Events,
+                ),
+            )
+
+            assertEquals("https://example.com/vivid", platformOps.lastOpenedUrl)
+            val event = assertIs<AnalyticsEvent.DiscoverCardClick>(
+                analytics.getTrackedEvent("discover_card_click"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.Source.CTA_CLICK, event.source)
+            assertEquals(AnalyticsEvent.DiscoverCardClick.CardType.EVENTS, event.cardType)
+            assertEquals("a", event.cardId)
+            assertNull(event.partnerSocialLink)
+        }
+
+    @Test
+    fun `GIVEN a partner social tap WHEN handled THEN the partner platform and url are attributed`() =
+        krailRunTest {
+            val viewModel = viewModel()
+
+            viewModel.onEvent(
+                DiscoverEvent.PartnerSocialLinkClicked(
+                    partnerSocialLink = Button.Social.PartnerSocial.PartnerSocialLink(
+                        type = SocialType.Instagram,
+                        url = "https://instagram.com/partner",
+                    ),
+                    cardId = "a",
+                    cardType = DiscoverCardType.Food,
+                ),
+            )
+
+            assertEquals("https://instagram.com/partner", platformOps.lastOpenedUrl)
+            val event = assertIs<AnalyticsEvent.DiscoverCardClick>(
+                analytics.getTrackedEvent("discover_card_click"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.Source.PARTNER_SOCIAL_LINK, event.source)
+            assertEquals(
+                AnalyticsEvent.SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM,
+                event.partnerSocialLink?.type,
+            )
+            assertEquals("https://instagram.com/partner", event.partnerSocialLink?.url)
+        }
+
+    @Test
+    fun `GIVEN a KRAIL social tap WHEN handled THEN it is sourced to the discover card`() = krailRunTest {
+        val viewModel = viewModel()
+
+        viewModel.onEvent(DiscoverEvent.AppSocialLinkClicked(KrailSocialType.Reddit))
+
+        assertEquals(KrailSocialType.Reddit.url, platformOps.lastOpenedUrl)
+        val event = assertIs<AnalyticsEvent.SocialConnectionLinkClickEvent>(
+            analytics.getTrackedEvent("social_connection_link_click"),
+        )
+        assertEquals(
+            AnalyticsEvent.SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT,
+            event.socialPlatformType,
+        )
+        assertEquals(
+            AnalyticsEvent.SocialConnectionLinkClickEvent.SocialConnectionSource.DISCOVER_CARD,
+            event.source,
+        )
+    }
+
+    @Test
+    fun `GIVEN a share tap WHEN handled THEN the card text, its cta link and the KRAIL tag are shared`() =
+        krailRunTest {
+            discoverManager.cards = listOf(
+                card(
+                    cardId = "a",
+                    title = "Vivid Sydney",
+                    description = "Lights on the harbour",
+                    type = DiscoverCardType.Events,
+                    buttons = listOf(Button.Cta(label = "Book", url = "https://example.com/vivid")),
+                ),
+            )
+            val viewModel = viewModel()
+
+            viewModel.uiState.test {
+                awaitItem()
+                runCurrent()
+                expectMostRecentItem()
+
+                viewModel.onEvent(
+                    DiscoverEvent.ShareButtonClicked(cardId = "a", cardType = DiscoverCardType.Events),
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            assertEquals(
+                "Vivid Sydney\nLights on the harbour\nhttps://example.com/vivid\n\n" +
+                    "See more events in KRAIL App\n#LetsKRAIL $KRAIL_WEBSITE_URL",
+                platformOps.lastSharedText,
+            )
+            val event = assertIs<AnalyticsEvent.DiscoverCardClick>(
+                analytics.getTrackedEvent("discover_card_click"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.Source.SHARE_CLICK, event.source)
+        }
+
+    @Test
+    fun `GIVEN a card scrolls into view WHEN seen THEN it is persisted and counted for the session`() =
+        krailRunTest {
+            val viewModel = viewModel()
+
+            viewModel.onEvent(DiscoverEvent.CardSeen(cardId = "a"))
+            viewModel.onEvent(DiscoverEvent.CardSeen(cardId = "a"))
+            viewModel.onEvent(DiscoverEvent.CardSeen(cardId = "b"))
+            runCurrent()
+
+            assertEquals(listOf("a", "a", "b"), discoverManager.seenCardIds)
+            // The session count is distinct cards, not impressions.
+            assertEquals(setOf("a", "b"), viewModel.analyticsSessionSeenCardIds)
+        }
+
+    @Test
+    fun `GIVEN a release build WHEN reset seen cards is requested THEN nothing is reset`() = krailRunTest {
+        appInfoProvider.mockAppInfo = FakeAppInfo(isDebug = false)
+        val viewModel = viewModel()
+
+        viewModel.onEvent(DiscoverEvent.ResetAllSeenCards)
+        runCurrent()
+
+        assertEquals(0, discoverManager.resetCallCount)
+    }
+
+    @Test
+    fun `GIVEN a debug build WHEN reset seen cards is requested THEN the store is cleared`() = krailRunTest {
+        appInfoProvider.mockAppInfo = FakeAppInfo(isDebug = true)
+        val viewModel = viewModel()
+
+        viewModel.onEvent(DiscoverEvent.ResetAllSeenCards)
+        runCurrent()
+
+        assertEquals(1, discoverManager.resetCallCount)
+    }
+
+    @Test
+    fun `GIVEN a card with a cta and a partner social WHEN resolving its link THEN button order decides`() =
+        krailRunTest {
+            val partnerSocial = Button.Social.PartnerSocial(
+                socialPartnerName = "Partner",
+                links = listOf(
+                    Button.Social.PartnerSocial.PartnerSocialLink(
+                        type = SocialType.Instagram,
+                        url = "https://instagram.com/partner",
+                    ),
+                ),
+            )
+            val cta = Button.Cta(label = "Book", url = "https://example.com/book")
+            discoverManager.cards = listOf(
+                card(cardId = "social-first", buttons = listOf(partnerSocial, cta, Button.Share)),
+                card(cardId = "cta-first", buttons = listOf(cta, partnerSocial, Button.Share)),
+            )
+
+            viewModel().uiState.test {
+                awaitItem()
+                runCurrent()
+                val state = expectMostRecentItem()
+
+                // There is no cta-beats-social precedence: the shared link is whichever link
+                // button the card lists first.
+                assertEquals(
+                    "https://instagram.com/partner",
+                    state.getCtaOrPartnerSocialLinkForCard("social-first"),
+                )
+                assertEquals("https://example.com/book", state.getCtaOrPartnerSocialLinkForCard("cta-first"))
+                assertNull(state.getCtaOrPartnerSocialLinkForCard("no-such-card"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a card with only a share button WHEN resolving its link THEN there is nothing to share`() =
+        krailRunTest {
+            discoverManager.cards = listOf(card(cardId = "a", buttons = listOf(Button.Share)))
+
+            viewModel().uiState.test {
+                awaitItem()
+                runCurrent()
+
+                assertNull(expectMostRecentItem().getCtaOrPartnerSocialLinkForCard("a"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    private fun KrailTestScope.viewModel() = DiscoverViewModel(
+        discoverSydneyManager = discoverManager,
+        ioDispatcher = ioDispatcher,
+        analytics = analytics,
+        platformOps = platformOps,
+        appInfoProvider = appInfoProvider,
+        appCoroutineScope = this,
+    )
+
+    private fun card(
+        cardId: String,
+        title: String = "Title",
+        description: String = "Description",
+        type: DiscoverCardType = DiscoverCardType.Events,
+        buttons: List<Button>? = null,
+    ) = DiscoverModel(
+        title = title,
+        description = description,
+        imageList = listOf("https://example.com/image.png"),
+        buttons = buttons,
+        type = type,
+        cardId = cardId,
+    )
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/business/TrackedJourneyMapMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/business/TrackedJourneyMapMapperTest.kt
@@ -1,0 +1,226 @@
+package xyz.ksharma.krail.trip.planner.ui.journeymap.business
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
+import xyz.ksharma.krail.feature.track.TrackedLeg
+import xyz.ksharma.krail.feature.track.TrackedStop
+import xyz.ksharma.krail.trip.planner.ui.journeymap.business.TrackedJourneyMapMapper.toJourneyMapState
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.RouteSegment
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.StopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `TrackedJourneyMapMapper` is the live-tracking counterpart of `JourneyMapMapper`. It is a pure
+ * function over a `TrackedJourneyDisplay` plus a caller-supplied coordinate lookup, so the
+ * behaviours that matter are: which legs are drawn at all, how a stop with no known coordinate is
+ * handled, and how the ORIGIN / INTERCHANGE / DESTINATION roles fall out across several legs.
+ */
+class TrackedJourneyMapMapperTest {
+
+    @Test
+    fun `GIVEN a walk leg between two transport legs WHEN mapped THEN only transport legs are drawn`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b"))),
+            TrackedLeg.Walk(durationText = "4 mins"),
+            transportLeg(lineName = "T4", stops = listOf(stop("c"), stop("d"))),
+        )
+
+        val state = display.toJourneyMapState(coordinates("a", "b", "c", "d"))
+
+        assertEquals(listOf("tracked_leg_0", "tracked_leg_1"), state.mapDisplay.legs.map { it.legId })
+        assertEquals(listOf("T1", "T4"), state.mapDisplay.legs.map { it.lineName })
+    }
+
+    @Test
+    fun `GIVEN a known line key WHEN mapped THEN the brand colour overrides the API colour code`() {
+        val display = display(
+            transportLeg(lineName = "T1", lineColorCode = "#000000", stops = listOf(stop("a"), stop("b"))),
+        )
+
+        val legFeature = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.legs.single()
+
+        assertEquals("#F99D1C", legFeature.lineColor)
+    }
+
+    @Test
+    fun `GIVEN a line key that is not in the catalogue WHEN mapped THEN the API colour code is kept`() {
+        val display = display(
+            transportLeg(
+                lineName = "333",
+                transportMode = TransportMode.Bus,
+                lineColorCode = "#123456",
+                stops = listOf(stop("a"), stop("b")),
+            ),
+        )
+
+        val legFeature = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.legs.single()
+
+        assertEquals("#123456", legFeature.lineColor)
+    }
+
+    @Test
+    fun `GIVEN route path coordinates WHEN mapped THEN the curved path is drawn instead of stop connectors`() {
+        val path = persistentListOf(
+            LatLng(latitude = -33.80, longitude = 151.20),
+            LatLng(latitude = -33.85, longitude = 151.25),
+        )
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b")), routePath = path),
+        )
+
+        val state = display.toJourneyMapState(coordinates("a", "b"))
+        val segment = state.mapDisplay.legs.single().routeSegment
+
+        assertEquals(path, assertIs<RouteSegment.PathSegment>(segment).points)
+    }
+
+    @Test
+    fun `GIVEN no route path WHEN mapped THEN the leg falls back to connecting its stops`() {
+        val display = display(transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b"))))
+
+        val state = display.toJourneyMapState(coordinates("a", "b"))
+        val segment = state.mapDisplay.legs.single().routeSegment
+
+        assertEquals(listOf("a", "b"), assertIs<RouteSegment.StopConnectorSegment>(segment).stops.map { it.stopId })
+    }
+
+    @Test
+    fun `GIVEN a stop with no known coordinate WHEN mapped THEN it is skipped and the rest still render`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("missing"), stop("b"))),
+        )
+
+        val stops = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.stops
+
+        assertEquals(listOf("a", "b"), stops.map { it.stopId })
+    }
+
+    @Test
+    fun `GIVEN three stops on one leg WHEN mapped THEN the middle stop is regular and the ends are terminals`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("mid"), stop("b"))),
+        )
+
+        val stops = display.toJourneyMapState(coordinates("a", "mid", "b")).mapDisplay.stops
+
+        assertEquals(
+            listOf(StopType.ORIGIN, StopType.REGULAR, StopType.DESTINATION),
+            stops.map { it.stopType },
+        )
+    }
+
+    @Test
+    fun `GIVEN two transport legs WHEN mapped THEN the changeover stops are interchanges, not terminals`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("swap"))),
+            transportLeg(lineName = "T4", stops = listOf(stop("swap"), stop("b"))),
+        )
+
+        val stops = display.toJourneyMapState(coordinates("a", "swap", "b")).mapDisplay.stops
+
+        assertEquals(
+            listOf(
+                "a" to StopType.ORIGIN,
+                "swap" to StopType.INTERCHANGE,
+                "swap" to StopType.INTERCHANGE,
+                "b" to StopType.DESTINATION,
+            ),
+            stops.map { it.stopId to it.stopType },
+        )
+    }
+
+    @Test
+    fun `GIVEN a tracked stop WHEN mapped THEN it carries its leg's line and its own departure time`() {
+        val display = display(
+            transportLeg(
+                lineName = "T1",
+                stops = listOf(stop("a", utcTime = "2026-04-09T02:00:00Z"), stop("b")),
+            ),
+        )
+
+        val stop = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.stops.first()
+
+        assertEquals("T1", stop.lineName)
+        assertEquals("#F99D1C", stop.lineColor)
+        assertEquals("2026-04-09T02:00:00Z", stop.departureTime)
+    }
+
+    @Test
+    fun `GIVEN a journey with only a walk leg WHEN mapped THEN nothing is drawn and there is no camera focus`() {
+        val display = display(TrackedLeg.Walk(durationText = "4 mins"))
+
+        val state = display.toJourneyMapState(emptyMap())
+
+        assertTrue(state.mapDisplay.legs.isEmpty())
+        assertTrue(state.mapDisplay.stops.isEmpty())
+        assertNull(state.cameraFocus)
+    }
+
+    @Test
+    fun `GIVEN stops spread across the network WHEN mapped THEN camera bounds enclose every stop`() {
+        val display = display(transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b"))))
+        val coords = mapOf(
+            "a" to LatLng(latitude = -33.95, longitude = 151.10),
+            "b" to LatLng(latitude = -33.80, longitude = 151.35),
+        )
+
+        val bounds = display.toJourneyMapState(coords).cameraFocus?.bounds
+
+        assertEquals(LatLng(latitude = -33.95, longitude = 151.10), bounds?.southwest)
+        assertEquals(LatLng(latitude = -33.80, longitude = 151.35), bounds?.northeast)
+    }
+
+    // region fixtures
+
+    private fun display(vararg legs: TrackedLeg) = TrackedJourneyDisplay(
+        fromStopId = "a",
+        toStopId = "b",
+        fromStopName = "A",
+        toStopName = "B",
+        originTime = "12:00pm",
+        scheduledOriginTime = null,
+        destinationTime = "12:30pm",
+        originUtcDateTime = "2026-04-09T02:00:00Z",
+        destinationUtcDateTime = "2026-04-09T02:30:00Z",
+        travelTime = "30 mins",
+        legs = legs.toList().toImmutableList(),
+    )
+
+    private fun transportLeg(
+        lineName: String,
+        stops: List<TrackedStop>,
+        transportMode: TransportMode = TransportMode.Train,
+        lineColorCode: String = "#FFFFFF",
+        routePath: List<LatLng> = emptyList(),
+    ) = TrackedLeg.Transport(
+        transportMode = transportMode,
+        lineName = lineName,
+        lineColorCode = lineColorCode,
+        headsign = null,
+        stops = stops.toImmutableList(),
+        routePathCoordinates = routePath.toImmutableList(),
+    )
+
+    private fun stop(stopId: String, utcTime: String = "2026-04-09T02:00:00Z") = TrackedStop(
+        stopId = stopId,
+        name = stopId.uppercase(),
+        scheduledTime = "12:00pm",
+        estimatedTime = null,
+        utcTime = utcTime,
+        scheduledUtcTime = utcTime,
+    )
+
+    private fun coordinates(vararg stopIds: String): Map<String, LatLng> =
+        stopIds.mapIndexed { index, id ->
+            id to LatLng(latitude = -33.8 - index * 0.01, longitude = 151.2 + index * 0.01)
+        }.toMap()
+
+    // endregion
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeDiscoverSydneyManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeDiscoverSydneyManager.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
+import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
+
+/**
+ * Canned cards plus a call record. All seen/reset bookkeeping in production lives behind this
+ * interface, so the fake holds no logic of its own — `DiscoverViewModel` is the real class under
+ * test.
+ */
+internal class FakeDiscoverSydneyManager : DiscoverSydneyManager {
+
+    var cards: List<DiscoverModel> = emptyList()
+
+    val seenCardIds = mutableListOf<String>()
+
+    var resetCallCount = 0
+        private set
+
+    override suspend fun fetchDiscoverData(): List<DiscoverModel> = cards
+
+    override suspend fun markCardAsSeen(cardId: String) {
+        seenCardIds += cardId
+    }
+
+    override suspend fun resetAllDiscoverCardsDebugOnly() {
+        resetCallCount++
+    }
+}


### PR DESCRIPTION
## What

Tests for `DiscoverViewModel` and its analytics mappers, both at 0%. Test-only, plus one fake.

## Changes

- `DiscoverViewModelTest.kt` (13 tests): fetch triggered by the first subscriber, chip row dedupe and sort and that it does not shrink under a filter, chip toggle-to-clear, the four click paths (CTA, partner social, KRAIL social, share) each opening the right URL with the right attribution, character-exact share text, seen-card persistence versus distinct session count, the debug-only reset gate, and link resolution order.
- `DiscoverAnalyticsMapperTest.kt` (2 tests): whole-map assertions over the enums, so a new domain entry cannot compile into a mislabelled bucket.
- `FakeDiscoverSydneyManager.kt`: canned data and call records only.

`getCtaOrPartnerSocialLinkForCard` has no CTA-beats-social precedence despite its name; it returns whichever link button the card lists first. The test states that rather than asserting a precedence the code does not have.

Not covered: `onCleared()` and its session-complete event. `ViewModel.clear()` is internal to androidx.lifecycle, so there is no host-side way to drive it without a mocking framework.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
- `./gradlew detekt --continue` green
- Proved able to fail: removed the chip toggle, removed `sortedBy(sortOrder)`, changed a click source enum, and no-opped `CardSeen`. Five tests failed as intended; all reverted.

Part of #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)
