### PR TITLE
test(trip-planner): drive SearchStop map and location paths

### DIFF
--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverAnalyticsMapperTest.kt
@@ -1,0 +1,50 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.DiscoverCardClick
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent.SocialConnectionLinkClickEvent
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.social.state.SocialType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The two Discover analytics mappers translate domain enums into the labels the dashboard groups
+ * by. A wrong pairing does not fail anything at runtime — it silently files clicks under the wrong
+ * category, and the mistake is only visible months later in a chart.
+ *
+ * Both tests assert the whole mapping at once, so adding a domain enum entry without an analytics
+ * label fails here rather than compiling into a mis-labelled default.
+ */
+class DiscoverAnalyticsMapperTest {
+
+    @Test
+    fun `GIVEN every discover card type WHEN mapped THEN each gets its own analytics label`() {
+        val expected = mapOf(
+            DiscoverCardType.Travel to DiscoverCardClick.CardType.TRAVEL,
+            DiscoverCardType.Events to DiscoverCardClick.CardType.EVENTS,
+            DiscoverCardType.Food to DiscoverCardClick.CardType.FOOD,
+            DiscoverCardType.Sports to DiscoverCardClick.CardType.SPORTS,
+            DiscoverCardType.Unknown to DiscoverCardClick.CardType.UNKNOWN,
+        )
+
+        assertEquals(
+            expected,
+            DiscoverCardType.entries.associateWith { it.toAnalyticsCardType() },
+        )
+    }
+
+    @Test
+    fun `GIVEN every social platform WHEN mapped THEN each gets its own analytics platform`() {
+        val expected = mapOf(
+            SocialType.LinkedIn to SocialConnectionLinkClickEvent.SocialPlatformType.LINKEDIN,
+            SocialType.Reddit to SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT,
+            SocialType.Instagram to SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM,
+            SocialType.Facebook to SocialConnectionLinkClickEvent.SocialPlatformType.FACEBOOK,
+        )
+
+        assertEquals(
+            expected,
+            SocialType.entries.associateWith { it.toAnalyticsSocialType() },
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/discover/DiscoverViewModelTest.kt
@@ -1,0 +1,358 @@
+package xyz.ksharma.krail.trip.planner.ui.discover
+
+import app.cash.turbine.test
+import xyz.ksharma.krail.core.analytics.event.AnalyticsEvent
+import xyz.ksharma.krail.core.appinfo.KRAIL_WEBSITE_URL
+import xyz.ksharma.krail.core.testing.coroutines.KrailTestScope
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.core.testing.fakes.FakeAnalytics
+import xyz.ksharma.krail.core.testing.fakes.FakeAppInfo
+import xyz.ksharma.krail.core.testing.fakes.FakeAppInfoProvider
+import xyz.ksharma.krail.core.testing.fakes.FakePlatformOps
+import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
+import xyz.ksharma.krail.discover.state.Button
+import xyz.ksharma.krail.discover.state.DiscoverCardType
+import xyz.ksharma.krail.discover.state.DiscoverEvent
+import xyz.ksharma.krail.social.state.KrailSocialType
+import xyz.ksharma.krail.social.state.SocialType
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeDiscoverSydneyManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `DiscoverViewModel` owns the card list, the filter chip row and every analytics call the Discover
+ * surface makes. None of it was covered.
+ *
+ * The fetch is triggered by the first subscriber (`onStart` on a `WhileSubscribed` state flow), so
+ * every test collects `uiState` rather than reading `.value` — reading the value alone never starts
+ * the fetch, which is exactly the bug this shape can hide.
+ */
+class DiscoverViewModelTest {
+
+    private val discoverManager = FakeDiscoverSydneyManager()
+    private val analytics = FakeAnalytics()
+    private val platformOps = FakePlatformOps()
+    private val appInfoProvider = FakeAppInfoProvider()
+
+    @Test
+    fun `GIVEN cards WHEN first collected THEN they are fetched and mapped into the ui list`() = krailRunTest {
+        discoverManager.cards = listOf(card(cardId = "a", title = "Vivid", type = DiscoverCardType.Events))
+
+        viewModel().uiState.test {
+            assertTrue(awaitItem().discoverCardsList.isEmpty())
+            runCurrent()
+
+            val card = expectMostRecentItem().discoverCardsList.single()
+            assertEquals("a", card.cardId)
+            assertEquals("Vivid", card.title)
+            assertEquals(DiscoverCardType.Events, card.type)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN mixed card types WHEN collected THEN the chip row is deduplicated and sort-ordered`() =
+        krailRunTest {
+            discoverManager.cards = listOf(
+                card(cardId = "a", type = DiscoverCardType.Sports),
+                card(cardId = "b", type = DiscoverCardType.Travel),
+                card(cardId = "c", type = DiscoverCardType.Sports),
+                card(cardId = "d", type = DiscoverCardType.Events),
+            )
+
+            viewModel().uiState.test {
+                awaitItem()
+                runCurrent()
+
+                val state = expectMostRecentItem()
+                assertEquals(
+                    listOf(DiscoverCardType.Travel, DiscoverCardType.Events, DiscoverCardType.Sports),
+                    state.sortedDiscoverCardTypes,
+                )
+                assertEquals(DiscoverCardType.Unknown, state.selectedType)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a chip tap WHEN filtering THEN only that type is listed and the choice is tracked`() =
+        krailRunTest {
+            discoverManager.cards = listOf(
+                card(cardId = "sport", type = DiscoverCardType.Sports),
+                card(cardId = "food", type = DiscoverCardType.Food),
+            )
+            val viewModel = viewModel()
+
+            viewModel.uiState.test {
+                awaitItem()
+                runCurrent()
+                expectMostRecentItem()
+
+                viewModel.onEvent(DiscoverEvent.FilterChipClicked(DiscoverCardType.Food))
+                runCurrent()
+
+                val filtered = expectMostRecentItem()
+                assertEquals(listOf("food"), filtered.discoverCardsList.map { it.cardId })
+                assertEquals(DiscoverCardType.Food, filtered.selectedType)
+                // The chip row still offers every type — filtering must not shrink the row it
+                // lives in.
+                assertEquals(
+                    listOf(DiscoverCardType.Food, DiscoverCardType.Sports),
+                    filtered.sortedDiscoverCardTypes,
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            val event = assertIs<AnalyticsEvent.DiscoverFilterChipSelected>(
+                analytics.getTrackedEvent("discover_filter_chip_selected"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.CardType.FOOD, event.cardType)
+        }
+
+    @Test
+    fun `GIVEN an active filter WHEN the same chip is tapped again THEN the filter clears`() = krailRunTest {
+        discoverManager.cards = listOf(
+            card(cardId = "sport", type = DiscoverCardType.Sports),
+            card(cardId = "food", type = DiscoverCardType.Food),
+        )
+        val viewModel = viewModel()
+
+        viewModel.uiState.test {
+            awaitItem()
+            runCurrent()
+            expectMostRecentItem()
+
+            viewModel.onEvent(DiscoverEvent.FilterChipClicked(DiscoverCardType.Food))
+            runCurrent()
+            expectMostRecentItem()
+
+            viewModel.onEvent(DiscoverEvent.FilterChipClicked(DiscoverCardType.Food))
+            runCurrent()
+
+            val cleared = expectMostRecentItem()
+            assertEquals(listOf("sport", "food"), cleared.discoverCardsList.map { it.cardId })
+            assertEquals(DiscoverCardType.Unknown, cleared.selectedType)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN a CTA tap WHEN handled THEN the link opens and the click is attributed to the cta`() =
+        krailRunTest {
+            val viewModel = viewModel()
+
+            viewModel.onEvent(
+                DiscoverEvent.CtaButtonClicked(
+                    url = "https://example.com/vivid",
+                    cardId = "a",
+                    cardType = DiscoverCardType.Events,
+                ),
+            )
+
+            assertEquals("https://example.com/vivid", platformOps.lastOpenedUrl)
+            val event = assertIs<AnalyticsEvent.DiscoverCardClick>(
+                analytics.getTrackedEvent("discover_card_click"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.Source.CTA_CLICK, event.source)
+            assertEquals(AnalyticsEvent.DiscoverCardClick.CardType.EVENTS, event.cardType)
+            assertEquals("a", event.cardId)
+            assertNull(event.partnerSocialLink)
+        }
+
+    @Test
+    fun `GIVEN a partner social tap WHEN handled THEN the partner platform and url are attributed`() =
+        krailRunTest {
+            val viewModel = viewModel()
+
+            viewModel.onEvent(
+                DiscoverEvent.PartnerSocialLinkClicked(
+                    partnerSocialLink = Button.Social.PartnerSocial.PartnerSocialLink(
+                        type = SocialType.Instagram,
+                        url = "https://instagram.com/partner",
+                    ),
+                    cardId = "a",
+                    cardType = DiscoverCardType.Food,
+                ),
+            )
+
+            assertEquals("https://instagram.com/partner", platformOps.lastOpenedUrl)
+            val event = assertIs<AnalyticsEvent.DiscoverCardClick>(
+                analytics.getTrackedEvent("discover_card_click"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.Source.PARTNER_SOCIAL_LINK, event.source)
+            assertEquals(
+                AnalyticsEvent.SocialConnectionLinkClickEvent.SocialPlatformType.INSTAGRAM,
+                event.partnerSocialLink?.type,
+            )
+            assertEquals("https://instagram.com/partner", event.partnerSocialLink?.url)
+        }
+
+    @Test
+    fun `GIVEN a KRAIL social tap WHEN handled THEN it is sourced to the discover card`() = krailRunTest {
+        val viewModel = viewModel()
+
+        viewModel.onEvent(DiscoverEvent.AppSocialLinkClicked(KrailSocialType.Reddit))
+
+        assertEquals(KrailSocialType.Reddit.url, platformOps.lastOpenedUrl)
+        val event = assertIs<AnalyticsEvent.SocialConnectionLinkClickEvent>(
+            analytics.getTrackedEvent("social_connection_link_click"),
+        )
+        assertEquals(
+            AnalyticsEvent.SocialConnectionLinkClickEvent.SocialPlatformType.REDDIT,
+            event.socialPlatformType,
+        )
+        assertEquals(
+            AnalyticsEvent.SocialConnectionLinkClickEvent.SocialConnectionSource.DISCOVER_CARD,
+            event.source,
+        )
+    }
+
+    @Test
+    fun `GIVEN a share tap WHEN handled THEN the card text, its cta link and the KRAIL tag are shared`() =
+        krailRunTest {
+            discoverManager.cards = listOf(
+                card(
+                    cardId = "a",
+                    title = "Vivid Sydney",
+                    description = "Lights on the harbour",
+                    type = DiscoverCardType.Events,
+                    buttons = listOf(Button.Cta(label = "Book", url = "https://example.com/vivid")),
+                ),
+            )
+            val viewModel = viewModel()
+
+            viewModel.uiState.test {
+                awaitItem()
+                runCurrent()
+                expectMostRecentItem()
+
+                viewModel.onEvent(
+                    DiscoverEvent.ShareButtonClicked(cardId = "a", cardType = DiscoverCardType.Events),
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            assertEquals(
+                "Vivid Sydney\nLights on the harbour\nhttps://example.com/vivid\n\n" +
+                    "See more events in KRAIL App\n#LetsKRAIL $KRAIL_WEBSITE_URL",
+                platformOps.lastSharedText,
+            )
+            val event = assertIs<AnalyticsEvent.DiscoverCardClick>(
+                analytics.getTrackedEvent("discover_card_click"),
+            )
+            assertEquals(AnalyticsEvent.DiscoverCardClick.Source.SHARE_CLICK, event.source)
+        }
+
+    @Test
+    fun `GIVEN a card scrolls into view WHEN seen THEN it is persisted and counted for the session`() =
+        krailRunTest {
+            val viewModel = viewModel()
+
+            viewModel.onEvent(DiscoverEvent.CardSeen(cardId = "a"))
+            viewModel.onEvent(DiscoverEvent.CardSeen(cardId = "a"))
+            viewModel.onEvent(DiscoverEvent.CardSeen(cardId = "b"))
+            runCurrent()
+
+            assertEquals(listOf("a", "a", "b"), discoverManager.seenCardIds)
+            // The session count is distinct cards, not impressions.
+            assertEquals(setOf("a", "b"), viewModel.analyticsSessionSeenCardIds)
+        }
+
+    @Test
+    fun `GIVEN a release build WHEN reset seen cards is requested THEN nothing is reset`() = krailRunTest {
+        appInfoProvider.mockAppInfo = FakeAppInfo(isDebug = false)
+        val viewModel = viewModel()
+
+        viewModel.onEvent(DiscoverEvent.ResetAllSeenCards)
+        runCurrent()
+
+        assertEquals(0, discoverManager.resetCallCount)
+    }
+
+    @Test
+    fun `GIVEN a debug build WHEN reset seen cards is requested THEN the store is cleared`() = krailRunTest {
+        appInfoProvider.mockAppInfo = FakeAppInfo(isDebug = true)
+        val viewModel = viewModel()
+
+        viewModel.onEvent(DiscoverEvent.ResetAllSeenCards)
+        runCurrent()
+
+        assertEquals(1, discoverManager.resetCallCount)
+    }
+
+    @Test
+    fun `GIVEN a card with a cta and a partner social WHEN resolving its link THEN button order decides`() =
+        krailRunTest {
+            val partnerSocial = Button.Social.PartnerSocial(
+                socialPartnerName = "Partner",
+                links = listOf(
+                    Button.Social.PartnerSocial.PartnerSocialLink(
+                        type = SocialType.Instagram,
+                        url = "https://instagram.com/partner",
+                    ),
+                ),
+            )
+            val cta = Button.Cta(label = "Book", url = "https://example.com/book")
+            discoverManager.cards = listOf(
+                card(cardId = "social-first", buttons = listOf(partnerSocial, cta, Button.Share)),
+                card(cardId = "cta-first", buttons = listOf(cta, partnerSocial, Button.Share)),
+            )
+
+            viewModel().uiState.test {
+                awaitItem()
+                runCurrent()
+                val state = expectMostRecentItem()
+
+                // There is no cta-beats-social precedence: the shared link is whichever link
+                // button the card lists first.
+                assertEquals(
+                    "https://instagram.com/partner",
+                    state.getCtaOrPartnerSocialLinkForCard("social-first"),
+                )
+                assertEquals("https://example.com/book", state.getCtaOrPartnerSocialLinkForCard("cta-first"))
+                assertNull(state.getCtaOrPartnerSocialLinkForCard("no-such-card"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN a card with only a share button WHEN resolving its link THEN there is nothing to share`() =
+        krailRunTest {
+            discoverManager.cards = listOf(card(cardId = "a", buttons = listOf(Button.Share)))
+
+            viewModel().uiState.test {
+                awaitItem()
+                runCurrent()
+
+                assertNull(expectMostRecentItem().getCtaOrPartnerSocialLinkForCard("a"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    private fun KrailTestScope.viewModel() = DiscoverViewModel(
+        discoverSydneyManager = discoverManager,
+        ioDispatcher = ioDispatcher,
+        analytics = analytics,
+        platformOps = platformOps,
+        appInfoProvider = appInfoProvider,
+        appCoroutineScope = this,
+    )
+
+    private fun card(
+        cardId: String,
+        title: String = "Title",
+        description: String = "Description",
+        type: DiscoverCardType = DiscoverCardType.Events,
+        buttons: List<Button>? = null,
+    ) = DiscoverModel(
+        title = title,
+        description = description,
+        imageList = listOf("https://example.com/image.png"),
+        buttons = buttons,
+        type = type,
+        cardId = cardId,
+    )
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/business/TrackedJourneyMapMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/journeymap/business/TrackedJourneyMapMapperTest.kt
@@ -1,0 +1,226 @@
+package xyz.ksharma.krail.trip.planner.ui.journeymap.business
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.feature.track.TrackedJourneyDisplay
+import xyz.ksharma.krail.feature.track.TrackedLeg
+import xyz.ksharma.krail.feature.track.TrackedStop
+import xyz.ksharma.krail.trip.planner.ui.journeymap.business.TrackedJourneyMapMapper.toJourneyMapState
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.RouteSegment
+import xyz.ksharma.krail.trip.planner.ui.state.journeymap.StopType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `TrackedJourneyMapMapper` is the live-tracking counterpart of `JourneyMapMapper`. It is a pure
+ * function over a `TrackedJourneyDisplay` plus a caller-supplied coordinate lookup, so the
+ * behaviours that matter are: which legs are drawn at all, how a stop with no known coordinate is
+ * handled, and how the ORIGIN / INTERCHANGE / DESTINATION roles fall out across several legs.
+ */
+class TrackedJourneyMapMapperTest {
+
+    @Test
+    fun `GIVEN a walk leg between two transport legs WHEN mapped THEN only transport legs are drawn`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b"))),
+            TrackedLeg.Walk(durationText = "4 mins"),
+            transportLeg(lineName = "T4", stops = listOf(stop("c"), stop("d"))),
+        )
+
+        val state = display.toJourneyMapState(coordinates("a", "b", "c", "d"))
+
+        assertEquals(listOf("tracked_leg_0", "tracked_leg_1"), state.mapDisplay.legs.map { it.legId })
+        assertEquals(listOf("T1", "T4"), state.mapDisplay.legs.map { it.lineName })
+    }
+
+    @Test
+    fun `GIVEN a known line key WHEN mapped THEN the brand colour overrides the API colour code`() {
+        val display = display(
+            transportLeg(lineName = "T1", lineColorCode = "#000000", stops = listOf(stop("a"), stop("b"))),
+        )
+
+        val legFeature = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.legs.single()
+
+        assertEquals("#F99D1C", legFeature.lineColor)
+    }
+
+    @Test
+    fun `GIVEN a line key that is not in the catalogue WHEN mapped THEN the API colour code is kept`() {
+        val display = display(
+            transportLeg(
+                lineName = "333",
+                transportMode = TransportMode.Bus,
+                lineColorCode = "#123456",
+                stops = listOf(stop("a"), stop("b")),
+            ),
+        )
+
+        val legFeature = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.legs.single()
+
+        assertEquals("#123456", legFeature.lineColor)
+    }
+
+    @Test
+    fun `GIVEN route path coordinates WHEN mapped THEN the curved path is drawn instead of stop connectors`() {
+        val path = persistentListOf(
+            LatLng(latitude = -33.80, longitude = 151.20),
+            LatLng(latitude = -33.85, longitude = 151.25),
+        )
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b")), routePath = path),
+        )
+
+        val state = display.toJourneyMapState(coordinates("a", "b"))
+        val segment = state.mapDisplay.legs.single().routeSegment
+
+        assertEquals(path, assertIs<RouteSegment.PathSegment>(segment).points)
+    }
+
+    @Test
+    fun `GIVEN no route path WHEN mapped THEN the leg falls back to connecting its stops`() {
+        val display = display(transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b"))))
+
+        val state = display.toJourneyMapState(coordinates("a", "b"))
+        val segment = state.mapDisplay.legs.single().routeSegment
+
+        assertEquals(listOf("a", "b"), assertIs<RouteSegment.StopConnectorSegment>(segment).stops.map { it.stopId })
+    }
+
+    @Test
+    fun `GIVEN a stop with no known coordinate WHEN mapped THEN it is skipped and the rest still render`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("missing"), stop("b"))),
+        )
+
+        val stops = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.stops
+
+        assertEquals(listOf("a", "b"), stops.map { it.stopId })
+    }
+
+    @Test
+    fun `GIVEN three stops on one leg WHEN mapped THEN the middle stop is regular and the ends are terminals`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("mid"), stop("b"))),
+        )
+
+        val stops = display.toJourneyMapState(coordinates("a", "mid", "b")).mapDisplay.stops
+
+        assertEquals(
+            listOf(StopType.ORIGIN, StopType.REGULAR, StopType.DESTINATION),
+            stops.map { it.stopType },
+        )
+    }
+
+    @Test
+    fun `GIVEN two transport legs WHEN mapped THEN the changeover stops are interchanges, not terminals`() {
+        val display = display(
+            transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("swap"))),
+            transportLeg(lineName = "T4", stops = listOf(stop("swap"), stop("b"))),
+        )
+
+        val stops = display.toJourneyMapState(coordinates("a", "swap", "b")).mapDisplay.stops
+
+        assertEquals(
+            listOf(
+                "a" to StopType.ORIGIN,
+                "swap" to StopType.INTERCHANGE,
+                "swap" to StopType.INTERCHANGE,
+                "b" to StopType.DESTINATION,
+            ),
+            stops.map { it.stopId to it.stopType },
+        )
+    }
+
+    @Test
+    fun `GIVEN a tracked stop WHEN mapped THEN it carries its leg's line and its own departure time`() {
+        val display = display(
+            transportLeg(
+                lineName = "T1",
+                stops = listOf(stop("a", utcTime = "2026-04-09T02:00:00Z"), stop("b")),
+            ),
+        )
+
+        val stop = display.toJourneyMapState(coordinates("a", "b")).mapDisplay.stops.first()
+
+        assertEquals("T1", stop.lineName)
+        assertEquals("#F99D1C", stop.lineColor)
+        assertEquals("2026-04-09T02:00:00Z", stop.departureTime)
+    }
+
+    @Test
+    fun `GIVEN a journey with only a walk leg WHEN mapped THEN nothing is drawn and there is no camera focus`() {
+        val display = display(TrackedLeg.Walk(durationText = "4 mins"))
+
+        val state = display.toJourneyMapState(emptyMap())
+
+        assertTrue(state.mapDisplay.legs.isEmpty())
+        assertTrue(state.mapDisplay.stops.isEmpty())
+        assertNull(state.cameraFocus)
+    }
+
+    @Test
+    fun `GIVEN stops spread across the network WHEN mapped THEN camera bounds enclose every stop`() {
+        val display = display(transportLeg(lineName = "T1", stops = listOf(stop("a"), stop("b"))))
+        val coords = mapOf(
+            "a" to LatLng(latitude = -33.95, longitude = 151.10),
+            "b" to LatLng(latitude = -33.80, longitude = 151.35),
+        )
+
+        val bounds = display.toJourneyMapState(coords).cameraFocus?.bounds
+
+        assertEquals(LatLng(latitude = -33.95, longitude = 151.10), bounds?.southwest)
+        assertEquals(LatLng(latitude = -33.80, longitude = 151.35), bounds?.northeast)
+    }
+
+    // region fixtures
+
+    private fun display(vararg legs: TrackedLeg) = TrackedJourneyDisplay(
+        fromStopId = "a",
+        toStopId = "b",
+        fromStopName = "A",
+        toStopName = "B",
+        originTime = "12:00pm",
+        scheduledOriginTime = null,
+        destinationTime = "12:30pm",
+        originUtcDateTime = "2026-04-09T02:00:00Z",
+        destinationUtcDateTime = "2026-04-09T02:30:00Z",
+        travelTime = "30 mins",
+        legs = legs.toList().toImmutableList(),
+    )
+
+    private fun transportLeg(
+        lineName: String,
+        stops: List<TrackedStop>,
+        transportMode: TransportMode = TransportMode.Train,
+        lineColorCode: String = "#FFFFFF",
+        routePath: List<LatLng> = emptyList(),
+    ) = TrackedLeg.Transport(
+        transportMode = transportMode,
+        lineName = lineName,
+        lineColorCode = lineColorCode,
+        headsign = null,
+        stops = stops.toImmutableList(),
+        routePathCoordinates = routePath.toImmutableList(),
+    )
+
+    private fun stop(stopId: String, utcTime: String = "2026-04-09T02:00:00Z") = TrackedStop(
+        stopId = stopId,
+        name = stopId.uppercase(),
+        scheduledTime = "12:00pm",
+        estimatedTime = null,
+        utcTime = utcTime,
+        scheduledUtcTime = utcTime,
+    )
+
+    private fun coordinates(vararg stopIds: String): Map<String, LatLng> =
+        stopIds.mapIndexed { index, id ->
+            id to LatLng(latitude = -33.8 - index * 0.01, longitude = 151.2 + index * 0.01)
+        }.toMap()
+
+    // endregion
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapLocationHelpersTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapLocationHelpersTest.kt
@@ -1,0 +1,112 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.map
+
+import kotlinx.coroutines.launch
+import org.maplibre.compose.camera.CameraPosition
+import org.maplibre.compose.camera.CameraState
+import xyz.ksharma.aagya.permission.PermissionStatus
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.maps.state.NearbyStopsConfig
+import xyz.ksharma.krail.core.maps.state.UserLocationConfig
+import xyz.ksharma.krail.core.testing.coroutines.krailRunTest
+import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeUserLocationManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The camera-seeding and location-button behaviour every full map surface shares. It was extracted
+ * from `SearchStopMap` precisely so a second map could not drift into a different permission flow,
+ * so the branch each caller depends on is what these tests hold.
+ */
+class MapLocationHelpersTest {
+
+    @Test
+    fun `GIVEN no known location WHEN seeding the camera THEN it starts on the Sydney default`() {
+        val position = initialCameraPosition(knownLocation = null)
+
+        assertEquals(NearbyStopsConfig.DEFAULT_CENTER_LAT, position.target.latitude)
+        assertEquals(NearbyStopsConfig.DEFAULT_CENTER_LON, position.target.longitude)
+        assertEquals(NearbyStopsConfig.DEFAULT_ZOOM, position.zoom)
+    }
+
+    @Test
+    fun `GIVEN a known location WHEN seeding the camera THEN re-entry does not flash at the default`() {
+        val position = initialCameraPosition(LatLng(latitude = -33.75, longitude = 151.05))
+
+        assertEquals(-33.75, position.target.latitude)
+        assertEquals(151.05, position.target.longitude)
+        assertEquals(UserLocationConfig.AUTO_CENTER_ZOOM, position.zoom)
+    }
+
+    @Test
+    fun `GIVEN a coordinate WHEN converted for MapLibre THEN latitude and longitude stay put`() {
+        val position = LatLng(latitude = -33.87, longitude = 151.21).toPosition()
+
+        assertEquals(-33.87, position.latitude)
+        assertEquals(151.21, position.longitude)
+    }
+
+    @Test
+    fun `GIVEN no fix and a hard denial WHEN the location button is tapped THEN the denial is surfaced`() =
+        krailRunTest {
+            val manager = FakeUserLocationManager(PermissionStatus.Denied(canAskAgain = false))
+            var denied: PermissionStatus? = null
+            var requested = false
+
+            handleLocationButtonClick(
+                userLoc = null,
+                cameraState = CameraState(CameraPosition()),
+                userLocationManager = manager,
+                onPermissionDenied = { denied = it },
+                onRequestPermission = { requested = true },
+            )
+
+            assertEquals(PermissionStatus.Denied(canAskAgain = false), denied)
+            // A denial routes to settings; asking again would show nothing on iOS and on a
+            // twice-denied Android.
+            assertEquals(false, requested)
+        }
+
+    @Test
+    fun `GIVEN no fix and an unasked permission WHEN the button is tapped THEN the rider is asked`() =
+        krailRunTest {
+            val manager = FakeUserLocationManager(PermissionStatus.NotDetermined)
+            var denied: PermissionStatus? = null
+            var requested = false
+
+            handleLocationButtonClick(
+                userLoc = null,
+                cameraState = CameraState(CameraPosition()),
+                userLocationManager = manager,
+                onPermissionDenied = { denied = it },
+                onRequestPermission = { requested = true },
+            )
+
+            assertNull(denied)
+            assertEquals(true, requested)
+        }
+
+    @Test
+    fun `GIVEN a known fix WHEN the button is tapped THEN it recentres without re-asking for permission`() =
+        krailRunTest {
+            val manager = FakeUserLocationManager(PermissionStatus.Denied(canAskAgain = false))
+            var touchedPermissionFlow = false
+
+            // animateTo parks until a real map attaches, which never happens off-device — the
+            // assertion is that the permission flow is not reached at all.
+            val job = launch {
+                handleLocationButtonClick(
+                    userLoc = LatLng(latitude = -33.87, longitude = 151.21),
+                    cameraState = CameraState(CameraPosition()),
+                    userLocationManager = manager,
+                    onPermissionDenied = { touchedPermissionFlow = true },
+                    onRequestPermission = { touchedPermissionFlow = true },
+                )
+            }
+            runCurrent()
+
+            assertEquals(0, manager.permissionChecks)
+            assertEquals(false, touchedPermissionFlow)
+            job.cancel()
+        }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapStateHelperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapStateHelperTest.kt
@@ -1,0 +1,136 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.map
+
+import kotlinx.collections.immutable.persistentSetOf
+import xyz.ksharma.krail.core.maps.data.model.NearbyStop
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * `MapStateHelper` is the SearchStop map's whole state-reduction layer and was uncovered.
+ *
+ * Every mutator funnels through a private `withMapState` guard that returns the state untouched
+ * when the map is not `Ready`. That guard is the thing worth holding: without it a pan or a mode
+ * toggle arriving while the map is still loading would either crash or silently promote a Loading
+ * map to Ready with a half-built display.
+ */
+class MapStateHelperTest {
+
+    private val ready = SearchStopState(mapUiState = MapUiState.Ready())
+    private val loading = SearchStopState(mapUiState = MapUiState.Loading)
+
+    @Test
+    fun `GIVEN a ready map WHEN reading it THEN the ready state is returned`() {
+        assertSame(ready.mapUiState, MapStateHelper.getReadyMapState(ready))
+    }
+
+    @Test
+    fun `GIVEN a map that is not ready WHEN reading it THEN null comes back instead of a cast crash`() {
+        assertNull(MapStateHelper.getReadyMapState(loading))
+        assertNull(MapStateHelper.getReadyMapState(SearchStopState(mapUiState = null)))
+        assertNull(MapStateHelper.getReadyMapState(SearchStopState(mapUiState = MapUiState.Error("boom"))))
+    }
+
+    @Test
+    fun `GIVEN a pan WHEN the centre updates THEN only the centre moves`() {
+        val moved = MapStateHelper.updateMapCenter(ready, LatLng(latitude = -33.75, longitude = 151.05))
+
+        assertEquals(LatLng(latitude = -33.75, longitude = 151.05), moved.display().mapCenter)
+        assertEquals(ready.display().userLocation, moved.display().userLocation)
+    }
+
+    @Test
+    fun `GIVEN a GPS fix WHEN the user location updates THEN it is stored and can be cleared again`() {
+        val located = MapStateHelper.updateUserLocation(ready, LatLng(latitude = -33.87, longitude = 151.21))
+        assertEquals(LatLng(latitude = -33.87, longitude = 151.21), located.display().userLocation)
+
+        val cleared = MapStateHelper.updateUserLocation(located, null)
+        assertNull(cleared.display().userLocation)
+    }
+
+    @Test
+    fun `GIVEN nearby stops WHEN they land THEN each becomes a map feature and loading is resolved`() {
+        val loadingState = MapStateHelper.setLoadingState(ready, isLoading = true)
+        assertTrue(loadingState.readyMap().isLoadingNearbyStops)
+
+        val updated = MapStateHelper.updateNearbyStops(
+            state = loadingState,
+            stops = listOf(
+                NearbyStop(
+                    stopId = "200060",
+                    stopName = "Central Station",
+                    latitude = -33.88,
+                    longitude = 151.21,
+                    transportModes = listOf(TransportMode.Train, TransportMode.Bus),
+                ),
+            ),
+        )
+
+        val feature = updated.display().nearbyStops.single()
+        assertEquals("200060", feature.stopId)
+        assertEquals("Central Station", feature.stopName)
+        assertEquals(LatLng(latitude = -33.88, longitude = 151.21), feature.position)
+        assertEquals(listOf(TransportMode.Train, TransportMode.Bus), feature.transportModes)
+        assertTrue(!updated.readyMap().isLoadingNearbyStops)
+    }
+
+    @Test
+    fun `GIVEN a mode filter WHEN toggled THEN its product class is added and removed again`() {
+        val onlyTrains = ready.copy(
+            mapUiState = MapUiState.Ready(
+                mapDisplay = MapDisplay(selectedTransportModes = persistentSetOf(TransportMode.Train.productClass)),
+            ),
+        )
+
+        val withFerry = MapStateHelper.toggleTransportMode(onlyTrains, TransportMode.Ferry)
+        assertEquals(
+            setOf(TransportMode.Train.productClass, TransportMode.Ferry.productClass),
+            withFerry.display().selectedTransportModes,
+        )
+
+        val ferryOff = MapStateHelper.toggleTransportMode(withFerry, TransportMode.Ferry)
+        assertEquals(setOf(TransportMode.Train.productClass), ferryOff.display().selectedTransportModes)
+    }
+
+    @Test
+    fun `GIVEN the map options sheet WHEN radius and chrome change THEN each lands on the display`() {
+        val tuned = MapStateHelper.toggleCompass(
+            MapStateHelper.toggleDistanceScale(
+                MapStateHelper.updateSearchRadius(ready, radiusKm = 5.0),
+                enabled = true,
+            ),
+            enabled = false,
+        )
+
+        assertEquals(5.0, tuned.display().searchRadiusKm)
+        assertTrue(tuned.display().showDistanceScale)
+        assertTrue(!tuned.display().showCompass)
+    }
+
+    @Test
+    fun `GIVEN a map that is not ready WHEN any mutator runs THEN the state is returned untouched`() {
+        val mutated = listOf(
+            MapStateHelper.updateMapCenter(loading, LatLng(latitude = -33.75, longitude = 151.05)),
+            MapStateHelper.updateUserLocation(loading, LatLng(latitude = -33.75, longitude = 151.05)),
+            MapStateHelper.updateNearbyStops(loading, stops = emptyList(), isLoading = true),
+            MapStateHelper.setLoadingState(loading, isLoading = true),
+            MapStateHelper.toggleTransportMode(loading, TransportMode.Ferry),
+            MapStateHelper.updateSearchRadius(loading, radiusKm = 5.0),
+            MapStateHelper.toggleDistanceScale(loading, enabled = true),
+            MapStateHelper.toggleCompass(loading, enabled = false),
+        )
+
+        assertEquals(List(mutated.size) { loading }, mutated)
+    }
+
+    private fun SearchStopState.readyMap() = mapUiState as MapUiState.Ready
+
+    private fun SearchStopState.display() = readyMap().mapDisplay
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopResultsMapMapperTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/StopResultsMapMapperTest.kt
@@ -1,0 +1,137 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop.map
+
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.maplibre.spatialk.geojson.Feature
+import org.maplibre.spatialk.geojson.LineString
+import org.maplibre.spatialk.geojson.Point
+import xyz.ksharma.krail.core.maps.state.LatLng
+import xyz.ksharma.krail.core.maps.state.RouteFeature
+import xyz.ksharma.krail.core.maps.state.StopFeature
+import xyz.ksharma.krail.trip.planner.ui.searchstop.map.StopResultsMapMapper.toFeatureCollection
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapDisplay
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.MapUiState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * `StopResultsMapMapper` feeds the SearchStop map its GeoJSON. Like the journey-map mapper it has
+ * to flip KRAIL's (latitude, longitude) into GeoJSON's (longitude, latitude), and it has to emit
+ * the property keys the route and stop layers filter on.
+ */
+class StopResultsMapMapperTest {
+
+    @Test
+    fun `GIVEN a route WHEN converted THEN it is a line in lon-lat order carrying its id and colour`() {
+        val state = ready(
+            routes = listOf(
+                RouteFeature(
+                    id = "T1",
+                    colorHex = "#F99D1C",
+                    points = listOf(
+                        LatLng(latitude = -33.80, longitude = 151.20),
+                        LatLng(latitude = -33.90, longitude = 151.30),
+                    ),
+                ),
+            ),
+        )
+
+        val feature = state.toFeatureCollection().features.single()
+
+        val geometry = assertIs<LineString>(feature.geometry)
+        assertEquals(listOf(151.20, 151.30), geometry.coordinates.map { it.longitude })
+        assertEquals(listOf(-33.80, -33.90), geometry.coordinates.map { it.latitude })
+        assertEquals("route", feature.props().str("type"))
+        assertEquals("T1", feature.props().str("lineId"))
+        assertEquals("#F99D1C", feature.props().str("color"))
+    }
+
+    @Test
+    fun `GIVEN a stop WHEN converted THEN it is a point in lon-lat order carrying id and name`() {
+        val state = ready(
+            stops = listOf(
+                StopFeature(
+                    stopId = "200060",
+                    stopName = "Central Station",
+                    lineId = "T1",
+                    position = LatLng(latitude = -33.88, longitude = 151.21),
+                ),
+            ),
+        )
+
+        val feature = state.toFeatureCollection().features.single()
+
+        val point = assertIs<Point>(feature.geometry)
+        assertEquals(151.21, point.coordinates.longitude)
+        assertEquals(-33.88, point.coordinates.latitude)
+        assertEquals("stop", feature.props().str("type"))
+        assertEquals("200060", feature.props().str("stopId"))
+        assertEquals("Central Station", feature.props().str("stopName"))
+        assertEquals("T1", feature.props().str("lineId"))
+    }
+
+    @Test
+    fun `GIVEN a stop with no line WHEN converted THEN lineId is an empty string, not a missing key`() {
+        val state = ready(
+            stops = listOf(
+                StopFeature(
+                    stopId = "200060",
+                    stopName = "Central Station",
+                    lineId = null,
+                    position = LatLng(latitude = -33.88, longitude = 151.21),
+                ),
+            ),
+        )
+
+        // The layer's filter reads the key unconditionally, so it has to exist.
+        assertEquals("", state.toFeatureCollection().features.single().props().str("lineId"))
+    }
+
+    @Test
+    fun `GIVEN routes and stops WHEN converted THEN routes are emitted before stops so lines sit under pins`() {
+        val state = ready(
+            routes = listOf(RouteFeature(id = "T1", colorHex = "#F99D1C", points = twoPoints())),
+            stops = listOf(
+                StopFeature(
+                    stopId = "200060",
+                    stopName = "Central Station",
+                    lineId = "T1",
+                    position = LatLng(latitude = -33.88, longitude = 151.21),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf("route", "stop"),
+            state.toFeatureCollection().features.map { it.props().str("type") },
+        )
+    }
+
+    @Test
+    fun `GIVEN nothing to draw WHEN converted THEN a placeholder feature keeps the serializer alive`() {
+        val features = ready().toFeatureCollection().features
+
+        assertEquals("empty", features.single().props().str("type"))
+    }
+
+    private fun ready(
+        routes: List<RouteFeature> = emptyList(),
+        stops: List<StopFeature> = emptyList(),
+    ) = MapUiState.Ready(
+        mapDisplay = MapDisplay(
+            routes = persistentListOf<RouteFeature>().addAll(routes),
+            stops = persistentListOf<StopFeature>().addAll(stops),
+        ),
+    )
+
+    private fun twoPoints() = listOf(
+        LatLng(latitude = -33.80, longitude = 151.20),
+        LatLng(latitude = -33.90, longitude = 151.30),
+    )
+
+    private fun Feature<*, *>.props(): JsonObject = properties as JsonObject
+
+    private fun JsonObject.str(key: String): String? = this[key]?.jsonPrimitive?.content
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeDiscoverSydneyManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeDiscoverSydneyManager.kt
@@ -1,0 +1,29 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import xyz.ksharma.krail.discover.network.api.DiscoverSydneyManager
+import xyz.ksharma.krail.discover.network.api.model.DiscoverModel
+
+/**
+ * Canned cards plus a call record. All seen/reset bookkeeping in production lives behind this
+ * interface, so the fake holds no logic of its own — `DiscoverViewModel` is the real class under
+ * test.
+ */
+internal class FakeDiscoverSydneyManager : DiscoverSydneyManager {
+
+    var cards: List<DiscoverModel> = emptyList()
+
+    val seenCardIds = mutableListOf<String>()
+
+    var resetCallCount = 0
+        private set
+
+    override suspend fun fetchDiscoverData(): List<DiscoverModel> = cards
+
+    override suspend fun markCardAsSeen(cardId: String) {
+        seenCardIds += cardId
+    }
+
+    override suspend fun resetAllDiscoverCardsDebugOnly() {
+        resetCallCount++
+    }
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeUserLocationManager.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/testfakes/FakeUserLocationManager.kt
@@ -1,0 +1,39 @@
+package xyz.ksharma.krail.trip.planner.ui.testfakes
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import xyz.ksharma.aagya.permission.PermissionStatus
+import xyz.ksharma.dhruva.location.Location
+import xyz.ksharma.dhruva.location.LocationConfig
+import xyz.ksharma.krail.core.maps.data.location.UserLocationManager
+
+/**
+ * Canned permission status plus a call record. Lives feature-local rather than in
+ * `:core:testing` because `UserLocationManager`'s signature pulls in aagya and dhruva, which
+ * `:core:maps:data` keeps as `implementation` — promoting this fake would widen the shared fakes
+ * module's API surface for a single consumer. Promote it the moment a second module needs it.
+ */
+internal class FakeUserLocationManager(
+    private val permissionStatus: PermissionStatus = PermissionStatus.NotDetermined,
+) : UserLocationManager {
+
+    var permissionChecks = 0
+        private set
+
+    var openAppSettingsCount = 0
+        private set
+
+    override suspend fun getCurrentLocation(): Result<Location> =
+        Result.failure(IllegalStateException("not used in these tests"))
+
+    override fun locationUpdates(config: LocationConfig): Flow<Location> = emptyFlow()
+
+    override suspend fun checkPermissionStatus(): PermissionStatus {
+        permissionChecks++
+        return permissionStatus
+    }
+
+    override fun openAppSettings() {
+        openAppSettingsCount++
+    }
+}


### PR DESCRIPTION
## What

Tests for the SearchStop map helpers: state mutation, GeoJSON conversion, and camera and location-button routing. Test-only, plus one fake.

## Changes

- `MapStateHelperTest.kt` (8 tests): all eight mutators, plus one test driving every mutator against a non-Ready map to hold the `withMapState` guard.
- `StopResultsMapMapperTest.kt` (5 tests): the lon/lat flip, `lineId` emitted as `""` rather than omitted, routes ordered before stops, and the placeholder feature.
- `MapLocationHelpersTest.kt` (6 tests): camera seeding (Sydney default versus a known fix) and location-button routing, where a hard denial goes to settings, otherwise the app asks, and a known fix recentres without touching the permission flow.
- `FakeUserLocationManager.kt`: feature-local rather than in `:core:testing`, because its signature pulls in dependencies that `:core:maps:data` keeps as `implementation`.

The recentre path only asserts that the permission flow is not entered: `CameraState.animateTo` parks on `awaitMap()` forever with no attached map.

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest` green
- `./gradlew detekt --continue` green
- Proved able to fail: removed the `withMapState` not-Ready guard, made the mode toggle add-only, flipped the stop lon/lat, made `lineId` conditional, collapsed the permission branch, and ignored `knownLocation` in the camera seed. Six tests failed as intended; all reverted.

Part of #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)
