### PR TITLE
fix(ai-text): report one availability vocabulary from both platforms

### DIFF
--- a/core/ai-text/src/androidMain/kotlin/xyz/ksharma/krail/core/aitext/AndroidAiTextService.kt
+++ b/core/ai-text/src/androidMain/kotlin/xyz/ksharma/krail/core/aitext/AndroidAiTextService.kt
@@ -17,6 +17,9 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons.CHECK_FAILED
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons.DEVICE_UNSUPPORTED
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons.MODEL_DOWNLOADING
 import xyz.ksharma.krail.core.log.log
 
 /**
@@ -67,15 +70,15 @@ internal class AndroidAiTextService(private val context: Context) : AiTextServic
                 // never block this call on it — a slow/failed download must not delay or
                 // break alert rendering.
                 runCatching { summarizer.downloadFeature(noOpDownloadCallback) }
-                AiAvailability.Unavailable(reason = "downloadable")
+                AiAvailability.Unavailable(reason = MODEL_DOWNLOADING)
             }
 
-            FeatureStatus.DOWNLOADING -> AiAvailability.Unavailable(reason = "downloading")
+            FeatureStatus.DOWNLOADING -> AiAvailability.Unavailable(reason = MODEL_DOWNLOADING)
 
-            else -> AiAvailability.Unavailable(reason = "unsupported_device")
+            else -> AiAvailability.Unavailable(reason = DEVICE_UNSUPPORTED)
         }
     }.getOrElse { throwable ->
-        AiAvailability.Unavailable(reason = "check_failed: ${throwable.message}")
+        AiAvailability.Unavailable(reason = "$CHECK_FAILED: ${throwable.message}")
     }.also { result ->
         // Deliberately unconditional, not debug-gated: `adb logcat | grep AiTextService`
         // is the one line that answers "why is nothing showing" (flag off vs. device
@@ -98,13 +101,19 @@ internal class AndroidAiTextService(private val context: Context) : AiTextServic
             FeatureStatus.AVAILABLE -> AiAvailability.Available
             FeatureStatus.DOWNLOADABLE -> {
                 triggerPromptModelDownload()
-                AiAvailability.Unavailable(reason = "downloadable")
+                AiAvailability.Unavailable(reason = MODEL_DOWNLOADING)
             }
-            FeatureStatus.DOWNLOADING -> AiAvailability.Unavailable(reason = "downloading")
-            else -> AiAvailability.Unavailable(reason = "unsupported_device (status=$status)")
+            FeatureStatus.DOWNLOADING -> AiAvailability.Unavailable(reason = MODEL_DOWNLOADING)
+            // The raw status stays in the log line below, not in the reason: the reason is a
+            // contract the UI branches on, and gluing a number onto it broke every equality
+            // check that ever tried to read it.
+            else -> {
+                log("AiTextService: extraction unsupported, status=$status")
+                AiAvailability.Unavailable(reason = DEVICE_UNSUPPORTED)
+            }
         }
     }.getOrElse { throwable ->
-        AiAvailability.Unavailable(reason = "check_failed: ${throwable.message}")
+        AiAvailability.Unavailable(reason = "$CHECK_FAILED: ${throwable.message}")
     }.also { result ->
         log("AiTextService: checkExtractionAvailability -> $result")
     }

--- a/core/ai-text/src/commonMain/kotlin/xyz/ksharma/krail/core/aitext/AiTextService.kt
+++ b/core/ai-text/src/commonMain/kotlin/xyz/ksharma/krail/core/aitext/AiTextService.kt
@@ -27,11 +27,12 @@ interface AiTextService {
      * specifically. Unlike [summarize] (which degrades silently — see [AiAvailability]'s
      * doc), a rider who typed something into the AI search-input flow and hit submit needs
      * to see *something* happen, so callers here are expected to actually branch on
-     * [AiAvailability.Unavailable.reason] — `"downloadable"`/`"downloading"` should render a
-     * distinct "setting up on-device AI" state rather than the generic "couldn't understand
-     * that" a genuine parse failure gets. Calling this also kicks off the on-demand model
-     * download as a side effect when the reason is `"downloadable"`, same fire-and-forget
-     * shape as [checkAvailability]'s own summarizer download trigger.
+     * [AiAvailability.Unavailable.reason], which is one of [AiUnavailableReasons]:
+     * [AiUnavailableReasons.MODEL_DOWNLOADING] should render a distinct "setting up on-device
+     * AI" state rather than the generic "couldn't understand that" a genuine parse failure
+     * gets, and the two permanent reasons should say which of them it was. Calling this also
+     * kicks off the on-demand model download as a side effect when one is available, same
+     * fire-and-forget shape as [checkAvailability]'s own summarizer download trigger.
      */
     suspend fun checkExtractionAvailability(): AiAvailability
 
@@ -90,9 +91,45 @@ data class TimeIntent(
 )
 
 /**
- * Whether [AiTextService] can be used right now. [Unavailable.reason] is for logging only —
- * never shown to the user, since both features this backs are additive and must degrade
- * silently to today's UI.
+ * The reasons both platform implementations report, and the only ones a caller may branch on.
+ *
+ * Modelled on [xyz.ksharma.krail.core.speechtotext.SpeechUnavailableReasons], and added for
+ * the same failure it was added for. The Android service reported ML Kit's own words
+ * ("downloadable", "downloading", "unsupported_device") and the iOS service reported Swift's
+ * string interpolation of `SystemLanguageModel.Availability.UnavailableReason`
+ * ("deviceNotEligible", "appleIntelligenceNotEnabled", "modelNotReady"). The one caller that
+ * branches on these tested for the Android spellings only, so on iOS *every* unavailability,
+ * including the temporary "still downloading" one, fell through to the generic could-not-read
+ * message and told riders to reword a sentence that was never the problem.
+ *
+ * Anything a platform reports that is not one of these is passed through as its own string
+ * for logs, and callers treat it as an unknown failure rather than guessing.
+ */
+object AiUnavailableReasons {
+
+    /** Temporary and retriable: the on-device model is downloading, or is about to. */
+    const val MODEL_DOWNLOADING = "model_downloading"
+
+    /** Permanent for this device: no hardware support, or an OS too old to have the API. */
+    const val DEVICE_UNSUPPORTED = "device_unsupported"
+
+    /**
+     * The device could do it and the rider has it switched off. The only reason with a fix the
+     * rider can actually carry out, which is why it is not folded into [DEVICE_UNSUPPORTED].
+     */
+    const val NEEDS_DEVICE_SETTING = "needs_device_setting"
+
+    /** The availability check itself failed. Says nothing about the device either way. */
+    const val CHECK_FAILED = "check_failed"
+}
+
+/**
+ * Whether [AiTextService] can be used right now.
+ *
+ * [Unavailable.reason] is one of [AiUnavailableReasons] wherever a platform can map onto one.
+ * For [AiTextService.summarize] it stays log-only — that feature is additive and degrades
+ * silently. For [AiTextService.checkExtractionAvailability] the caller is expected to branch
+ * on it, because a rider who typed a sentence and pressed send is owed a reason.
  */
 sealed interface AiAvailability {
     data object Available : AiAvailability

--- a/core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift
+++ b/core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift
@@ -5,6 +5,12 @@ import FoundationModels
 
 @objcMembers public class AiTextBridge: NSObject {
 
+    /// Reason strings are the shared vocabulary in `AiUnavailableReasons`, not Swift's
+    /// interpolation of `UnavailableReason`. Interpolating the enum sent Kotlin
+    /// "deviceNotEligible"/"appleIntelligenceNotEnabled"/"modelNotReady", which matched
+    /// nothing the caller tested for, so a model that was merely still downloading was
+    /// reported to riders as a sentence they had written wrong. Keep these in step with
+    /// `AiUnavailableReasons` in commonMain.
     public func checkAvailability(completion: @escaping (Bool, String) -> Void) {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
@@ -12,15 +18,24 @@ import FoundationModels
             case .available:
                 completion(true, "available")
             case .unavailable(let reason):
-                completion(false, "\(reason)")
+                switch reason {
+                case .appleIntelligenceNotEnabled:
+                    completion(false, "needs_device_setting")
+                case .modelNotReady:
+                    completion(false, "model_downloading")
+                case .deviceNotEligible:
+                    completion(false, "device_unsupported")
+                @unknown default:
+                    completion(false, "device_unsupported")
+                }
             @unknown default:
-                completion(false, "unknown")
+                completion(false, "check_failed")
             }
         } else {
-            completion(false, "ios_version_unsupported")
+            completion(false, "device_unsupported")
         }
         #else
-        completion(false, "foundation_models_unavailable")
+        completion(false, "device_unsupported")
         #endif
     }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/summary/AlertSummaryViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/summary/AlertSummaryViewModel.kt
@@ -11,16 +11,21 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import xyz.ksharma.krail.core.aitext.AiAvailability
 import xyz.ksharma.krail.core.aitext.AiTextService
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
 import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.taj.components.AlertFeedbackVoteChoice
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 
 private const val GENERATING_MIN_DURATION_MS = 1000L
 
-// Same transient-reason convention AiSearchInputViewModel's DOWNLOADING phase check uses -
-// these mean "not ready yet", not "never available", so a dedupe key set for one of these
-// must not permanently block a later retry of the same alert set.
-private val RETRIABLE_REASONS = setOf("downloadable", "downloading")
+// "Not ready yet", not "never available", so a dedupe key set for one of these must not
+// permanently block a later retry of the same alert set.
+//
+// These were the two raw ML Kit spellings, which meant iOS never matched: Foundation Models
+// reports its own words for a model that is still downloading, and a rider on an iPhone had
+// every retry treated as a permanent failure. Both platforms now report the shared
+// AiUnavailableReasons vocabulary, which is the whole reason that object exists.
+private val RETRIABLE_REASONS = setOf(AiUnavailableReasons.MODEL_DOWNLOADING)
 
 /**
  * Owns the trip's single aggregate AI summary card: request lifecycle and the vote feedback

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/summary/AlertSummaryViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/summary/AlertSummaryViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.krail.core.aitext.AiAvailability
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
 import xyz.ksharma.krail.taj.components.AlertFeedbackVoteChoice
 import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
 import xyz.ksharma.krail.trip.planner.ui.testfakes.FakeAiTextService
@@ -109,7 +110,7 @@ class AlertSummaryViewModelTest {
         advanceUntilIdle()
         assertTrue(viewModel.uiState.value is AlertSummaryUiState.Resolved)
 
-        aiTextService.availability = AiAvailability.Unavailable(reason = "unsupported_device")
+        aiTextService.availability = AiAvailability.Unavailable(reason = AiUnavailableReasons.DEVICE_UNSUPPORTED)
         viewModel.onEvent(AlertSummaryEvent.SummaryRequested(persistentSetOf(ALERT_TWO)))
         advanceUntilIdle()
 
@@ -118,7 +119,7 @@ class AlertSummaryViewModelTest {
 
     @Test
     fun `downloading reason resets the dedupe key so a later retry actually runs`() = runTest(testDispatcher) {
-        aiTextService.availability = AiAvailability.Unavailable(reason = "downloading")
+        aiTextService.availability = AiAvailability.Unavailable(reason = AiUnavailableReasons.MODEL_DOWNLOADING)
         viewModel.onEvent(AlertSummaryEvent.SummaryRequested(persistentSetOf(ALERT_ONE)))
         advanceUntilIdle()
         assertNull(viewModel.uiState.value)
@@ -132,7 +133,7 @@ class AlertSummaryViewModelTest {
 
     @Test
     fun `unsupported_device reason does not reset the dedupe key`() = runTest(testDispatcher) {
-        aiTextService.availability = AiAvailability.Unavailable(reason = "unsupported_device")
+        aiTextService.availability = AiAvailability.Unavailable(reason = AiUnavailableReasons.DEVICE_UNSUPPORTED)
         viewModel.onEvent(AlertSummaryEvent.SummaryRequested(persistentSetOf(ALERT_ONE)))
         advanceUntilIdle()
         assertNull(viewModel.uiState.value)


### PR DESCRIPTION
## What

Both platform AI services reported unavailability in their own words, and both callers only understood the Android ones. Adds a shared vocabulary and maps each platform onto it.

## Changes

- `AiUnavailableReasons` in `core/ai-text` commonMain: `MODEL_DOWNLOADING`, `DEVICE_UNSUPPORTED`, `NEEDS_DEVICE_SETTING`, `CHECK_FAILED`. Modelled on the existing `SpeechUnavailableReasons`, which was added for the same class of bug.
- `AndroidAiTextService` maps ML Kit's `FeatureStatus` onto it. The raw status integer moves out of the reason string and into the log line, since the reason is a value callers compare against and a glued-on number broke every comparison.
- `AiTextBridge.swift` maps `SystemLanguageModel.Availability.UnavailableReason` cases explicitly instead of interpolating the enum into a string.
- `AlertSummaryViewModel.RETRIABLE_REASONS` held the same two raw ML Kit strings and had the same hole, so it reads the shared constants now.

Note that `modelNotReady` on iOS means the model is still downloading, which is retriable. Under the old string comparison it was classified alongside a device that can never run the model.

The `summarize` path keeps its silent-degradation contract; only the reason strings changed there.

## Testing

- `./gradlew testAndroidHostTest --continue` green, including `AlertSummaryViewModelTest` updated to the shared constants
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green
- Verified on a physical Pixel 10 Pro: `checkExtractionAvailability -> Available`. On an emulator with no Gemini Nano, `FeatureStatus` 0 maps to `device_unsupported` as intended.

The Swift changes are compile-verified through the Kotlin/Native bridge only; Foundation Models availability branches cannot run on the simulator, which is an Apple platform restriction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb