### PR TITLE
fix(trip-planner): tell the rider why Ask KRAIL could not read their trip

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputPieces.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiInputPieces.kt
@@ -275,6 +275,17 @@ private fun AiSearchInputUiState.unresolvedMessage(): String = when (unresolvedR
     UnresolvedReason.COULD_NOT_READ ->
         "That did not come through. Have another go, or use fewer words."
 
+    // Neither the sentence nor anything the rider can do. Saying so and pointing at the way
+    // that does work beats an apology, and beats the advice this used to give, which was to
+    // reword a sentence nothing had read.
+    UnresolvedReason.MODEL_UNAVAILABLE ->
+        "This phone cannot run the on device AI that Ask KRAIL needs. Tap the stops to plan a " +
+            "trip instead."
+
+    // The one model problem with a fix the rider owns, so it names the switch.
+    UnresolvedReason.MODEL_NEEDS_SETTING ->
+        "Ask KRAIL needs Apple Intelligence turned on. Switch it on in Settings, then try again."
+
     null -> "Something is missing there. Name where you are going, and where from."
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/savedtrips/SavedTripsScreen.kt
@@ -88,6 +88,7 @@ import xyz.ksharma.krail.trip.planner.ui.components.ai.rememberAiGreeting
 import xyz.ksharma.krail.trip.planner.ui.navigation.savers.parkRideExpansionSaver
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputEvent
 import xyz.ksharma.krail.trip.planner.ui.search.ai.AiSearchInputUiState
+import xyz.ksharma.krail.trip.planner.ui.search.ai.isWayInAvailable
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripUiEvent
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.SavedTripsState
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
@@ -273,7 +274,7 @@ fun SavedTripsScreen(
                     toButtonClick = toButtonClick,
                     onSearchButtonClick = { onSearchButtonClick() },
                     onAiEvent = onAiEvent,
-                    isAiSearchAvailable = aiState.isFeatureEnabled,
+                    isAiSearchAvailable = aiState.isWayInAvailable,
                     isAiHandoffSettling = askKrailFocus.handoffSpin,
                     dateTimeSelectionText = savedTripsState.dateTimeSelectionItem?.toDateTimeText(),
                     onDateTimeSelectionClear = { onEvent(SavedTripUiEvent.DateTimeSelectionChanged(null)) },

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputUiState.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputUiState.kt
@@ -12,8 +12,18 @@ enum class AiSearchInputPhase { IDLE, EXTRACTING, DOWNLOADING, RESOLVED, UNRESOL
  * @property NO_PLACE_MENTIONED The sentence was read fine and named no place at all.
  * @property STOP_NOT_FOUND A place was named and no stop matches it.
  * @property COULD_NOT_READ The model itself gave nothing usable back.
+ * @property MODEL_UNAVAILABLE This device cannot run the on-device model at all. Nothing about
+ * the sentence is the problem and no rewording will help.
+ * @property MODEL_NEEDS_SETTING The device could run it and the rider has it switched off. The
+ * only one of these with a fix the rider can carry out themselves.
  */
-enum class UnresolvedReason { NO_PLACE_MENTIONED, STOP_NOT_FOUND, COULD_NOT_READ }
+enum class UnresolvedReason {
+    NO_PLACE_MENTIONED,
+    STOP_NOT_FOUND,
+    COULD_NOT_READ,
+    MODEL_UNAVAILABLE,
+    MODEL_NEEDS_SETTING,
+}
 
 /**
  * @param isInputOpen Whether the AI search sheet is showing over the home screen. Owned here
@@ -24,6 +34,10 @@ enum class UnresolvedReason { NO_PLACE_MENTIONED, STOP_NOT_FOUND, COULD_NOT_READ
  * flag reached the ViewModel, which refused to submit, but never reached the UI, so with the
  * feature off the wheel still rendered and did nothing when tapped. A button that does
  * nothing is worse than no button.
+ * @param isDeviceCapable Whether this device can run the on-device model at all. Same argument
+ * as [isFeatureEnabled], one layer down: the flag can be on for a rider whose phone has no
+ * on-device AI, and for them the wheel was a button that always failed. True until the
+ * asynchronous check says otherwise, so the button does not appear late on every launch.
  */
 data class AiSearchInputUiState(
     val typedText: String = "",
@@ -37,7 +51,19 @@ data class AiSearchInputUiState(
     /** The place the rider named that no stop matched, quoted back to them. */
     val unmatchedPlace: String? = null,
     val isFeatureEnabled: Boolean = false,
+    val isDeviceCapable: Boolean = true,
 )
+
+/**
+ * Whether to offer the way in at all. The flag says the feature is switched on for this rider;
+ * [AiSearchInputUiState.isDeviceCapable] says their phone can actually run it.
+ *
+ * The gate used to be the flag alone, so on a device with no on-device AI the wheel rendered,
+ * accepted a sentence, and failed every time. A button that always fails is worse than no
+ * button, which is the same reason the flag reached the UI in the first place.
+ */
+val AiSearchInputUiState.isWayInAvailable: Boolean
+    get() = isFeatureEnabled && isDeviceCapable
 
 /**
  * @param fromText / [toText] The raw extracted text, kept alongside the resolved stops so a

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -79,7 +79,11 @@ class AiSearchInputViewModel(
     private val speechToTextService: SpeechToTextService,
     // A chain of capabilities rather than one search call, so what counts as "smart" about
     // resolving a place is declared in one ordered list (see StopTextResolver) instead of
-    // growing branches in here.
+    // growing branches in here. Its chain decides which capability answers: the rider's own
+    // labels first, then the same stop search the search-stop screen uses. The answer is
+    // treated as a guess - no auto-pick concept exists anywhere else in this codebase, and it
+    // stays deliberately scoped to this AI context - so a miss resolves to null and leaves the
+    // field for the rider to fill by hand.
     private val stopTextResolver: StopTextResolver,
     // Where a journey starts when the rider did not say. One collaborator rather than a
     // location lambda, a nearby repository and a label locator sitting side by side: they only
@@ -107,6 +111,7 @@ class AiSearchInputViewModel(
         // entry, so this is re-read often enough, and [AiSearchInputEvent.OpenInput] reads it
         // again at the moment it matters.
         _uiState.update { it.copy(isFeatureEnabled = isAiSearchInputEnabled()) }
+        checkDeviceCapability()
     }
 
     private var listeningJob: Job? = null
@@ -114,6 +119,10 @@ class AiSearchInputViewModel(
 
     // Only ever compared against an earlier reading of itself, never read as a total.
     private var wordsHeardSoFar: Int = 0
+
+    // Held outside the state as well as in it, because every reset below rebuilds the state
+    // from scratch and this is the one fact about the device that a reset must not forget.
+    private var isDeviceCapable: Boolean = true
 
     fun onEvent(event: AiSearchInputEvent) {
         when (event) {
@@ -170,7 +179,11 @@ class AiSearchInputViewModel(
             AiSearchInputEvent.OpenInput -> {
                 val enabled = isAiSearchInputEnabled()
                 _uiState.update {
-                    AiSearchInputUiState(isInputOpen = enabled, isFeatureEnabled = enabled)
+                    AiSearchInputUiState(
+                        isInputOpen = enabled,
+                        isFeatureEnabled = enabled,
+                        isDeviceCapable = isDeviceCapable,
+                    )
                 }
             }
             AiSearchInputEvent.CloseInput -> closeInput()
@@ -178,7 +191,12 @@ class AiSearchInputViewModel(
             // Everything the rider produced is thrown away; what the app knows about itself
             // is not, or starting over would hide the way back in.
             AiSearchInputEvent.StartOver ->
-                _uiState.update { AiSearchInputUiState(isFeatureEnabled = it.isFeatureEnabled) }
+                _uiState.update {
+                    AiSearchInputUiState(
+                        isFeatureEnabled = it.isFeatureEnabled,
+                        isDeviceCapable = isDeviceCapable,
+                    )
+                }
             AiSearchInputEvent.StartListening -> startListening()
             AiSearchInputEvent.StopListening -> stopListening()
         }
@@ -200,7 +218,12 @@ class AiSearchInputViewModel(
         listeningTimeoutJob?.cancel()
         listeningTimeoutJob = null
         if (_uiState.value.isListening) speechToTextService.stopListening()
-        _uiState.update { AiSearchInputUiState(isFeatureEnabled = it.isFeatureEnabled) }
+        _uiState.update {
+            AiSearchInputUiState(
+                isFeatureEnabled = it.isFeatureEnabled,
+                isDeviceCapable = isDeviceCapable,
+            )
+        }
     }
 
     /**
@@ -349,10 +372,8 @@ class AiSearchInputViewModel(
 
             val availability = aiTextService.checkExtractionAvailability()
             if (availability is AiAvailability.Unavailable) {
-                val isTemporary = availability.reason == "downloadable" || availability.reason == "downloading"
-                _uiState.update {
-                    it.copy(phase = if (isTemporary) AiSearchInputPhase.DOWNLOADING else AiSearchInputPhase.UNRESOLVED)
-                }
+                isDeviceCapable = availability.reason.canBecomeAvailable()
+                _uiState.update { it.withUnavailableModel(availability.reason) }
                 logOutcome(reason = "model_unavailable_${availability.reason}")
                 return@launch
             }
@@ -375,10 +396,10 @@ class AiSearchInputViewModel(
                 .withSinglePlaceInTheRightField(text)
                 .withLabelWordAsDestination(riderText = text, labels = riderLabels())
 
-            val toStopItem = extraction.destinationText?.let { resolveStop(it) }
+            val toStopItem = extraction.destinationText?.let { stopTextResolver.resolve(it) }
             val originText = extraction.originText
             val (fromText, fromStopItem) = when {
-                originText != null -> originText to resolveStop(originText)
+                originText != null -> originText to stopTextResolver.resolve(originText)
 
                 // Only fall back to the nearest stop when a destination was actually
                 // understood. Without that condition, a sentence about nothing at all ("hey
@@ -463,15 +484,6 @@ class AiSearchInputViewModel(
     }
 
     /**
-     * Hands the extracted text to [stopTextResolver], whose chain decides which capability
-     * answers: the rider's own labels first, then the same stop search the search-stop screen
-     * uses. The answer is treated as a guess — no auto-pick concept exists anywhere else in
-     * this codebase, and it stays deliberately scoped to this AI context — so a miss resolves
-     * to `null` and leaves the field for the rider to fill by hand.
-     */
-    private suspend fun resolveStop(query: String): StopItem? = stopTextResolver.resolve(query)
-
-    /**
      * The rider didn't say where they're leaving from ("need to be at Central by 6:30pm" —
      * no "from X") — falls back to the nearest transit stop to their current GPS location
      * via [resolveNearbyStop], same as tapping a "near me" pill would, rather than leaving
@@ -484,6 +496,27 @@ class AiSearchInputViewModel(
     private suspend fun resolveCurrentLocationStop(excludeStopId: String?): Pair<String?, StopItem?> {
         val stop = riderOriginLocator.originStop(excludeStopId = excludeStopId)
         return stop?.stopName to stop
+    }
+
+    /**
+     * Asked once on entry so the wheel is not offered on a phone that cannot run the model.
+     * The gate used to be the remote-config flag alone, so a rider whose device has no
+     * on-device AI saw the button, typed a sentence, and got a failure every single time.
+     *
+     * Optimistic until it answers: [isDeviceCapable] starts true, so the button is there for
+     * the fraction of a second this takes rather than appearing late on every launch. Both
+     * platform implementations cache the underlying check, so this is one real call per
+     * process, not one per screen entry.
+     */
+    private fun checkDeviceCapability() {
+        viewModelScope.launch {
+            val available = aiTextService.checkExtractionAvailability()
+            val capable = available !is AiAvailability.Unavailable ||
+                available.reason.canBecomeAvailable()
+            isDeviceCapable = capable
+            _uiState.update { it.copy(isDeviceCapable = capable) }
+            log("$AI_OUTCOME_TAG deviceCapable=$capable")
+        }
     }
 }
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/TripIntentResolution.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/TripIntentResolution.kt
@@ -1,0 +1,51 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai
+
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
+
+/**
+ * The parts of a submit that are decisions rather than orchestration, kept out of
+ * [AiSearchInputViewModel] so that class stays a coordinator.
+ *
+ * A separate file rather than private functions on the ViewModel, deliberately: detekt counts
+ * branches inside nested and local functions toward the enclosing one, so moving this out of
+ * the ViewModel only reduces its complexity if it moves out of the class as well. The functions
+ * here are pure, which also means they can be reasoned about without a ViewModel around them.
+ */
+
+/**
+ * The model could not be asked, and the rider is told which of those it was.
+ *
+ * Every one of these used to land as [AiSearchInputPhase.UNRESOLVED] with no reason set, which
+ * the banner renders as "Something is missing there. Name where you are going, and where from."
+ * That is advice about a sentence, given to a rider whose sentence was never read. On a phone
+ * that cannot run the model at all it is unanswerable, and riders reworded the same request
+ * until they gave up. Each reason now names the thing that would actually help, and only one of
+ * them is about the sentence.
+ */
+internal fun AiSearchInputUiState.withUnavailableModel(reason: String): AiSearchInputUiState {
+    val isStillArriving = reason == AiUnavailableReasons.MODEL_DOWNLOADING
+    return copy(
+        phase = if (isStillArriving) AiSearchInputPhase.DOWNLOADING else AiSearchInputPhase.UNRESOLVED,
+        unresolvedReason = when (reason) {
+            // DOWNLOADING carries its own message; a reason here would be a second one.
+            AiUnavailableReasons.MODEL_DOWNLOADING -> null
+            AiUnavailableReasons.NEEDS_DEVICE_SETTING -> UnresolvedReason.MODEL_NEEDS_SETTING
+            AiUnavailableReasons.DEVICE_UNSUPPORTED -> UnresolvedReason.MODEL_UNAVAILABLE
+            // Includes CHECK_FAILED, which Android suffixes with the throwable message, so
+            // that arrives here by fallthrough rather than by equality. A check that failed
+            // says nothing about the device: it is worth retrying, which is exactly what
+            // COULD_NOT_READ tells the rider to do.
+            else -> UnresolvedReason.COULD_NOT_READ
+        },
+        // Only a device that can never run it loses the way in. A model still downloading, or
+        // one switched off in Settings, both become available without a new build, and hiding
+        // the button would hide the thing that says so.
+        isDeviceCapable = reason.canBecomeAvailable(),
+    )
+}
+
+/**
+ * Whether this reason could stop being true without the rider changing phone. Downloads finish
+ * and settings get switched on; a device with no on-device AI stays that way.
+ */
+internal fun String.canBecomeAvailable(): Boolean = this != AiUnavailableReasons.DEVICE_UNSUPPORTED

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import xyz.ksharma.dhruva.location.Location
 import xyz.ksharma.krail.core.aitext.AiAvailability
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
 import xyz.ksharma.krail.core.aitext.TimeIntent
 import xyz.ksharma.krail.core.aitext.TripIntentExtraction
 import xyz.ksharma.krail.core.maps.data.model.NearbyStop
@@ -439,7 +440,7 @@ class AiSearchInputViewModelTest {
 
     @Test
     fun `model downloadable lands in DOWNLOADING, not the generic unresolved state`() = runTest(testDispatcher) {
-        aiTextService.extractionAvailability = AiAvailability.Unavailable(reason = "downloadable")
+        aiTextService.extractionAvailability = AiAvailability.Unavailable(reason = AiUnavailableReasons.MODEL_DOWNLOADING)
         viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
 
         viewModel.onEvent(AiSearchInputEvent.Submit)
@@ -450,7 +451,7 @@ class AiSearchInputViewModelTest {
 
     @Test
     fun `model downloading lands in DOWNLOADING too`() = runTest(testDispatcher) {
-        aiTextService.extractionAvailability = AiAvailability.Unavailable(reason = "downloading")
+        aiTextService.extractionAvailability = AiAvailability.Unavailable(reason = AiUnavailableReasons.MODEL_DOWNLOADING)
         viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
 
         viewModel.onEvent(AiSearchInputEvent.Submit)
@@ -461,13 +462,119 @@ class AiSearchInputViewModelTest {
 
     @Test
     fun `unsupported device lands in UNRESOLVED, not DOWNLOADING`() = runTest(testDispatcher) {
-        aiTextService.extractionAvailability = AiAvailability.Unavailable(reason = "unsupported_device")
+        aiTextService.extractionAvailability =
+            AiAvailability.Unavailable(reason = AiUnavailableReasons.DEVICE_UNSUPPORTED)
         viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
 
         viewModel.onEvent(AiSearchInputEvent.Submit)
         advanceUntilIdle()
 
         assertEquals(AiSearchInputPhase.UNRESOLVED, viewModel.uiState.value.phase)
+    }
+
+    /**
+     * The phase alone was asserted here for a long time, and the phase alone was right while
+     * the rider was being told the wrong thing: UNRESOLVED with no reason renders as "Something
+     * is missing there. Name where you are going, and where from.", which is advice about a
+     * sentence nothing had read. These pin the reason, because the reason is the message.
+     */
+    @Test
+    fun `a device that cannot run the model says so, rather than blaming the sentence`() =
+        runTest(testDispatcher) {
+            aiTextService.extractionAvailability =
+                AiAvailability.Unavailable(reason = AiUnavailableReasons.DEVICE_UNSUPPORTED)
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            assertEquals(UnresolvedReason.MODEL_UNAVAILABLE, viewModel.uiState.value.unresolvedReason)
+        }
+
+    @Test
+    fun `a model switched off in settings is told apart from one that can never run`() =
+        runTest(testDispatcher) {
+            aiTextService.extractionAvailability =
+                AiAvailability.Unavailable(reason = AiUnavailableReasons.NEEDS_DEVICE_SETTING)
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            assertEquals(UnresolvedReason.MODEL_NEEDS_SETTING, viewModel.uiState.value.unresolvedReason)
+        }
+
+    @Test
+    fun `a failed availability check is worth retrying, not a verdict on the device`() =
+        runTest(testDispatcher) {
+            // Android suffixes the throwable message onto this one, so it is matched by
+            // fallthrough rather than by equality. Written with the suffix on purpose.
+            aiTextService.extractionAvailability =
+                AiAvailability.Unavailable(reason = "${AiUnavailableReasons.CHECK_FAILED}: boom")
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            assertEquals(UnresolvedReason.COULD_NOT_READ, viewModel.uiState.value.unresolvedReason)
+            assertTrue(viewModel.uiState.value.isDeviceCapable)
+        }
+
+    @Test
+    fun `a phone that cannot run the model loses the way in`() = runTest(testDispatcher) {
+        aiTextService.extractionAvailability =
+            AiAvailability.Unavailable(reason = AiUnavailableReasons.DEVICE_UNSUPPORTED)
+        viewModel = AiSearchInputViewModel(
+            aiTextService = aiTextService,
+            speechToTextService = speechToTextService,
+            stopTextResolver = stopTextResolver,
+            riderOriginLocator = RiderOriginLocator(nearbyStopsRepository = nearbyStopsRepository),
+            isAiSearchInputEnabled = { true },
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isFeatureEnabled)
+        assertFalse(viewModel.uiState.value.isDeviceCapable)
+        assertFalse(viewModel.uiState.value.isWayInAvailable)
+    }
+
+    @Test
+    fun `a model still downloading keeps the way in`() = runTest(testDispatcher) {
+        aiTextService.extractionAvailability =
+            AiAvailability.Unavailable(reason = AiUnavailableReasons.MODEL_DOWNLOADING)
+        viewModel = AiSearchInputViewModel(
+            aiTextService = aiTextService,
+            speechToTextService = speechToTextService,
+            stopTextResolver = stopTextResolver,
+            riderOriginLocator = RiderOriginLocator(nearbyStopsRepository = nearbyStopsRepository),
+            isAiSearchInputEnabled = { true },
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.isWayInAvailable)
+    }
+
+    @Test
+    fun `a device verdict survives the reset that opening the box does`() = runTest(testDispatcher) {
+        aiTextService.extractionAvailability =
+            AiAvailability.Unavailable(reason = AiUnavailableReasons.DEVICE_UNSUPPORTED)
+        viewModel = AiSearchInputViewModel(
+            aiTextService = aiTextService,
+            speechToTextService = speechToTextService,
+            stopTextResolver = stopTextResolver,
+            riderOriginLocator = RiderOriginLocator(nearbyStopsRepository = nearbyStopsRepository),
+            isAiSearchInputEnabled = { true },
+        )
+        advanceUntilIdle()
+
+        // OpenInput, StartOver and CloseInput each rebuild the state from scratch. The
+        // device's answer is not something a reset may forget.
+        viewModel.onEvent(AiSearchInputEvent.OpenInput)
+        assertFalse(viewModel.uiState.value.isDeviceCapable)
+        viewModel.onEvent(AiSearchInputEvent.StartOver)
+        assertFalse(viewModel.uiState.value.isDeviceCapable)
+        viewModel.onEvent(AiSearchInputEvent.CloseInput)
+        assertFalse(viewModel.uiState.value.isDeviceCapable)
     }
 
     @Test


### PR DESCRIPTION
## What

Every model-unavailable path landed in `UNRESOLVED` with no reason set, which the banner renders as "Something is missing there. Name where you are going, and where from." That is advice about a sentence, shown to a rider whose sentence was never read.

## Changes

- Adds `UnresolvedReason.MODEL_UNAVAILABLE` and `MODEL_NEEDS_SETTING`, with messages naming what the rider can act on. On a device that cannot run the model, the message points at tapping the stops instead; on one with the setting switched off, it names the setting.
- `withUnavailableModel` in a new `TripIntentResolution.kt` maps each `AiUnavailableReasons` value onto a phase and reason. `CHECK_FAILED` falls through to `COULD_NOT_READ`, since a failed check says nothing about the device and is worth retrying. It is matched by fallthrough rather than equality because Android suffixes the throwable message onto it.
- Adds `isDeviceCapable` to the state and `isWayInAvailable` (flag AND device) as the entry-point gate. The wheel was gated on the remote-config flag alone, so it rendered on devices with no on-device AI and failed on every submit.
- Only `DEVICE_UNSUPPORTED` removes the entry point. A model still downloading, or one switched off in Settings, both keep it, because both become available without a new build.
- `isDeviceCapable` is held as a ViewModel field as well as in the state, since `OpenInput`, `StartOver` and `CloseInput` each rebuild the state from scratch.
- Pure functions live in a separate file rather than as private ViewModel methods: detekt counts branches in nested functions toward the enclosing one, so the extraction only helps if it leaves the class.

The existing `unsupported device lands in UNRESOLVED` test asserted the phase and never the message, which is why this was green while the wrong text shipped. New tests pin the reason.

## Testing

- `./gradlew testAndroidHostTest --continue` green; 6 new tests covering each reason, the entry-point gate, and the device verdict surviving all three state resets
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green
- Physical Pixel 10 Pro: `[AI_OUTCOME] deviceCapable=true`, entry point present, a submit resolved both ends. Emulator without Gemini Nano: `deviceCapable=false`, entry point correctly absent.

## Snapshots

Not captured. The banner copy only renders on a device where the model is unavailable, and the emulator that reproduces that state also hides the entry point needed to reach the banner. Verified through unit tests on the reason mapping instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb