### PR TITLE
fix(trip-planner): never resolve a trip from a stop to itself

### DIFF
--- a/core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift
+++ b/core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift
@@ -74,20 +74,48 @@ import FoundationModels
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
             Task {
+                // Kept deliberately in step with `buildExtractionPrompt` in
+                // AndroidAiTextService. This side used to be a shortened paraphrase of it
+                // with no examples, and the two drifted where it mattered: Android listed
+                // "let's go to X" in the lone-place rule and carried three worked examples,
+                // this one listed neither. "lets go to work" came back with work in BOTH
+                // fields and the rider got a trip from their work stop to their work stop.
+                // The deterministic guard in AiSearchInputViewModel is what actually stops
+                // that reaching the row; this is the half that stops the model producing it.
                 let instructions = """
-                Extract trip-planning fields from a rider's message for a public transport \
-                app. originText/destinationText are short place names as the rider said \
-                them (e.g. "home", "Central Station"), omitted if not mentioned. isArrival \
-                is true for "arrive by"/"need to be there by", false for "leave at"/ \
-                "leaving around" - omit the whole time field if the rider gave no time. \
-                timeText is the time phrase verbatim (e.g. "9am", "6:30pm"), never \
+                You extract structured trip-planning fields from a rider's message for a \
+                public transport app.
+
+                Rules:
+                - originText / destinationText are short place names as the rider said \
+                them (e.g. "home", "Central Station"), never a full sentence. Omitted if \
+                not mentioned.
+                - isArrival is true for "arrive by"/"need to be there by"/"by <time>", \
+                false for "leave at"/"leaving around"/"departing at". Omit the whole time \
+                field if the rider gave no time at all.
+                - timeText is the time phrase verbatim (e.g. "9am", "6:30pm"), never \
                 resolved, and includes any day word said with it ("tomorrow at 9am", \
-                "friday 6pm") because the day is resolved later from this same string. \
-                modeHints lists any transport mode words mentioned, verbatim, \
-                lowercase. Never invent a field the rider didn't actually say. If the \
-                rider names only one place, decide from the phrasing: "go home", "take \
-                me to X" and "heading to X" mean X is the destination and origin is \
-                omitted; only "from X" or "leaving X" makes a lone place the origin.
+                "friday 6pm") because the day is resolved later from this same string.
+                - modeHints lists any transport mode words mentioned, verbatim, lowercase. \
+                Empty if none mentioned.
+                - If the rider names only ONE place, decide which field it belongs in from \
+                the phrasing. "go home", "let's go to X", "lets go to X", "take me to X", \
+                "heading to X" and "I need to get to X" all mean X is the DESTINATION and \
+                originText is omitted. Only put a lone place in originText when the wording \
+                is clearly about leaving, such as "from X" or "leaving X". A rider saying \
+                where they are going is far more common than a rider saying only where they \
+                are.
+                - NEVER put the same place in both originText and destinationText. A rider \
+                who names one place has named one end of the trip, not both.
+                - Never invent a field the rider didn't actually say. Omit it instead.
+
+                Examples:
+                "let's go home" -> destinationText "home", originText omitted.
+                "lets go to work" -> destinationText "work", originText omitted.
+                "leaving home around 9" -> originText "home", destinationText omitted, \
+                isArrival false, timeText "around 9".
+                "town hall to bondi junction by 6pm friday" -> originText "town hall", \
+                destinationText "bondi junction", isArrival true, timeText "6pm friday".
                 """
                 do {
                     let session = LanguageModelSession(instructions: instructions)

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -398,19 +398,13 @@ class AiSearchInputViewModel(
 
             val toStopItem = extraction.destinationText?.let { stopTextResolver.resolve(it) }
             val originText = extraction.originText
-            val (fromText, fromStopItem) = when {
-                originText != null -> originText to stopTextResolver.resolve(originText)
+            val (fromText, fromStopItem) = resolveTripOrigin(
+                originText = originText,
+                namedOrigin = originText?.let { stopTextResolver.resolve(it) },
+                toStopItem = toStopItem,
+                nearbyOrigin = ::resolveCurrentLocationStop,
+            )
 
-                // Only fall back to the nearest stop when a destination was actually
-                // understood. Without that condition, a sentence about nothing at all ("hey
-                // how are you") resolved to no places, took the fallback anyway, and filled
-                // the From field with wherever the rider happened to be standing. That reads
-                // as the app having understood something, which is the one thing it must not
-                // fake.
-                toStopItem != null -> resolveCurrentLocationStop(excludeStopId = toStopItem.stopId)
-
-                else -> null to null
-            }
             // No fallback to "leave now". A rider who mentioned no time gets no time, because
             // the home screen now shows this as a chip: falling back produced "Leave Today
             // 12:29 AM" on a sentence that said nothing about when, which is the app inventing

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/TripIntentResolution.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/TripIntentResolution.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.search.ai
 
 import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
 /**
  * The parts of a submit that are decisions rather than orchestration, kept out of
@@ -8,9 +9,70 @@ import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
  *
  * A separate file rather than private functions on the ViewModel, deliberately: detekt counts
  * branches inside nested and local functions toward the enclosing one, so moving this out of
- * the ViewModel only reduces its complexity if it moves out of the class as well. The functions
- * here are pure, which also means they can be reasoned about without a ViewModel around them.
+ * `submit` only reduces its complexity if it moves out of the class as well. The functions here
+ * are pure, which also means they can be reasoned about without a ViewModel around them.
  */
+
+/**
+ * Which stop, if any, the journey starts from.
+ *
+ * @param originText what the rider called the origin, or null if they did not name one.
+ * @param namedOrigin what [originText] resolved to, or null if it resolved to nothing.
+ * @param toStopItem the resolved destination, used to refuse an origin equal to it.
+ * @return the origin text to show and the stop it resolved to, either of which may be null.
+ * @param nearbyOrigin the fallback for an unstated origin, invoked only when it is needed:
+ * it reads the rider's location, which is not something to do speculatively.
+ */
+internal suspend fun resolveTripOrigin(
+    originText: String?,
+    namedOrigin: StopItem?,
+    toStopItem: StopItem?,
+    nearbyOrigin: suspend (excludeStopId: String?) -> Pair<String?, StopItem?>,
+): Pair<String?, StopItem?> {
+    // A trip from a stop to itself is never something a rider asked for. "lets go to work"
+    // came back from the iOS model with "work" in BOTH fields, both resolved to the rider's
+    // Work stop, and the row was filled Work to Work. Both prompts now say not to do it, but a
+    // prompt is advice and this is the contract.
+    val originIsTheDestination = namedOrigin.sameStopAs(toStopItem)
+
+    return when {
+        // A named origin keeps this branch even when it resolved to nothing: the rider said a
+        // place, and the row shows the words they used with the field left for them to fill.
+        // Only a named origin that collapsed ONTO the destination is diverted, to the same
+        // fallback an unstated origin takes, which already knows to exclude it.
+        originText != null && !originIsTheDestination -> originText to namedOrigin
+
+        // Only fall back to the nearest stop when a destination was actually understood.
+        // Without that condition, a sentence about nothing at all ("hey how are you") resolved
+        // to no places, took the fallback anyway, and filled the From field with wherever the
+        // rider happened to be standing. That reads as the app having understood something,
+        // which is the one thing it must not fake.
+        toStopItem != null -> {
+            val (text, stop) = nearbyOrigin(toStopItem.stopId)
+            // The fallback excludes by stop id, and the same station can carry more than one
+            // (a label pinned to the parent, a nearby result on a platform). Checked again by
+            // name here so the row cannot end up showing one station twice under two ids.
+            if (stop.sameStopAs(toStopItem)) null to null else text to stop
+        }
+
+        else -> null to null
+    }
+}
+
+/**
+ * Whether two resolutions are the same place, for the one purpose of refusing to put a station
+ * in both ends of a trip.
+ *
+ * Not just an id comparison. The same station carries more than one stop id in this data (a
+ * label pinned to the parent, a nearby-stop result on a platform), so an id check alone let
+ * "Central Station to Central Station" through under two different ids. Names are compared as
+ * well, which is safe here because the only decision it drives is dropping an origin the rider
+ * never asked for.
+ */
+internal fun StopItem?.sameStopAs(other: StopItem?): Boolean {
+    if (this == null || other == null) return false
+    return stopId == other.stopId || stopName.equals(other.stopName, ignoreCase = true)
+}
 
 /**
  * The model could not be asked, and the rider is told which of those it was.

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -577,6 +577,80 @@ class AiSearchInputViewModelTest {
         assertFalse(viewModel.uiState.value.isDeviceCapable)
     }
 
+    /**
+     * "lets go to work" on iOS came back with "work" in BOTH fields, both resolved to the
+     * rider's Work stop, and the home row was filled Work to Work. A trip from a stop to
+     * itself is never something a rider asked for.
+     */
+    @Test
+    fun `the same place in both fields never becomes a trip from a stop to itself`() =
+        runTest(testDispatcher) {
+            sandook.upsertStopLabel(
+                label = "work",
+                emoji = "💼",
+                stopId = "10102",
+                stopName = "Town Hall",
+                sortOrder = 0L,
+            )
+            aiTextService.extractionResult = TripIntentExtraction(
+                originText = "work",
+                destinationText = "work",
+                timeIntent = null,
+            )
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("lets go to work"))
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            val resolved = viewModel.uiState.value.resolved
+            assertEquals(StopItem(stopName = "Town Hall", stopId = "10102"), resolved?.toStopItem)
+            // The destination is kept and the origin dropped, never the other way round: the
+            // rider said where they were going.
+            assertNull(resolved?.fromStopItem)
+        }
+
+    @Test
+    fun `two different names for the same station are still one station`() =
+        runTest(testDispatcher) {
+            // Same station, two ids: a label pinned to the parent and a search result on a
+            // platform. An id comparison alone let this through.
+            sandook.upsertStopLabel(
+                label = "work",
+                emoji = "💼",
+                stopId = "10102A",
+                stopName = "Town Hall",
+                sortOrder = 0L,
+            )
+            aiTextService.extractionResult = TripIntentExtraction(
+                originText = "work",
+                destinationText = "Town Hall",
+                timeIntent = null,
+            )
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("work to town hall"))
+
+            viewModel.onEvent(AiSearchInputEvent.Submit)
+            advanceUntilIdle()
+
+            assertNull(viewModel.uiState.value.resolved?.fromStopItem)
+        }
+
+    @Test
+    fun `a genuinely different origin is left alone`() = runTest(testDispatcher) {
+        aiTextService.extractionResult = TripIntentExtraction(
+            originText = "Central Station",
+            destinationText = "Town Hall",
+            timeIntent = null,
+        )
+        viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("central to town hall"))
+
+        viewModel.onEvent(AiSearchInputEvent.Submit)
+        runCurrent()
+
+        val resolved = viewModel.uiState.value.resolved
+        assertEquals(StopItem(stopName = "Central Station", stopId = "10101"), resolved?.fromStopItem)
+        assertEquals(StopItem(stopName = "Town Hall", stopId = "10102"), resolved?.toStopItem)
+    }
+
     @Test
     fun `no time mentioned means no time, not a time we chose`() = runTest(testDispatcher) {
         aiTextService.extractionResult = TripIntentExtraction(


### PR DESCRIPTION
## What

"lets go to work" came back from the iOS model with "work" in both `originText` and `destinationText`. Both resolved to the rider's Work stop and the home row was filled Work to Work.

## Changes

- `resolveTripOrigin` drops an origin that resolved to the destination and falls through to the nearby-stop fallback an unstated origin already takes, which knows to exclude it. If that also comes back empty the field is left blank and editable.
- `sameStopAs` compares stop id **or** name. One station carries several ids in this data (a label pinned to the parent, a search result on a platform), so an id check alone let the same station through twice under two ids. The name comparison is safe here because the only decision it drives is dropping an origin the rider never asked for.
- The nearby-stop fallback result is re-checked by the same predicate, for the same reason.
- A named origin that resolved to nothing keeps its text on the row as before. Only one equal to the destination is dropped, and the destination is always the field kept, since that is the end the rider actually named.
- Brings the iOS extraction prompt back in step with the Android one: adds the worked examples, adds "let's go to X" and "lets go to X" to the lone-place rule, and states that one place must never fill both fields.

`withSinglePlaceInTheRightField` could not catch this: it only fires when exactly one field is filled, and here both were.

The prompt change alone would not be sufficient. A prompt is advice, and this repo already learned that from `SinglePlaceIntent.kt`, so the guard is deterministic and tested.

## Testing

- `./gradlew testAndroidHostTest --continue` green; 3 new tests covering the same place in both fields, two ids for one station, and a genuinely different origin being left alone
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green
- Physical Pixel 10 Pro: a real submit resolved two distinct stops, confirming the guard does not over-fire on a legitimate two-ended trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb