### PR TITLE
fix(trip-planner): let riders dismiss the Ask KRAIL dialog

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AskKrailScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AskKrailScreen.kt
@@ -14,7 +14,11 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,7 +29,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -43,9 +49,11 @@ import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -54,14 +62,18 @@ import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.util.lerp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import xyz.ksharma.krail.core.appinfo.DevicePlatformType
+import xyz.ksharma.krail.core.appinfo.getAppPlatformType
 import xyz.ksharma.krail.taj.LocalThemeColor
 import xyz.ksharma.krail.taj.components.AiWheelMark
+import xyz.ksharma.krail.taj.components.CloseIcon
 import xyz.ksharma.krail.taj.components.CloudFieldSpec
 import xyz.ksharma.krail.taj.components.CloudGradientBackground
 import xyz.ksharma.krail.taj.components.Text
 import xyz.ksharma.krail.taj.components.TitleBar
 import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.modifier.aiGradientBorder
+import xyz.ksharma.krail.taj.modifier.klickable
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import xyz.ksharma.krail.taj.tokens.AiThemeGradientTokens
@@ -333,7 +345,30 @@ private fun AskKrailDialog(
         // measured once at its final size and nothing reflows mid animation.
         val visibleState = remember { MutableTransitionState(false).apply { targetState = true } }
 
-        Box(modifier = Modifier.fillMaxSize().imePadding(), contentAlignment = Alignment.Center) {
+        // The scrim tap, done here rather than left to the Dialog.
+        //
+        // Compose Multiplatform decides "outside" geometrically: the dialog layer's
+        // boundsInWindow is set to the MEASURED SIZE OF THIS CONTENT, and only pointers
+        // landing outside that rectangle reach the outside-pointer listener that calls
+        // onDismissRequest. This content fills the window (it has to, to centre the card and
+        // own the keyboard inset), so the bounds were the whole screen and no tap was ever
+        // outside anything. Android got away with it because a Compose dialog there is a real
+        // platform window with a working back press; iOS has neither, so the card was a room
+        // with no door and the only way out was a sentence that resolved.
+        //
+        // No indication and no interaction source: this is a scrim, not a button, and a ripple
+        // spreading across the whole screen on the way out is not what a dismissal looks like.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onDismiss,
+                )
+                .imePadding(),
+            contentAlignment = Alignment.Center,
+        ) {
             AnimatedVisibility(
                 visibleState = visibleState,
                 enter = fadeIn(tween(ENTER_MILLIS)) + scaleIn(
@@ -347,6 +382,12 @@ private fun AskKrailDialog(
             ) {
                 Column(
                     modifier = modifier
+                        // The card is not the scrim. Without this, a tap on the card's own
+                        // padding travels up to the dismiss handler on the box behind it and
+                        // closes the surface the rider was reaching for. detectTapGestures
+                        // rather than a no-op clickable so nothing announces the card itself
+                        // as a control.
+                        .pointerInput(Unit) { detectTapGestures { } }
                         // Fixed on a tablet, edge-margined on a phone: the padding narrows the
                         // incoming constraint first, then widthIn caps what fillMaxWidth may
                         // take, so a phone gets the screen minus its margins and anything wider
@@ -398,6 +439,7 @@ private fun AskKrailDialog(
                         suggestion = suggestion,
                         busyVisible = state.isListening || workingBorder.spinning,
                         onEvent = onEvent,
+                        onDismiss = onDismiss,
                     )
                 }
             }
@@ -425,6 +467,7 @@ internal fun AiDialogContent(
     busyVisible: Boolean,
     onEvent: (AiSearchInputEvent) -> Unit,
     modifier: Modifier = Modifier,
+    onDismiss: () -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
@@ -433,15 +476,47 @@ internal fun AiDialogContent(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(dim.spacingL),
     ) {
-        Text(
-            text = AI_INPUT_QUESTION,
-            style = KrailTheme.typography.titleMedium,
-            color = KrailTheme.colors.onSurface,
-            textAlign = TextAlign.Center,
-            // Extra air between the ring and the title: at the container's own padding the
-            // name sat against the border and read as underlined by it.
-            modifier = Modifier.fillMaxWidth().padding(top = dim.spacingM),
-        )
+        // Title centred in the full width, close button laid over the end of it rather than
+        // in a Row beside it, so the button does not shift the name off centre.
+        //
+        // iOS only, and that is the whole reason it exists. A Compose dialog on iOS has no
+        // back press and no swipe, so before the scrim tap below it there was no way out of
+        // this card at all; a drawn control is what makes the way out discoverable rather
+        // than something a rider has to think to try. Android already has the system back
+        // gesture, so there the scrim tap is the addition and a second control would be
+        // clutter on a card this small.
+        Box(modifier = Modifier.fillMaxWidth()) {
+            val showsCloseButton = getAppPlatformType() == DevicePlatformType.IOS
+            Text(
+                text = AI_INPUT_QUESTION,
+                style = KrailTheme.typography.titleMedium,
+                color = KrailTheme.colors.onSurface,
+                textAlign = TextAlign.Center,
+                // Cleared past the button, so a title long enough to wrap wraps instead of
+                // running under it. Symmetric so the name stays centred, and only claimed
+                // where there is a button to clear.
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = if (showsCloseButton) dim.spacingXXL else dim.spacingNone)
+                    .padding(top = dim.spacingM),
+            )
+            if (showsCloseButton) {
+                Image(
+                    imageVector = CloseIcon,
+                    contentDescription = "Close",
+                    colorFilter = ColorFilter.tint(KrailTheme.colors.onSurface),
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .clip(CircleShape)
+                        .klickable(onClick = onDismiss)
+                        // The padding is the touch target, not decoration: a 20dp glyph alone
+                        // is a quarter of what a finger needs, and this is the control a rider
+                        // reaches for when they have changed their mind.
+                        .padding(dim.spacingL)
+                        .size(dim.iconSmall),
+                )
+            }
+        }
 
         // The line's three states, resolved in one place so their handover is auditable:
         // resolved beats busy (the border's beat outlives the answer, and "Found it" is what

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloseIcon.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/CloseIcon.kt
@@ -1,0 +1,42 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * A cross: close, dismiss, put this away.
+ *
+ * Authored as path data and stroked at the same weight as [SendIcon], [MicIcon] and [StopIcon]
+ * so it sits beside them without looking lighter or heavier than the row it is in.
+ *
+ * It exists because a surface that can only be left by a gesture cannot be left at all by
+ * someone who does not know the gesture. The Ask KRAIL card is a Compose dialog, and on iOS a
+ * Compose dialog has no back press and no swipe: with nothing drawn to tap, the only way out
+ * was a sentence the model happened to understand.
+ */
+val CloseIcon: ImageVector by lazy {
+    ImageVector.Builder(
+        name = "Close",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).apply {
+        path(
+            stroke = SolidColor(Color.White),
+            strokeLineWidth = 2.2f,
+            strokeLineCap = StrokeCap.Round,
+            strokeLineJoin = StrokeJoin.Round,
+        ) {
+            moveTo(6f, 6f)
+            lineTo(18f, 18f)
+            moveTo(18f, 6f)
+            lineTo(6f, 18f)
+        }
+    }.build()
+}


### PR DESCRIPTION
## What

Tapping outside the Ask KRAIL dialog did nothing, on either platform. On iOS that left the card with no way out at all.

## Changes

- The scrim handles the dismiss tap itself, with the card swallowing its own via `detectTapGestures` so a tap on the card does not close it.
- iOS additionally gets a close button in the dialog header. Android does not draw one: the system back gesture is already a way out, and a second control is clutter on a card this size. Gated with the existing `getAppPlatformType()` pattern.
- Adds `CloseIcon` to taj, stroked at the same weight as `SendIcon` and `MicIcon`.
- The title's horizontal clearance is only claimed where the button is drawn, so it stays centred on Android.
- The full-screen variant used past `ACTIONS_STACK_SCALE` already had a title bar back action and is untouched.

### Why the platform default did not work

Compose Multiplatform decides "outside" geometrically. In `Dialog.skiko.kt`:

```kotlin
layer.setOutsidePointerEventListener(onOutsidePointerEvent)
...
layer.boundsInWindow = IntRect(positionWithInsets, contentSize)
```

`contentSize` is the measured size of the dialog's content. This content fills the window, which it must in order to centre the card and own the keyboard inset, so the bounds were the whole screen and no pointer was ever outside them. Android survived on `dismissOnBackPress`; iOS has neither a back press nor a swipe on a Compose dialog.

`ModalBottomSheet.ios.kt` already solves this the same way for its own scrim, so this brings the dialog in line with a pattern the codebase had.

This is the only Compose `Dialog` in the app, so the trap is not repeated elsewhere.

## Testing

- `./gradlew testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green
- Installed on a physical Pixel 10 Pro, where the dialog is reachable

## Snapshots

Not captured. The dialog only renders where the on-device model is available, and the one device here that satisfies that is a personal phone, so no screenshots of it are attached. Worth a look on device before approving, since the header layout is the visible part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb