### PR TITLE
fix(taj): stop the AI gradient ring leaving a pale rim at its corners

### DIFF
--- a/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
+++ b/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cfff8ba7d380ec3e1fb83ff7d949d86cca2c039b1d9c7994b05236540dbfa30
+size 46498

--- a/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
+++ b/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3e808b78fb7b542f030a32ae0b09aec321563d2bd0ff4e9acecc0105d701d1
+size 46058

--- a/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
+++ b/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3e808b78fb7b542f030a32ae0b09aec321563d2bd0ff4e9acecc0105d701d1
+size 46058

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/AiGradientBorder.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/modifier/AiGradientBorder.kt
@@ -1,8 +1,14 @@
 package xyz.ksharma.krail.taj.modifier
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -16,8 +22,13 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import xyz.ksharma.krail.core.snapshot.ScreenshotTest
 import xyz.ksharma.krail.taj.animations.AiSpinDefaults
 import xyz.ksharma.krail.taj.animations.rememberAiSpinAngle
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
 import xyz.ksharma.krail.taj.tokens.AiGradientTokens
 import xyz.ksharma.krail.taj.tokens.StrokeTokens
 import kotlin.math.hypot
@@ -72,6 +83,20 @@ fun Modifier.aiGradientBorder(
         val ringTopLeft = Offset(half, half)
         val ringSize = Size(size.width - strokePx, size.height - strokePx)
 
+        // The centreline's radius, not the shape's.
+        //
+        // [cornerRadius] is the radius of the surface this ring sits on, which is the radius
+        // its OUTER edge has to follow. The stroke is centred on a rect inset by half its
+        // width, and a stroke's outer edge curves at the centreline radius plus that same
+        // half. Passing the shape's radius straight through therefore drew the outer edge at
+        // `cornerRadius + half`: a tighter-cornered ring than the card it was tracing, so at
+        // every corner the ring pulled inward and the card's own background showed as a pale
+        // rim outside it. At the dialog's working stroke that rim was 3dp of white.
+        //
+        // Floored at zero, so a stroke thicker than the radius degrades to a square-cornered
+        // ring rather than inverting into a negative radius.
+        val ringCornerRadius = (cornerRadius.toPx() - half).coerceAtLeast(0f)
+
         // The gradient-filled square must fully cover the ring's bounding box at every
         // rotation angle, so its side is the card's own diagonal, centered on the card.
         val coverSide = hypot(size.width, size.height)
@@ -90,7 +115,7 @@ fun Modifier.aiGradientBorder(
                 // fading the mask fades the ring.
                 color = Color.Black.copy(alpha = alpha),
                 style = Stroke(width = strokePx),
-                cornerRadius = CornerRadius(cornerRadius.toPx()),
+                cornerRadius = CornerRadius(ringCornerRadius),
                 topLeft = ringTopLeft,
                 size = ringSize,
             )
@@ -110,3 +135,44 @@ fun Modifier.aiGradientBorder(
         }
     }
 }
+
+// region Previews
+
+/**
+ * The exact stack the Ask KRAIL dialog wears: a clipped, filled, rounded surface with this ring
+ * on top of it, over a dark backdrop that makes any gap between the two visible.
+ *
+ * It exists because a gap was there and nobody could see it in a preview. The ring kept the
+ * shape's corner radius for its own centreline, so its outer edge curved at a tighter radius
+ * than the card, and the card's white background showed through at every corner. On a white
+ * card against a grey scrim that reads as a pale rim, which is easy to mistake for a shadow.
+ *
+ * The backdrop is deliberately dark and the surface deliberately light: the failure is invisible
+ * when both are the same colour, which is exactly how it survived.
+ */
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewAiGradientBorderOnFilledSurface() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        Box(
+            modifier = Modifier
+                .background(Color(0xFF404040))
+                .padding(16.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(width = 220.dp, height = 96.dp)
+                    .clip(RoundedCornerShape(28.dp))
+                    .background(Color.White)
+                    .aiGradientBorder(
+                        spinning = false,
+                        cornerRadius = 28.dp,
+                        strokeWidth = 6.dp,
+                    ),
+            )
+        }
+    }
+}
+
+// endregion


### PR DESCRIPTION
## What

The AI gradient ring left a pale rim at its corners. Reported on the Ask KRAIL dialog, where it reads as a white border between the gradient and the card.

## The bug

The ring is stroked along a rect inset by half the stroke width, but the centreline was given the **surface's** corner radius:

```kotlin
val half = strokePx / 2f
drawRoundRect(
    style = Stroke(width = strokePx),
    cornerRadius = CornerRadius(cornerRadius.toPx()),   // full radius on the centreline
    topLeft = Offset(half, half),
    size = Size(size.width - strokePx, size.height - strokePx),
)
```

A stroke's outer edge curves at the centreline radius plus half the width, so the outer edge curved at `R + half` while the card's `clip` curves at `R`. A tighter-cornered ring than the card it was tracing: at every corner it pulled inward and the background showed through outside it.

Straight edges were fine, which is why this looked like a rendering oddity rather than a geometry error.

## Measured

Walking the top-left diagonal inward on the recorded snapshot, classifying each pixel as backdrop / gradient / white:

```
before   backdrop(43)  gradient(1)  WHITE(1)  gradient(12)  WHITE(83)
after    backdrop(43)  gradient(12)           WHITE(85)
```

The ring was split by a band of card background.

## Changes

- The centreline now uses `cornerRadius - half`, so the stroke's outer edge lands exactly on the shape's own radius. Floored at zero, so a stroke thicker than the radius degrades to square corners rather than inverting into a negative radius.
- Adds a snapshot preview reproducing the failure conditions: light surface, this ring, dark backdrop.

The fix is in the modifier, so all three callers get it: the Ask KRAIL dialog, `AiInputBar`, and `AiAlertSummaryCard`.

## Why it was not caught

Every existing preview of this modifier puts the ring on a surface the same colour as the gap. With nothing behind it to contrast against, there is nothing to see. The new preview is deliberately a light card on a dark backdrop for that reason.

## Testing

- `./gradlew testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green
- `./scripts/fullQualityChecks.sh` green
- Snapshots recorded and the committed golden re-checked pixel by pixel; the diagonal above is read off the file in the PR

## Snapshots

| Case | Result |
|---|---|
| Ring on a light surface, dark backdrop | <img src="https://github.com/ksharma-xyz/KRAIL/raw/fix/ai-gradient-border-corner-radius/taj/screenshots/PreviewAiGradientBorderOnFilledSurface.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png" width="220"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb