### PR TITLE
feat(taj): add a contrast helper that can reach any target

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.taj.theme
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import xyz.ksharma.krail.taj.brighten
 import xyz.ksharma.krail.taj.darken
@@ -94,3 +95,77 @@ fun Color.ensureMinimumContrast(
     }
     return adapted
 }
+
+/**
+ * Blends this colour toward [toward] until it clears [minContrast] against [background].
+ *
+ * ## Why this exists alongside [ensureMinimumContrast]
+ *
+ * [ensureMinimumContrast] raises HSV *value* and nothing else, so it cannot help a colour that
+ * is already at full value — every hue with a low luminance ceiling (violets, blues, deep reds)
+ * comes back still failing, and silently, because the loop returns the colour anyway when it
+ * runs out of steps. Swept over 1920 hue/saturation/value combinations it returns a
+ * still-failing colour for 24% of them against the bottom-sheet ground. [ContrastAdaptationTest]
+ * holds that number at zero for this function.
+ *
+ * ## Why a ladder scan and not a binary search
+ *
+ * The obvious implementation binary-searches the blend factor, which is only correct if contrast
+ * rises monotonically along the blend. It does not: Compose's [lerp] interpolates in Oklab, and
+ * 110 of 7680 measured ladders reverse somewhere in the middle. So this walks the ladder from
+ * the smallest blend up and takes the first rung that clears — no monotonicity assumed, and the
+ * result is the least-adapted colour on the ladder rather than merely *a* passing one.
+ *
+ * ## The background must be opaque
+ *
+ * [contrastRatio] reads `luminance()`, which ignores the alpha channel, so a translucent
+ * [background] is measured as though it were fully opaque and the result over-adapts. Composite
+ * a translucent ground over what is behind it before passing it here.
+ *
+ * ## Why it is total
+ *
+ * The last rung is [toward] itself. Callers pass the ground's own `onSurface`, which clears every
+ * threshold against it by definition — `KrailColorTokenContrastTest` holds that precondition — so
+ * a passing rung always exists. When [toward] does not clear, there is nothing better available
+ * and it is returned as the best effort.
+ *
+ * Quantising to [BLEND_LADDER_STEPS] rungs is also what keeps the output stable: a one-digit
+ * edit to a surface token can move a continuous search by 1/255 in every derived colour and
+ * churn every screenshot golden, where a ladder holds still until the change is big enough to
+ * cross a rung.
+ *
+ * @param background The ground the colour will be drawn on.
+ * @param toward The colour to blend towards — the ground's own content colour.
+ * @param minContrast Minimum ratio required, before [CONTRAST_SAFETY_MARGIN] is added.
+ */
+fun Color.ensureContrastWith(
+    background: Color,
+    toward: Color,
+    minContrast: Float = DEFAULT_TEXT_SIZE_CONTRAST_AA,
+): Color {
+    val target = minContrast + CONTRAST_SAFETY_MARGIN
+    if (contrastRatio(background) >= target) return this
+
+    return (1..BLEND_LADDER_STEPS)
+        .asSequence()
+        .map { rung -> lerp(this, toward, rung.toFloat() / BLEND_LADDER_STEPS) }
+        .firstOrNull { candidate -> candidate.contrastRatio(background) >= target }
+        ?: toward
+}
+
+/**
+ * Never land exactly on the threshold. Ratios are compared as floats, the result is quantised to
+ * 8 bits per channel on the way into [Color], and anti-aliasing moves the rendered value again —
+ * a colour measured at exactly 4.50 is one rounding away from failing.
+ */
+internal const val CONTRAST_SAFETY_MARGIN = 0.05f
+
+/**
+ * Rungs on the blend ladder [ensureContrastWith] walks.
+ *
+ * Coarse enough that a one-digit token edit cannot shift every derived colour, fine enough that
+ * the first passing rung is not far past the threshold. At 16 the shipped themes landed up to 0.5
+ * above their target, which is brand identity given away for nothing; 32 halves that, and 64 buys
+ * almost nothing on top.
+ */
+internal const val BLEND_LADDER_STEPS = 32

--- a/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/theme/ContrastAdaptationTest.kt
+++ b/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/theme/ContrastAdaptationTest.kt
@@ -1,0 +1,242 @@
+package xyz.ksharma.krail.taj.theme
+
+import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.taj.contrast.ContrastAnalyzer.Companion.TEXT_CONTRAST_AA
+import xyz.ksharma.krail.taj.contrast.ContrastAnalyzer.Companion.UI_COMPONENT_CONTRAST_AA
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * [ensureContrastWith] must be **total**: for any colour, on any ground the app draws on, it
+ * returns something that clears the threshold. Not "usually", not "for the colours we ship" —
+ * the whole point of deriving a colour instead of hand-picking one is that a theme nobody has
+ * invented yet is already handled.
+ *
+ * That is a property, so this measures a property rather than a list of colours: every hue at
+ * [HUE_STEP_DEGREES] degrees, across four saturations and four values, against every
+ * opaque ground in both schemes, at both thresholds.
+ *
+ * The same sweep run against [ensureMinimumContrast] is what motivated this function existing at
+ * all — it returns a still-failing colour for roughly a quarter of them on the sheet ground, and
+ * returns it silently. `the old helper still cannot reach the target` pins that so the justification
+ * cannot rot: if it ever starts passing, [ensureMinimumContrast] was fixed and this function's
+ * KDoc needs rewriting.
+ */
+class ContrastAdaptationTest {
+
+    @Test
+    fun `every colour on every ground reaches its target`() {
+        val unreachable = mutableListOf<String>()
+        var adapted = 0
+        var measured = 0
+
+        pairings().forEach { (ground, threshold, colour) ->
+            measured++
+            val result = colour.ensureContrastWith(
+                background = ground.background,
+                toward = ground.onBackground,
+                minContrast = threshold,
+            )
+            if (result != colour) adapted++
+            if (result.contrastRatio(ground.background) < threshold) {
+                unreachable += "${colour.hex()} on ${ground.name} at $threshold " +
+                    "-> ${result.hex()} measures ${result.contrastRatio(ground.background)}"
+            }
+        }
+
+        // Scan-broke detector: a sweep that measures nothing, or that never has to adapt
+        // anything, passes vacuously and covers nothing.
+        assertTrue(
+            measured >= MIN_EXPECTED_MEASUREMENTS,
+            "Sweep only measured $measured pairings — the colour generator is broken.",
+        )
+        assertTrue(
+            adapted > 0,
+            "Nothing in the sweep needed adapting, so nothing was actually exercised.",
+        )
+
+        if (unreachable.isNotEmpty()) {
+            fail(
+                buildString {
+                    appendLine("${unreachable.size} of $measured pairings did not reach their target:")
+                    unreachable.take(MAX_REPORTED_FAILURES).forEach { appendLine("  - $it") }
+                    if (unreachable.size > MAX_REPORTED_FAILURES) {
+                        appendLine("  ... and ${unreachable.size - MAX_REPORTED_FAILURES} more")
+                    }
+                    appendLine(
+                        "ensureContrastWith is supposed to be total. Either the ladder no longer " +
+                            "ends at `toward`, or a ground was added whose onBackground does not " +
+                            "clear the threshold against it.",
+                    )
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `a colour that already passes is returned untouched`() {
+        // Bus cyan on the dark surface measures 7.25 — nothing to do, and doing nothing matters:
+        // a theme that already reads well must not drift because the helper was called.
+        val bus = bus_theme
+        assertEquals(
+            bus,
+            bus.ensureContrastWith(
+                background = md_theme_dark_surface,
+                toward = md_theme_dark_onSurface,
+            ),
+            "A colour already clearing the threshold must be returned identically.",
+        )
+    }
+
+    @Test
+    fun `the result is the least adapted rung that clears`() {
+        GROUNDS.forEach { ground ->
+            SHIPPED_THEME_COLOURS.forEach { colour ->
+                val result = colour.ensureContrastWith(
+                    background = ground.background,
+                    toward = ground.onBackground,
+                    minContrast = TEXT_CONTRAST_AA,
+                )
+                if (result == colour) return@forEach
+
+                val rung = ladderRungOf(result, from = colour, toward = ground.onBackground)
+                assertTrue(
+                    rung > 0,
+                    "${colour.hex()} on ${ground.name}: result ${result.hex()} is not on the ladder.",
+                )
+                if (rung == 1) return@forEach
+
+                val previous = androidx.compose.ui.graphics.lerp(
+                    colour,
+                    ground.onBackground,
+                    (rung - 1).toFloat() / BLEND_LADDER_STEPS,
+                )
+                assertTrue(
+                    previous.contrastRatio(ground.background) <
+                        TEXT_CONTRAST_AA + CONTRAST_SAFETY_MARGIN,
+                    "${colour.hex()} on ${ground.name}: rung ${rung - 1} already clears, so rung " +
+                        "$rung over-adapts. The scan must stop at the first passing rung.",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the old helper still cannot reach the target`() {
+        // Purple Drip on the bottom-sheet ground is the case that started this: raising HSV value
+        // tops out below 4.5 because the colour is already fully saturated with little value left.
+        val stillFailing = purple_drip_theme.ensureMinimumContrast(
+            background = md_theme_dark_modal_sheet_background,
+            minContrast = TEXT_CONTRAST_AA,
+        )
+
+        assertTrue(
+            stillFailing.contrastRatio(md_theme_dark_modal_sheet_background) < TEXT_CONTRAST_AA,
+            "ensureMinimumContrast now reaches AA for Purple Drip on the sheet. It was fixed, or " +
+                "a token moved. Rewrite ensureContrastWith's KDoc, which cites this as the reason " +
+                "it exists, and delete this test.",
+        )
+    }
+
+    // region helpers
+
+    private data class Ground(val name: String, val background: Color, val onBackground: Color)
+
+    private data class Pairing(val ground: Ground, val threshold: Float, val colour: Color)
+
+    /** Flattened so the assertion loop stays one level deep and reads as one measurement. */
+    private fun pairings(): List<Pairing> {
+        val colours = sweepColours()
+        return GROUNDS.flatMap { ground ->
+            THRESHOLDS.flatMap { threshold ->
+                colours.map { colour -> Pairing(ground, threshold, colour) }
+            }
+        }
+    }
+
+    private fun sweepColours(): List<Color> = buildList {
+        var hue = 0f
+        while (hue < FULL_TURN_DEGREES) {
+            SATURATIONS.forEach { saturation ->
+                VALUES.forEach { value ->
+                    add(Color.hsv(hue = hue, saturation = saturation, value = value))
+                }
+            }
+            hue += HUE_STEP_DEGREES
+        }
+    }
+
+    /** Which rung of the blend ladder [result] sits on, or -1 if it is not on the ladder. */
+    private fun ladderRungOf(result: Color, from: Color, toward: Color): Int {
+        for (rung in 0..BLEND_LADDER_STEPS) {
+            val candidate = androidx.compose.ui.graphics.lerp(
+                from,
+                toward,
+                rung.toFloat() / BLEND_LADDER_STEPS,
+            )
+            if (candidate == result) return rung
+        }
+        return -1
+    }
+
+    private fun Color.hex(): String {
+        fun channel(value: Float) =
+            (value * CHANNEL_MAX).toInt().toString(HEX_RADIX).padStart(2, '0').uppercase()
+        return "#${channel(red)}${channel(green)}${channel(blue)}"
+    }
+
+    // endregion
+
+    private companion object {
+        const val HUE_STEP_DEGREES = 3f
+        const val FULL_TURN_DEGREES = 360f
+        val SATURATIONS = listOf(0.4f, 0.6f, 0.8f, 1.0f)
+        val VALUES = listOf(0.4f, 0.6f, 0.8f, 1.0f)
+
+        const val MIN_EXPECTED_MEASUREMENTS = 10_000
+        const val MAX_REPORTED_FAILURES = 12
+        const val CHANNEL_MAX = 255
+        const val HEX_RADIX = 16
+
+        val THRESHOLDS = listOf(TEXT_CONTRAST_AA, UI_COMPONENT_CONTRAST_AA)
+
+        /**
+         * Every opaque ground an adapted colour can land on, paired with the content colour it
+         * would be blended towards. Adding a ground token here is how a new surface gets covered.
+         */
+        val GROUNDS = listOf(
+            Ground("dark surface", md_theme_dark_surface, md_theme_dark_onSurface),
+            Ground("dark sheet", md_theme_dark_modal_sheet_background, md_theme_dark_onSurface),
+            Ground(
+                "dark past-row",
+                md_theme_dark_past_departure_row_surface,
+                md_theme_dark_onSurface,
+            ),
+            Ground("light surface", md_theme_light_surface, md_theme_light_onSurface),
+            Ground("light sheet", md_theme_light_modal_sheet_background, md_theme_light_onSurface),
+            Ground(
+                "light past-row",
+                md_theme_light_past_departure_row_surface,
+                md_theme_light_onSurface,
+            ),
+        )
+
+        val SHIPPED_THEME_COLOURS = KrailThemeStyle.entries.map {
+            Color(
+                red = it.hexColorCode.channel(HEX_OFFSET_RED),
+                green = it.hexColorCode.channel(HEX_OFFSET_GREEN),
+                blue = it.hexColorCode.channel(HEX_OFFSET_BLUE),
+            )
+        }
+
+        const val HEX_OFFSET_RED = 3
+        const val HEX_OFFSET_GREEN = 5
+        const val HEX_OFFSET_BLUE = 7
+
+        /** `#AARRGGBB` — reads two hex digits at [offset] as a 0..1 channel. */
+        fun String.channel(offset: Int): Float =
+            substring(offset, offset + 2).toInt(HEX_RADIX) / CHANNEL_MAX.toFloat()
+    }
+}


### PR DESCRIPTION
## What

Adds `Color.ensureContrastWith`, a contrast-adaptation helper that can reach its target for any
colour on any ground. Nothing calls it yet; `ensureMinimumContrast` is untouched.

## Changes

- `A11yColors.kt`: new `ensureContrastWith(background, toward, minContrast)`. It blends toward the
  ground's own content colour rather than raising HSV value, so the ladder always ends on a colour
  that clears the threshold by definition.
- Walks a 32-rung ladder from the smallest blend up rather than binary searching. Contrast is not
  monotone along the blend because Compose's `lerp` interpolates in Oklab, and 110 of 7680 measured
  ladders reverse somewhere in the middle. A scan needs no monotonicity and returns the
  least-adapted rung that clears.
- Quantising to rungs keeps output stable: a one-digit edit to a surface token cannot shift every
  derived colour by 1/255 and churn screenshot goldens.
- `CONTRAST_SAFETY_MARGIN` of 0.05 so a result never lands exactly on the threshold, where float
  comparison and 8-bit quantisation can push it under.
- `ContrastAdaptationTest`: sweeps 1920 hue/saturation/value combinations against every opaque
  ground in both schemes at both thresholds and asserts every one reaches its target. Includes a
  scan-broke detector so it cannot pass vacuously, and pins the old helper's failure so the
  justification for the new one cannot rot.

Why the existing helper was not enough: `ensureMinimumContrast` raises HSV value only, so a colour
already at full value cannot be adapted further, and when the loop runs out of steps it returns the
colour anyway with no signal. Over the same sweep it returns a still-failing colour for 24% of
combinations against the bottom-sheet ground and 14% against the dark surface. Light mode is
unaffected because darkening has no floor, which is why the gap was not visible.

## Testing

- `./gradlew :taj:testAndroidHostTest` green
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
