### PR TITLE
feat(taj): split the theme colour into ground, ink, wash and decoration

### DIFF
--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt
@@ -2,10 +2,14 @@ package xyz.ksharma.krail.taj
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import xyz.ksharma.krail.taj.contrast.ContrastAnalyzer.Companion.TEXT_CONTRAST_AA
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.asThemeInk
+import xyz.ksharma.krail.taj.theme.ensureContrastWith
 import xyz.ksharma.krail.taj.theme.isAppInDarkMode
 import kotlin.math.absoluteValue
 
@@ -55,8 +59,89 @@ private fun String.isValidHexColorCode(): Boolean {
     return hexColorRegex.matches(this)
 }
 
+/**
+ * The rider's theme colour, unadapted.
+ *
+ * Prefer one of the four role accessors below. They exist because this one is asked for in four
+ * situations with four different contrast obligations, and the call site never says which:
+ *
+ * - [themeGroundColor] fills a shape that content is drawn on top of.
+ * - [themeInkColor] is text, an icon or a stroke drawn onto one of the app's own grounds.
+ * - [themeBackgroundColor] is the translucent wash used for card fills.
+ * - [themeDecorColor] is a gradient or ripple with no legibility obligation at all.
+ *
+ * Only the ink role needs adapting, and only the split makes that checkable.
+ */
+@Deprecated(
+    "Pick the role: themeGroundColor, themeInkColor, themeBackgroundColor or themeDecorColor.",
+    ReplaceWith("themeGroundColor()"),
+)
 @Composable
 fun themeColor(): Color {
+    val themeColor by LocalThemeColor.current
+    return themeColor.hexToComposeColor()
+}
+
+/**
+ * The theme colour as a **ground**: a filled shape with content drawn on top of it, where the
+ * content colour comes from [getForegroundColor]. `ThemeContrastTest` holds that pairing.
+ *
+ * Unadapted on purpose. This is the colour the rider picked, and it is what makes the Save
+ * button, the `P` badge and a selected chip look like the theme.
+ */
+@Composable
+fun themeGroundColor(): Color {
+    val themeColor by LocalThemeColor.current
+    return themeColor.hexToComposeColor()
+}
+
+/**
+ * The theme colour as **ink**: text, an icon or a stroke drawn straight onto an app ground.
+ *
+ * Adapted so it is legible on every ground in the current scheme, and identical across all of
+ * them so a sheet opened over a screen does not show two shades of the same theme. See
+ * [asThemeInk] for why it is derived once per scheme rather than per ground.
+ *
+ * @param minContrast 4.5 for anything a rider reads, 3.0 for strokes, tracks and icons.
+ */
+@Composable
+fun themeInkColor(minContrast: Float = TEXT_CONTRAST_AA): Color {
+    val themeColor by LocalThemeColor.current
+    val darkMode = isAppInDarkMode()
+    return remember(themeColor, darkMode, minContrast) {
+        themeColor.hexToComposeColor().asThemeInk(darkMode = darkMode, minContrast = minContrast)
+    }
+}
+
+/**
+ * The theme colour as ink on a ground that is **not** one of the app's own surfaces — today only
+ * the time picker's hand, which sits on a dial filled with [themeBackgroundColor].
+ *
+ * Every other ink call site wants [themeInkColor], which keeps one shade across the whole app.
+ * Reach for this only when the ground genuinely differs, and pass the ground you are drawing on.
+ */
+@Composable
+fun themeInkColorOn(background: Color, minContrast: Float = TEXT_CONTRAST_AA): Color {
+    val themeColor by LocalThemeColor.current
+    val onBackground = KrailTheme.colors.onSurface
+    return remember(themeColor, background, onBackground, minContrast) {
+        themeColor.hexToComposeColor().ensureContrastWith(
+            background = background,
+            toward = onBackground,
+            minContrast = minContrast,
+        )
+    }
+}
+
+/**
+ * The theme colour as **decoration**: a gradient stop, a ripple, the cloud field. Nothing is read
+ * off it, so it carries no contrast obligation and is never adapted.
+ *
+ * Saying so explicitly is the point. It is how a call site records that the raw colour is a
+ * decision rather than an oversight, which is what lets the ink rule stay an unconditional gate.
+ */
+@Composable
+fun themeDecorColor(): Color {
     val themeColor by LocalThemeColor.current
     return themeColor.hexToComposeColor()
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeInk.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/ThemeInk.kt
@@ -1,0 +1,83 @@
+package xyz.ksharma.krail.taj.theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+
+/**
+ * Derives the colour the rider's theme wears when it is used as **ink** — text, an icon, a
+ * stroke — drawn straight onto one of the app's own grounds.
+ *
+ * ## Why the theme colour cannot be used raw
+ *
+ * A theme colour is chosen to look like the product, not to be legible on a near-black surface.
+ * Purple Drip measures 2.95:1 on the dark surface and 2.49:1 on the bottom sheet, against a 4.5
+ * requirement for text. It is the only shipped theme that fails, but "only one fails today" is
+ * not a property anyone can rely on for the next theme.
+ *
+ * ## Why one ink per scheme, rather than one per ground
+ *
+ * The obvious thing is to adapt against whatever ground the ink happens to land on. That produces
+ * a different purple on the surface, on a sheet and on a card, and a sheet opened over a screen
+ * shows two of them at once. So the ink is derived **once per theme and scheme**, against the
+ * hardest ground in that scheme, and used everywhere. Harder ground means more contrast
+ * everywhere else, so one value clears them all.
+ *
+ * [themeInkColorOn] exists for the genuine exception: ink drawn on a ground that is not one of
+ * these at all, such as the time picker's hand on its own theme-tinted dial.
+ *
+ * ## Why the hardest ground is computed and not named
+ *
+ * Naming it means a new ground token silently invalidates every ink. Picking it by luminance from
+ * [inkGrounds] means adding a token to that list is the only step, and `ThemeInkContrastTest`
+ * fails until a new [KrailColors] ground is either listed or explicitly excused.
+ */
+fun Color.asThemeInk(
+    darkMode: Boolean,
+    minContrast: Float = DEFAULT_TEXT_SIZE_CONTRAST_AA,
+): Color = ensureContrastWith(
+    background = hardestInkGround(darkMode),
+    toward = if (darkMode) md_theme_dark_onSurface else md_theme_light_onSurface,
+    minContrast = minContrast,
+)
+
+/**
+ * The ground in [inkGrounds] that a scheme-appropriate ink has the least contrast against.
+ *
+ * Dark inks are light, so the *lightest* ground is hardest; light inks are dark, so the *darkest*
+ * ground is hardest. Getting this backwards is easy and silent, which is why it is arithmetic
+ * rather than a constant.
+ */
+internal fun hardestInkGround(darkMode: Boolean): Color {
+    val grounds = inkGrounds(darkMode)
+    return if (darkMode) {
+        grounds.maxBy { it.luminance() }
+    } else {
+        grounds.minBy { it.luminance() }
+    }
+}
+
+/**
+ * Every opaque ground the rider's theme colour can be drawn onto as ink.
+ *
+ * This is the list `ThemeInkContrastTest` measures against, and the list it holds against
+ * [KrailColors] so a newly added surface token cannot quietly skip the check.
+ */
+internal fun inkGrounds(darkMode: Boolean): List<Color> = if (darkMode) {
+    listOf(
+        md_theme_dark_surface,
+        md_theme_dark_modal_sheet_background,
+        md_theme_dark_discover_chip_background,
+        md_theme_dark_discover_card_background,
+        md_theme_dark_theme_selection_background,
+        md_theme_dark_past_departure_row_surface,
+    )
+} else {
+    listOf(
+        md_theme_light_surface,
+        md_theme_light_modal_sheet_background,
+        md_theme_light_discover_chip_background,
+        md_theme_light_discover_card_background,
+        md_theme_light_theme_selection_background,
+        md_theme_light_past_departure_row_surface,
+    )
+}

--- a/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/theme/ThemeInkContrastTest.kt
+++ b/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/theme/ThemeInkContrastTest.kt
@@ -1,0 +1,205 @@
+package xyz.ksharma.krail.taj.theme
+
+import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.taj.contrast.ContrastAnalyzer.Companion.TEXT_CONTRAST_AA
+import xyz.ksharma.krail.taj.contrast.ContrastAnalyzer.Companion.UI_COMPONENT_CONTRAST_AA
+import xyz.ksharma.krail.taj.hexToComposeColor
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The hole the other three contrast guards leave between them.
+ *
+ * `ThemeContrastTest` measures content drawn **on** a theme colour. `KrailColorTokenContrastTest`
+ * measures the fixed [KrailColors] tokens. `TransportModeContrastTest` measures `TransportMode`
+ * colours, which do not include Purple Drip or Barbie Pink because those are theme-only. Nothing
+ * measured a theme colour used as **ink** against the surfaces it is drawn on, which is exactly
+ * where Purple Drip was failing at 2.95:1 on the dark surface and 2.49:1 on a bottom sheet.
+ *
+ * Self-healing over `KrailThemeStyle.entries` and over [inkGrounds], so a seventh theme or a new
+ * ground token is measured the day it is added rather than the day someone remembers.
+ *
+ * There is no known-failure set here and there should never be one: [asThemeInk] is total, so a
+ * failure means the derivation broke, not that a colour is awkward.
+ */
+class ThemeInkContrastTest {
+
+    @Test
+    fun `every theme's ink clears its threshold on every ground in its scheme`() {
+        val failures = mutableListOf<String>()
+        var measured = 0
+
+        SCHEMES.forEach { (schemeName, darkMode) ->
+            THRESHOLDS.forEach { threshold ->
+                failures += measureScheme(schemeName, darkMode, threshold).also { measured++ }
+            }
+        }
+
+        assertTrue(
+            measured == SCHEMES.size * THRESHOLDS.size,
+            "Expected ${SCHEMES.size * THRESHOLDS.size} scheme/threshold combinations, ran $measured.",
+        )
+        assertTrue(
+            KrailThemeStyle.entries.isNotEmpty() && inkGrounds(darkMode = true).isNotEmpty(),
+            "Nothing to measure — the theme enum or the ground list came back empty.",
+        )
+
+        if (failures.isNotEmpty()) {
+            fail(
+                buildString {
+                    appendLine("Theme ink below its threshold:")
+                    failures.forEach { appendLine("  - $it") }
+                    appendLine(
+                        "asThemeInk is supposed to make this impossible. Check that " +
+                            "hardestInkGround still picks the extreme of inkGrounds for the " +
+                            "scheme, and that ensureContrastWith is still reached. Never lower " +
+                            "the threshold.",
+                    )
+                },
+            )
+        }
+    }
+
+    /**
+     * Why the ink is derived once per scheme rather than once per ground.
+     *
+     * Adapting against whatever ground the ink lands on is the obvious implementation and it is
+     * wrong: it produces a different shade of the same theme on the surface, on a sheet and on a
+     * card, and a sheet opened over a screen shows two of them at once. This asserts that the
+     * cheap approach really would split the colour, so the guarantee is not mistaken for a
+     * coincidence, and that the single derived value covers every ground anyway.
+     */
+    @Test
+    fun `deriving per ground would split a theme into several shades`() {
+        val split = KrailThemeStyle.entries.flatMap { style ->
+            SCHEMES.map { (schemeName, darkMode) ->
+                Triple(style, schemeName, perGroundShades(style, darkMode))
+            }
+        }
+
+        assertTrue(
+            split.any { it.third.size > 1 },
+            "No theme splits when adapted per ground, so deriving against the hardest ground " +
+                "buys nothing. Either the ground tokens converged or the derivation stopped " +
+                "adapting. Re-check before simplifying asThemeInk to take a ground.",
+        )
+
+        split.forEach { (style, schemeName, shades) ->
+            val single = style.colour().asThemeInk(darkMode = schemeName == "dark")
+            assertTrue(
+                shades.isNotEmpty(),
+                "${style.name} $schemeName produced no per-ground shades to compare against.",
+            )
+            inkGrounds(darkMode = schemeName == "dark").forEach { ground ->
+                assertTrue(
+                    single.contrastRatio(ground) >= TEXT_CONTRAST_AA,
+                    "${style.name} $schemeName: the single ink ${single.hex()} measures " +
+                        "${single.contrastRatio(ground)} on ${ground.hex()}, so one value does " +
+                        "not in fact cover every ground.",
+                )
+            }
+        }
+    }
+
+    /**
+     * Self-heal over the ground tokens. A property of [KrailColors] that reads as a ground must be
+     * either measured by [inkGrounds] or excused here with the reason it can never host theme ink.
+     *
+     * The classifier is a naming rule, not reflection, which common code does not have. Its limit
+     * is honest: a ground token named without `Surface`, `Background` or `Container` in it would
+     * slip past. Name new ground tokens accordingly.
+     */
+    @Test
+    fun `every KrailColors ground is either measured or excused`() {
+        val groundsInTokens = PROPERTY_NAME.findAll(KrailLightColors.toString())
+            .map { it.groupValues[1] }
+            .filter { name -> GROUND_NAME.containsMatchIn(name) && !name.startsWith("on") }
+            .toSet()
+
+        val accounted = MEASURED_GROUND_PROPERTIES + NOT_AN_INK_GROUND.keys
+
+        val unclassified = groundsInTokens - accounted
+        assertTrue(
+            unclassified.isEmpty(),
+            "New KrailColors ground ${unclassified.joinToString()} is not accounted for. Add it " +
+                "to inkGrounds() in ThemeInk.kt and to MEASURED_GROUND_PROPERTIES here, or to " +
+                "NOT_AN_INK_GROUND with the reason theme ink is never drawn on it.",
+        )
+
+        val stale = accounted - groundsInTokens
+        assertTrue(
+            stale.isEmpty(),
+            "${stale.joinToString()} is listed here but is no longer a KrailColors ground — " +
+                "delete the entry, and its line in inkGrounds() if it has one.",
+        )
+
+        assertTrue(
+            MEASURED_GROUND_PROPERTIES.size == inkGrounds(darkMode = true).size,
+            "MEASURED_GROUND_PROPERTIES lists ${MEASURED_GROUND_PROPERTIES.size} grounds but " +
+                "inkGrounds() returns ${inkGrounds(darkMode = true).size}. They describe the same " +
+                "set and have drifted apart.",
+        )
+    }
+
+    // region helpers
+
+    private fun measureScheme(scheme: String, darkMode: Boolean, threshold: Float): List<String> =
+        KrailThemeStyle.entries.flatMap { style ->
+            val ink = style.colour().asThemeInk(darkMode = darkMode, minContrast = threshold)
+            inkGrounds(darkMode)
+                .filter { ink.contrastRatio(it) < threshold }
+                .map { ground ->
+                    "${style.name} $scheme ink ${ink.hex()} on ${ground.hex()} measures " +
+                        "${ink.contrastRatio(ground)}, needs $threshold"
+                }
+        }
+
+    /** The distinct colours this theme would take if each ground adapted it separately. */
+    private fun perGroundShades(style: KrailThemeStyle, darkMode: Boolean): Set<Color> =
+        inkGrounds(darkMode).map { ground ->
+            style.colour().ensureContrastWith(
+                background = ground,
+                toward = if (darkMode) md_theme_dark_onSurface else md_theme_light_onSurface,
+            )
+        }.toSet()
+
+    private fun KrailThemeStyle.colour(): Color = hexColorCode.hexToComposeColor()
+
+    private fun Color.hex(): String {
+        fun channel(value: Float) =
+            (value * CHANNEL_MAX).toInt().toString(HEX_RADIX).padStart(2, '0').uppercase()
+        return "#${channel(red)}${channel(green)}${channel(blue)}"
+    }
+
+    // endregion
+
+    private companion object {
+        val SCHEMES = listOf("light" to false, "dark" to true)
+        val THRESHOLDS = listOf(TEXT_CONTRAST_AA, UI_COMPONENT_CONTRAST_AA)
+
+        val PROPERTY_NAME = Regex("(\\w+)=")
+        val GROUND_NAME = Regex("[Ss]urface|[Bb]ackground|[Cc]ontainer")
+
+        const val CHANNEL_MAX = 255
+        const val HEX_RADIX = 16
+
+        /** Mirrors `inkGrounds()` in ThemeInk.kt, by KrailColors property name. */
+        val MEASURED_GROUND_PROPERTIES = setOf(
+            "surface",
+            "bottomSheetBackground",
+            "discoverChipBackground",
+            "discoverCardBackground",
+            "themeSelectionBackground",
+            "pastDepartureRowSurface",
+        )
+
+        val NOT_AN_INK_GROUND = mapOf(
+            "errorContainer" to
+                "error content is drawn in onErrorContainer, never in the rider's theme colour",
+            "stopLabelSurface" to
+                "stop-label pills pair with onStopLabelSurface and are the same dark value in " +
+                "both schemes, so the theme colour is never ink on them",
+        )
+    }
+}


### PR DESCRIPTION
## What

Splits `themeColor()` into four role accessors so each call site says which contrast obligation it
carries, and derives the ink role so it is legible on every ground. No call sites change yet.

## Changes

- `ColorsExt.kt`: adds `themeGroundColor`, `themeInkColor`, `themeInkColorOn` and `themeDecorColor`
  beside the existing `themeBackgroundColor` wash. Deprecates `themeColor`.
- `ThemeInk.kt`: `asThemeInk` derives the ink once per theme and scheme against the hardest ground
  in that scheme. The hardest ground is picked by luminance from `inkGrounds()` rather than named,
  so adding a surface token cannot silently invalidate every ink.
- `ThemeInkContrastTest`: measures every `KrailThemeStyle` against every ground in both schemes at
  both thresholds, self-healing over the enum and the ground list. Also holds `inkGrounds()`
  against `KrailColors`, so a new ground token has to be listed or excused with a reason. No
  known-failure set, and there should never be one.

Only ink is adapted. Ground keeps the raw colour because content drawn on it derives its own colour
from `getForegroundColor`, which `ThemeContrastTest` already covers. Decoration carries no
obligation at all, and saying so explicitly is what lets a future rule on ink stay unconditional
rather than needing a permanent baseline.

Why one ink per scheme rather than one per ground: adapting against whatever ground the ink lands on
produces a different shade on the surface, on a sheet and on a card, and a sheet opened over a
screen shows two of them at once. Deriving against the hardest ground means one value clears them
all. `themeInkColorOn` exists for the genuine exception, ink on a ground that is not an app surface.

Why this gap existed: `ThemeContrastTest` measures content drawn on a theme colour,
`KrailColorTokenContrastTest` measures the fixed tokens, and `TransportModeContrastTest` iterates
`TransportMode.all`, which does not include the theme-only colours. Nothing measured a theme colour
used as ink against the surfaces it is drawn on.

## Testing

- `./gradlew :taj:testAndroidHostTest` green
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
