### PR TITLE
refactor(taj): declare each theme's AI gradient partner on the enum

### DIFF
--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/contrast/BrandHexUniquenessTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/contrast/BrandHexUniquenessTest.kt
@@ -106,8 +106,6 @@ class BrandHexUniquenessTest {
                 "taj cannot depend on :core:transport; these are the theme tokens themselves.",
             "taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiGradientTokens.kt" to
                 "Same: the AI gradient's stops are mode colours, declared taj-side.",
-            "taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt" to
-                "Same, for the per-theme variant of that gradient.",
             // Preview and sample fixtures. Each should take the colour from TransportMode.
             "feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/" +
                 "components/DepartureBoardStopCard.kt" to "Preview fixture.",

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailThemeStyle.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/KrailThemeStyle.kt
@@ -1,38 +1,66 @@
 package xyz.ksharma.krail.taj.theme
 
+import androidx.compose.ui.graphics.Color
 import xyz.ksharma.krail.taj.toHex
 
 val DEFAULT_THEME_STYLE = KrailThemeStyle.Train
 
-enum class KrailThemeStyle(val hexColorCode: String, val id: Int, val tagLine: String) {
+/**
+ * @param aiGradientPartner The second colour the AI surface's gradient travels to. It has to be a
+ *   decision rather than something derived, so it lives here beside the colour it partners: a new
+ *   theme cannot compile without choosing one. It used to sit in a map inside
+ *   `AiThemeGradientTokens` with a default, which meant a seventh theme silently wore Train's
+ *   gradient instead of failing. `ThemeGradientPairTest` holds the hue distance that makes a pair
+ *   work.
+ */
+enum class KrailThemeStyle(
+    val hexColorCode: String,
+    val id: Int,
+    val tagLine: String,
+    val aiGradientPartner: Color,
+) {
     Train(
         hexColorCode = train_theme.toHex(),
         id = 1,
         tagLine = "On the track, no lookin' back!",
+        aiGradientPartner = purple_drip_theme,
     ),
+
+    // Teal into yellow, not into purple. Purple Drip is a magenta, so the teal theme's gradient
+    // read as teal and pink, and the two ends fought rather than travelled. Yellow is the same
+    // cool-to-warm crossing that works for Bus.
     Metro(
         hexColorCode = metro_theme.toHex(),
         id = 2,
         tagLine = "Surf the sub, no cap!",
+        aiGradientPartner = magic_yellow,
     ),
+
+    // Yellow, not pink. Blue into pink travels through purple and reads as somebody else's AI
+    // product; blue into yellow is the one pair here that crosses from cool to warm, so the two
+    // ends stay told apart wherever the gradient is in its drift.
     Bus(
         hexColorCode = bus_theme.toHex(),
         id = 5,
         tagLine = "Hoppin' the concrete jungle!",
+        aiGradientPartner = magic_yellow,
     ),
     PurpleDrip(
         hexColorCode = purple_drip_theme.toHex(),
         id = 7,
         tagLine = "Purple drip, endless trip!",
+        aiGradientPartner = bus_theme,
     ),
     Ferry(
         hexColorCode = ferry_theme.toHex(),
         id = 9,
         tagLine = "Smooth sail, no fail!",
+        aiGradientPartner = barbie_pink_theme,
     ),
     BarbiePink(
         hexColorCode = barbie_pink_theme.toHex(),
         id = 100,
         tagLine = "Dressed in pink, fastest link!",
+        aiGradientPartner = bus_theme,
     ),
 }

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/tokens/AiThemeGradientTokens.kt
@@ -1,9 +1,9 @@
 package xyz.ksharma.krail.taj.tokens
 
 import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.theme.DEFAULT_THEME_STYLE
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
-import xyz.ksharma.krail.taj.theme.magic_yellow
 
 /**
  * The gradient the AI search surface wears: the rider's own theme colour, plus one other
@@ -16,8 +16,10 @@ import xyz.ksharma.krail.taj.theme.magic_yellow
  * theme so the surface still belongs to the app the rider chose to look at.
  *
  * The partner is not the nearest colour. Anything under roughly 40 degrees of hue apart
- * blends into one muddy band, so each pair here sits between 97 and 134 degrees apart: far
- * enough that the gradient has somewhere to travel, near enough to stay related.
+ * blends into one muddy band, so every pair sits far enough that the gradient has somewhere
+ * to travel while staying related: 96.8 degrees at the tightest (Purple Drip into Bus) and
+ * 147.5 at the widest (Bus into Magic Yellow, the one deliberate cool-to-warm crossing).
+ * `ThemeGradientPairTest` holds that window, which is what a new theme's partner has to land in.
  *
  * Three stops, not two. A straight RGB blend across that much hue passes near grey in the
  * middle (teal into violet is the worst of them). [midStop] bends the path around that dull
@@ -26,37 +28,15 @@ import xyz.ksharma.krail.taj.theme.magic_yellow
  */
 object AiThemeGradientTokens {
 
-    private val Train = Color(0xFFF6891F)
-    private val Metro = Color(0xFF009B77)
-    private val Bus = Color(0xFF00B5EF)
-    private val PurpleDrip = Color(0xFFAC00C9)
-    private val Ferry = Color(0xFF5AB031)
-    private val BarbiePink = Color(0xFFE0218A)
-    private val MagicYellow = magic_yellow
-
-    private val partners: Map<KrailThemeStyle, Pair<Color, Color>> = mapOf(
-        KrailThemeStyle.Train to (Train to PurpleDrip),
-        // Teal into yellow, not into purple. Purple Drip is a magenta, so the teal theme's
-        // gradient read as teal and pink, and the two ends fought rather than travelled. Yellow
-        // is the same cool-to-warm crossing that works for Bus, at 119 degrees.
-        KrailThemeStyle.Metro to (Metro to MagicYellow),
-        // Yellow, not pink. Blue into pink travels through purple and reads as somebody
-        // else's AI product; blue into yellow is the one pair here that crosses from cool to
-        // warm, so the two ends stay told apart wherever the gradient is in its drift. It is
-        // also KRAIL's own yellow rather than a colour invented for this.
-        KrailThemeStyle.Bus to (Bus to MagicYellow),
-        KrailThemeStyle.PurpleDrip to (PurpleDrip to Bus),
-        KrailThemeStyle.Ferry to (Ferry to BarbiePink),
-        KrailThemeStyle.BarbiePink to (BarbiePink to Bus),
-    )
-
     /**
-     * Theme colour first, so the gradient starts on the colour the rider picked and travels
-     * away from it. Bus and Purple Drip share a pair led from opposite ends, which is the
-     * point: the theme end is what changes.
+     * Theme colour first, so the gradient starts on the colour the rider picked and travels away
+     * from it. The partner is declared on [KrailThemeStyle] itself, so a theme cannot exist
+     * without one. This used to be a map with a default, which meant a theme missing from the map
+     * silently wore the default theme's gradient rather than failing to build.
      */
     fun stopsFor(style: KrailThemeStyle): List<Color> {
-        val (start, end) = partners[style] ?: partners.getValue(DEFAULT_THEME_STYLE)
+        val start = style.hexColorCode.hexToComposeColor()
+        val end = style.aiGradientPartner
         return listOf(start, midStop(start, end), end)
     }
 

--- a/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/tokens/ThemeGradientPairTest.kt
+++ b/taj/src/commonTest/kotlin/xyz/ksharma/krail/taj/tokens/ThemeGradientPairTest.kt
@@ -1,0 +1,126 @@
+package xyz.ksharma.krail.taj.tokens
+
+import androidx.compose.ui.graphics.Color
+import xyz.ksharma.krail.taj.hexToComposeColor
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `KrailThemeStyle.aiGradientPartner` being a constructor parameter means a new theme cannot
+ * compile without one. It cannot make the choice a *good* one, which is what this measures.
+ *
+ * The rule the partner exists to satisfy was written in prose in `AiThemeGradientTokens`' KDoc and
+ * checked by nobody: under roughly 40 degrees of hue apart the two ends blend into one muddy band,
+ * and too far apart they stop reading as related.
+ *
+ * That KDoc also claimed the shipped pairs sit between 97 and 134 degrees. They do not, and writing
+ * this test is how that surfaced. The real spread is 96.8 (Purple Drip into Bus) to 147.5 (Bus into
+ * Magic Yellow, the deliberate cool-to-warm crossing). The window below is set from the design rule
+ * rather than from that prose: a floor comfortably clear of the muddy zone, and a ceiling just past
+ * the widest pair anyone chose on purpose.
+ *
+ * Self-healing over the enum, so a seventh theme is measured the day it is added and fails with the
+ * angle it actually chose rather than with "you forgot something".
+ */
+class ThemeGradientPairTest {
+
+    @Test
+    fun `every theme's gradient partner sits far enough around the wheel`() {
+        KrailThemeStyle.entries.forEach { style ->
+            val gap = hueDistance(style.hexColorCode.hexToComposeColor(), style.aiGradientPartner)
+
+            assertTrue(
+                gap in MIN_PARTNER_HUE..MAX_PARTNER_HUE,
+                "${style.name}: its gradient partner is ${gap.toInt()} degrees away. Under " +
+                    "${MIN_PARTNER_HUE.toInt()} the two ends blend into one muddy band; over " +
+                    "${MAX_PARTNER_HUE.toInt()} they stop reading as related. Pick a different " +
+                    "KRAIL colour rather than widening this window.",
+            )
+        }
+    }
+
+    @Test
+    fun `a theme is never its own partner`() {
+        KrailThemeStyle.entries.forEach { style ->
+            assertTrue(
+                style.aiGradientPartner != style.hexColorCode.hexToComposeColor(),
+                "${style.name} partners itself, so its gradient has nowhere to travel.",
+            )
+        }
+    }
+
+    /**
+     * The gradient's middle stop exists to bend the path around the dull zone a straight blend
+     * passes through. If it ever came back as one of the ends, the bend is gone.
+     */
+    @Test
+    fun `the middle stop is distinct from both ends`() {
+        KrailThemeStyle.entries.forEach { style ->
+            val stops = AiThemeGradientTokens.stopsFor(style)
+
+            assertEquals(
+                STOP_COUNT,
+                stops.size,
+                "${style.name}: expected $STOP_COUNT gradient stops, got ${stops.size}.",
+            )
+            assertTrue(
+                stops[1] != stops[0] && stops[1] != stops[2],
+                "${style.name}: the middle stop equals one of the ends, so the gradient is a " +
+                    "straight blend again.",
+            )
+        }
+    }
+
+    /**
+     * A hex the enum does not know can only come from persisted preferences written by an older
+     * build, so falling back is right. Drawing nothing, or crashing, would not be.
+     */
+    @Test
+    fun `an unknown theme hex falls back to a usable gradient`() {
+        val stops = AiThemeGradientTokens.stopsFor("#FF123456")
+
+        assertEquals(STOP_COUNT, stops.size)
+        assertTrue(
+            stops.toSet().size == STOP_COUNT,
+            "The fallback gradient collapsed to fewer than $STOP_COUNT distinct colours.",
+        )
+    }
+
+    private fun hueDistance(first: Color, second: Color): Float {
+        val raw = abs(hueOf(first) - hueOf(second))
+        return if (raw > HALF_TURN) FULL_TURN - raw else raw
+    }
+
+    private fun hueOf(color: Color): Float {
+        val max = maxOf(color.red, color.green, color.blue)
+        val min = minOf(color.red, color.green, color.blue)
+        val chroma = max - min
+        if (chroma == 0f) return 0f
+
+        val hue = when (max) {
+            color.red -> SECTOR * (((color.green - color.blue) / chroma) % SECTORS)
+            color.green -> SECTOR * (((color.blue - color.red) / chroma) + GREEN_OFFSET)
+            else -> SECTOR * (((color.red - color.green) / chroma) + BLUE_OFFSET)
+        }
+        return (hue + FULL_TURN) % FULL_TURN
+    }
+
+    private companion object {
+        /** Well clear of the ~40 degree muddy zone, and under the tightest shipped pair at 96.8. */
+        const val MIN_PARTNER_HUE = 90f
+
+        /** Just past Bus into Magic Yellow at 147.5, the widest pair chosen deliberately. */
+        const val MAX_PARTNER_HUE = 150f
+        const val STOP_COUNT = 3
+
+        const val FULL_TURN = 360f
+        const val HALF_TURN = 180f
+        const val SECTOR = 60f
+        const val SECTORS = 6f
+        const val GREEN_OFFSET = 2f
+        const val BLUE_OFFSET = 4f
+    }
+}


### PR DESCRIPTION
## What

Moves each theme's AI gradient partner from a lookup map with a default onto a `KrailThemeStyle`
constructor parameter, so a new theme cannot be added without choosing one.

## Changes

- `KrailThemeStyle` gains `aiGradientPartner: Color`. The per-pair reasoning that was in
  `AiThemeGradientTokens`' map comments moves with it.
- `AiThemeGradientTokens.stopsFor(style)` reads the partner off the enum. The `partners` map and its
  `?: partners.getValue(DEFAULT_THEME_STYLE)` both go.
- `ThemeGradientPairTest`: measures the hue distance for every entry, asserts a theme never partners
  itself, and asserts the middle stop stays distinct from both ends. Self-healing over the enum.
- Drops the now-stale `AiThemeGradientTokens.kt` entry from `BrandHexUniquenessTest`'s allowlist.
  Removing the mode-colour literals from that file left the entry excusing something that no longer
  exists, which the guard's own stale check flagged.

Why this shape: a theme missing from the old map did not fail to build and did not draw nothing, it
silently wore Train's gradient, and nothing would have caught it. A constructor parameter makes the
same mistake a compile error at the line being edited, rather than a test failure in another file or
a wrong colour on a device.

A constructor parameter can only force a choice, not a good one, hence the hue-distance test.
Writing it turned up that the invariant stated in the KDoc was wrong: it claimed every pair sits
between 97 and 134 degrees apart, but Bus into Magic Yellow is 147.5 and Purple Drip into Bus is
96.8. The window is now set from the design rule the KDoc actually argues for, and the prose is
corrected to the measured numbers.

Left unchanged: `stopsFor(hex)` keeps its fallback. An unknown hex can only come from preferences
written by an older build, so falling back is correct there, and a test pins that it still yields a
usable gradient.

## Testing

- `./gradlew testAndroidHostTest --continue` green across all modules
- `./gradlew detekt --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green

No rendered output changes: every shipped theme keeps the partner it already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
