### PR TITLE
build(detekt): add ThemeColorRoleRule to hold the theme colour's roles apart

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -110,6 +110,11 @@ krail:
     # source-set check reads it as production. Its fakes build fixture timestamps off the real
     # clock on purpose — same reasoning as the test-source exemption.
     excludes: ['**/core/testing/**']
+  # The theme colour has four roles with four different contrast obligations, so taj exposes four
+  # accessors. Flags the deprecated themeColor() and the unadapted themeGroundColor() in an ink
+  # position. themeDecorColor() is the sanctioned way out, so there is no baseline.
+  ThemeColorRoleRule:
+    active: true
   # collectAsState() keeps collecting while backgrounded — collectAsStateWithLifecycle() only.
   # See docs/POLLING_LIFECYCLE.md.
   CollectAsStateBan:

--- a/docs/testing/GUARDS.md
+++ b/docs/testing/GUARDS.md
@@ -47,7 +47,7 @@ Ruleset id `krail`, in the `gradle/build-logic` included build:
 as `detektPlugins "xyz.ksharma.krail.gradle:detekt-rules:unspecified"` — a coordinate, not a
 project reference, because composite-build substitution resolves it.
 
-All seven run in `./gradlew detekt`. Config lives in the `krail:` block of
+All eight run in `./gradlew detekt`. Config lives in the `krail:` block of
 [`config/detekt.yml`](../../config/detekt.yml).
 
 ### `ClockSystemBan`
@@ -148,6 +148,28 @@ dark-mode contrast regression or a 2×-font clipping bug lands green.
 |---|---|
 | Baseline | [`config/screenshot-annotation-baseline.txt`](../../config/screenshot-annotation-baseline.txt) — 33 rows, `path\|function` |
 | Ratchet | Shrink-only by header rule. Fixing one means swapping the annotation, **re-recording the goldens**, and deleting the line in the same change. |
+
+### `ThemeColorRoleRule`
+
+Two things, both about the rider's theme colour:
+
+1. `themeColor()`, the deprecated accessor. It could not say which of the colour's four roles it
+   meant, so nothing could check any of them.
+2. `themeGroundColor()` — the deliberately unadapted fill colour — passed to a `color =`, `tint =`,
+   `textColor =` or `contentColor =` argument, or into `BorderStroke(`. Those positions draw ink
+   onto a surface, and some theme colours do not clear WCAG AA there: Purple Drip measured 2.95:1
+   on the dark surface and 2.49:1 on a bottom sheet.
+
+**Instead:** `themeInkColor()`, or `themeInkColorOn(background)` when the ground is not one of the
+app's own surfaces. `themeDecorColor()` is the sanctioned way out for a gradient stop or ripple
+that nothing is read off — saying so explicitly is what lets this rule stay an unconditional gate
+instead of accumulating a baseline.
+
+No type resolution, so the check is syntactic and misses a ground colour laundered through a local
+`val` first. `ThemeInkContrastTest` in `:taj` covers the values themselves; this covers the shape
+of the call.
+
+No baseline — zero offenders, unconditional gate.
 
 ### `SnackbarBan`
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -81,7 +81,6 @@ import xyz.ksharma.krail.taj.preview.PreviewScreen
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.KrailThemeStyle
 import xyz.ksharma.krail.taj.theme.PreviewTheme
-import xyz.ksharma.krail.taj.themeColor
 import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.AddressSearchListItem
 import xyz.ksharma.krail.trip.planner.ui.components.AssignNewLabelSheet

--- a/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/KrailRuleSetProvider.kt
+++ b/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/KrailRuleSetProvider.kt
@@ -18,6 +18,7 @@ class KrailRuleSetProvider : RuleSetProvider {
             PublicImplementationClass(config),
             ScreenshotPreviewAnnotation(config),
             SnackbarBan(config),
+            ThemeColorRoleRule(config),
         ),
     )
 }

--- a/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/ThemeColorRoleRule.kt
+++ b/gradle/build-logic/detekt-rules/src/main/kotlin/xyz/ksharma/krail/detekt/ThemeColorRoleRule.kt
@@ -1,0 +1,119 @@
+package xyz.ksharma.krail.detekt
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtValueArgument
+
+/**
+ * The rider's theme colour is asked for in four situations with four different contrast
+ * obligations, so `taj` exposes four accessors instead of one. This holds the split.
+ *
+ * - `themeGroundColor()` fills a shape that content is drawn on top of, and stays unadapted.
+ * - `themeInkColor()` is text, an icon or a stroke drawn onto an app surface, and is adapted.
+ * - `themeBackgroundColor()` is the translucent wash used for card fills.
+ * - `themeDecorColor()` is a gradient stop or a ripple, with no legibility obligation at all.
+ *
+ * Two things are flagged.
+ *
+ * **`themeColor()`**, the deprecated accessor that could not say which of the four it meant. A
+ * deprecation warning alone does not hold: warnings are not errors here, so the call would compile
+ * and the colour would be wrong only for the themes that happen to fail.
+ *
+ * **`themeGroundColor()` in an ink position** — passed to a `color =` or `tint =` argument, or into
+ * `BorderStroke(`. Reaching past the ink accessor back to the raw colour is exactly how Purple Drip
+ * came to be drawn at 2.95:1 on the dark surface, and it reads as deliberate at the call site.
+ *
+ * `themeDecorColor()` is the sanctioned way out. A gradient stop genuinely has no obligation, and
+ * saying so explicitly is what lets this rule stay an unconditional gate with no baseline rather
+ * than a list of grandfathered offenders that never shrinks.
+ *
+ * No type resolution, so the check is syntactic: an argument named `color` or `tint` whose
+ * expression mentions `themeGroundColor()`, on a callee that is not one of the fill-taking ones in
+ * [FILL_TAKING_CALLEES]. `Modifier.background(color = ...)` takes a ground and
+ * `Modifier.border(color = ...)` takes ink, and both name the argument `color`, so the callee has
+ * to be part of the decision.
+ *
+ * Two known limits: a ground colour laundered through a local `val` first is invisible to it, and a
+ * fill-taking callee outside that set would false-positive. The accessor split is what makes the
+ * common case checkable, not this rule alone.
+ */
+class ThemeColorRoleRule(config: Config) : Rule(config) {
+
+    override val issue = Issue(
+        id = "ThemeColorRoleRule",
+        severity = Severity.Defect,
+        description = "The theme colour must be read through the accessor for the role it is " +
+            "drawn in: themeGroundColor, themeInkColor, themeBackgroundColor or themeDecorColor.",
+        debt = Debt.TEN_MINS,
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
+        val callee = expression.calleeExpression?.text
+        if (callee == DEPRECATED_ACCESSOR) {
+            report(CodeSmell(issue, Entity.from(expression), deprecatedMessage()))
+            return
+        }
+
+        // `color =` means a fill on some callees and a stroke on others: Modifier.background()
+        // takes a ground, Modifier.border() takes ink, and both name the argument `color`. The
+        // argument name alone cannot tell them apart, so callees that take a fill are skipped.
+        if (callee in FILL_TAKING_CALLEES) return
+
+        expression.valueArguments.forEach { argument ->
+            if (!argument.mentionsGround()) return@forEach
+            val position = argument.getArgumentName()?.asName?.asString()
+            when {
+                position in INK_ARGUMENT_NAMES ->
+                    report(CodeSmell(issue, Entity.from(argument), inkMessage(position.orEmpty())))
+
+                position == null && callee == BORDER_STROKE ->
+                    report(CodeSmell(issue, Entity.from(argument), inkMessage(BORDER_STROKE)))
+            }
+        }
+    }
+
+    override fun visitImportDirective(importDirective: KtImportDirective) {
+        super.visitImportDirective(importDirective)
+
+        val name = importDirective.importedFqName?.shortName()?.asString() ?: return
+        if (name != DEPRECATED_ACCESSOR) return
+        report(CodeSmell(issue, Entity.from(importDirective), deprecatedMessage()))
+    }
+
+    private fun KtValueArgument.mentionsGround() =
+        getArgumentExpression()?.text?.contains(GROUND_ACCESSOR) == true
+
+    private fun deprecatedMessage() = "'$DEPRECATED_ACCESSOR()' does not say which role the " +
+        "theme colour is being used in, so nothing can check it. Use themeGroundColor() for a " +
+        "fill with content on top, themeInkColor() for text, icons and strokes drawn on a " +
+        "surface, themeBackgroundColor() for the translucent wash, or themeDecorColor() for a " +
+        "gradient or ripple that nothing is read off."
+
+    private fun inkMessage(position: String) = "'$GROUND_ACCESSOR()' is the unadapted theme " +
+        "colour, and '$position' draws ink onto a surface. Some theme colours do not clear WCAG " +
+        "AA there. Use themeInkColor(), or themeInkColorOn(background) when the ground is not " +
+        "an app surface. If nothing is read off this colour, say so with themeDecorColor()."
+
+    private companion object {
+        const val DEPRECATED_ACCESSOR = "themeColor"
+        const val GROUND_ACCESSOR = "themeGroundColor"
+        const val BORDER_STROKE = "BorderStroke"
+        val INK_ARGUMENT_NAMES = setOf("color", "tint", "textColor", "contentColor")
+
+        /**
+         * Callees whose `color` argument is a fill with content drawn on top, not ink. The ground
+         * accessor is the right choice there, so flagging it would be a false positive with no
+         * correct fix available at the call site.
+         */
+        val FILL_TAKING_CALLEES = setOf("background", "drawRect", "drawCircle", "drawRoundRect")
+    }
+}

--- a/gradle/build-logic/detekt-rules/src/test/kotlin/xyz/ksharma/krail/detekt/ThemeColorRoleRuleTest.kt
+++ b/gradle/build-logic/detekt-rules/src/test/kotlin/xyz/ksharma/krail/detekt/ThemeColorRoleRuleTest.kt
@@ -1,0 +1,211 @@
+package xyz.ksharma.krail.detekt
+
+import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.lint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ThemeColorRoleRuleTest {
+
+    private val rule = ThemeColorRoleRule(TestConfig())
+
+    @Test
+    fun `flags the deprecated accessor`() {
+        val code = """
+            @Composable
+            fun Title() {
+                Text(text = "KRAIL", color = themeColor())
+            }
+        """.trimIndent()
+
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `flags the deprecated accessor's import`() {
+        val code = """
+            import xyz.ksharma.krail.taj.themeColor
+
+            fun nothing() = Unit
+        """.trimIndent()
+
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `flags the ground colour passed as a text colour`() {
+        val code = """
+            @Composable
+            fun Title() {
+                Text(text = "KRAIL", color = themeGroundColor())
+            }
+        """.trimIndent()
+
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `flags the ground colour passed as an icon tint`() {
+        val code = """
+            @Composable
+            fun Chevron() {
+                Icon(painter = painter, tint = themeGroundColor())
+            }
+        """.trimIndent()
+
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `flags the ground colour inside a BorderStroke`() {
+        val code = """
+            @Composable
+            fun Chip() {
+                Box(modifier = Modifier.border(BorderStroke(1.dp, themeGroundColor())))
+            }
+        """.trimIndent()
+
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not flag the ground colour used as a fill`() {
+        val code = """
+            @Composable
+            fun Badge() {
+                TransportModeBadge(backgroundColor = themeGroundColor())
+            }
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    /**
+     * `Modifier.background(color = ...)` is a fill with content drawn on top, so the ground
+     * accessor is exactly right there. It names its argument `color`, the same as
+     * `Modifier.border()`, which takes ink — so the callee has to be part of the decision. This
+     * shape is real: DiscoverChip's selected state, which the rule flagged wrongly at first.
+     */
+    @Test
+    fun `does not flag the ground colour in a background fill`() {
+        val code = """
+            @Composable
+            fun Chip(selected: Boolean) {
+                Box(
+                    modifier = Modifier.background(
+                        color = if (selected) themeGroundColor() else KrailTheme.colors.surface,
+                        shape = RoundedCornerShape(8.dp),
+                    ),
+                )
+            }
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    /** The same argument name on a stroke still has to be caught. */
+    @Test
+    fun `still flags the ground colour in a border stroke`() {
+        val code = """
+            @Composable
+            fun Chip() {
+                Box(modifier = Modifier.border(width = 1.dp, color = themeGroundColor()))
+            }
+        """.trimIndent()
+
+        assertEquals(1, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not flag the ink accessor in an ink position`() {
+        val code = """
+            @Composable
+            fun Title() {
+                Text(text = "KRAIL", color = themeInkColor())
+            }
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not flag the decoration accessor, which is the sanctioned way out`() {
+        val code = """
+            @Composable
+            fun Row() {
+                Box(modifier = Modifier.klickable(indication = krailRipple(color = themeDecorColor())))
+            }
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    /**
+     * `Klickable.kt` declares `indication: Indication? = krailRipple(color = themeDecorColor())`
+     * as a **default argument**, so the decoration accessor appears in a literal `color =`
+     * position in the one file every clickable surface in the app routes through. Confirming it
+     * does not trip, because a false positive there would be unavoidable rather than fixable.
+     */
+    @Test
+    fun `does not flag the klickable default argument`() {
+        val code = """
+            @Composable
+            fun Klickable(
+                indication: Indication? = krailRipple(color = themeDecorColor()),
+            ) = Unit
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not flag the wash accessor`() {
+        val code = """
+            @Composable
+            fun Card() {
+                Box(modifier = Modifier.background(color = themeBackgroundColor()))
+            }
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    @Test
+    fun `does not flag an unrelated colour in an ink position`() {
+        val code = """
+            @Composable
+            fun Title() {
+                Text(text = "Park & Ride", color = KrailTheme.colors.label)
+            }
+        """.trimIndent()
+
+        assertEquals(0, rule.lint(code).size)
+    }
+
+    @Test
+    fun `the deprecated message names all four roles`() {
+        val code = """
+            @Composable
+            fun Title() = Text(color = themeColor())
+        """.trimIndent()
+
+        val message = rule.lint(code).single().message
+
+        listOf("themeGroundColor", "themeInkColor", "themeBackgroundColor", "themeDecorColor")
+            .forEach { assertTrue(message.contains(it), "message should mention $it: $message") }
+    }
+
+    @Test
+    fun `the ink message offers themeInkColorOn for a non-surface ground`() {
+        val code = """
+            @Composable
+            fun Hand() = Icon(tint = themeGroundColor())
+        """.trimIndent()
+
+        val message = rule.lint(code).single().message
+
+        assertTrue(message.contains("themeInkColorOn"), message)
+        assertTrue(message.contains("themeDecorColor"), message)
+    }
+}


### PR DESCRIPTION
## What

Adds a `krail` ruleset rule that keeps call sites on the four theme-colour role accessors, so the
split introduced earlier in this stack cannot quietly erode.

## Changes

- `ThemeColorRoleRule` flags `themeColor()` and its import, and `themeGroundColor()` passed to a
  `color`, `tint`, `textColor` or `contentColor` argument or into `BorderStroke(`.
- Registered in `KrailRuleSetProvider` and enabled in the `krail:` block of `config/detekt.yml`.
- `ThemeColorRoleRuleTest`: twelve cases, most of them asserting what it must *not* flag — the ink
  accessor, the wash, the decoration escape hatch, the ground colour used as a fill, and an
  unrelated colour in an ink position.
- `docs/testing/GUARDS.md`: new row, and the rule count goes from seven to eight.

Why a rule and not just the deprecation: warnings are not errors in this build, so a `themeColor()`
call compiles and produces a wrong colour only for the themes that happen to fail. That is
precisely how Purple Drip came to render at 2.95:1 on the dark surface.

`themeDecorColor()` is the sanctioned way out for a gradient stop or ripple that nothing is read
off. Having a way to record "this genuinely has no obligation" is what lets the rule ship as an
unconditional gate with no baseline rather than a grandfathered list. There are zero offenders
today.

Known limit, recorded in the KDoc and in GUARDS.md: no type resolution, so the check is syntactic
and misses a ground colour laundered through a local `val` first. `ThemeInkContrastTest` covers the
values; this covers the shape of the call.

## Testing

- `./gradlew -p gradle/build-logic :detekt-rules:test` green, 12 tests
- `./gradlew detekt --continue` green across the repo with the rule active, zero findings
- `./gradlew testAndroidHostTest --continue` green
- `compileDebugSources` and `compileKotlinIosSimulatorArm64` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)