### PR TITLE
fix(maestro): make the nightly lane actually run its flows

### DIFF
--- a/.github/workflows/maestro-nightly.yml
+++ b/.github/workflows/maestro-nightly.yml
@@ -86,7 +86,15 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
-          target: google_apis
+          # google_atd, not google_apis. The ATD ("Automated Test Device") images
+          # are Google's own CI build: Play Services kept, because Firebase needs
+          # them, and the rest of the Google app suite stripped out. On the
+          # google_apis image the emulator sat at 100% CPU for the entire two
+          # minutes the runner waited for it, with TTS, YouTube Music, the
+          # launcher and quicksearch between them taking more of the machine than
+          # anything under test. That is not a boot storm that passes, which is
+          # what the previous attempt at this assumed; it is the image.
+          target: google_atd
           arch: x86_64
           profile: pixel_6
           disable-animations: true

--- a/.maestro/ci/run-flows.sh
+++ b/.maestro/ci/run-flows.sh
@@ -95,14 +95,23 @@ done
 
 # `dumpsys cpuinfo` prints the same "N% TOTAL" line the ANR dump above did, over
 # a window since the previous call, and unlike /proc/pressure it is readable by
-# the shell user (SELinux denies that one, which is why this does not use the
-# figure the dump quoted).
+# the shell user (SELinux denies that one).
 #
-# 85 rather than something tighter: an idle emulator still reads around 60% here,
-# because software rendering and the emulated kernel are themselves the load. The
-# state being excluded is the 99% one, not ordinary emulator overhead.
-SETTLE_TARGET=85
-SETTLE_TIMEOUT=120
+# Waits for the reading to PLATEAU rather than to drop below a fixed number.
+# The first version of this waited for CPU under 85% and never got it: a
+# software-rendered emulator on a two-core runner reported a flat 100% for the
+# whole two minutes, every sample, so the wait was pure dead time and the flows
+# started against exactly the same machine they would have anyway. An absolute
+# threshold is only meaningful if the idle figure is known, and here it is a
+# property of the runner, not of the work.
+#
+# A plateau is the thing actually worth waiting for: while the image is still
+# bringing services up the number moves, and once it stops moving the device is
+# as quiet as it is going to get. That holds whether the plateau is at 30% or at
+# 100%.
+SETTLE_TOLERANCE=5
+SETTLE_TIMEOUT=90
+previous=""
 settled=0
 # Discarded: the first call reports a window stretching back to boot, which is
 # exactly the busy period being waited out.
@@ -118,19 +127,20 @@ for _ in $(seq 1 $((SETTLE_TIMEOUT / 5))); do
     settled=1
     break
   fi
-  if awk "BEGIN { exit !($total < $SETTLE_TARGET) }"; then
-    echo "Device settled: CPU ${total}%."
+  if [ -n "$previous" ] && awk "BEGIN { d = $total - $previous; if (d < 0) d = -d; exit !(d <= $SETTLE_TOLERANCE) }"; then
+    echo "Device settled: CPU ${total}% (was ${previous}%)."
     settled=1
     break
   fi
   echo "Waiting for device to settle: CPU ${total}%."
+  previous="$total"
   sleep 5
 done
 # A warning, not a failure. A loaded runner still produces a usable result more
 # often than not, and turning this into a hard stop would replace a flaky lane
 # with one that refuses to run.
 if [ "$settled" -eq 0 ]; then
-  echo "::warning::Device still busy after ${SETTLE_TIMEOUT}s; running anyway."
+  echo "::warning::Device CPU still moving after ${SETTLE_TIMEOUT}s; running anyway."
 fi
 
 # Deliberately no `set -e`: a failing flow is an expected outcome here, and its

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,0 +1,24 @@
+# Which directories under .maestro/ hold Flows.
+#
+# Maestro does not recurse into subdirectories on its own. Pointed at a directory
+# whose Flows all live one level down, it does not run a reduced set or warn: it
+# finds nothing and exits non-zero with
+#
+#     Top-level directories do not contain any Flows: .../.maestro
+#
+# The nightly lane passes `.maestro/` in order to run the whole tree, so without
+# this file it has never executed a single Flow. It failed on flow discovery, and
+# because that still exits 1 the lane looked like a red test suite rather than a
+# lane that never started. The PR smoke lane never hit this because it passes
+# `.maestro/smoke/`, a directory with Flows directly in it.
+#
+# `shared/` is deliberately absent. It holds helper Flows invoked through
+# `runFlow`, and listing it here would run each of them as a test in its own
+# right, which is exactly what keeping them outside the two lanes was meant to
+# prevent.
+#
+# `ci/` is absent for the same reason: it holds this lane's shell runner, not
+# Flows.
+flows:
+  - "smoke/*"
+  - "nightly/*"

--- a/.maestro/smoke/02-plan-trip.yaml
+++ b/.maestro/smoke/02-plan-trip.yaml
@@ -3,6 +3,17 @@
 # Every selector is a testTag, and results are chosen by index rather than by
 # name, so the flow does not break when NSW renames a stop or reorders results.
 # The stop names typed in are inputs, not assertions.
+#
+# The waits here are sized for a software-rendered CI emulator, not for a
+# developer machine. That emulator reports pinned CPU for the whole run, and this
+# is the only flow in either lane long enough to be affected: it was the only one
+# failing while the other five passed, and it failed at a DIFFERENT step on each
+# attempt of the same run, once on the search screen appearing and once on the
+# journey list. Two different steps timing out in one run is the signature of a
+# budget that is too tight, not of a broken screen.
+#
+# The journey wait is the longest because it is the only one that includes a live
+# NSW API round trip on top of the render.
 appId: ${APP_ID}
 ---
 - launchApp:
@@ -26,7 +37,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "searchstop.query"
-    timeout: 15000
+    timeout: 30000
 
 - tapOn:
     id: "searchstop.query"
@@ -45,7 +56,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "searchrow.root"
-    timeout: 15000
+    timeout: 30000
 
 # --- Destination ---
 - tapOn:
@@ -54,7 +65,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "searchstop.query"
-    timeout: 15000
+    timeout: 30000
 
 - tapOn:
     id: "searchstop.query"
@@ -72,7 +83,7 @@ appId: ${APP_ID}
 - extendedWaitUntil:
     visible:
       id: "searchrow.root"
-    timeout: 15000
+    timeout: 30000
 
 # --- Timetable ---
 - tapOn:
@@ -102,4 +113,4 @@ appId: ${APP_ID}
     element:
       id: "timetable.journey..*"
     direction: DOWN
-    timeout: 45000
+    timeout: 90000


### PR DESCRIPTION
## What

The nightly Maestro lane has never run a single flow. This fixes that, and sizes the one flow that then turned out to be genuinely flaky.

## The real bug

The lane passes `.maestro/` so it can cover the whole tree. Maestro does not recurse: pointed at a directory whose flows all live one level down, it finds nothing and exits non-zero with

```
Top-level directories do not contain any Flows: .../.maestro
```

Because that still exits 1, the lane looked like a red **test suite** rather than one that never started. Reproduced locally against the same commit, same message.

`.maestro/config.yaml` names the two lane directories. `shared/` is deliberately excluded (helper flows invoked via `runFlow`; listing it would run each as a test in its own right, which is what keeping them outside both lanes was for), and `ci/` too, since it holds the shell runner.

### Correcting the previous PR

#1938 claimed the nightly failed the same way as the PR smoke lane, on the `02-plan-trip` assertion. That was wrong. The smoke lane passes `.maestro/smoke/`, a directory with flows directly in it, so it always found them. The nightly's failure was never the same one.

## Supporting changes

**The settle wait now looks for a plateau, not a threshold.** #1939 waited for CPU under 85%. It ran, and disproved its own premise: the device reported a flat 100% on every sample for the full 120s, so the wait was pure dead time. An absolute threshold only means something if the idle figure is known, and here it is a property of the runner. Waiting for the reading to stop *moving* works whether the plateau sits at 30% or 100%, and now settles in ~5s.

**`google_atd` instead of `google_apis`.** ATD is Google's CI image: Play Services kept for Firebase, the rest of the app suite stripped. Honest caveat: this did **not** measurably move the reported CPU figure, which still reads 99%. It is kept because the apps it removes were the ones competing for the two cores the emulator gets, and a single aggregate sample is weak evidence either way. If it is judged unproven, it is the one change here safe to drop.

**`02-plan-trip` timeouts.** Once the lane ran, 5 of 6 flows passed and only this one failed, at a *different step on each attempt of the same run*: first the search screen at 15s, then on the retry all the way to the timetable and the journey list at 45s. Two different steps timing out in one run is a budget too tight, not a broken screen. Screen transitions go to 30s; the journey wait to 90s, being the only one with a live NSW API round trip on top of the render. The reasoning is written into the flow so the numbers do not read as arbitrary.

## Testing

Local, against the merged `main`:
- `maestro test .maestro/` before this: instant `Top-level directories do not contain any Flows`
- after: discovers and runs both lanes, whole suite **exit code 0**
- the plateau settle block run standalone against an emulator: `Device settled: CPU 6% (was 6%)`

CI, dispatched on this branch:
- before the config fix: no flows, immediate failure
- after: `01-launch-home`, `03-rotation-sweep`, `04-background-foreground`, `05-kill-relaunch`, `06-permissions-denied` all **Passed**; `02-plan-trip` failed on timing, which is what the last commit addresses
- a run with the raised timeouts is queued at time of writing

## Note on gating

This lane still gates nothing, deliberately. It should be watched for a stretch of consistently green runs before anyone considers making it a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb