### PR TITLE
docs(readme): replace the broken platform icons in the heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# KRAIL <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/Kotlin_Icon.png/1200px-Kotlin_Icon.png" height="30">  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Android_robot_head.svg/1100px-Android_robot_head.svg.png" height="30">  <img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/IOS_logo.svg" height="30">
+# KRAIL
 
 KRAIL is a modern, Compose Multiplatform app providing a seamless trip-planning experience across
 Android and iOS. Built using Kotlin and Swift (for minor iOS-specific parts), the app offers
 real-time public transport information, personalised features like trip-saving and themes, and
 modular architecture for maintainability.
 
-[![Krail App CI](https://github.com/ksharma-xyz/Krail/actions/workflows/build.yml/badge.svg)](https://github.com/ksharma-xyz/Krail/actions/workflows/build.yml)
-[![codecov](https://codecov.io/gh/ksharma-xyz/Krail/branch/main/graph/badge.svg)](https://codecov.io/gh/ksharma-xyz/Krail)
+![Kotlin](https://img.shields.io/badge/Kotlin-7F52FF?logo=kotlin&logoColor=white)
+![Compose Multiplatform](https://img.shields.io/badge/Compose%20Multiplatform-4285F4?logo=jetpackcompose&logoColor=white)
+![Android](https://img.shields.io/badge/Android-3DDC84?logo=android&logoColor=white)
+![iOS](https://img.shields.io/badge/iOS-000000?logo=apple&logoColor=white)
+
+[![Krail App CI](https://github.com/ksharma-xyz/KRAIL/actions/workflows/build.yml/badge.svg)](https://github.com/ksharma-xyz/KRAIL/actions/workflows/build.yml)
+[![codecov](https://codecov.io/gh/ksharma-xyz/KRAIL/branch/main/graph/badge.svg)](https://codecov.io/gh/ksharma-xyz/KRAIL)
 
 ## Table of Contents
 


### PR DESCRIPTION
## What

The Kotlin and Android icons in the README heading were broken.

## Changes

Both were hotlinked Wikimedia thumbnail URLs returning HTTP 400:

```
400  .../thumb/7/74/Kotlin_Icon.png/1200px-Kotlin_Icon.png
400  .../thumb/3/31/Android_robot_head.svg/1100px-Android_robot_head.svg.png
200  .../c/ca/IOS_logo.svg
```

The iOS one still resolves, but it is an SVG on the same host and is one URL change away from going the same way, so all three are replaced rather than just the two that are currently broken.

- Platform icons become shields.io badges, which are built for this, cached, and already the mechanism the CI and coverage badges below use
- They move out of the `H1` into the badge block, so the heading is plain text and the platform facts sit with the other badges
- Compose Multiplatform added alongside, since the first line of the README already leads with it
- CI and coverage badge URLs corrected from `ksharma-xyz/Krail` to `ksharma-xyz/KRAIL`. Both resolve today via GitHub's case-insensitive redirect, so this changes nothing visible; the repository has one name and links should use it.

## Testing

Every URL in the file was requested and checked. All resolve after this change. LinkedIn answers automated requests with `999` and is fine in a browser, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb