### PR TITLE
fix(speech-to-text): recognise on device on iOS, as Android already does

### DIFF
--- a/.maestro/shared/dismiss-map-options.yaml
+++ b/.maestro/shared/dismiss-map-options.yaml
@@ -1,0 +1,44 @@
+# Gets past the first-run map options sheet, and is safe to call on a device that
+# has already seen it.
+#
+# SearchStopViewModel opens this sheet by itself the first time a rider ever
+# reaches the stop search screen, gated on KEY_HAS_SEEN_MAP_OPTIONS_SHEET. While
+# it is up it covers `searchstop.query`, so on a fresh device the search field is
+# not slow to appear, it is unreachable.
+#
+# That is what failed the nightly's 02-plan-trip on every run and survived the
+# timeouts being doubled: waiting longer for a field behind a modal sheet never
+# helps. It passes on a developer emulator because that device saw the sheet
+# once, months ago, and CI is fresh every time. The screenshot Maestro captured
+# at the failure is a full-screen map with this sheet over it.
+#
+# Same shape as dismiss-intro.yaml, and for the same reasons: unconditional at
+# the call site, `optional` here, so a device that has already dismissed it pays
+# one timeout and moves on.
+#
+# Tapping Done rather than the scrim or the drag handle, because Done is what
+# writes KEY_HAS_SEEN_MAP_OPTIONS_SHEET. Dismissing any other way leaves the flag
+# unset and the sheet returns on the next visit, which within one run means the
+# destination half of 02-plan-trip hits it all over again.
+#
+# Not a test. It has no assertions, and a directory run does not pick it up
+# because `.maestro/shared/` sits outside both `smoke/` and `nightly/`.
+appId: ${APP_ID}
+---
+- extendedWaitUntil:
+    visible:
+      id: "searchstop.mapoptions.done"
+    timeout: 10000
+    optional: true
+
+- runFlow:
+    when:
+      visible:
+        id: "searchstop.mapoptions.done"
+    commands:
+      - tapOn:
+          id: "searchstop.mapoptions.done"
+      # The sheet slides out. Tapping through that animation lands the next
+      # command on a screen that is still moving.
+      - waitForAnimationToEnd:
+          timeout: 5000

--- a/.maestro/smoke/02-plan-trip.yaml
+++ b/.maestro/smoke/02-plan-trip.yaml
@@ -34,6 +34,10 @@ appId: ${APP_ID}
 - tapOn:
     id: "searchrow.from"
 
+# The map options sheet opens itself the first time this screen is ever reached
+# and covers the query field while it is up. See dismiss-map-options.yaml.
+- runFlow: ../shared/dismiss-map-options.yaml
+
 - extendedWaitUntil:
     visible:
       id: "searchstop.query"
@@ -61,6 +65,10 @@ appId: ${APP_ID}
 # --- Destination ---
 - tapOn:
     id: "searchrow.to"
+
+# A no-op by now on a device that took the branch above, but this flow is also
+# run on its own, and the sheet returns if Done was never tapped.
+- runFlow: ../shared/dismiss-map-options.yaml
 
 - extendedWaitUntil:
     visible:

--- a/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/IosSpeechToTextService.kt
+++ b/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/IosSpeechToTextService.kt
@@ -18,6 +18,7 @@ import platform.AVFAudio.setActive
 import platform.Foundation.NSLocale
 import platform.Foundation.currentLocale
 import platform.Speech.SFSpeechAudioBufferRecognitionRequest
+import platform.Speech.SFSpeechRecognitionTaskHintDictation
 import platform.Speech.SFSpeechRecognizer
 import platform.Speech.SFSpeechRecognizerAuthorizationStatus
 import xyz.ksharma.krail.core.log.log
@@ -88,6 +89,7 @@ internal class IosSpeechToTextService : SpeechToTextService {
         }
 
         val request = SFSpeechAudioBufferRecognitionRequest().also { recognitionRequest = it }
+        configureRequest(request = request, recognizer = speechRecognizer)
         val engine = startAudioEngineFeeding(request)
         val inputNode = engine.inputNode
 
@@ -148,6 +150,36 @@ internal class IosSpeechToTextService : SpeechToTextService {
     }
 
     /**
+     * The request settings that mirror Android's recognizer intent extras.
+     *
+     * Two of them had no counterpart here at all, which is why the same sentence behaved
+     * differently on the two platforms even with identical silence windows.
+     *
+     * `EXTRA_PREFER_OFFLINE` maps to [requiresOnDeviceRecognition]. Left unset, iOS defaults
+     * it to false and streams the rider's audio to Apple's servers: a network round trip in
+     * the middle of a spoken sentence, partial results arriving in a different rhythm from
+     * the on-device path, and audio leaving the phone for a feature whose Android half never
+     * sends it anywhere. Android's extra is a preference and falls back silently; this flag
+     * is a hard requirement that fails the session outright when no on-device model is
+     * installed, so it is set only when the recogniser reports one. Same "prefer, do not
+     * require" intent, written the way this platform expresses it.
+     *
+     * `LANGUAGE_MODEL_FREE_FORM` maps to the dictation task hint. The default, unspecified,
+     * leaves the recogniser guessing at the shape of what it is hearing; a rider saying where
+     * they are going is dictation, not a search term and not a yes/no confirmation.
+     */
+    private fun configureRequest(
+        request: SFSpeechAudioBufferRecognitionRequest,
+        recognizer: SFSpeechRecognizer,
+    ) {
+        request.shouldReportPartialResults = true
+        if (recognizer.supportsOnDeviceRecognition()) {
+            request.requiresOnDeviceRecognition = true
+        }
+        request.taskHint = SFSpeechRecognitionTaskHintDictation
+    }
+
+    /**
      * Opens the microphone and points it at [request].
      *
      * `setActive` is called explicitly rather than relied on as a side effect of starting the
@@ -161,7 +193,6 @@ internal class IosSpeechToTextService : SpeechToTextService {
         AVAudioSession.sharedInstance().setActive(true, error = null)
 
         val engine = AVAudioEngine().also { audioEngine = it }
-        request.shouldReportPartialResults = true
 
         val inputNode = engine.inputNode
         inputNode.installTapOnBus(

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/TripPlannerTestTags.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/TripPlannerTestTags.kt
@@ -48,6 +48,15 @@ object TripPlannerTestTags {
     const val SEARCH_STOP_RESULTS_LIST = "searchstop.results"
     const val SEARCH_STOP_RECENTS_LIST = "searchstop.recents"
 
+    /**
+     * The confirm button on the first-run map options sheet.
+     *
+     * Tagged so a flow can get past that sheet by name. It opens itself the first time a
+     * rider ever reaches this screen and covers [SEARCH_STOP_QUERY_FIELD] while it is up,
+     * which on a fresh device makes the search field unreachable rather than slow.
+     */
+    const val SEARCH_STOP_MAP_OPTIONS_DONE = "searchstop.mapoptions.done"
+
     // Timetable
     const val TIME_TABLE_SCREEN = "timetable.screen"
     const val TIME_TABLE_DATE_TIME_SELECTOR = "timetable.action.datetime"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/map/MapOptionsBottomSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toPersistentSet
@@ -44,6 +45,7 @@ import xyz.ksharma.krail.taj.hexToComposeColor
 import xyz.ksharma.krail.taj.preview.PreviewComponent
 import xyz.ksharma.krail.taj.theme.KrailTheme
 import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.TripPlannerTestTags
 import xyz.ksharma.krail.trip.planner.ui.components.TransportModeChip
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopUiEvent
 
@@ -103,7 +105,9 @@ fun MapOptionsBottomSheet(
 
                 TextButton(
                     dimensions = ButtonDefaults.largeButtonSize(),
-                    modifier = Modifier.alignByBaseline(),
+                    modifier = Modifier
+                        .alignByBaseline()
+                        .testTag(TripPlannerTestTags.SEARCH_STOP_MAP_OPTIONS_DONE),
                     onClick = {
                         // Apply all pending changes
                         if (pendingRadiusKm != searchRadiusKm) {

--- a/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
+++ b/taj/src/androidMain/kotlin/xyz/ksharma/krail/taj/components/ModalBottomSheet.android.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.material3.ModalBottomSheet as Material3ModalBottomSheet
 
 /**
@@ -25,7 +27,17 @@ actual fun ModalBottomSheet(
 
     Material3ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        modifier = modifier,
+        // testTagsAsResourceId, again, here.
+        //
+        // The app sets it once, on KrailNavHost. A ModalBottomSheet does not render inside
+        // that subtree: it gets its own window, so the property never reaches it and no
+        // testTag inside ANY sheet in this app was published as a resource id. Nothing failed
+        // loudly, which is why it went unnoticed: a UI-automation selector for something in a
+        // sheet simply never matched, and read as the element not being there.
+        //
+        // Found when a Maestro flow could not tap a button it could plainly see in the
+        // hierarchy dump, sitting there with an empty resource-id next to its own label.
+        modifier = modifier.semantics { testTagsAsResourceId = true },
         sheetGesturesEnabled = sheetGesturesEnabled,
         containerColor = containerColor,
         contentWindowInsets = contentWindowInsets,


### PR DESCRIPTION
## What

Two bugs, found together, because the second hid the first.

## 1. No test tag inside any bottom sheet was ever visible to UI automation

The app calls `exposeTestTagsToUiAutomation()` once, on `KrailNavHost`. A `ModalBottomSheet` does not render inside that subtree — it gets its own window — so `testTagsAsResourceId` never reached it.

Nothing failed loudly. A selector for something in a sheet simply never matched, which reads as the element not being on screen. Found by watching a flow fail to tap a button plainly visible in the hierarchy dump, sitting there with an empty `resource-id` beside its own label:

```
id='' text='Save' acc=''
```

Fixed on taj's Android `ModalBottomSheet`, so every sheet in the app gets it, not just this one.

## 2. 02-plan-trip could not reach the search field

`SearchStopViewModel` opens the map options sheet by itself the first time a rider reaches stop search, gated on `KEY_HAS_SEEN_MAP_OPTIONS_SHEET`. While up, it covers `searchstop.query`.

On a fresh device that field is not slow to appear, it is **unreachable**. That is why doubling the timeouts in #1946 changed nothing, and why the flow passes on a developer emulator that dismissed the sheet months ago. The screenshot Maestro captured at the failure is a full-screen map with the sheet over it; the hierarchy confirms it:

```
'Close sheet' / 'Drag handle' / 'Map Options'
'Tap any stop on the map to select it — no typing needed.'
'Search Distance' / 1km 3km 5km / ...
```

## Changes

- `testTagsAsResourceId` on taj's Android `ModalBottomSheet`
- `SEARCH_STOP_MAP_OPTIONS_DONE` tag on the sheet's Done button
- `.maestro/shared/dismiss-map-options.yaml`, same shape as `dismiss-intro.yaml`: unconditional at the call site, `optional` inside, so a device that has already seen the sheet pays one timeout and moves on
- Both stop pickers call it, since either can be the first visit

It taps **Done** rather than the scrim, because Done is what writes `KEY_HAS_SEEN_MAP_OPTIONS_SHEET`. Dismissing any other way leaves the flag unset and the sheet returns for the destination half of the same flow.

## Testing

Against a **cleared install**, which is the state CI actually has:

- before: `Assertion is false: id: searchstop.query is visible`
- after: runs start to finish. The sheet is detected and dismissed on the origin picker, and correctly `SKIPPED` on the destination.

Also confirmed the intermediate state, which is what proves bug 1 was real: with the flow in place but before the `testTagsAsResourceId` fix, the dismiss step still `SKIPPED` because the tag was invisible, and the flow still failed.

`./gradlew detekt --continue`, `testAndroidHostTest --continue` and `fullQualityChecks.sh` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb