### PR TITLE
docs(taj): write down the theme colour's four roles and how ink is derived

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,33 @@ maintainer rather than suppressing. There is no "genuinely not possible" escape 
 `LongMethod` is exempt only on `@Composable` functions (already configured); never suppress
 it elsewhere — refactor instead.
 
+## The rider's theme colour has four roles
+
+Before drawing anything in the theme colour, read
+[`taj/THEME_COLOUR_ROLES.md`](taj/THEME_COLOUR_ROLES.md).
+
+One accessor per role, because a call site that does not say which role it means cannot be
+checked:
+
+| Accessor | For | Adapted |
+|---|---|---|
+| `themeGroundColor()` | a fill with content drawn on top | no |
+| `themeInkColor()` | text, icons, strokes drawn onto a surface | **yes** |
+| `themeBackgroundColor()` | the translucent card wash | no |
+| `themeDecorColor()` | gradients, ripples, nothing read off it | no |
+
+Pick with one question: is something drawn **on top of** this colour (ground), or is this colour
+drawn **on top of** something (ink)? Pass `UI_COMPONENT_CONTRAST_AA` to `themeInkColor()` for
+strokes and icons; the 4.5 default is for text. A chip's label is text even though the chip is a
+control.
+
+`themeColor()` is deprecated and `ThemeColorRoleRule` flags it. Ink is **derived**, so adding a
+theme needs no new colour and no new test.
+
+Two traps, both documented in full in that file: `contrastRatio` ignores alpha, so composite a
+translucent ground before measuring against it; and never key a derivation on
+`KrailTheme.colors.surface`, which animates for 1500 ms during a theme switch.
+
 ## LazyColumn / LazyRow item keys
 
 **Always provide an explicit `key` for every `item {}` call** — this is critical for correct
@@ -422,6 +449,8 @@ that contradicts the doc should also update the doc in the same change.
   `onAddressSearchTextChanged` or the `search_stop_address_*` Remote Config contract.
 - `docs/TABLET_FOLDABLE_UX.md` — adaptive layout rules for tablets, foldables, and phone
   landscape (per-screen dual-pane behaviour, compact-height adaptations, breakpoint contract).
+- `taj/THEME_COLOUR_ROLES.md` — the four theme-colour roles, when to use which, how ink is
+  derived, and what each guard holds; read before drawing in the rider's theme colour.
 - `docs/LAYOUT_AND_INSETS.md` — inset authority, `adjustResize`, `weight` vs `fillMaxSize`,
   and how to tell a layout bug from the window moving; read before changing a screen root or
   a bottom-anchored input.

--- a/docs/learning/2026-08-22-three-contrast-guards-and-the-gap-between-them.md
+++ b/docs/learning/2026-08-22-three-contrast-guards-and-the-gap-between-them.md
@@ -1,0 +1,104 @@
+# Three contrast guards, and the theme colour that fell between them
+
+**2026-08-22** · Design system / a guard that measured the wrong pairing · ~6 builds, 2 install cycles, one afternoon
+
+## Symptom
+
+With **Purple Drip** selected and the device in dark mode, the rider's chosen stop name on the
+search row was barely readable — dimmer than the "Destination" placeholder beside it, which is
+deliberately quiet. The same purple was used for "Not now", "Reset", "Show previous departures",
+the date chevrons and the KRAIL wordmark.
+
+Worst of all, the time picker's hand was drawn in the theme colour on a dial *filled* with the
+same theme colour. Purple on purple.
+
+Light mode looked fine. Every other theme looked fine.
+
+## Root cause
+
+Two, and the second is the one worth remembering.
+
+**1. `#AC00C9` measures 2.95:1 on the dark surface and 2.49:1 on a bottom sheet.** Text needs 4.5,
+non-text needs 3.0. It was the only shipped theme that failed on dark.
+
+**2. Three contrast guards already existed, all passing, and none of them measured this pairing.**
+
+| Guard | Measures | Why it missed |
+|---|---|---|
+| `ThemeContrastTest` | content drawn **on** each theme colour | only looks at the theme colour as a *ground* |
+| `KrailColorTokenContrastTest` | the fixed `KrailColors` tokens | theme colours are not `KrailColors` tokens |
+| `TransportModeContrastTest` | `TransportMode.all` against both surfaces | `TransportMode.all` is Train, Metro, Bus, Light Rail, Ferry, Coach, School Bus. **Purple Drip and Barbie Pink are `KrailThemeStyle`-only and are never iterated.** |
+
+The union looks like full coverage. It is not: nothing measured *a theme colour used as ink against
+the surface it is drawn on*. The gap was invisible because each guard's name suggests it covers the
+theme colours, and each one genuinely does cover something.
+
+**3. The escape hatch could not have fixed it either.** `ensureMinimumContrast` raises HSV *value*
+and nothing else, so a fully saturated colour with little value left cannot be adapted. When its
+loop exhausts, it **returns the colour anyway, with no signal**. Swept over 1920
+hue/saturation/value combinations it returns a still-failing colour for 24% of them against the
+sheet ground. Light mode never fails, because darkening has no floor — that asymmetry is why this
+sat undetected.
+
+## Why it took so long
+
+**Wrong turn 1: assuming the fix was a better hex.** The first instinct is to hand-pick a
+dark-mode purple. That fixes one theme and leaves the next one to whoever adds it, which is the
+same trap one level along.
+
+**Wrong turn 2: reaching for the existing helper.** `ensureMinimumContrast` is right there and
+named for exactly this job. Only measuring it revealed that it cannot reach 4.5 for this hue —
+it tops out at `#DA00FF` / 4.45 after exhausting all 20 steps and returns it silently.
+
+**Wrong turn 3: binary-searching the blend.** The obvious implementation of a replacement is to
+binary-search the blend factor, which is correct only if contrast rises monotonically along the
+blend. Compose's `lerp` interpolates in **Oklab**, and 110 of 7680 measured ladders reverse
+somewhere in the middle. This was caught by sweeping before writing, not by a failing test.
+
+**Wrong turn 4: deriving per ground.** Adapting the ink against whatever ground it lands on gives
+a different shade on the surface, on a sheet and on a card — and a sheet opened over a screen shows
+two at once. Caught by a reviewer question, not by a check.
+
+**Wrong turn 5: measuring against a translucent ground.** `contrastRatio` reads `luminance()`,
+which ignores alpha. The time picker's dial was passed in as `themeBackgroundColor()` — 45% purple
+— so it was measured as though opaque and the hand over-adapted to near-white `#E1ADE6`. Only
+sampling the rendered pixels off a device screenshot showed it. `KrailColorTokenContrastTest`'s
+KDoc already warned about exactly this; the warning was in the wrong file to be seen.
+
+## What would have caught it sooner
+
+**Measure pixels, not intentions.** Every number in the fix was confirmed by sampling the actual
+PNG from a device screenshot. That is what caught the near-white clock hand, and what proved the
+derived value is byte-identical on device (`#CD7BDC`) to the host-side model.
+
+**Sweep the input space before trusting a helper.** A 1920-colour sweep took minutes to write and
+immediately falsified two assumptions: that `ensureMinimumContrast` was total, and that contrast is
+monotone along an Oklab blend. Both would have been expensive to discover from a bug report.
+
+**Ask what a guard measures, not what it is called.** All three existing guards passed. The useful
+question was not "is there a contrast test?" but "which *pairing* does each one measure?" — a
+three-row table that made the hole obvious.
+
+**A union of guards is not coverage.** When several checks each cover part of a space, write down
+the space and mark the parts. The gap here sat exactly where two reasonable scopes stopped.
+
+## Actions taken
+
+- [x] `Color.ensureContrastWith` — total by construction, blends toward the ground's `onSurface`
+      along a quantised ladder, no monotonicity assumed.
+      ([A11yColors.kt](../../taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/theme/A11yColors.kt))
+- [x] Four role accessors so a call site states its obligation: `themeGroundColor`,
+      `themeInkColor`, `themeBackgroundColor`, `themeDecorColor`.
+      ([ColorsExt.kt](../../taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/ColorsExt.kt))
+- [x] `ContrastAdaptationTest` — the 1920-colour sweep, asserting the derivation is total, and
+      pinning the old helper's failure so the justification cannot rot.
+- [x] `ThemeInkContrastTest` — the missing pairing, self-healing over `KrailThemeStyle.entries`
+      and over `inkGrounds()`, and it holds that ground list against `KrailColors`.
+- [x] `ThemeColorRoleRule` — detekt rule banning the deprecated accessor and the unadapted ground
+      colour in an ink position. Zero offenders, no baseline.
+      ([GUARDS.md](../testing/GUARDS.md))
+- [x] `aiGradientPartner` moved from a map-with-default onto the `KrailThemeStyle` constructor, so
+      a new theme cannot silently inherit Train's gradient. `ThemeGradientPairTest` holds the hue
+      window — writing it revealed the KDoc's stated 97–134° range was never true.
+- [x] The instruction lives in
+      [taj/THEME_COLOUR_ROLES.md](../../taj/THEME_COLOUR_ROLES.md); this entry is the story.

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -64,3 +64,4 @@ Rules, scripts, tests or docs added. Link them. Unchecked boxes if not done yet.
 |---|---|---|
 | 2026-08-16 | [IME pan and the unbounded Column child](2026-08-16-ime-pan-and-unbounded-column.md) | Layout / window insets |
 | 2026-08-16 | [Clipped inside its own parent](2026-08-16-clipped-inside-its-own-parent.md) | Layout / test that could not fail |
+| 2026-08-22 | [Three contrast guards, and the theme colour that fell between them](2026-08-22-three-contrast-guards-and-the-gap-between-them.md) | Design system / a guard that measured the wrong pairing |

--- a/docs/testing/GUARDS.md
+++ b/docs/testing/GUARDS.md
@@ -165,9 +165,15 @@ app's own surfaces. `themeDecorColor()` is the sanctioned way out for a gradient
 that nothing is read off — saying so explicitly is what lets this rule stay an unconditional gate
 instead of accumulating a baseline.
 
-No type resolution, so the check is syntactic and misses a ground colour laundered through a local
-`val` first. `ThemeInkContrastTest` in `:taj` covers the values themselves; this covers the shape
-of the call.
+`color =` means a fill on some callees and a stroke on others: `Modifier.background()` takes a
+ground, `Modifier.border()` takes ink, and both name the argument `color`. So the callee is part of
+the decision and fill-taking callees are skipped. Without that the rule flags a chip's selected
+background, where the ground accessor is right and the call site has no correct fix available.
+
+No type resolution, so the check is syntactic. Two limits: a ground colour laundered through a
+local `val` first is invisible to it, and a fill-taking callee outside the listed set would
+false-positive. `ThemeInkContrastTest` in `:taj` covers the values themselves; this covers the
+shape of the call.
 
 No baseline — zero offenders, unconditional gate.
 

--- a/taj/README.md
+++ b/taj/README.md
@@ -1,6 +1,19 @@
-# Taj Design System - Snapshot Tests
+# Taj Design System
 
-This directory contains snapshot tests for the Taj design system components.
+## Drawing in the rider's theme colour
+
+Read **[THEME_COLOUR_ROLES.md](THEME_COLOUR_ROLES.md)** before using the theme colour for
+anything. It has the four accessors, which one to pick, and why ink is derived rather than
+declared. Picking the wrong one is not caught by the compiler and ships as unreadable text for
+some themes and not others.
+
+Short version: something drawn **on top of** the colour means `themeGroundColor()`; the colour
+drawn **on top of** something means `themeInkColor()`; nothing read off it means
+`themeDecorColor()`.
+
+## Snapshot tests
+
+The rest of this file covers snapshot tests for the Taj design system components.
 
 ## Quick Start
 

--- a/taj/THEME_COLOUR_ROLES.md
+++ b/taj/THEME_COLOUR_ROLES.md
@@ -1,0 +1,154 @@
+# The rider's theme colour has four roles
+
+Read this before drawing anything in the rider's theme colour.
+
+The colour a rider picks in **Change Theme** is used in four different ways, and each way carries
+a different legibility obligation. `taj` exposes one accessor per role rather than one accessor
+for the colour, because a call site that does not say which role it means cannot be checked by
+anything.
+
+---
+
+## Pick one
+
+| Accessor | Use it for | Adapted? | Obligation, and who holds it |
+|---|---|---|---|
+| `themeGroundColor()` | a **filled shape with content drawn on top** — the Save button, the `P` badge, a selected chip | no | content-on-it ≥ 4.5, via `getForegroundColor`. Held by `ThemeContrastTest`. |
+| `themeInkColor()` | **text, an icon or a stroke drawn straight onto a surface** — a stop name, Reset, the date chevrons, a card border | **yes** | the colour itself ≥ 4.5 text / 3.0 non-text. Held by `ThemeInkContrastTest`. |
+| `themeBackgroundColor()` | the **translucent wash** behind card fills | no | content-on-it ≥ 4.5. |
+| `themeDecorColor()` | **decoration** — a gradient stop, a ripple, the cloud field | no | none, and saying so is the point. |
+
+There is one more, for a single genuine exception:
+
+| `themeInkColorOn(background, minContrast)` | ink drawn on a ground that is **not** an app surface | yes, against the ground you pass |
+
+Today only the time picker's hand uses it: the hand sits on a dial filled with
+`themeBackgroundColor()`, not on a surface.
+
+### Choosing in one question
+
+> Is something drawn **on top of** this colour, or is this colour drawn **on top of** something?
+
+- On top of it → **ground** (or **wash**, if translucent).
+- It is on top of something → **ink**.
+- Neither, because nothing is read → **decoration**.
+
+### Thresholds
+
+`themeInkColor()` defaults to `TEXT_CONTRAST_AA` (4.5). Pass `UI_COMPONENT_CONTRAST_AA` (3.0) when
+the thing is a stroke, a track or an icon rather than text:
+
+```kotlin
+Text(text = stopName, color = themeInkColor())                          // read as text
+Icon(painter = chevron, tint = themeInkColor(UI_COMPONENT_CONTRAST_AA)) // not text
+```
+
+Getting this wrong is easy and quiet. A chip's **label** is text even though the chip is a
+control; the chevron beside it is not.
+
+---
+
+## Why this exists
+
+Purple Drip measured **2.95:1** against the dark surface and **2.49:1** on a bottom sheet, against
+a 4.5 requirement for text. It shipped that way. The rider's chosen stop name, the Reset button,
+the date chevrons and the "Show previous departures" link were all drawn in it.
+
+It was the only shipped theme that failed, but "only one fails today" is not a property anyone can
+rely on for the next theme. The fix is not a better hex; it is that **ink is derived rather than
+declared**, so a theme nobody has invented yet is already handled.
+
+### Why one ink per scheme, not one per ground
+
+Adapting against whatever ground the ink happens to land on is the obvious implementation, and it
+is wrong: it produces a different shade of the same theme on the surface, on a sheet and on a card.
+Open a sheet over a screen and two of them are visible at once.
+
+So the ink is derived **once per theme and per scheme**, against the hardest ground in that scheme.
+Harder ground means more contrast everywhere else, so a single value clears them all.
+
+The hardest ground is **computed** from `inkGrounds()` by luminance, not named. Naming it means a
+new surface token silently invalidates every ink. It is `pastDepartureRowSurface` in both schemes,
+which is not the one most people would guess — in dark mode the *lightest* ground is hardest,
+because dark-mode ink is light.
+
+### What the derivation does
+
+`Color.ensureContrastWith(background, toward, minContrast)` blends the colour toward the ground's
+own `onSurface` along a 32-rung ladder and stops at the first rung that clears.
+
+- **Total.** The last rung is `onSurface`, which clears every threshold against its own ground by
+  definition, so a passing rung always exists.
+- **A ladder scan, not a binary search.** Compose's `lerp` interpolates in Oklab, and contrast is
+  not monotone along that path — 110 of 7680 measured ladders reverse somewhere in the middle. A
+  binary search would return a wrong answer for those.
+- **Quantised on purpose.** Rungs mean a one-digit edit to a surface token cannot shift every
+  derived colour by 1/255 and churn every screenshot golden.
+- **Unchanged when it can be.** A colour that already clears is returned byte-identical. Train,
+  Bus and Ferry are untouched in dark mode; Purple Drip is untouched in light mode.
+
+Hue drift across all six themes and every ground is at most **2.2°**, so the brand survives.
+
+### The predecessor, and why it was not enough
+
+`ensureMinimumContrast` raises HSV *value* and nothing else, so a colour already at full value
+cannot be adapted further — and when its loop runs out of steps it **returns the colour anyway**,
+with no signal. Swept over 1920 hue/saturation/value combinations it returns a still-failing colour
+for **24%** of them against the sheet ground. Light mode never failed, because darkening has no
+floor. That asymmetry is why the gap went unnoticed for so long.
+
+It is still in the tree for callers that adapt a **transport line** colour against a known
+background. For the rider's theme colour, use the role accessors.
+
+---
+
+## Two traps
+
+**Alpha is ignored.** `contrastRatio` reads `luminance()`, which does not look at the alpha
+channel. Passing a translucent colour — anything from `themeBackgroundColor()` — as a background
+measures it as though it were opaque and over-adapts. Composite it over what is behind it first:
+
+```kotlin
+val dial = themeBackgroundColor()
+val ground = dial.compositeOver(KrailTheme.colors.bottomSheetBackground)
+val hand = themeInkColorOn(background = ground, minContrast = UI_COMPONENT_CONTRAST_AA)
+```
+
+**Do not key the derivation on an animated colour.** `KrailTheme.colors.surface` animates for
+1500 ms during a light/dark transition. Deriving against it re-runs the search every frame and
+shimmers the ink. `themeInkColor()` keys its `remember` on `(themeHex, isDarkMode)` for exactly
+this reason.
+
+---
+
+## What holds this
+
+| Check | Where | Catches |
+|---|---|---|
+| `ContrastAdaptationTest` | `:taj` | the derivation failing to reach its target for **any** colour on any ground — 1920 colours × every ground × both thresholds |
+| `ThemeInkContrastTest` | `:taj` | a shipped theme's ink failing on a ground; also holds `inkGrounds()` against `KrailColors`, so a new ground token must be listed or excused |
+| `ThemeGradientPairTest` | `:taj` | a theme's AI gradient partner chosen too near or too far in hue |
+| `ThemeColorRoleRule` | detekt | the deprecated `themeColor()` and its import, and `themeGroundColor()` in an ink position — a `color`/`tint` argument or a `BorderStroke`, on a callee that does not take a fill |
+| `ThemeContrastTest` | `:taj` | content drawn **on** a theme colour (the ground role) |
+
+The first three are **self-healing over `KrailThemeStyle.entries`**, so a seventh theme is measured
+the day it is added rather than the day someone remembers to extend a list.
+
+---
+
+## Adding a seventh theme
+
+Nothing here needs updating. Concretely:
+
+1. Add the entry to `KrailThemeStyle`. The compiler will demand `aiGradientPartner` — it is a
+   constructor parameter precisely so it cannot be forgotten. It used to live in a map with a
+   default, which meant a new theme silently wore Train's gradient.
+2. Build. `ThemeGradientPairTest` fails if the partner sits outside the 90–150° window, and tells
+   you the angle you chose.
+3. That is all. The ink, the wash, the cloud-field tints and the on-theme glyph colour are all
+   derived, and the contrast guards pick the new theme up automatically.
+
+The ordering behind that is deliberate, strongest first: **derive it** (nothing to declare) →
+**put it in the enum constructor** (a compile error at the line being edited) → **iterate
+`entries` in a test** (grows itself) → **a detekt rule** (stops the wrong call). Reach for a test
+only when the two above it cannot apply.


### PR DESCRIPTION
## What

The role split was documented only in KDoc. Nobody greps KDoc when deciding which function to
call, so this writes the instruction down where it will be found.

## Changes

- **`taj/THEME_COLOUR_ROLES.md`** — the reference. The four accessors and what each is for, a
  one-question rule for picking between them, which threshold a stroke takes versus a label, why
  ink is derived once per theme and scheme rather than per ground, the two traps (alpha-blind
  `contrastRatio`, and never keying a derivation on the animated surface), and a table of what
  each guard actually holds. Ends with what adding a seventh theme requires, which is nothing.
- **`taj/README.md`** — was only about snapshot tests; now opens with a pointer and the
  one-line version of the rule.
- **`CLAUDE.md`** — a section with the accessor table, plus a row in the per-feature docs list.
- **`docs/learning/2026-08-22-...`** — a learning-log entry, and its index row.

## Why the learning entry

The case meets that log's own stated bar exactly: *"Detekt, unit tests and compile were all green
while the bug was live."* Three contrast guards existed, all passed, and the bug shipped anyway,
because none of them measured a theme colour used as ink against the surface it sits on. Each
guard's name suggests it covers the theme colours, and each genuinely covers something, so the
union looked like coverage.

Per that log's rules the entry names the wrong turns rather than only the answer, including two
that cost real time: binary-searching a blend that is not monotone in Oklab, and measuring against
a translucent ground when `contrastRatio` ignores alpha.

## Testing

- `./gradlew :composeApp:testAndroidHostTest --tests "*LearningLogActionsTest*"` green. It failed
  first: the guard resolves a backticked token as a path, and the entry had backticked filenames
  inside markdown link text. Fixed by dropping the backticks, which is how the existing entries
  are written.
- `./gradlew testAndroidHostTest --continue` green
- `./gradlew detekt --continue` green
- `scripts/check_layout_invariants.py` green

Docs only, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)