### PR TITLE
fix(maestro): get the nightly's iOS leg green

### DIFF
--- a/.github/workflows/maestro-nightly.yml
+++ b/.github/workflows/maestro-nightly.yml
@@ -221,12 +221,17 @@ jobs:
       # rather than gates, so one retry buys signal without hiding a real break:
       # a genuine regression fails twice. The PR lane gets no retry on purpose —
       # a flake that blocks a merge should be fixed, not papered over.
+      # --exclude-tags=android-only skips 03-rotation-sweep here. setOrientation
+      # is a no-op on the simulator: it reports success, the app stays portrait,
+      # and the accessibility tree empties for that moment, so the flow fails
+      # against a screen that is drawn correctly. See that file's own header.
       - name: Run smoke and nightly flows
         run: |
           set -o pipefail
           run_suite() {
             maestro --device "${{ steps.sim.outputs.udid }}" \
-              test -e APP_ID=xyz.ksharma.krail .maestro/smoke/ .maestro/nightly/
+              test --exclude-tags=android-only \
+              -e APP_ID=xyz.ksharma.krail .maestro/smoke/ .maestro/nightly/
           }
           if ! run_suite; then
             echo "::warning::Maestro suite failed on iOS; retrying once."

--- a/.maestro/nightly/03-rotation-sweep.yaml
+++ b/.maestro/nightly/03-rotation-sweep.yaml
@@ -18,6 +18,22 @@
 # are not on screen. That is exactly how this file was first written, and the
 # two cascading failures it caused are the reason for the hook.
 appId: ${APP_ID}
+# Android only, and excluded from the iOS leg by tag.
+#
+# Not a preference: setOrientation does not work on the iOS simulator. It reports
+# COMPLETED, the app stays in portrait (the screenshot at the failure is a
+# fully drawn portrait home screen with the search row plainly on it), and the
+# accessibility tree comes back EMPTY for that moment, so every id assertion
+# after the rotate fails against a screen that is actually fine. Reproduced on
+# an iPhone 17 simulator; the app's Info.plist does allow landscape, so this is
+# the driver, not the app.
+#
+# It would be Android-only regardless. What this flow exists to catch is Activity
+# recreation: a route missing from the NavKey SerializersModule, or state in
+# `remember` instead of `rememberSaveable`. iOS does not destroy and rebuild the
+# world on rotation, so there is no equivalent failure for it to find.
+tags:
+  - android-only
 onFlowComplete:
   - setOrientation: PORTRAIT
 ---

--- a/.maestro/nightly/06-permissions-denied.yaml
+++ b/.maestro/nightly/06-permissions-denied.yaml
@@ -18,7 +18,18 @@ appId: ${APP_ID}
     clearState: false
     stopApp: true
     permissions:
-      location: deny
+      # `never`, not `deny`. Both drivers accept `never`; only Android accepts
+      # `deny`, and on iOS it does not fail the assertion, it throws out of
+      # launchApp itself:
+      #
+      #   IllegalArgumentException: wrong argument value 'deny' was provided
+      #   for 'location' permission
+      #     at util.LocalSimulatorUtils.setLocationPermission
+      #
+      # That is why this flow died in under a second on the iOS leg of the
+      # nightly while every assertion below it went unread. Verified against
+      # both a simulator and an emulator.
+      location: never
 
 # Unconditional. The shared flow settles the app and no-ops on a device that has
 # already been through the carousel; guarding it here raced the first frame.


### PR DESCRIPTION
## What

Both flows failing on the nightly's iOS leg. Reproduced on an iPhone 17 simulator; **neither is an app bug**.

## 06-permissions-denied

Died in under a second, before a single assertion was read. `deny` is Android-only vocabulary for this permission:

```
IllegalArgumentException: wrong argument value 'deny' was provided for 'location' permission
  at util.LocalSimulatorUtils.setLocationPermission(LocalSimulatorUtils.kt:578)
```

It threw out of `launchApp` itself, which is why the flow's actual subject, that the app works with location denied, was never exercised on iOS.

`never` is accepted by **both** drivers. Verified against a simulator and an emulator separately before changing the flow, so this stays one value rather than a platform split.

## 03-rotation-sweep

Excluded from the iOS leg by tag. `setOrientation` does not work on the simulator:

- it reports `COMPLETED`
- the app stays in portrait: the hierarchy bounds after the rotate are still `[0,0][402,874]`, and the screenshot is a fully rendered **portrait** home screen with the search row plainly on it
- the accessibility tree comes back **empty** for that moment (zero resource-ids), so every id assertion after the rotate fails against a screen that is drawn correctly

The app's `Info.plist` lists `UIInterfaceOrientationLandscapeLeft` and `LandscapeRight`, so landscape is supported and this is the driver, not the app.

It would be Android-only regardless. The flow exists to catch **Activity recreation** faults, a route missing from the NavKey `SerializersModule` or state in `remember` rather than `rememberSaveable`, and iOS does not destroy and rebuild the world on rotation. There is no equivalent failure there for it to find.

`--exclude-tags=android-only` on the iOS leg; the Android leg is untouched and still runs it.

## Why tagging rather than deleting

Excluding a flow because it fails is how a suite ends up proving nothing, so the reasoning is written into the flow's own header, with the evidence, rather than left as a bare tag.

## Testing

Local, against the merged `main`:

| | before | after |
|---|---|---|
| iOS `.maestro/nightly/` | 2 of 4 failing | **3 of 3 passed** (rotation excluded) |
| Android `.maestro/nightly/` | — | **4 of 4 passed**, rotation sweep included |

`detekt` green; `actionlint` reports the same 8 pre-existing `SC2086` notes as before, none new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb