### PR TITLE
docs(learning): record the nightly lane and the platform-drift bugs

### DIFF
--- a/docs/learning/2026-08-22-a-lane-that-never-ran.md
+++ b/docs/learning/2026-08-22-a-lane-that-never-ran.md
@@ -1,0 +1,104 @@
+# The Maestro nightly had never run a single flow, and looked like a failing test suite
+
+**2026-08-22** · **CI / end-to-end lane** · **Cost: four dispatched nightly runs, two wrong diagnoses, one unnecessary PR**
+
+## Symptom
+
+The nightly lane was red every run. The PR smoke lane was red on every pull request,
+regardless of what the pull request changed. Both had been red for days and people had
+learned to scroll past them.
+
+The visible failure on the smoke lane was:
+
+```
+[Failed] 02-plan-trip (44s) (Assertion is false: id: searchstop.query is visible)
+```
+
+The nightly's job log ended without ever naming a flow.
+
+## Root cause
+
+Three separate bugs, stacked. Each one hid the next.
+
+1. **The nightly never started.** It passes `.maestro/` so it can cover the whole tree, and
+   Maestro does not recurse into subdirectories. Pointed at a directory whose flows all live
+   one level down it finds nothing and exits **non-zero**:
+
+   ```
+   Top-level directories do not contain any Flows: .../.maestro
+   ```
+
+   Because that is the same exit code a failing suite uses, a lane that never started was
+   indistinguishable from a lane that ran and failed.
+
+2. **No `testTag` inside any `ModalBottomSheet` was published as a resource id.** The app
+   calls `exposeTestTagsToUiAutomation()` once, on `KrailNavHost`. A sheet renders in its own
+   window, outside that subtree, so `testTagsAsResourceId` never reached it. Nothing failed
+   loudly: a UI-automation selector for anything inside a sheet simply never matched, which
+   reads exactly like the element not being on screen.
+
+3. **A first-run sheet covered the field the flow was waiting for.** `SearchStopViewModel`
+   opens the map options sheet by itself the first time a rider reaches stop search, gated on
+   `KEY_HAS_SEEN_MAP_OPTIONS_SHEET`. While up it covers `searchstop.query`. On a fresh device
+   that field is not slow to appear, it is unreachable.
+
+## Why it took so long
+
+**Wrong theory 1: the two lanes were failing the same way.** The smoke lane named a flow and
+an assertion; the nightly named nothing. Assuming one cause for both is what sent the first
+change in the wrong direction, and it was written into a merged PR description before anyone
+checked. The two lanes pass different paths: `.maestro/smoke/` has flows directly in it and
+always found them, `.maestro/` never did.
+
+**Wrong theory 2: the emulator was too slow.** The ANR dump printed at the failure showed 99%
+CPU with the whole Google app suite competing on two cores, and KRAIL not even in the table.
+That is real, and it is not what broke the flow. A change was shipped to wait for the device
+to go quiet; it ran, reported a flat 100% on every sample for the full two minutes, and
+disproved its own premise. A follow-up doubled every timeout in the flow. The flow then failed
+at exactly the same two points. **Doubling a timeout and getting an identical failure is proof
+the wait was never the problem** — that signal was available and was not read for another
+round.
+
+**What actually broke the deadlock** was reading the screenshot Maestro had been saving next to
+every failure the whole time. It is a full-screen map with a bottom sheet over it. The
+hierarchy dump beside it lists `Map Options`, `Save`, and `Tap any stop on the map to select
+it`, with `searchstop.query` nowhere. No theory survives that image.
+
+**And then the fix did not work either**, because of bug 2: the dismiss step was added, the
+flow still failed, and the sheet's Done button sat in the hierarchy dump with an empty
+`resource-id` beside its own label. That empty string is the only visible trace bug 2 ever
+leaves.
+
+## What would have caught it sooner
+
+- **Read the artifact before theorising.** Both wrong turns were theories built on a log line.
+  The screenshot and the hierarchy JSON were in the uploaded artifact from the first failure
+  onward and answered the question in one look. Same lesson as
+  `docs/LAYOUT_AND_INSETS.md`: measure before theorising.
+- **A timeout increase that changes nothing is evidence, not a reason to increase it again.**
+  If two different steps time out in one run, suspect a blocker, not a budget.
+- **Distrust a non-zero exit that names nothing.** A tool that exits 1 without naming a test
+  has usually not run any.
+- **Test automation against the state CI actually has.** Every one of these passed on a
+  developer emulator, because that device had dismissed the first-run sheet months earlier.
+  `adb shell pm clear` before a local run is the difference between reproducing CI and
+  reassuring yourself.
+
+## Actions taken
+
+- [x] `.maestro/config.yaml` names the two lane directories, so `.maestro/` discovers flows.
+      `shared/` and `ci/` deliberately excluded.
+- [x] `testTagsAsResourceId` set on taj's Android `ModalBottomSheet`, fixing every sheet in
+      the app rather than the one that exposed it.
+- [x] `.maestro/shared/dismiss-map-options.yaml`, same shape as `.maestro/shared/dismiss-intro.yaml`. Taps
+      **Done**, because Done is what writes `KEY_HAS_SEEN_MAP_OPTIONS_SHEET`; dismissing any
+      other way leaves the flag unset and the sheet returns later in the same flow.
+- [x] The smoke lane no longer runs on pull requests. It was never a required check, so a
+      permanently red mark that blocked nothing was worse than no mark.
+- [x] The settle pre-flight waits for CPU to **plateau** rather than to fall below a fixed
+      number. An absolute threshold is only meaningful if the idle figure is known, and here
+      it is a property of the runner: at a flat 100%, 85% was unreachable and the wait was
+      dead time.
+- [ ] The Android leg still needs its retry to go green: one attempt failed with an **empty
+      view hierarchy and a black screenshot**, which is the emulator's compositor stalling
+      under load, not the app and not the NSW API. Unexplained.

--- a/docs/learning/2026-08-22-two-platforms-two-vocabularies.md
+++ b/docs/learning/2026-08-22-two-platforms-two-vocabularies.md
@@ -1,0 +1,111 @@
+# The same platform-divergence bug, found four times in one day
+
+**2026-08-22** · **KMP / expect-actual contracts** · **Cost: four separate fixes, one rider-facing message that was wrong for months**
+
+## Symptom
+
+Four iOS bugs reported together, all in Ask KRAIL. They looked unrelated:
+
+1. The dialog could not be dismissed by tapping outside it.
+2. Listening ran for ten to fifteen seconds after the rider stopped talking; Android took four.
+3. Some riders could not use the feature at all, and were told to reword their sentence.
+4. "lets go to work" filled both From and To with the rider's Work stop.
+
+Every one of them worked correctly on Android.
+
+## Root cause
+
+One shape, four times: **a contract that both platforms are supposed to honour, where only one
+of them actually does, and nothing fails when the other does not.**
+
+1. **Dismiss.** Compose Multiplatform decides "outside" geometrically:
+   `layer.boundsInWindow` is set to the measured size of the dialog's content, and only
+   pointers landing outside that rectangle reach the dismiss listener. The content filled the
+   window, so nothing was ever outside. Android survived on `dismissOnBackPress`; iOS has no
+   back press, so the card had no exit at all.
+
+2. **Silence.** `SFSpeechAudioBufferRecognitionRequest` never decides the rider has finished.
+   `isFinal` arrives only after `endAudio()`, and nothing called it. Android's recogniser ends
+   itself on silence. The ViewModel ceiling, written as a backstop "for a recogniser that never
+   reports an end", had quietly become the only thing ending any iOS session.
+
+3. **Availability reasons.** Android reported ML Kit's words (`downloadable`, `downloading`,
+   `unsupported_device`); iOS reported Swift's string interpolation of an enum
+   (`modelNotReady`, `appleIntelligenceNotEnabled`, `deviceNotEligible`). Both callers tested
+   for the Android spellings only. On iOS nothing ever matched, so a model that was merely
+   still downloading was reported as a permanent failure, and the banner told riders on a
+   phone that cannot run the model to rename the places in their sentence. Unanswerable advice,
+   repeatable forever.
+
+4. **Prompt.** The Android extraction prompt lists `"let's go to X"` in its lone-place rule and
+   carries three worked examples. The iOS prompt was a shortened paraphrase with neither, and
+   nothing telling the model not to put one place in both fields.
+
+Two more of the same shape turned up while fixing these: iOS left
+`requiresOnDeviceRecognition` unset, so every spoken trip was **streamed to Apple's servers**
+while Android's `EXTRA_PREFER_OFFLINE` kept it local; and no `testTag` inside any
+`ModalBottomSheet` was ever published as a resource id
+(see [a lane that never ran](2026-08-22-a-lane-that-never-ran.md)).
+
+## Why it took so long
+
+**Nothing fails when a platform quietly disagrees.** Every case compiles, passes detekt, and
+passes unit tests. The Kotlin type system enforces that an `actual` exists, never that it
+behaves the same. `SpeechUnavailableReasons` already existed as a shared vocabulary for exactly
+this reason, and `AiAvailability` still went out with free-form strings on both sides.
+
+**The tests asserted the phase, never the message.** `unsupported device lands in UNRESOLVED,
+not DOWNLOADING` was green the entire time riders were reading the wrong sentence, because
+UNRESOLVED was the correct phase. The reason field, which is what the banner renders, was never
+asserted.
+
+**Matching the numbers hid a mismatched mechanism.** The silence windows were made identical
+across platforms, 4000ms on both. It still felt wrong, because the constants matched while the
+pipeline underneath did not: Android measured silence on device, iOS measured transcript change
+against a server round trip. **Two platforms agreeing on a constant is not the same as agreeing
+on behaviour**, and the matching numbers made the remaining difference harder to see, not
+easier.
+
+**The prompts were the same "in spirit".** Nothing compares them, so they drifted at exactly
+the phrase the rider used.
+
+## What would have caught it sooner
+
+- **A shared constants object per cross-platform contract, always.** If both sides return a
+  string a caller branches on, that string belongs in `commonMain` as named constants. This is
+  now the second time (`SpeechUnavailableReasons` was the first) and it should be the last.
+- **Assert what the rider reads, not what the state machine holds.** A phase test passes while
+  the message is wrong. Test the message.
+- **When an `actual` exists on both platforms, ask what the OTHER one does by default.** Three
+  of these are an iOS default nobody chose: `requiresOnDeviceRecognition = false`,
+  `taskHint = .unspecified`, no silence detection. Android set an explicit flag; iOS inherited
+  a different one.
+- **A prompt is advice, never a contract.** `SinglePlaceIntent.kt` already said so in a comment,
+  from an earlier version of this same bug. The guard against a stop resolving to itself is
+  deterministic code with a test; the prompt fix is the other half, not the fix.
+
+## Actions taken
+
+- [x] `AiUnavailableReasons` in `core/ai-text` commonMain, modelled on
+      `SpeechUnavailableReasons`. Both platforms map onto it; `AlertSummaryViewModel`, which
+      had the identical hole, reads it too.
+- [x] `UnresolvedReason.MODEL_UNAVAILABLE` and `MODEL_NEEDS_SETTING`, with messages naming
+      something the rider can act on, plus tests that assert the **reason**, not just the phase.
+- [x] The Ask KRAIL entry point is gated on device capability, not the flag alone. A button
+      that always fails is worse than no button.
+- [x] `resolveTripOrigin` refuses an origin equal to the destination, by id **or** name, since
+      one station carries several ids here. Tested.
+- [x] iOS sets `requiresOnDeviceRecognition` when the recogniser supports it, and
+      `taskHint = .dictation`, mirroring `EXTRA_PREFER_OFFLINE` and `LANGUAGE_MODEL_FREE_FORM`.
+- [x] iOS silence detection with windows matched to Android's, kept in step by hand and
+      commented on both sides.
+- [x] The audio session is released with `NotifyOthersOnDeactivation`. It was left in the
+      record category, so a rider who used the mic once lost their music until the app was
+      killed.
+- [x] `AiUnavailableReasonCoverageTest` walks the vocabulary and fails if any reason falls
+      through to the generic banner, or decides the wrong thing about hiding the entry point.
+      Mutation-checked: reverting the DEVICE_UNSUPPORTED arm to `null` fails it.
+- [ ] Android's `POSSIBLY_COMPLETE_SILENCE_LENGTH` has no iOS equivalent, so iOS stays about a
+      second slower to finish. No way to close it from here; documented in the service.
+- [ ] Nothing yet compares the two extraction prompts. They are two string literals in two
+      languages and will drift again.

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -64,4 +64,7 @@ Rules, scripts, tests or docs added. Link them. Unchecked boxes if not done yet.
 |---|---|---|
 | 2026-08-16 | [IME pan and the unbounded Column child](2026-08-16-ime-pan-and-unbounded-column.md) | Layout / window insets |
 | 2026-08-16 | [Clipped inside its own parent](2026-08-16-clipped-inside-its-own-parent.md) | Layout / test that could not fail |
+| 2026-08-21 | [Sheet closed by a text callback](2026-08-21-sheet-closed-by-a-text-callback.md) | State / unintended callback |
 | 2026-08-22 | [Three contrast guards, and the theme colour that fell between them](2026-08-22-three-contrast-guards-and-the-gap-between-them.md) | Design system / a guard that measured the wrong pairing |
+| 2026-08-22 | [A lane that never ran](2026-08-22-a-lane-that-never-ran.md) | CI / a non-zero exit that named nothing |
+| 2026-08-22 | [Two platforms, two vocabularies](2026-08-22-two-platforms-two-vocabularies.md) | KMP / expect-actual behavioural drift |

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiUnavailableReasonCoverageTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiUnavailableReasonCoverageTest.kt
@@ -1,0 +1,90 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai
+
+import xyz.ksharma.krail.core.aitext.AiUnavailableReasons
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Every reason the platforms can report has to produce something the rider can act on.
+ *
+ * The bug this exists to prevent shipped and survived for months: an unhandled reason fell
+ * through to UNRESOLVED with no [UnresolvedReason] set, which the banner renders as "Something
+ * is missing there. Name where you are going, and where from." That is advice about a
+ * sentence, shown to a rider whose sentence was never read, and on a phone that cannot run the
+ * model it is unanswerable.
+ *
+ * The test that was supposed to cover it asserted the PHASE and passed the whole time, because
+ * UNRESOLVED was the right phase. What was wrong was the reason, which is the part the rider
+ * actually reads.
+ *
+ * So this walks the vocabulary itself rather than a list written out by hand. Adding a constant
+ * to [AiUnavailableReasons] without deciding what it says to a rider fails here.
+ *
+ * See docs/learning/2026-08-22-two-platforms-two-vocabularies.md.
+ */
+class AiUnavailableReasonCoverageTest {
+
+    // Reflection is not available in common code, so the vocabulary is listed once here and
+    // pinned by a count. A new constant makes the count assertion fail, which is the prompt to
+    // come and decide what it means.
+    private val allReasons = listOf(
+        AiUnavailableReasons.MODEL_DOWNLOADING,
+        AiUnavailableReasons.DEVICE_UNSUPPORTED,
+        AiUnavailableReasons.NEEDS_DEVICE_SETTING,
+        AiUnavailableReasons.CHECK_FAILED,
+    )
+
+    @Test
+    fun `every reason in the vocabulary is listed here`() {
+        // Bump this deliberately, having added the new constant above AND decided below what
+        // it should say. If you are reading this because it failed, that is the point.
+        assertEquals(4, allReasons.size)
+        assertEquals(allReasons.size, allReasons.toSet().size, "duplicate reason constant")
+    }
+
+    @Test
+    fun `no reason leaves the rider with the generic could-not-read-your-sentence banner`() {
+        allReasons.forEach { reason ->
+            val state = AiSearchInputUiState().withUnavailableModel(reason)
+            if (state.phase == AiSearchInputPhase.DOWNLOADING) {
+                // DOWNLOADING carries its own message; a reason as well would be a second one.
+                assertNull(state.unresolvedReason, "$reason should not also set a reason")
+            } else {
+                assertEquals(AiSearchInputPhase.UNRESOLVED, state.phase, "unexpected phase for $reason")
+                assertNotNull(
+                    state.unresolvedReason,
+                    "$reason falls through to the generic banner, which tells a rider to " +
+                        "reword a sentence nothing read",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `only a permanently unsupported device loses the way in`() {
+        allReasons.forEach { reason ->
+            val capable = AiSearchInputUiState().withUnavailableModel(reason).isDeviceCapable
+            assertEquals(
+                reason != AiUnavailableReasons.DEVICE_UNSUPPORTED,
+                capable,
+                "$reason decided the wrong thing about hiding the entry point",
+            )
+        }
+    }
+
+    /**
+     * Android suffixes the throwable message onto CHECK_FAILED, so it arrives as a prefix
+     * rather than an exact value. Matching it by equality is the mistake that would silently
+     * send it to the wrong arm.
+     */
+    @Test
+    fun `a suffixed check failure is still treated as retriable, not as a dead device`() {
+        val state = AiSearchInputUiState()
+            .withUnavailableModel("${AiUnavailableReasons.CHECK_FAILED}: java.io.IOException")
+        assertEquals(UnresolvedReason.COULD_NOT_READ, state.unresolvedReason)
+        assertTrue(state.isDeviceCapable, "a failed check says nothing about the device")
+    }
+}


### PR DESCRIPTION
## What

Nothing from today's work was in `docs/learning/`, and most of it qualifies under that log's own rules: detekt and tests were green while the bugs were live, the first fix was wrong and so was the second, and diagnosis needed artifacts rather than reading code.

## Entries

**[A lane that never ran](docs/learning/2026-08-22-a-lane-that-never-ran.md)** — the Maestro nightly. Three stacked bugs, each hiding the next: the lane never discovered a flow and exited 1 anyway (so it looked like a failing suite), no `testTag` inside any `ModalBottomSheet` was ever published as a resource id, and a first-run sheet covered the field a flow was waiting for.

**[Two platforms, two vocabularies](docs/learning/2026-08-22-two-platforms-two-vocabularies.md)** — the four Ask KRAIL bugs, reported as unrelated, all one shape: a contract both platforms are meant to honour where only one does, and nothing fails when the other does not.

Both entries lead with the **wrong turns**, per the log's rules. Mine, in this case:

- assuming the two Maestro lanes failed the same way, which reached a merged PR description before anyone checked
- doubling flow timeouts, getting an identical failure, and reading that as a reason to increase them again rather than as proof the wait was never the problem
- naming "the NSW API" as a cause for an Android failure whose screenshot was solid black with an empty hierarchy

## The check

`AiUnavailableReasonCoverageTest` walks `AiUnavailableReasons` and fails if any value falls through to the generic banner, or decides the wrong thing about hiding the entry point. It also pins the vocabulary size, so adding a constant without deciding what it says to a rider fails.

**Mutation-checked before committing**: reverting the `DEVICE_UNSUPPORTED` arm to `null` fails it with the right message. The pre-existing test it supplements asserted the *phase* and stayed green for months while riders read the wrong sentence, which is exactly the failure mode the entry describes.

## A note on the guard that reviewed this PR

`LearningLogActionsTest` rejected my first draft: a ticked box named `` `dismiss-intro.yaml` `` and that does not resolve from the repo root. Fixed to the full path rather than loosening the guard. That test is the reason a ticked box means anything, and it did its job on the person adding entries.

Also adds the 2026-08-21 entry to the index, which was written without being listed.

## Testing

`./gradlew detekt --continue` and `./gradlew testAndroidHostTest --continue` both green, including `LearningLogActionsTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8SAxiB2G4nGs66NBvNkVb