### PR TITLE
docs-gardener: seventh audit (report-only)

### DIFF
--- a/.github/docs-gardener/AUDIT.md
+++ b/.github/docs-gardener/AUDIT.md
@@ -1,320 +1,292 @@
-# Docs Gardener Audit — 2026-08-15
+# Docs Gardener Audit — 2026-08-22
 
 Run mode: **report-only** (per Part B of `CHARTER.md`). No documentation was
 modified, moved, or deleted by this run. Everything below is a proposal for a
 human (or a future `active`-mode run) to act on.
 
-This is the sixth run. It builds on the
+This is the seventh run. It builds on the
 [first run](https://github.com/ksharma-xyz/KRAIL/pull/1727) (merged), the
 [second run](https://github.com/ksharma-xyz/KRAIL/pull/1732) (merged), the
 [third run](https://github.com/ksharma-xyz/KRAIL/pull/1777) (merged), the
-[fourth run](https://github.com/ksharma-xyz/KRAIL/pull/1782) (merged), and the
-[fifth run](https://github.com/ksharma-xyz/KRAIL/pull/1807) (merged), and adds a
-delta review of everything that changed since (`6207db8..HEAD`, 41 commits over
-6 days) — the largest delta this audit has covered: a full on-device AI search
-input + alert summary feature, two new capability modules, and a new
-store-listing screenshot framework.
+[fourth run](https://github.com/ksharma-xyz/KRAIL/pull/1782) (merged), the
+[fifth run](https://github.com/ksharma-xyz/KRAIL/pull/1807) (merged), and the
+[sixth run](https://github.com/ksharma-xyz/KRAIL/pull/1852) (merged), and adds
+a delta review of everything that changed since (`e66426b..8ea85bf`, 131
+commits over 7 days) — the largest delta yet: a full rebuild of the "Ask
+KRAIL" AI search surface into one input bar, a four-role theme-colour system,
+a testing-doctrine split, new Maestro end-to-end infrastructure, and six new
+bug-postmortem entries in a new `docs/learning/` log.
 
 ## Feedback ingestion
 
 Searched `is:pr label:docs-gardener` (any state) against `ksharma-xyz/krail`:
-five results, PR #1727 (first run), #1732 (second run), #1777 (third run),
-#1782 (fourth run), and #1807 (fifth run), all merged. All five report zero
-issue comments and zero reviews — no `charter:`-prefixed feedback on any of
-them. Nothing to fold into the Steering Log this run; no prior rejection to
-avoid re-proposing.
+six results, PR #1727 (first run), #1732 (second run), #1777 (third run),
+#1782 (fourth run), #1807 (fifth run), and #1852 (sixth run), all merged.
+Checked issue comments, review comments, and review threads directly on all
+six (not just the PRs' own descriptions) — all six report zero on every
+channel. No `charter:`-prefixed feedback anywhere. Nothing to fold into the
+Steering Log this run; no prior rejection to avoid re-proposing.
 
 ## Charter Part A drift
 
-Performed this run via a shallow clone of `ksharma-xyz/krail-bff`, then diffed
-its `.github/docs-gardener/CHARTER.md` Part A section (everything between the
-`## Part A: Core Policy` and `## Part B: Repo Overrides` headings) against this
-repo's Part A byte-for-byte. **No drift** — the two Part A sections are
-identical (the only diff line is the Part B heading itself, which is
+Performed this run via `add_repo` (read access) + a shallow clone of
+`ksharma-xyz/krail-bff`, then diffed its `.github/docs-gardener/CHARTER.md`
+Part A section (everything between the `## Part A: Core Policy` and
+`## Part B: Repo Overrides` headings) against this repo's Part A
+byte-for-byte. **No drift** — the two Part A sections are identical (the
+only diff line across the whole file is the Part B heading itself, which is
 repo-specific by design and outside Part A).
 
 ## Delta review this run
 
-`6207db8` (the fifth run's own delta endpoint, i.e. the state audited by PR
-#1807) to `origin/main` (`e66426b`) is 41 commits over 6 days (2026-08-09 to
-2026-08-15). Highlights: the full on-device AI search input + alert summary
-feature (`652e125` and ~25 follow-on fix/feat commits), two new capability
-modules (`core:speech-to-text`, `core:text-recognition`), the analytics
-registry auto-sync bot going live (`#1809`, `#1810`), a new cross-platform
-store-listing screenshot framework (`#1803`), a saved-trips park-and-ride fix
-(`#1813`), and a GTFS data bump (`#1814`).
+`e66426b` (the sixth run's own delta endpoint, i.e. the state audited by PR
+#1852) to `origin/main` (`8ea85bf`) is 131 commits over 7 days (2026-08-15 to
+2026-08-22). Highlights: the Ask KRAIL AI search surface rebuilt around one
+input bar (`8289ff6` and ~15 follow-on commits: suggestion sourcing from the
+rider's own stops, a situations table, dropping an invented listening-ceiling
+time, theme-painted AI surfaces), a theme-colour system split into four
+explicit roles (ground/ink/background/decor, `3fd27c4` and follow-ons), a
+large testing-doctrine expansion (`TESTING.md` split into
+`docs/testing/{LAYERS,GUARDS,COVERAGE}.md`, new Maestro E2E smoke/nightly
+flows, a Kover+Codecov coverage pipeline), six dated postmortems in a new
+`docs/learning/` log, a new rider-facing `docs/marketing/` doc, and multiple
+bug fixes (park-ride refresh cadence, rate limiting, polling-lifecycle
+guards, layout/inset bugs).
 
-`git diff --stat 6207db8..origin/main -- '*.md'` touches 19 markdown files.
-Two protected ledgers changed as expected
-(`docs/ANALYTICS_REGISTRY_HANDOFF.md` from the registry-sync work — no action
-possible or needed) and `CLAUDE.md` changed (protected, flagged only, see
-below). The rest are reviewed below.
+`git diff --stat e66426b..8ea85bf -- '*.md'` touches 29 markdown files
+(excluding this audit file itself). One protected file changed as expected
+(`CLAUDE.md`, 105 lines — flagged only, see below); the two protected
+ledgers (`docs/ANALYTICS_EVENTS.md`, `docs/ANALYTICS_REGISTRY_HANDOFF.md`)
+and `docs/release-notes/**`/`.claude/**` were **not** touched this delta. The
+rest are reviewed below.
 
-### New docs classified and verified
+### New and changed docs classified and verified
 
-- **`feature/trip-planner/ui/AI_SEARCH_UX.md`** (`ux-contract`) — the
-  "Where are you going?" surface's failure-mode table and its "nothing the
-  model produces is ever shown" rule. Spot-checked the load-bearing claims:
-  - `isFeatureEnabled` and `OpenInput` — both present in
-    `feature/trip-planner/ui/src/commonMain/kotlin/.../search/ai/AiSearchInputUiState.kt`
-    and `AiSearchInputViewModel.kt`, matching the doc's flag-gating claim.
-  - `SavedTripsState.dateTimeSelectionItem` and `TripPlannerRoutes`'s
-    `dateTimeSelectionItemJson` — both present, matching the doc's claim that
-    a parsed time now travels via the route rather than being discarded.
-  - The regression test `a place the model invented is never quoted back at
-    the rider` exists in `AiSearchInputViewModelTest.kt`.
-  - Verdict: **accurate**. The doc itself says "Both of the open defects
-    recorded here are now fixed" — see the `CLAUDE.md` finding below, where
-    that fix landed *after* CLAUDE.md's own summary of this doc was written.
-- **`feature/trip-planner/ui/ALERT_SUMMARY_UX.md`** (`ux-contract`) — the
-  on-device AI alert-summary card. Checked every class it names:
-  `AiTextService`, `AlertSummaryViewModel`, `CollapsibleAlert.kt`,
-  `FlagKeys` (for `ALERT_SUMMARY_ENABLED`), `AiWheelMark.kt`,
-  `AiSpinAnimation.kt` — all present at the stated paths. Verdict:
-  **accurate**.
-- **`docs/SEARCH_QUERY_TELEMETRY_SPEC.md`** (`ux-contract`) — what may be sent
-  about a typed search query. Checked `SearchQueryAnalytics.kt`,
-  `SearchQueryAnalyticsRedaction.kt`, `MAX_ZERO_RESULT_QUERY_LENGTH`,
-  `zeroResultQueryOrNull`, `resolveLocalZeroResultQuery`, and
-  `FuzzyStopSearchEvalTest` — all present. Verdict: **accurate**. Note: this
-  doc is not yet listed in `CHARTER.md`'s Part B "ux-contract docs" list
-  (neither is `AI_SEARCH_UX.md` or `ALERT_SUMMARY_UX.md`, above) even though
-  `CLAUDE.md`'s own "Per-feature UX rule docs" section already treats all
-  three as binding specs. Not an action this run — Part B is a repo override
-  a human edits, not something a `report-only` run touches — but worth a
-  human syncing that list the next time Part B is edited.
-- **`docs/ANALYTICS_REGISTRY_SYNC.md`** (`reference`) — how the
-  Pending-to-Registered flip is automated. Checked
-  `.github/workflows/analytics-registry-sync.yml` and
-  `scripts/validate_flip_diff.py` — both exist. Verdict: **accurate**.
-- **`core/speech-to-text/README.md`** (`reference`) — new module, explicitly
-  self-described as "interface + module boundary only... both actuals always
-  report Unavailable." Two broken references found (see Findings below).
-- **`core/text-recognition/README.md`** (`reference`) — new module,
-  self-described as "implemented on both platforms... not yet wired into
-  `AiScreenshotExtractCard`." `AiScreenshotExtractCard` does not exist yet
-  (`grep -rln "AiScreenshotExtractCard" --include="*.kt" .`: zero hits) — but
-  the doc already says this itself ("not yet wired"), so this is a consistent
-  forward-reference to planned work, not a stale claim. No action.
-- **`docs/investigations/AI_SEARCH_INPUT_MODE.md`** (`investigation`) — the
-  original exploration/architecture proposal. Now stale, see Findings below.
-- **`docs/investigations/IOS_FOUNDATION_MODELS_BRIDGE.md`** (`investigation`)
-  — working notes for the iOS Foundation Models bridge. Now stale, see
-  Findings below.
-- **`store-listing/framework/README.md`**, **`AGENT-GUIDE.md`**,
-  **`QA-CHECKLIST.md`** (`guide`) — app-agnostic screenshot-pipeline
-  groundwork. Cross-checked every file the framework README's "repository
-  contract" and the agent guide's read-order list name
-  (`verify-listing.py`, `render-store-images.py`, `manifest.json`,
-  `listing-qa.json`, `DECISIONS.md`, `capture-flows/`) against
-  `store-listing/framework/` and `store-listing/krail/` — all present.
+- **`taj/THEME_COLOUR_ROLES.md`** (`ux-contract`, new) — the four-role theme
+  colour rule already referenced from `CLAUDE.md`. Verified all five
+  accessors (`themeGroundColor`, `themeInkColor`, `themeInkColorOn`,
+  `themeDecorColor`, `themeBackgroundColor`) at
+  `taj/src/commonMain/kotlin/.../ColorsExt.kt`; `themeColor()` confirmed
+  `@Deprecated(..., ReplaceWith("themeGroundColor()"))` in the same file;
+  `ThemeColorRoleRule` confirmed at
+  `gradle/build-logic/detekt-rules/.../ThemeColorRoleRule.kt`; the doc's
+  `pastDepartureRowSurface` claim about `inkGrounds()`/`hardestInkGround()`
+  matches `taj/.../theme/ThemeInk.kt` exactly. Verdict: **accurate**.
+- **`feature/trip-planner/ui/ASK_KRAIL_UX.md`** (`ux-contract`, new) and
+  **`ASK_KRAIL_MANUAL_TESTS.md`** (`guide`, new) — the rebuilt screen surface
+  and its manual QA runbook. Every cited class/test
+  (`AiSuggestionSituations.kt`, `AiGreeting.kt`, `LabelSynonyms.kt`,
+  `AskKrailScreen.kt`, `AiInputBar.kt`'s `showWorkingBorder`,
+  `closeAfterHandoff`/`isAiHandoffSettling`/`isHandoffActionable`, the test
+  "the row-write gate closes with the dialog") found at the paths claimed.
   Verdict: **accurate**.
-- **`store-listing/krail/README.md`**, **`capture-flows/README.md`**
-  (`guide`) — app-specific runbook and flow docs. Not individually verified
-  line-by-line this run (low staleness risk: six days old, tooling-only,
-  no behavioral claims about app code); flagged for a closer read in a
-  future run if they age past this delta.
-- **`store-listing/krail/DECISIONS.md`** (`ledger`) — "the durable feedback
-  record for the approved 2026-08-09 KRAIL store listing set... Future
-  sessions must read it before changing captures." Append-only feedback
-  record, matches the `ledger` taxonomy definition exactly. Protected by
-  classification (content never modified), though not yet on `CHARTER.md`'s
-  explicit protected-files list — same non-blocking note as the ux-contract
-  docs above.
-- **`store-listing/krail/upload-ready/2026-08-09/README.md`** (`guide`) —
-  three-line upload instructions for one dated artifact folder. Six days old,
-  not a dated report/investigation under the taxonomy (no findings or
-  analysis to go stale), no action.
+- **`feature/trip-planner/ui/AI_SEARCH_UX.md`** (14-line diff) — re-verified
+  against `ASK_KRAIL_UX.md`: the two are **not** duplicates or a
+  supersession. `AI_SEARCH_UX.md` covers the `search/ai/` extraction pipeline
+  and the "nothing the model produces is shown" rule; `ASK_KRAIL_UX.md`
+  covers the `components/ai/` screen surface, copy, and speech UX. Each
+  explicitly cross-references the other at the top. No archive action
+  warranted; both current.
+- **`docs/testing/LAYERS.md`, `GUARDS.md`, `COVERAGE.md`** (`reference`, new)
+  and the restructured **`TESTING.md`** — confirmed `TESTING.md`'s own claim
+  (also echoed in `CLAUDE.md`) that it now points to these three files; all
+  three exist, resolve, and are substantive (494/354/267 lines, not stubs).
+  Verdict: **accurate**.
+- **`docs/learning/README.md`** (`reference`, new, index) and six dated
+  entries (`2026-08-16-clipped-inside-its-own-parent.md`,
+  `2026-08-16-ime-pan-and-unbounded-column.md`,
+  `2026-08-21-sheet-closed-by-a-text-callback.md`,
+  `2026-08-22-a-lane-that-never-ran.md`,
+  `2026-08-22-...three-contrast-guards-and-the-gap-between-them.md`,
+  `2026-08-22-two-platforms-two-vocabularies.md`) — all six dated entries
+  conform to the format the README itself specifies. Verdict: **accurate**.
+- **`docs/marketing/ASK_KRAIL_CAPABILITIES.md`** (new) — a rider-facing
+  capability summary for release notes / store listings, distinct from the
+  ux-contract docs it links out to. **Does not fit any existing taxonomy
+  label**: not `ledger` (not append-only), not `ux-contract` (not a binding
+  team spec, it's external-facing copy), not `reference`/`guide`/`plan`/
+  `investigation`. See Findings below — flagged as a taxonomy gap, no action
+  taken per the charter's "propose an addition, do not act on it" rule.
+- **`.maestro/README.md`** (`guide`, new) — `smoke/`, `nightly/`, `shared/`,
+  `ci/run-flows.sh`, `config.yaml` all confirmed present and matching the
+  doc's description. Verdict: **accurate**.
+- **`docs/INTEGRATION_TESTING_PLAN.md`** (`plan`, new) — genuinely
+  in-progress, not prune-eligible. Confirmed `AskKrailHandoffFlowTest.kt` and
+  `SearchStopRoundTripFlowTest.kt` exist (marked done in the doc), while
+  items 3 and 4 have no matching test file and are correctly left
+  un-struck-through as still-proposed. Also confirmed
+  `RealStopResultsManagerTest.kt` no longer exists, matching the doc's claim
+  it was deleted as dead-weight coverage. Verdict: **accurate, correctly
+  self-describes as partial**.
+- **`docs/ANALYTICS_ASSUMPTIONS.md`** (`ledger`, new) — per `CLAUDE.md`'s own
+  description of this file's purpose and format. Verdict: **accurate**.
+- **`README.md`, `docs/FEATURE_QUALITY_CHECKLIST.md`,
+  `docs/POLLING_LIFECYCLE.md`, `docs/TABLET_FOLDABLE_UX.md`,
+  `feature/trip-planner/ui/SEARCH_STOP_UX.md`, `taj/README.md`** (small
+  diffs, existing labels) — all changes self-consistent, no new staleness.
+  Notably: `docs/POLLING_LIFECYCLE.md`'s additions
+  (`PollingLifecycleGuardTest`, `TripPoller`,
+  `ParkRideRefreshHelper.pollWhileCardsAreOpen`,
+  `TimeTableRefreshPolicy.shouldAutoRefresh`,
+  `DepartureBoardRepository.fetchIfWindowOpen`, `VirtualClock`) all verified
+  present; `docs/TABLET_FOLDABLE_UX.md`'s additions
+  (`DualPaneScaffold`/`DUAL_PANE_LIST_WIDTH`/`DualPaneScaffoldTest`,
+  `RoutePaneMetadataTest`, new route rows) all verified present, and
+  `ServiceAlertRoute`/`DateTimeSelectorRoute` confirmed genuinely deleted,
+  matching the doc's "deleted (#1916)" claim;
+  `feature/trip-planner/ui/SEARCH_STOP_UX.md`'s claim that
+  `StopFilterByProductClassTest.kt` "has been removed" confirmed accurate.
 
 ### New findings
 
-1. **`core/speech-to-text/README.md`** (priority 1: broken references) —
-   links two paths that do not exist anywhere in the repo:
-   - `docs/investigations/ai_search_input_mockup.html` —
-     `find . -iname "ai_search_input_mockup.html"`: zero hits.
-   - `ios_permission_must_request.md` (cited as "this project's... lesson") —
-     `find . -iname "ios_permission_must_request.md"`: zero hits.
+1. **`docs/marketing/ASK_KRAIL_CAPABILITIES.md`** (priority: taxonomy
+   addition, not a code-verifiable staleness issue) — new content type not
+   covered by the charter's seven-label taxonomy. Proposed new label:
+   `marketing-copy` — evergreen, rider-facing capability/feature summaries
+   for release notes and store listings; content-rule-gated (no numbers,
+   per its own stated rule, same public-repo constraint as
+   `docs/ANALYTICS_ASSUMPTIONS.md`); kept current as capability changes
+   (unlike an append-only ledger); verified the same way as `reference` docs
+   — code-level evidence for every capability claim. Flagged only, per
+   charter step 4; no action taken this run.
 
-   Both may refer to session-local or externally-tracked artifacts (the same
-   pattern as the still-open `TESTING.md` finding from the first run), but as
-   written they are dead references in a committed, in-repo doc.
-
-2. **`docs/investigations/IOS_FOUNDATION_MODELS_BRIDGE.md`** (priority 4:
-   trim) — Status section's branch table still reads "Branches, stacked, not
-   yet raised as PRs," listing `feat/ai-text-service`,
-   `feat/taj-alert-feedback-vote`, and others. All of this already merged to
-   `main` in `652e125` (`feat(trip-planner): add the on-device AI search
-   input and alert summary`) and its follow-on commits:
-   - `core/ai-text/src/iosMain/kotlin/.../IosAiTextService.kt` on `main`
-     already calls the real `AiTextBridge` (Foundation Models), not a stub.
-   - `core/ai-text/src/swift/aiTextBridge/AiTextBridge.swift` exists on
-     `main`.
-   - `taj/src/commonMain/kotlin/.../components/AlertFeedbackVote.kt` (the
-     component `feat/taj-alert-feedback-vote` was building) exists on `main`.
-
-   This is the same pattern the third run found in
-   `docs/investigations/IN_APP_REVIEW_TIMING.md` (still open, carried forward
-   below): a Status section describing a branch stack as unmerged survives
-   past the merge itself. Trim candidate: replace the branch table with a
-   one-line "shipped in `652e125`" note; the rest of the doc (the technical
-   walkthrough of the Swift shim, the simulator caveat) is still accurate and
-   should stay.
-
-3. **`docs/investigations/AI_SEARCH_INPUT_MODE.md`** (priority 4: trim) —
-   Status line reads "build in progress... speech-to-text, OCR, and the
-   ViewModel/navigation wiring that actually uses it are not yet built." The
-   ViewModel/navigation wiring is now built and shipped:
-   `AiSearchInputViewModel` (imports and is constructed with a
-   `SpeechToTextService`), full-screen/dialog presentation
-   (`feat(trip-planner): AI input as a full screen on phones, a dialog on
-   tablets`), and home-screen wiring (`refactor(trip-planner): wire the home
-   screen to the AI sheet`) are all present on `main`. Speech-to-text and OCR
-   *capability* genuinely are still unbuilt (`core:speech-to-text` and
-   `core:text-recognition` both self-report their platform actuals as
-   stubs/unimplemented, per their READMEs above), so the doc is half right —
-   but as written the Status line undersells how much of the vertical slice
-   already shipped. Trim candidate: narrow the "not yet built" claim to the
-   two capability modules specifically.
-
-4. **`CLAUDE.md`** (protected, flagged only) — new instance of the same
-   pattern as the existing Submodules finding (carried-forward #1, below).
-   Its "Per-feature UX rule docs" entry for `AI_SEARCH_UX.md` still reads
-   "the two open defects (flag-off dead button, parsed time discarded at
-   navigation)" (`CLAUDE.md` line 388), but `AI_SEARCH_UX.md` itself now
-   says "Both of the open defects recorded here are now fixed" (line 42).
-   Confirmed by commit order: `CLAUDE.md`'s line was written in `25b5fb2`
-   (`docs(trip-planner): hold the AI rules down with a test and a ledger`);
-   the defect fixes landed afterward in `5b140a7` (`fix(trip-planner): with
-   the feature off, there is no way in`), `9c36556`/`4109671` (carrying a
-   chosen time through to the timetable), and `CLAUDE.md` was never touched
-   again to match. No action possible — protected content.
-
-5. **`docs/dimension-tokens-plan.md`** (no action, updated evidence) — Phase
-   2 migration count re-run: `grep -rn "[0-9]\+\.dp\b" --include="*.kt" . |
-   grep -v build | grep -v /tokens/` now returns **250** hits, up from 236 at
-   the fifth run — expected, since this delta added several new `taj`
-   components (`AiListeningIndicator.kt`, `AiThinkingIndicator.kt`,
-   `AiWheelMark.kt`, `MicIcon.kt`, `StopIcon.kt`, gradient tokens) with their
-   own raw `.dp` literals. Still not fully implemented, still no archive
-   action per the prune criteria.
+No other new doc in this delta produced a priority 1-4 finding (no broken
+links, no archive-eligible docs, no index fixes, no trim candidates) — every
+other new or changed doc checked out accurate against current code.
 
 ### Coverage
 
-Two of the three new capability modules landed with their own README the same
-delta that created them (`core:speech-to-text`, `core:text-recognition`) —
-exactly what the coverage duty asks for, no gap. The third,
-**`core/ai-text`**, has no README at all
-(`find core/ai-text -name "*.md"`: zero hits) despite being the most mature
-of the three — it already has real Android (ML Kit GenAI) and iOS (Foundation
-Models) actuals, while its two sibling modules are still stubs. It sits at 7
-Kotlin files, just under this charter's "roughly 10+ source files" coverage
-threshold (`find core/ai-text -name "*.kt" | grep -v build | wc -l`), so it is
-not added to the coverage-gap table below, but it is the one module in this
-delta most worth watching: `docs/investigations/IOS_FOUNDATION_MODELS_BRIDGE.md`
-and `feature/trip-planner/ui/ALERT_SUMMARY_UX.md` both describe pieces of it,
-but neither is a substitute for a module-level README the way
-`core/speech-to-text/README.md` is for its module.
+Two directories crossed the roughly-10-file threshold in this delta, both
+already covered by existing docs (same pattern prior runs used for
+sub-areas of already-documented modules):
 
-No other new source directories from this delta cross the 10-file threshold
-without a doc — `feature/trip-planner/ui/.../search/ai/`,
-`.../components/ai/`, and `.../alerts/summary/` are all sub-areas of the
-already-documented `feature/trip-planner/ui` module and are covered by
-`AI_SEARCH_UX.md` and `ALERT_SUMMARY_UX.md` above.
+- `feature/trip-planner/ui/.../search/ai/resolve/` (14 Kotlin files) —
+  covered by `AI_SEARCH_UX.md` and `ASK_KRAIL_UX.md` §5 (label resolution,
+  synonyms, resolvers named and explained).
+- `gradle/build-logic/detekt-rules/src/main` (10 Kotlin files) — covered by
+  `docs/testing/GUARDS.md` lines 44-198, which names the module path and
+  documents `ThemeColorRoleRule` specifically.
 
-`fix(analytics): fire park_ride_user_facility when saved trips auto-sync Park
-& Ride` (`#1813`) touches only `feature/park-ride` source and test files, no
-doc — consistent with the carried-forward `feature/park-ride` coverage gap
-below, not a new finding.
+No new coverage gap this run.
 
 ---
 
-## Carried-forward findings from the 2026-07-17 run
+## Carried-forward findings from the 2026-08-15 run
 
-Re-verified this run; all still apply verbatim.
+Re-verified this run with fresh grep/find/git-log evidence.
 
-1. **`CLAUDE.md`** (protected, flagged only) — "Submodules" section still
-   describes the removed `krail-api-proto` git submodule; no `.gitmodules`
-   file and no `krail-api-proto/` directory in the tree. No action possible
-   (protected content).
-2. **`TESTING.md`** (priority 1: broken link) — line 200 still links
-   `.claude/plans/on-a-worktee-look-expressive-cat.md`, which still does not
-   exist in the repo.
+1. **`CLAUDE.md`** (protected, flagged only) — "Submodules" section (line
+   246) still describes `krail-api-proto` as a live pulled-in submodule; no
+   `.gitmodules` file and no `krail-api-proto/` directory exist. A caveat
+   was added elsewhere in the file (line 294, under Worktree setup: "the
+   repo no longer uses the `krail-api-proto` submodule") but the misleading
+   section header itself is unchanged. No action possible (protected
+   content).
+2. **`TESTING.md`** (was priority 1: broken link) — **NOW FIXED**. The link
+   to `.claude/plans/on-a-worktee-look-expressive-cat.md` did not survive
+   this delta's restructure of `TESTING.md` into
+   `docs/testing/{LAYERS,GUARDS,COVERAGE}.md`
+   (`grep -rn "on-a-worktee-look-expressive-cat" .`: zero hits in
+   `TESTING.md` or anywhere else in the tracked tree). Dropped from the
+   carried-forward list.
 3. **`docs/bff-integration-plan.md`** (priority 2: archive) — still fully
    shipped and still describes the superseded submodule proto-distribution
-   mechanism.
+   mechanism as current (14 fresh grep hits for "submodule", unchanged).
 4. **`docs/ci_cd/ci-cd-architecture.md`** (priority 4: trim) — still lists
-   `distribute-google-play-manual.yml` (line 42), which still does not exist
-   in `.github/workflows/`.
-5. **`docs/dimension-tokens-plan.md`** (no action) — Phase 2 migration still
-   incomplete; raw-`.dp` count now 250 (see updated evidence above).
+   `distribute-google-play-manual.yml` (line 42); `.github/workflows/` still
+   has only `distribute-google-play.yml`, no "-manual" variant.
+5. **`docs/dimension-tokens-plan.md`** (no action) — raw-`.dp` literal count
+   re-run: **257** (up from 250 at the sixth run), from this delta's new
+   `taj` AI-input and theme-role components. Still not fully implemented,
+   still no archive action per the prune criteria.
 6. **`docs/plans/STOP_LABEL_ANALYTICS_PLAN.md`** (priority 2: archive) —
-   still verified shipped against `AnalyticsEvent.kt`. This delta's analytics
-   commit (`#1813`, park-ride facility ids) targets a different event
-   entirely; nothing to re-check against this plan's four stop-label events.
+   re-confirmed shipped: all four named events
+   (`stop_label_created`, `stop_label_stop_assigned`, `stop_label_removed`,
+   `stop_label_reordered`) present in `AnalyticsEvent.kt` at lines 382, 421,
+   460, 497.
 7. **`feature/trip-planner/ui/LABEL_DISPLAY_PLAN.md`** (no action) — PR3
-   (`StopSearchListItem`/`labelSubtitle`) still not found in code
-   (re-ran `grep -rn "labelSubtitle"`: zero hits).
+   (`StopSearchListItem`/`labelSubtitle`) still not found in source
+   (re-ran `grep -rn "labelSubtitle"`: only the plan doc itself and last
+   run's audit file reference it; zero `.kt` hits).
 8. **`feature/trip-planner/ui/STOP_LABEL_UX_REDESIGN_PROPOSAL.md`** (priority
-   2: archive) — still self-marked shipped/superseded, still verified
+   2: archive) — still self-marked `Status: **shipped.**`, still verified
    (`ManageStopLabelsSheet.kt` still absent from the tree).
 9. **`iosApp/README.md`** (priority 1 / coverage gap) — still links
-   `docs/ios-dsym-crashlytics.md`, which still does not exist.
+   `docs/ios-dsym-crashlytics.md` (line 7), which still does not exist.
 10. **`docs/investigations/IN_APP_REVIEW_TIMING.md`** (priority 4: trim,
-    found third run) — Status section still claims four
-    `app-review`/`user-lifecycle-store` branches are "not yet raised as PRs";
-    they merged to `main` back in July (see PR #1777 for the full `git log`
-    evidence). Rest of the doc still verified accurate. Still a trim
-    candidate, not archive.
+    escalating) — Status section still claims four
+    `app-review`/`user-lifecycle-store` branches are "not yet raised as
+    PRs." This is now *more* stale than at the third or sixth run: the
+    feature is fully merged and live in production code, not just
+    merged-as-a-branch — `core/app-review` exists, and its emitted event
+    `review_prompt_requested` is present in `AnalyticsEvent.kt` (line 1625).
+    `git log --oneline --all | grep -i app-review` shows the branches
+    landed as ordinary merged commits (`feat(app-review): trigger review on
+    shared delight moments`, `feat(app-review): gate review requests on
+    engagement and Remote Config`, `refactor(app-review): ...`), not open
+    branches. Same trim shape as the `IOS_FOUNDATION_MODELS_BRIDGE.md`
+    finding two runs ago: replace the Status section with a one-line
+    "shipped" note; the rest of the doc's rationale and design notes remain
+    a live reference.
 
-`SECURITY.md` re-checked: still no staleness surface (external links only).
+`SECURITY.md` not re-checked this run (no delta touched it; last verified
+clean at the second run).
 
 ### Coverage gaps (carried forward)
 
-Per the coverage duty (10+ source files, no README/doc), re-counted this run;
-no doc was added for any of these since they were first flagged:
+Per the coverage duty (10+ source files, no README/doc), re-counted this
+run:
 
-| Directory | Kotlin files | Doc? |
-|---|---|---|
-| `feature/park-ride` (found third run) | 19 | none — touched again this delta (#1813, an analytics fix) with no accompanying doc |
-| `feature/track` (found first run) | 32 | none |
-| `feature/departures` (found first run) | 27 | none |
-| `discover` (found first run) | 16 | none |
-| `feature/debug-settings` (found first run) | 14 | none |
-| `core/app-review` (found third run) | 10 | none — `docs/investigations/IN_APP_REVIEW_TIMING.md` covers its design/rationale in detail; a short `core/app-review/README.md` pointing there plus summarizing module layout would still close the gap |
-| `core/remote-config` (found first run) | 10 | none |
+| Directory | Kotlin files (last run) | Kotlin files (this run) | Doc? |
+|---|---|---|---|
+| `feature/track` (found first run) | 32 | **36** (+4) | none |
+| `feature/departures` (found first run) | 27 | 27 | none |
+| `feature/debug-settings` (found first run) | 14 | **15** (+1) | none |
+| `discover` (found first run) | 16 | 16 | none |
+| `feature/park-ride` (found third run) | 19 | 19 | none |
+| `core/remote-config` (found first run) | 10 | **11** (+1) | none |
+| `core/app-review` (found third run) | 10 | 10 | none — `docs/investigations/IN_APP_REVIEW_TIMING.md` covers its design/rationale in detail; a short `core/app-review/README.md` pointing there plus summarizing module layout would still close the gap |
 
-All seven counts are unchanged since the fifth run — none of this delta's 41
-commits touched these directories except the one park-ride fix noted above.
-`park-ride` remains the largest undocumented surface and, again this run, the
-most recently touched by shipped code.
+`feature/track` remains the largest undocumented surface and grew again
+this delta (theme/AI-surface touches to shared track UI). `core/remote-config`
+and `feature/debug-settings` also grew slightly. None of the seven gained a
+doc since first flagged.
+
+**`core/ai-text`** (watch item since the sixth run) — still **7** Kotlin
+files, unchanged, still no `*.md` in the directory, still just under the
+~10-file threshold. Still worth watching, no action.
 
 ---
 
 ## Deferred items
 
 Everything above remains deferred to a future `active`-mode run (or human
-action), since `report-only` makes no doc changes by design.
+action), since `report-only` makes no doc changes by design. In addition:
+the `marketing-copy` taxonomy proposal (new finding #1) needs a human
+decision on whether to add it to `CHARTER.md`'s classification taxonomy —
+a `report-only` run cannot edit the charter itself for this.
 
 ## Proposed action queue for the next `active` run, in charter priority order
 
-1. Fix broken links: `TESTING.md`, `iosApp/README.md`,
-   `core/speech-to-text/README.md` (two dead references — confirm with a
-   human whether `ai_search_input_mockup.html` and
-   `ios_permission_must_request.md` should be committed, or the references
-   removed).
+1. Fix broken links: `iosApp/README.md` (`docs/ios-dsym-crashlytics.md` does
+   not exist).
 2. Archive with tombstones: `docs/bff-integration-plan.md`,
    `docs/plans/STOP_LABEL_ANALYTICS_PLAN.md`,
    `feature/trip-planner/ui/STOP_LABEL_UX_REDESIGN_PROPOSAL.md`.
 3. Update index/README files to match the above archive moves.
 4. Trim stale sections: `docs/ci_cd/ci-cd-architecture.md`'s
    `distribute-google-play-manual.yml` line;
-   `docs/investigations/IN_APP_REVIEW_TIMING.md`'s Status table;
-   `docs/investigations/IOS_FOUNDATION_MODELS_BRIDGE.md`'s "not yet raised as
-   PRs" branch table; `docs/investigations/AI_SEARCH_INPUT_MODE.md`'s Status
-   line.
-5. Create small docs for the coverage gaps, `feature/park-ride` first (largest
-   and most recently active undocumented surface), then `core/app-review`,
-   then `feature/debug-settings`, then `feature/track`, `feature/departures`,
-   `discover`, `core/remote-config`. Watch `core/ai-text` (currently 7 files,
-   just under threshold) for a README once it grows or gains another platform
-   integration.
+   `docs/investigations/IN_APP_REVIEW_TIMING.md`'s Status section (now the
+   most out-of-date carried-forward finding — the feature it describes as
+   unmerged branches has been live in production for weeks).
+5. Create small docs for the coverage gaps, `feature/track` first (largest
+   and still growing), then `feature/departures`, `feature/debug-settings`,
+   `discover`, `feature/park-ride`, `core/remote-config`, then
+   `core/app-review` (has a ready-made source doc to summarize/link).
+   Watch `core/ai-text` (still 7 files) for a README once it crosses the
+   threshold.
+
+A human should also decide whether to add `marketing-copy` to `CHARTER.md`'s
+classification taxonomy (new finding #1) before the next run, so
+`docs/marketing/ASK_KRAIL_CAPABILITIES.md` (and any future doc like it)
+stops being flagged as unclassifiable.


### PR DESCRIPTION
## What

Updates `.github/docs-gardener/AUDIT.md` with the seventh docs-gardener run. Run mode is `report-only` per the charter's current Part B setting, so **no documentation content was changed, moved, or deleted** — this PR touches exactly one file.

## Changes

- Run mode: `report-only`.
- Feedback ingestion: searched `is:pr label:docs-gardener` (any state) — six prior PRs (#1727, #1732, #1777, #1782, #1807, #1852), all merged. Checked issue comments, review comments, and review threads directly on all six — zero on every channel. Nothing to fold into the Steering Log this run.
- Charter Part A drift check: performed via `add_repo` (read access) + a shallow clone of `ksharma-xyz/krail-bff`, diffed its `.github/docs-gardener/CHARTER.md` Part A section against this repo's byte-for-byte. **No drift.**
- Delta review of `e66426b..8ea85bf` (131 commits over 7 days) — the largest delta yet: the Ask KRAIL AI search surface rebuilt around one input bar, a four-role theme-colour system, a testing-doctrine split (`TESTING.md` into `docs/testing/{LAYERS,GUARDS,COVERAGE}.md`), new Maestro end-to-end infrastructure, a new `docs/learning/` postmortem log (six entries), and a new rider-facing `docs/marketing/` doc.
  - Every new/changed non-protected markdown file (14 of them) classified and cross-checked against code — every cited class, function, file, and test verified present at the claimed path. All accurate; no broken links or stale claims found in this delta's own new docs.
  - One taxonomy gap: `docs/marketing/ASK_KRAIL_CAPABILITIES.md` doesn't fit any of the charter's seven existing labels (it's rider-facing capability copy, not a team-binding spec or a how-it-works reference). Proposed a new `marketing-copy` label per the charter's "propose an addition, do not act on it" rule — flagged only.
  - Confirmed `AI_SEARCH_UX.md` and the new `ASK_KRAIL_UX.md` are complementary, not duplicates (pipeline vs. screen surface, each cross-references the other) — not an archive candidate.
- All 10 carried-forward findings and 7 coverage gaps re-verified with fresh grep/find/git-log evidence:
  - One dropped: `TESTING.md`'s dead link to `.claude/plans/on-a-worktee-look-expressive-cat.md` did not survive this delta's restructure — confirmed zero hits anywhere in the tree now.
  - One escalated: `docs/investigations/IN_APP_REVIEW_TIMING.md`'s Status section still describes the app-review feature as unmerged branches, but it's now not just merged — it's live in production (`core/app-review` exists, `review_prompt_requested` fires in `AnalyticsEvent.kt`). Same trim shape as a prior run's `IOS_FOUNDATION_MODELS_BRIDGE.md` finding.
  - The other 8 findings and all 7 coverage-gap directories are unchanged or wider (`feature/track` grew from 32 to 36 Kotlin files, `core/remote-config` from 10 to 11, `feature/debug-settings` from 14 to 15) — still no doc for any of them.
- The proposed action queue for a future `active`-mode run is updated: `TESTING.md`'s broken-link item dropped, `IN_APP_REVIEW_TIMING.md`'s trim escalated in priority, coverage-gap ordering re-ranked by current size.

## Testing

Docs-only change (one file under `.github/docs-gardener/`); no code, build files, or CI workflows touched. No test suite applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLVPymYCus549tkU4hh7ea)_