### PR TITLE
fix(speech): end iOS sessions on silence and drop blank transcripts

### DIFF
--- a/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/TranscriptWatchTest.kt
+++ b/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/TranscriptWatchTest.kt
@@ -1,0 +1,142 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+/**
+ * The two rules the iOS speech surface turns on, tested here because iOS source has no test task
+ * in this project. Both were rider-facing bugs: a sentence cleared from the field, and a session
+ * that never ended on its own.
+ */
+class TranscriptWatchTest {
+
+    @Test
+    fun `partials carry the words as they arrive`() {
+        val watch = TranscriptWatch()
+
+        assertEquals(SpeechToTextResult.Partial("central"), watch.record("central", isFinal = false))
+        assertEquals(
+            SpeechToTextResult.Partial("central to town hall"),
+            watch.record("central to town hall", isFinal = false),
+        )
+        assertTrue(watch.heardAnything)
+    }
+
+    @Test
+    fun `a blank partial is not sent on`() {
+        val watch = TranscriptWatch()
+        watch.record("central to town hall", isFinal = false)
+
+        // Nothing to send, rather than an empty string to write into the rider's field.
+        assertNull(watch.record("", isFinal = false))
+    }
+
+    @Test
+    fun `a blank final reports the last words actually heard`() {
+        val watch = TranscriptWatch()
+        watch.record("central to town hall", isFinal = false)
+
+        assertEquals(
+            SpeechToTextResult.Final("central to town hall"),
+            watch.record("", isFinal = true),
+        )
+    }
+
+    @Test
+    fun `a session that heard nothing ends as a session with no result`() {
+        val watch = TranscriptWatch()
+
+        assertEquals(
+            SpeechToTextResult.Error(SpeechUnavailableReasons.NO_RESULT),
+            watch.record("", isFinal = true),
+        )
+        assertTrue(!watch.heardAnything)
+    }
+
+    @Test
+    fun `a whitespace-only transcript counts as nothing heard`() {
+        val watch = TranscriptWatch()
+
+        // isBlank, not isEmpty. A recogniser that reports a space or a newline is reporting the
+        // same nothing, and " " written into the field is still the rider's sentence gone.
+        assertNull(watch.record("   ", isFinal = false))
+        assertEquals(
+            SpeechToTextResult.Error(SpeechUnavailableReasons.NO_RESULT),
+            watch.record("\n", isFinal = true),
+        )
+    }
+
+    @Test
+    fun `new words restart the quiet window`() {
+        val time = TestTimeSource()
+        val watch = TranscriptWatch(timeSource = time)
+
+        time += 3.seconds
+        watch.record("central", isFinal = false)
+        time += 1.seconds
+
+        assertEquals(1_000L, watch.quietForMillis())
+    }
+
+    @Test
+    fun `a revision that adds no words does not restart the quiet window`() {
+        val time = TestTimeSource()
+        val watch = TranscriptWatch(timeSource = time)
+        watch.record("central to town hall", isFinal = false)
+
+        // The rider stopped here. Everything after this is the recogniser tidying up what it
+        // already heard: capitalisation, then punctuation. Treated as speech, these kept the
+        // microphone open until the ViewModel's ceiling cut it off.
+        time += 2.seconds
+        watch.record("Central to Town Hall", isFinal = false)
+        time += 1.seconds
+        watch.record("Central to Town Hall.", isFinal = false)
+
+        assertEquals(3_000L, watch.quietForMillis())
+    }
+
+    @Test
+    fun `a revision that drops a word does not restart the window either`() {
+        val time = TestTimeSource()
+        val watch = TranscriptWatch(timeSource = time)
+        watch.record("central to town hall station", isFinal = false)
+
+        // The recogniser deciding it heard one word too many is not the rider speaking. Only
+        // growth counts, so a shorter transcript leaves the clock exactly where it was.
+        time += 2.seconds
+        watch.record("central to town hall", isFinal = false)
+        time += 1.seconds
+
+        assertEquals(3_000L, watch.quietForMillis())
+    }
+
+    @Test
+    fun `the last words heard survive a revision down to nothing`() {
+        val watch = TranscriptWatch()
+        watch.record("central to town hall", isFinal = false)
+        watch.record("", isFinal = false)
+
+        // The blank in the middle must not become what the session is worth.
+        assertEquals(
+            SpeechToTextResult.Final("central to town hall"),
+            watch.record("", isFinal = true),
+        )
+    }
+
+    @Test
+    fun `a revision that adds a word does restart it`() {
+        val time = TestTimeSource()
+        val watch = TranscriptWatch(timeSource = time)
+        watch.record("central to town", isFinal = false)
+
+        time += 2.seconds
+        watch.record("central to town hall", isFinal = false)
+        time += 1.seconds
+
+        assertEquals(1_000L, watch.quietForMillis())
+    }
+}

--- a/core/speech-to-text/src/androidMain/kotlin/xyz/ksharma/krail/core/speechtotext/AndroidSpeechToTextService.kt
+++ b/core/speech-to-text/src/androidMain/kotlin/xyz/ksharma/krail/core/speechtotext/AndroidSpeechToTextService.kt
@@ -147,5 +147,9 @@ internal class AndroidSpeechToTextService(private val context: Context) : Speech
             PackageManager.PERMISSION_GRANTED
 }
 
+// A blank candidate counts as no candidate, so a result of "" is reported as the session having
+// no result rather than being written into the rider's field as an empty sentence. An OEM
+// recogniser returning one is rare; iOS returns one routinely, and the two platforms answer the
+// same shape the same way.
 private fun Bundle.firstRecognitionCandidate(): String? =
-    getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()
+    getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)?.firstOrNull()?.takeIf { it.isNotBlank() }

--- a/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechToTextService.kt
+++ b/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechToTextService.kt
@@ -52,6 +52,15 @@ sealed interface SpeechToTextAvailability {
     data class Unavailable(val reason: String) : SpeechToTextAvailability
 }
 
+/**
+ * [Partial] and [Final] always carry words. A recogniser reporting a blank transcription is
+ * saying it has nothing to add, never that the rider unsaid what they said, so an
+ * implementation drops it rather than emitting it: the caller writes each transcript straight
+ * into the field the rider is looking at, and a blank one erases the sentence they just watched
+ * arrive. A session that heard nothing at all ends as [Error] with
+ * [SpeechUnavailableReasons.NO_RESULT], which is a session with no result rather than a session
+ * whose result is nothing.
+ */
 sealed interface SpeechToTextResult {
     data class Partial(val text: String) : SpeechToTextResult
     data class Final(val text: String) : SpeechToTextResult

--- a/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/TranscriptWatch.kt
+++ b/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/TranscriptWatch.kt
@@ -1,0 +1,70 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * One listening session's running state: what has been heard, when the last word arrived, and
+ * what to send on for each transcription the recogniser produces.
+ *
+ * Used by `IosSpeechToTextService`, which is the platform that has to work this out for itself —
+ * Android's recogniser ends a session on its own and reports its own results. It lives in
+ * `commonMain` anyway, because iOS source has no test task in this project and these are the two
+ * rules the surface actually turns on:
+ *
+ * **A blank transcription is never sent on as one.** `endAudio` asks the recogniser to finish,
+ * and the result that comes back can carry an empty transcription for the segment that was open
+ * at the time rather than a repeat of the sentence — the ordinary ending of a session here, not
+ * a rare one, since the caller waits seconds of quiet before finishing. Sent on, it reached the
+ * rider's field as their sentence being cleared for them a beat after they watched it arrive.
+ * The last words actually heard are what a session is worth, so a blank final reports those, and
+ * a session that heard nothing at all reports [SpeechUnavailableReasons.NO_RESULT] — which is
+ * what `AndroidSpeechToTextService` does with a missing recognition candidate.
+ *
+ * **Only new words mean the rider is still talking.** The recogniser goes on revising what it
+ * already heard for seconds after they stop, and every revision arrives as a changed transcript.
+ *
+ * [timeSource] is a parameter so the quiet window can be tested without waiting through it.
+ */
+internal class TranscriptWatch(private val timeSource: TimeSource = TimeSource.Monotonic) {
+
+    var heardAnything: Boolean = false
+        private set
+
+    private var lastWordsHeard: String = ""
+    private var lastTranscript: String = ""
+    private var wordsSoFar: Int = 0
+    private var lastNewWordAt: TimeMark = timeSource.markNow()
+
+    /** Null means there is nothing worth sending on for this transcription. */
+    fun record(text: String, isFinal: Boolean): SpeechToTextResult? {
+        if (text != lastTranscript) {
+            lastTranscript = text
+            if (text.isNotBlank()) {
+                heardAnything = true
+                lastWordsHeard = text
+            }
+            // Words, not changes. Capitalising a station name, swapping a homophone or
+            // re-punctuating all arrive as a changed transcript seconds after the rider stopped
+            // talking. Resetting the quiet window on any change let a finished sentence keep the
+            // microphone open on the strength of the recogniser talking to itself, and the
+            // session ran to the ViewModel's ceiling instead of ending on its own.
+            val words = text.split(' ', '\n', '\t').count { it.isNotBlank() }
+            if (words > wordsSoFar) {
+                wordsSoFar = words
+                lastNewWordAt = timeSource.markNow()
+            }
+        }
+        return when {
+            isFinal && lastWordsHeard.isBlank() ->
+                SpeechToTextResult.Error(reason = SpeechUnavailableReasons.NO_RESULT)
+
+            isFinal -> SpeechToTextResult.Final(text = lastWordsHeard)
+            text.isNotBlank() -> SpeechToTextResult.Partial(text = text)
+            else -> null
+        }
+    }
+
+    /** How long since a new word arrived, which is what "the rider stopped" means here. */
+    fun quietForMillis(): Long = lastNewWordAt.elapsedNow().inWholeMilliseconds
+}

--- a/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/IosSpeechToTextService.kt
+++ b/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/IosSpeechToTextService.kt
@@ -23,8 +23,6 @@ import platform.Speech.SFSpeechRecognizer
 import platform.Speech.SFSpeechRecognizerAuthorizationStatus
 import xyz.ksharma.krail.core.log.log
 import kotlin.coroutines.resume
-import kotlin.time.TimeMark
-import kotlin.time.TimeSource
 
 /**
  * `SFSpeechRecognizer` + `AVAudioEngine`, both plain Objective-C-compatible frameworks (no
@@ -96,9 +94,7 @@ internal class IosSpeechToTextService : SpeechToTextService {
         // What the silence watcher below reads. Written from the recognition callback, read
         // from a coroutine: both run on the main dispatcher, so no synchronisation is needed
         // beyond them not being able to interleave mid-statement.
-        var lastTranscript = ""
-        var lastChangeAt = TimeSource.Monotonic.markNow()
-        var heardAnything = false
+        val session = TranscriptWatch()
 
         speechRecognizer.recognitionTaskWithRequest(request) { result, error ->
             when {
@@ -108,30 +104,16 @@ internal class IosSpeechToTextService : SpeechToTextService {
                 }
 
                 result != null -> {
-                    val text = result.bestTranscription.formattedString
-                    if (text != lastTranscript) {
-                        lastTranscript = text
-                        lastChangeAt = TimeSource.Monotonic.markNow()
-                        if (text.isNotBlank()) heardAnything = true
-                    }
-                    if (result.isFinal()) {
-                        trySend(SpeechToTextResult.Final(text = text))
-                        close()
-                    } else {
-                        trySend(SpeechToTextResult.Partial(text = text))
-                    }
+                    val isFinal = result.isFinal()
+                    session.record(text = result.bestTranscription.formattedString, isFinal = isFinal)
+                        ?.let { trySend(it) }
+                    if (isFinal) close()
                 }
             }
         }
 
         // The end-of-speech detection iOS does not have. See watchForSilence.
-        launch {
-            watchForSilence(
-                lastChangeAt = { lastChangeAt },
-                heardAnything = { heardAnything },
-                request = request,
-            )
-        }
+        launch { watchForSilence(session = session) }
 
         awaitClose {
             engine.stop()
@@ -143,7 +125,17 @@ internal class IosSpeechToTextService : SpeechToTextService {
         }
     }
 
-    override fun stopListening() {
+    override fun stopListening() = stopFeedingAudio()
+
+    /**
+     * Takes the microphone away and tells the request that was all the audio there is, in that
+     * order. Both are needed and the order is the point: `endAudio` on a request still being
+     * appended to leaves the recogniser waiting on audio nobody meant to send.
+     *
+     * The recogniser still owes a final transcript afterwards, so this ends the *listening*, not
+     * the flow — see [watchForSilence], which is the other caller.
+     */
+    private fun stopFeedingAudio() {
         audioEngine?.stop()
         audioEngine?.inputNode?.removeTapOnBus(0u)
         recognitionRequest?.endAudio()
@@ -218,34 +210,44 @@ internal class IosSpeechToTextService : SpeechToTextService {
      * second ceiling here. That ceiling is a backstop for a recogniser that never reports an
      * end, and on iOS it had quietly become the only thing ending any session at all.
      *
-     * Watches for an unchanging transcript rather than for quiet audio: the audio tap sees room
-     * noise on every buffer, while the transcript only moves when words are recognised, which
-     * is the thing actually being waited on.
+     * Watches for words rather than for quiet audio: the audio tap sees room noise on every
+     * buffer, while the transcript only gains a word when one is recognised, which is the thing
+     * actually being waited on. Words, not changes — see [TranscriptWatch.record].
      *
-     * The windows are deliberately in step with SILENCE_THAT_ENDS_THE_SESSION_MILLIS on the
-     * Android side. Kept by hand, since the two live in different source sets on purpose.
+     * One window, where Android has two: four seconds of quiet after a phrase that sounds
+     * unfinished, three after one that sounds complete. A trip said out loud almost always ends
+     * on a complete-sounding phrase, so three is the window that fires there. iOS cannot tell
+     * those two apart, so it gets the one that matches the common case, and it used to copy the
+     * other one - which is the second of extra waiting this used to have.
+     *
+     * The two platforms are still not measuring the same event, so the numbers being equal is a
+     * coincidence worth not relying on: Android measures silence, this measures the recogniser's
+     * last word ARRIVING, which lags the rider's last word by however long recognition takes.
      */
-    private suspend fun watchForSilence(
-        lastChangeAt: () -> TimeMark,
-        heardAnything: () -> Boolean,
-        request: SFSpeechAudioBufferRecognitionRequest,
-    ) {
+    private suspend fun watchForSilence(session: TranscriptWatch) {
         while (currentCoroutineContext().isActive) {
             delay(SILENCE_POLL_MILLIS)
-            val quietFor = lastChangeAt().elapsedNow().inWholeMilliseconds
+            val quietFor = session.quietForMillis()
             // Nothing recognised yet earns a longer grace period: that window covers a rider
             // who tapped the mic and is still drawing breath, not one who has trailed off mid
             // sentence.
-            val longEnough = if (heardAnything()) {
+            val longEnough = if (session.heardAnything) {
                 SILENCE_THAT_ENDS_THE_SESSION_MILLIS
             } else {
                 SILENCE_BEFORE_ANY_SPEECH_MILLIS
             }
             if (quietFor >= longEnough) {
                 log("SpeechToTextService: ${quietFor}ms without new words, ending audio")
-                // endAudio, not close: the recogniser still owes a final transcript, and this
-                // is the same graceful finish stopListening asks for.
-                request.endAudio()
+                // The exact finish stopListening asks for, and for the same reason it takes the
+                // microphone away first. `endAudio` means "that was all the audio there is", and
+                // the tap was still running underneath it, appending room noise to a request
+                // that had been told it was closed. The recogniser is under no obligation to
+                // finish a request still being written to, which is how a session that had
+                // decided the rider was done still ran to the ViewModel's ceiling.
+                //
+                // Not close(): the recogniser still owes a final transcript, and the flow stays
+                // open to receive it.
+                stopFeedingAudio()
                 return
             }
         }
@@ -291,10 +293,18 @@ internal class IosSpeechToTextService : SpeechToTextService {
         AVAudioApplication.sharedInstance().recordPermission == AVAudioApplicationRecordPermissionGranted
 }
 
-// Matches SILENCE_THAT_ENDS_THE_SESSION_MILLIS in AndroidSpeechToTextService, so a sentence
-// takes the same time to finish on both platforms. A trip said out loud has thinking pauses in
-// it, which is why this is four seconds and not one.
-private const val SILENCE_THAT_ENDS_THE_SESSION_MILLIS = 4_000L
+// The same number as Android's SILENCE_AFTER_A_COMPLETE_SOUNDING_PHRASE_MILLIS, which is the
+// window that actually fires over there: a trip said out loud almost always ends on a
+// complete-sounding phrase. NOT Android's other window, the four-second one this used to copy,
+// which is why iOS took about a second longer to finish the same sentence.
+//
+// What this measures is not the same event Android measures, and that is worth knowing before
+// tuning it: iOS waits on the recogniser's last word ARRIVING, which already lags the rider's
+// last word being spoken, so three seconds here is felt as a little more than Android's three.
+// Two was tried and is the floor - below it, "from Central to..." <thinking> starts being cut
+// off, which is a rider-reported bug on the Android side already and the reason those windows
+// were widened rather than narrowed.
+private const val SILENCE_THAT_ENDS_THE_SESSION_MILLIS = 3_000L
 
 // Before the first word. Longer than the mid-sentence window: the rider has just tapped the
 // mic and may still be deciding what to ask for. Still well inside the ViewModel's ten second

--- a/docs/learning/2026-08-22-two-platforms-two-vocabularies.md
+++ b/docs/learning/2026-08-22-two-platforms-two-vocabularies.md
@@ -105,7 +105,12 @@ the phrase the rider used.
 - [x] `AiUnavailableReasonCoverageTest` walks the vocabulary and fails if any reason falls
       through to the generic banner, or decides the wrong thing about hiding the entry point.
       Mutation-checked: reverting the DEVICE_UNSUPPORTED arm to `null` fails it.
-- [ ] Android's `POSSIBLY_COMPLETE_SILENCE_LENGTH` has no iOS equivalent, so iOS stays about a
-      second slower to finish. No way to close it from here; documented in the service.
+- [x] Android's `POSSIBLY_COMPLETE_SILENCE_LENGTH` has no iOS equivalent, so iOS stayed about a
+      second slower to finish. Closed the following day, and the fix was to stop matching the
+      numbers: iOS measures a different event (the recogniser's last word *arriving*, which lags
+      the rider's last word), so its single window is now deliberately shorter than either
+      Android window rather than equal to one of them. See
+      [the blank transcript entry](2026-08-23-the-blank-transcript-that-cleared-the-field.md),
+      which is where the rest of that session's ending bugs are written up.
 - [ ] Nothing yet compares the two extraction prompts. They are two string literals in two
       languages and will drift again.

--- a/docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md
+++ b/docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md
@@ -1,0 +1,121 @@
+# iOS cleared the rider's spoken sentence a beat after they watched it arrive
+
+**2026-08-23** · **KMP / cross-platform contracts, speech-to-text** · **Cost: one report, one read of two service implementations side by side**
+
+## Symptom
+
+Speak into Ask KRAIL on iOS. The words appear in the field as they are recognised, exactly as
+intended. Stop talking. A beat later the field empties itself. Nothing is said about why, no
+banner appears, and the only way back to the sentence is to say it again.
+
+Android does the same thing correctly with the same ViewModel, the same field and the same
+state.
+
+## Root cause
+
+`SpeechToTextResult.Partial` and `Final` carry a `String`, and nothing said that string always
+has words in it.
+
+The ViewModel writes every transcript straight into `typedText`, which is the field the rider is
+looking at. That is deliberate: partials landing in the field is what makes speaking feel like
+it is being heard. A blank transcript written the same way is the rider's sentence being erased.
+
+`AndroidSpeechToTextService` never produced one, by accident rather than by design: it reads the
+recogniser's first candidate through a nullable helper, and reports a missing candidate as
+`Error(NO_RESULT)` instead of a result.
+
+`IosSpeechToTextService` passed `result.bestTranscription.formattedString` through unguarded.
+`endAudio()` asks `SFSpeechRecognizer` to finish, and the result that comes back can carry an
+empty transcription for the segment that was open at the time rather than a repeat of the
+sentence. This service waits four seconds of quiet before calling `endAudio()`, so that is the
+**ordinary** ending of a session, not a rare one.
+
+## Why it took so long
+
+**The type allowed it and the tests agreed with the type.** `Final(text: String)` accepts `""`
+happily. Every existing speech test emitted a realistic sentence, so nothing ever asked what the
+field does with a blank one. Detekt, the unit tests and both compiles were green the whole time.
+
+**Wrong theories, in the order they looked plausible.** First: the Compose Multiplatform iOS
+text-input session clobbering a programmatic `setTextAndPlaceCursorAtEnd` with a stale empty
+value — plausible because the state round-trips through `TextFieldState` and back into the
+ViewModel as `TypedTextChanged`, and because that round trip really is the only path that can
+write an empty string into `typedText` from the UI. Second: the dialog recomposing and rebuilding
+an empty `TextFieldState`, whose first `onTextChange` would report `""`. Both were theories about
+Compose, and both survived reading the Compose code because the Compose code is not where the
+`""` comes from.
+
+**What ended it was reading the two service implementations against each other rather than
+reading the shared caller.** The asymmetry is four lines apart in two files that no build step
+compares.
+
+## The same session, two more ways it did not end
+
+Reported straight after the clearing bug: iOS also would not notice that the rider had finished.
+Two separate causes, both in the silence watcher, neither of them the window length everyone
+reaches for first.
+
+**Audio was still being appended to a request that had been told it was closed.** The watcher
+called `endAudio()` and nothing else, while the `AVAudioEngine` tap kept running underneath and
+kept calling `appendAudioPCMBuffer`. `endAudio` means "that was all the audio there is", and a
+recogniser is under no obligation to finish a request still being written to. `stopListening()`
+had always taken the microphone away first; the watcher, which is the path that ends almost every
+session, did not. Both now call the same `stopFeedingAudio()`.
+
+**The quiet window was reset by the recogniser talking to itself.** It reset on any *changed*
+transcript, and a recogniser goes on revising what it already heard for seconds after the rider
+stops: capitalising a station name, swapping a homophone, re-punctuating. Each revision looked
+like the rider still speaking. It now resets only when the transcript gains a **word**.
+
+**Then, and only then, the window.** It was 4000ms, matched by hand to Android's
+`COMPLETE_SILENCE_LENGTH`. Matching it was the mistake: Android sets *two* windows and the one
+that fires for a trip sentence is the 3000ms `POSSIBLY_COMPLETE_SILENCE_LENGTH`, since a trip said
+out loud ends on a complete-sounding phrase. iOS cannot tell the two apart, and what it measures
+is not silence but the recogniser's last word *arriving*, which already lags the rider's last word.
+Matching the *wrong* number therefore cost a full second on every sentence. It is now **3000ms**,
+the same number as the Android window that actually fires, with the reasoning written at the
+constant — including the warning that the two platforms measure different events, so the numbers
+being equal is a coincidence and not a contract.
+
+2000ms was tried first and is the floor. Below it, "from Central to…" *(thinking)* starts being cut
+off, which is a rider-reported bug on the Android side already and the reason those windows were
+widened rather than narrowed.
+
+## What would have caught it sooner
+
+- **A shared type that only allows valid values, or a documented contract on the type when it
+  cannot.** This is the third time (`SpeechUnavailableReasons`, then `AiUnavailableReasons`, now
+  this) that a cross-platform result type carried a value one platform produces and the other
+  never does. The type is the only place both sides look.
+- **Test the degenerate value, not just the realistic one.** Every speech test emitted a
+  sentence. A blank, a whitespace-only string and a very long one are three tests, and one of
+  them was this bug.
+- **When an `actual` exists on both platforms, ask what the OTHER one does by default.** Written
+  as the top lesson of [the four-in-one-day entry](2026-08-22-two-platforms-two-vocabularies.md)
+  the day before, and this is the same shape again: Android's guard was incidental, iOS inherited
+  the platform's raw output.
+
+## Actions taken
+
+- [x] `SpeechToTextResult` states the contract on the type: transcripts always carry words, and a
+      session that heard nothing ends as `Error(NO_RESULT)` rather than as a result that is
+      nothing.
+- [x] `IosSpeechToTextService` sends the last words actually heard for a blank final, and
+      `NO_RESULT` when there were none. The session bookkeeping moved into a `TranscriptWatch`
+      that owns the rule, so the callback cannot forget it.
+- [x] `AndroidSpeechToTextService` treats a blank candidate as no candidate, so an OEM recogniser
+      returning one is answered the same way.
+- [x] `AiSearchInputViewModel` refuses to write a blank transcript into the field whichever
+      platform produced it, with `a blank final does not wipe the sentence the rider watched
+      arrive` and `a blank partial does not wipe the words already heard`.
+- [x] Failure mode #14 in `feature/trip-planner/ui/AI_SEARCH_UX.md`.
+- [x] The two session rules moved out of `iosMain` into a `TranscriptWatch` in `commonMain`,
+      which put them somewhere a test can reach: `TranscriptWatchTest` covers the blank partial,
+      the blank final, the session that heard nothing, and — the ending bug — a revision that
+      adds no words not restarting the quiet window. It takes a `TimeSource` so the window is
+      tested without waiting through it.
+- [x] `stopFeedingAudio()` is the one way to finish listening, so the watcher and the rider's
+      stop button cannot diverge again.
+- [ ] The window length itself is still a hand-tuned number with no test that could tell 2000ms
+      from 3000ms. What "too soon" means is a rider mid-thought, and nothing here can measure
+      that; it is a device-QA question and stays one.

--- a/docs/learning/README.md
+++ b/docs/learning/README.md
@@ -69,3 +69,4 @@ Rules, scripts, tests or docs added. Link them. Unchecked boxes if not done yet.
 | 2026-08-22 | [A lane that never ran](2026-08-22-a-lane-that-never-ran.md) | CI / a non-zero exit that named nothing |
 | 2026-08-22 | [Two platforms, two vocabularies](2026-08-22-two-platforms-two-vocabularies.md) | KMP / expect-actual behavioural drift |
 | 2026-08-23 | [The screen that opened on the wrong surface](2026-08-23-the-screen-that-opened-on-the-wrong-surface.md) | UI / a default no test could see |
+| 2026-08-23 | [The blank transcript that cleared the field](2026-08-23-the-blank-transcript-that-cleared-the-field.md) | KMP / a value one platform never produces |

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -40,9 +40,20 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 | 8 | Only one end resolves | That field fills, the other is left | `one stop resolving is still a result` |
 | 9 | Origin unstated, destination found, GPS off or denied | From left empty | `nearby-stop resolver failure leaves origin unresolved, not a crash` |
 | 10 | Microphone denied, blocked, unsupported, or the recogniser errors | A different message for each; a blocked mic opens Settings | `speech unavailable surfaces the reason`, `a recogniser error is reported as itself` |
-| 11 | Recogniser never reports an end | Stops itself at 10s, or 15s if words were still arriving | `listening stops itself once it hits the ceiling`, `a rider still speaking at the ceiling is given longer`, `words that stopped before the ceiling do not earn the extension` |
+| 11 | Recogniser never reports an end | Stops itself at 10s, or 15s if words were still arriving. This is a backstop: both platforms end an ordinary session on their own, Android on its own silence windows (3s after a complete-sounding phrase, 4s otherwise) and iOS on 3s without a new word | `listening stops itself once it hits the ceiling`, `a rider still speaking at the ceiling is given longer`, `words that stopped before the ceiling do not earn the extension` |
 | 12 | Time understood ("by 6pm") | Shown on the search row, and the timetable opens with it | `resolves a time intent into the confirm state`, plus three in `TimeTableViewModelTest` covering the route carrying it, no time meaning now, and unreadable JSON falling back to now |
 | 13 | Dismissed mid-flight | Mic stopped, draft discarded | `closing the box while listening stops the mic`, `closing the box throws the draft away` |
+| 14 | Recogniser reports a blank transcript | Nothing. The words already heard stay in the field; a session that heard nothing at all ends as a recogniser error | `a blank final does not wipe the sentence the rider watched arrive`, `a blank partial does not wipe the words already heard` |
+
+**#14 was iOS only, and rider-facing.** `endAudio` asks `SFSpeechRecognizer` to finish, and the
+result that comes back can carry an empty transcription for the segment that was open rather
+than a repeat of the sentence — the same shape a pause mid-sentence produces, and this service
+waits seconds of quiet before finishing, so it was the ordinary ending rather than a rare one. Written through, it cleared the rider's sentence a beat after they watched it arrive.
+Android never reached it because its recogniser reports a missing result as an error instead.
+Held in three places now: `SpeechToTextResult` says transcripts always carry words,
+`IosSpeechToTextService` sends the last words heard instead of a blank final (and
+`NO_RESULT` when there were none), and the ViewModel refuses to write a blank transcript into
+the field whichever platform produced it.
 
 Both of the open defects recorded here are now fixed.
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -277,7 +277,13 @@ class AiSearchInputViewModel(
                         // so writing only the transcript meant a rider watched an empty box
                         // while they talked and everything appeared at once when they stopped.
                         // Partials are what make speaking feel like it is being heard.
-                        _uiState.update { it.copy(speechTranscript = result.text, typedText = result.text) }
+                        //
+                        // Blank is not a transcript. A recogniser that reports one is saying it
+                        // has nothing to add, not that the rider unsaid what they said, and
+                        // writing it through erases words already in the field.
+                        if (result.text.isNotBlank()) {
+                            _uiState.update { it.copy(speechTranscript = result.text, typedText = result.text) }
+                        }
                     }
 
                     is SpeechToTextResult.Final -> {
@@ -287,8 +293,24 @@ class AiSearchInputViewModel(
                         // saying one, and a mis-heard word was already on its way to a search
                         // before they could look at it. Speaking is a way of typing; send is
                         // still theirs to press.
+                        //
+                        // A blank final stops the session and leaves the field exactly as the
+                        // partials left it. iOS ends a session by asking the recogniser to
+                        // finish, and the result that comes back can carry an empty
+                        // transcription — a session boundary, not a correction. Writing it in
+                        // wiped the sentence the rider had just watched arrive, with nothing on
+                        // screen to say why. Android never reaches this because its recogniser
+                        // reports a missing result as an error instead.
                         _uiState.update {
-                            it.copy(isListening = false, speechTranscript = result.text, typedText = result.text)
+                            if (result.text.isBlank()) {
+                                it.copy(isListening = false)
+                            } else {
+                                it.copy(
+                                    isListening = false,
+                                    speechTranscript = result.text,
+                                    typedText = result.text,
+                                )
+                            }
                         }
                     }
 

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -1055,6 +1055,60 @@ class AiSearchInputViewModelTest {
 
             assertEquals(false, viewModel.uiState.value.isListening)
         }
+
+    @Test
+    fun `a blank final does not wipe the sentence the rider watched arrive`() =
+        runTest(testDispatcher) {
+            // The iOS bug this guards: ending a session asks the recogniser to finish, and the
+            // result that comes back can carry an empty transcription rather than a repeat of
+            // the sentence. Written through, it cleared the field a beat after the rider
+            // finished speaking, with nothing on screen to say why, and no way back to the
+            // words except saying them again. Android could not reach it, because its
+            // recogniser reports a missing result as an error instead.
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+            speechToTextService.results.emit(SpeechToTextResult.Partial("central to town hall"))
+            runCurrent()
+
+            speechToTextService.results.emit(SpeechToTextResult.Final(""))
+            runCurrent()
+
+            assertEquals("central to town hall", viewModel.uiState.value.typedText)
+            assertEquals(false, viewModel.uiState.value.isListening)
+        }
+
+    @Test
+    fun `a whitespace-only final does not wipe it either`() = runTest(testDispatcher) {
+        // Blank, not empty. A recogniser reporting a single space is reporting the same nothing,
+        // and a field holding " " is still the rider's sentence gone.
+        viewModel.onEvent(AiSearchInputEvent.StartListening)
+        runCurrent()
+        speechToTextService.results.emit(SpeechToTextResult.Partial("central to town hall"))
+        runCurrent()
+
+        speechToTextService.results.emit(SpeechToTextResult.Final("   "))
+        runCurrent()
+
+        assertEquals("central to town hall", viewModel.uiState.value.typedText)
+        assertEquals(false, viewModel.uiState.value.isListening)
+    }
+
+    @Test
+    fun `a blank partial does not wipe the words already heard`() = runTest(testDispatcher) {
+        // Same shape mid-sentence: a recogniser opening a fresh segment after a pause reports
+        // an empty transcript for it. It is saying it has nothing to add, not that the rider
+        // unsaid what they said.
+        viewModel.onEvent(AiSearchInputEvent.StartListening)
+        runCurrent()
+        speechToTextService.results.emit(SpeechToTextResult.Partial("central to town hall"))
+        runCurrent()
+
+        speechToTextService.results.emit(SpeechToTextResult.Partial(""))
+        runCurrent()
+
+        assertEquals("central to town hall", viewModel.uiState.value.typedText)
+        assertTrue(viewModel.uiState.value.isListening)
+    }
 }
 
 private const val LISTENING_CEILING_IN_TEST = 10_000L


### PR DESCRIPTION
## What

An iOS listening session in Ask KRAIL would not end when the rider stopped talking, and when it did end it cleared the sentence the rider had just watched arrive. Both were in code that only exists on iOS, because `SFSpeechAudioBufferRecognitionRequest` has no notion of a speaker finishing: `isFinal` arrives only after the app calls `endAudio()`. Android's `SpeechRecognizer` owns that decision itself.

## Changes

**Blank transcripts (all platforms)**

- `SpeechToTextResult` documents the contract: `Partial` and `Final` always carry words. A session that heard nothing ends as `Error(NO_RESULT)` rather than as a result that is nothing.
- `AndroidSpeechToTextService` treats a blank recognition candidate as no candidate. It could not previously produce one, but only because the candidate is read through a nullable helper.
- `AiSearchInputViewModel` refuses to write a blank transcript into the field whichever platform produced it, for partials and finals alike. The field is what the rider is looking at, so a blank write is their sentence being erased.

**Session ending (iOS)**

- `stopFeedingAudio()` is now the one way to finish listening: microphone off, tap removed, then `endAudio()`. The silence watcher previously called `endAudio()` alone while the `AVAudioEngine` tap kept appending buffers to the same request, so the recogniser had no reason to finish and the ViewModel's ten second backstop became the only thing ending a session. The rider's stop button always did this correctly; the watcher, which ends nearly every session, did not.
- The quiet window restarts only when the transcript gains a word. It previously restarted on any changed transcript, and the recogniser goes on revising for seconds after the rider stops (capitalisation, homophones, punctuation), so a finished sentence held the microphone open on the strength of the recogniser tidying up after itself.
- `SILENCE_THAT_ENDS_THE_SESSION_MILLIS` is 3000, was 4000. Android sets two windows and the one that fires for a trip sentence is the 3000ms complete-sounding-phrase window, so matching the other one cost about a second on every sentence. The constant carries a note that the two platforms measure different events (Android measures silence, iOS measures the last word arriving) and that equal numbers are a coincidence, not a contract.
- The session rules moved into `TranscriptWatch` in `commonMain`. `iosMain` has no host test task in this project, which is why none of this had coverage.

**Left untouched**

- The ViewModel's 10s and 15s ceilings stay. They are the correct backstop for a recogniser that never reports an end; the fault was that they had become the normal path.
- The `SFSpeechRecognizer` path itself is unchanged. `SpeechAnalyzer` with `DictationTranscriber` and `SpeechDetector` is the better fit for this surface and is a separate piece of work: it needs a Swift shim, since the API is Swift only.

## Testing

- `./gradlew :core:speech-to-text:testAndroidHostTest :feature:trip-planner:ui:testAndroidHostTest --continue` green. `TranscriptWatchTest` is new, 10 tests. `AiSearchInputViewModelTest` is 54, three of them new.
- `./scripts/fullQualityChecks.sh` green: `compileDebugSources`, `compileKotlinIosSimulatorArm64`, `detekt --continue`.
- `LongMethod` on `startListening` was resolved by extracting `TranscriptWatch`, not suppressed.
- Device QA on iOS was not possible here. The Ask KRAIL entry point is gated on on-device AI capability, so the surface does not open on the iOS simulator or the Android emulator. Both apps build, install and launch, and the emulator log has no `FATAL EXCEPTION`, but the microphone path itself has not been exercised on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
