### PR TITLE
feat(speech): add an iOS SpeechAnalyzer bridge and its end-of-speech rule

### DIFF
--- a/core/speech-to-text/build.gradle.kts
+++ b/core/speech-to-text/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.frankois944.spmForKmp.swiftPackageConfig
 import xyz.ksharma.krail.gradle.AndroidVersion
 
 plugins {
@@ -5,6 +6,7 @@ plugins {
     alias(libs.plugins.krail.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.krail.android.kmp.library)
+    alias(libs.plugins.spmForKmp)
 }
 
 kotlin {
@@ -17,8 +19,9 @@ kotlin {
         withHostTest {}
     }
 
-    iosArm64()
-    iosSimulatorArm64()
+    listOf(iosArm64(), iosSimulatorArm64()).forEach { target ->
+        target.swiftPackageConfig(cinteropName = "speechBridge") {}
+    }
 
     java {
         toolchain {

--- a/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatchTest.kt
+++ b/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatchTest.kt
@@ -1,0 +1,100 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The end-of-speech rule for the iOS 26 path, tested here because Swift source has no test task
+ * in this project. The bridge reports Apple's voice activity answers; this decides what they
+ * mean, and everything the rider notices about how long listening lasts comes from these rules.
+ */
+class SpeechActivityWatchTest {
+
+    @Test
+    fun `quiet is measured from the last speech, in audio time`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 2.0)
+        watch.record(speechDetected = false, audioSeconds = 3.5)
+
+        assertEquals(1.5, watch.quietForSeconds())
+    }
+
+    @Test
+    fun `a rider still speaking has not finished`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 1.0)
+        watch.record(speechDetected = true, audioSeconds = 4.0)
+        watch.record(speechDetected = false, audioSeconds = 5.0)
+
+        assertFalse(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `three seconds of silence after speech ends the session`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 2.4)
+        watch.record(speechDetected = false, audioSeconds = 5.4)
+
+        assertTrue(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `a thinking pause inside the window does not end the session`() {
+        val watch = SpeechActivityWatch()
+
+        // "from Central to..." then a pause, then the rest. The pause is real silence, so only
+        // the window's length protects the rider here. Two seconds of it must not be enough.
+        watch.record(speechDetected = true, audioSeconds = 1.5)
+        watch.record(speechDetected = false, audioSeconds = 3.4)
+        assertFalse(watch.riderHasFinished())
+
+        watch.record(speechDetected = true, audioSeconds = 3.6)
+        watch.record(speechDetected = false, audioSeconds = 5.0)
+        assertFalse(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `a rider who has said nothing yet gets the longer wait`() {
+        val watch = SpeechActivityWatch()
+
+        // Tapped the mic, still deciding what to ask for. Four seconds of nothing would end a
+        // session that had heard words; here it must not.
+        watch.record(speechDetected = false, audioSeconds = 4.0)
+
+        assertFalse(watch.heardSpeech)
+        assertFalse(watch.riderHasFinished())
+
+        watch.record(speechDetected = false, audioSeconds = 6.0)
+        assertTrue(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `an answer arriving late cannot move the clock backwards`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 2.0)
+        watch.record(speechDetected = false, audioSeconds = 5.2)
+
+        // Callbacks cross a thread boundary from Swift, so ordering is not guaranteed. An old
+        // answer arriving after a newer one must not rewind the session or resurrect speech
+        // that was already accounted for.
+        watch.record(speechDetected = false, audioSeconds = 3.0)
+        assertEquals(3.2, watch.quietForSeconds())
+
+        watch.record(speechDetected = true, audioSeconds = 1.0)
+        assertEquals(3.2, watch.quietForSeconds())
+    }
+
+    @Test
+    fun `quiet is never negative before any answer arrives`() {
+        val watch = SpeechActivityWatch()
+
+        assertEquals(0.0, watch.quietForSeconds())
+        assertFalse(watch.riderHasFinished())
+    }
+}

--- a/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatch.kt
+++ b/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatch.kt
@@ -1,0 +1,77 @@
+package xyz.ksharma.krail.core.speechtotext
+
+/**
+ * Decides when a rider has finished talking, from Apple's own voice activity detection.
+ *
+ * The iOS 26 `SpeechDetector` module answers one question, "is there speech", and stamps every
+ * answer with the **audio time** it applies to. This turns that stream of answers into one
+ * decision. It lives in `commonMain` rather than beside the bridge that feeds it because Swift
+ * source in this project has no test task, and this is the rule the whole surface turns on.
+ *
+ * ## Why audio time is the point
+ *
+ * The previous implementation had no voice activity detection available to it, so it watched
+ * the transcript instead and called a sentence finished when the words stopped changing. That
+ * measured the recogniser, not the rider: recognition lags speech, so every session waited its
+ * window **plus** however long the last word took to come back, and revisions arriving after
+ * the rider stopped restarted the wait. See
+ * `docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md`.
+ *
+ * Here, [record] is given the time in the audio itself, so the window is the rider's silence
+ * and nothing else. It is the same quantity Android's recogniser measures internally, which is
+ * why [QUIET_THAT_ENDS_THE_SESSION_SECONDS] can carry the same number Android uses and mean it
+ * this time.
+ */
+internal class SpeechActivityWatch(
+    private val quietThatEndsTheSession: Double = QUIET_THAT_ENDS_THE_SESSION_SECONDS,
+    private val quietBeforeAnySpeech: Double = QUIET_BEFORE_ANY_SPEECH_SECONDS,
+) {
+
+    /** Whether any speech has been detected at all, which changes how long the wait is. */
+    var heardSpeech: Boolean = false
+        private set
+
+    private var lastSpeechAt: Double = 0.0
+    private var latestAudioAt: Double = 0.0
+
+    /**
+     * Takes one detector answer. [audioSeconds] is where in the audio it applies, so answers
+     * arriving out of order or late cannot move the clock backwards.
+     */
+    fun record(speechDetected: Boolean, audioSeconds: Double) {
+        if (audioSeconds > latestAudioAt) latestAudioAt = audioSeconds
+        if (speechDetected) {
+            heardSpeech = true
+            if (audioSeconds > lastSpeechAt) lastSpeechAt = audioSeconds
+        }
+    }
+
+    /** Seconds of audio since speech was last heard. Zero until the first answer arrives. */
+    fun quietForSeconds(): Double = (latestAudioAt - lastSpeechAt).coerceAtLeast(0.0)
+
+    /**
+     * True once the rider has been quiet long enough to be finished.
+     *
+     * A session that has heard nothing yet gets the longer wait: that window covers someone who
+     * tapped the mic and is still deciding what to ask for, not someone who trailed off mid
+     * sentence.
+     */
+    fun riderHasFinished(): Boolean {
+        val longEnough = if (heardSpeech) quietThatEndsTheSession else quietBeforeAnySpeech
+        return quietForSeconds() >= longEnough
+    }
+}
+
+// The same number as Android's SILENCE_AFTER_A_COMPLETE_SOUNDING_PHRASE_MILLIS, and for the
+// first time the same measurement: seconds of actual silence, from a real voice activity
+// detector, rather than seconds without a transcript update. Android picks between two windows
+// by how finished the phrase sounds; iOS cannot tell those apart, so it takes the one that fires
+// for a trip sentence, which almost always ends on something complete sounding.
+//
+// A trip said out loud has thinking pauses in it. This is the tolerance for those, and it is why
+// the window is seconds rather than the few hundred milliseconds true silence detection would
+// otherwise allow.
+private const val QUIET_THAT_ENDS_THE_SESSION_SECONDS = 3.0
+
+// Before the first word, matching the legacy path's own grace period.
+private const val QUIET_BEFORE_ANY_SPEECH_SECONDS = 6.0

--- a/core/speech-to-text/src/swift/speechBridge/SpeechBridge.swift
+++ b/core/speech-to-text/src/swift/speechBridge/SpeechBridge.swift
@@ -1,0 +1,273 @@
+import AVFoundation
+import Foundation
+import Speech
+
+/// Wraps iOS 26's `SpeechAnalyzer` behind plain Objective-C entry points, because
+/// Kotlin/Native cinterop reads Objective-C headers and `SpeechAnalyzer` is a Swift `actor`
+/// with `AsyncSequence` results and no Objective-C surface at all.
+///
+/// Same shape and same reason as `AiTextBridge` in `:core:ai-text`: primitives and closures
+/// only across the boundary, no Swift types, no generics, no async.
+///
+/// **This file owns mechanism, never policy.** It reports what Apple's modules say, including
+/// `SpeechDetector`'s voice activity in audio time, and it does not decide when the rider has
+/// finished talking. That decision lives in `SpeechActivityWatch` in `commonMain`, where a test
+/// can reach it. Swift source in this project has no test task, which is exactly how three
+/// rider-facing faults lived in the old `SFSpeechRecognizer` path unnoticed.
+@objcMembers public class SpeechBridge: NSObject {
+
+    private var session: AnyObject?
+
+    /// Availability reasons are the shared vocabulary in `SpeechUnavailableReasons`, never
+    /// Swift's own spelling of anything. The lesson `AiTextBridge` documents: a reason string
+    /// only one side knows is a message the rider never sees.
+    public func checkAvailability(completion: @escaping (Bool, String) -> Void) {
+        guard #available(iOS 26.0, *) else {
+            completion(false, "not_available")
+            return
+        }
+        Task {
+            let locale = Locale.current
+            let installed = await DictationTranscriber.installedLocales
+            if installed.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+                completion(true, "available")
+                return
+            }
+            let supported = await DictationTranscriber.supportedLocales
+            if supported.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+                // Downloadable, not missing. Same distinction the AI side draws, and the
+                // caller words the two differently.
+                completion(false, "model_downloading")
+            } else {
+                completion(false, "not_available")
+            }
+        }
+    }
+
+    /// Starts listening. Every callback may arrive on any thread.
+    ///
+    /// `onSpeechActivity` carries `SpeechDetector`'s answer and the audio time it applies to,
+    /// in seconds. Audio time, not wall clock, is the whole reason this exists: it is when the
+    /// rider spoke, not when a transcription happened to reach us.
+    public func start(
+        onPartial: @escaping (String) -> Void,
+        onFinal: @escaping (String) -> Void,
+        onSpeechActivity: @escaping (Bool, Double) -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        guard #available(iOS 26.0, *) else {
+            onError("not_available")
+            return
+        }
+        let session = AnalyzerSession(
+            onPartial: onPartial,
+            onFinal: onFinal,
+            onSpeechActivity: onSpeechActivity,
+            onError: onError
+        )
+        self.session = session
+        session.start()
+    }
+
+    /// Stops the microphone and asks for a final transcript. The caller still gets `onFinal`.
+    public func finish() {
+        guard #available(iOS 26.0, *), let session = session as? AnalyzerSession else { return }
+        session.finish()
+    }
+
+    /// Tears everything down without waiting for a final transcript.
+    public func cancel() {
+        guard #available(iOS 26.0, *), let session = session as? AnalyzerSession else { return }
+        session.cancel()
+        self.session = nil
+    }
+}
+
+@available(iOS 26.0, *)
+private final class AnalyzerSession {
+
+    private let onPartial: (String) -> Void
+    private let onFinal: (String) -> Void
+    private let onSpeechActivity: (Bool, Double) -> Void
+    private let onError: (String) -> Void
+
+    private let audioEngine = AVAudioEngine()
+    private var analyzer: SpeechAnalyzer?
+    private var transcriber: DictationTranscriber?
+    private var inputBuilder: AsyncStream<AnalyzerInput>.Continuation?
+    private var converter: AVAudioConverter?
+    private var tasks: [Task<Void, Never>] = []
+    private var didFinish = false
+
+    init(
+        onPartial: @escaping (String) -> Void,
+        onFinal: @escaping (String) -> Void,
+        onSpeechActivity: @escaping (Bool, Double) -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        self.onPartial = onPartial
+        self.onFinal = onFinal
+        self.onSpeechActivity = onSpeechActivity
+        self.onError = onError
+    }
+
+    func start() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.startAnalyzing()
+            } catch {
+                self.onError(error.localizedDescription)
+            }
+        }
+    }
+
+    private func startAnalyzing() async throws {
+        // .progressiveShortDictation, not .shortDictation: the rider watches their words
+        // arrive as they speak, so results have to be delivered live rather than at the end.
+        // Not .phrase either, which produces no live results at all.
+        let transcriber = DictationTranscriber(
+            locale: Locale.current,
+            preset: .progressiveShortDictation
+        )
+        self.transcriber = transcriber
+
+        // Apple's own voice activity detection, which is the thing the old implementation had
+        // to fake by watching the transcript change. It cannot run alone; pairing it with the
+        // transcriber in one analyzer is the documented arrangement.
+        let detector = SpeechDetector(
+            detectionOptions: SpeechDetector.DetectionOptions(sensitivityLevel: .medium),
+            reportResults: true
+        )
+
+        let analyzer = SpeechAnalyzer(modules: [detector, transcriber])
+        self.analyzer = analyzer
+
+        let (inputSequence, inputBuilder) = AsyncStream.makeStream(of: AnalyzerInput.self)
+        self.inputBuilder = inputBuilder
+
+        let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [detector, transcriber]
+        )
+
+        try startMicrophone(analyzerFormat: analyzerFormat)
+        try await analyzer.start(inputSequence: inputSequence)
+
+        tasks.append(Task { [weak self] in
+            guard let self else { return }
+            do {
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    if result.isFinal {
+                        self.onFinal(text)
+                    } else {
+                        self.onPartial(text)
+                    }
+                }
+            } catch {
+                self.onError(error.localizedDescription)
+            }
+        })
+
+        tasks.append(Task { [weak self] in
+            guard let self else { return }
+            do {
+                for try await result in detector.results {
+                    self.onSpeechActivity(
+                        result.speechDetected,
+                        CMTimeGetSeconds(result.range.end)
+                    )
+                }
+            } catch {
+                // A detector that stops reporting is not a failed session: the transcriber is
+                // still running and the caller's own ceiling still ends it. Reporting an error
+                // here would tear down a working transcription.
+            }
+        })
+    }
+
+    /// Feeds the microphone into the analyzer, converting to the format the modules asked for.
+    ///
+    /// The tap's own format is whatever the hardware gives; the analyzer publishes what it
+    /// wants. Handing it the wrong one is silent, in that the session runs and never
+    /// transcribes anything, so the conversion is not optional.
+    private func startMicrophone(analyzerFormat: AVAudioFormat?) throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+        let inputNode = audioEngine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+        if let analyzerFormat, analyzerFormat != inputFormat {
+            converter = AVAudioConverter(from: inputFormat, to: analyzerFormat)
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            guard let converted = self.convert(buffer: buffer, to: analyzerFormat) else { return }
+            self.inputBuilder?.yield(AnalyzerInput(buffer: converted))
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    private func convert(buffer: AVAudioPCMBuffer, to format: AVAudioFormat?) -> AVAudioPCMBuffer? {
+        guard let format, let converter else { return buffer }
+        let ratio = format.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1024
+        guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
+            return nil
+        }
+        var consumed = false
+        var error: NSError?
+        converter.convert(to: output, error: &error) { _, status in
+            if consumed {
+                status.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            status.pointee = .haveData
+            return buffer
+        }
+        return error == nil ? output : nil
+    }
+
+    /// The graceful finish. Apple is explicit that ending the input sequence does not end the
+    /// session, so both are needed, and the microphone goes first: nothing should be arriving
+    /// after we have said that was all the audio there is.
+    func finish() {
+        guard !didFinish else { return }
+        didFinish = true
+        stopMicrophone()
+        inputBuilder?.finish()
+        Task { [weak self] in
+            guard let self, let analyzer = self.analyzer else { return }
+            do {
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+            } catch {
+                self.onError(error.localizedDescription)
+            }
+        }
+    }
+
+    func cancel() {
+        didFinish = true
+        stopMicrophone()
+        inputBuilder?.finish()
+        tasks.forEach { $0.cancel() }
+        tasks.removeAll()
+        let analyzer = self.analyzer
+        Task { await analyzer?.cancelAndFinishNow() }
+        self.analyzer = nil
+    }
+
+    private func stopMicrophone() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        try? AVAudioSession.sharedInstance().setActive(
+            false,
+            options: .notifyOthersOnDeactivation
+        )
+    }
+}


### PR DESCRIPTION
## What

iOS 26 replaced `SFSpeechRecognizer` with `SpeechAnalyzer`, a modular analyzer. Two of its modules are exactly the jobs `IosSpeechToTextService` currently does by hand: `DictationTranscriber` (short queries, on the same on-device model `SFSpeechRecognizer` uses) and `SpeechDetector` (voice activity detection, reported in audio time).

`SpeechAnalyzer` is a Swift `actor` with `AsyncSequence` results and no Objective-C surface, so Kotlin/Native cinterop cannot see it. This adds the SPM bridge, the same shape and for the same reason as `AiTextBridge` in `:core:ai-text`, plus the one rule the surface turns on. **Nothing calls it yet**; the next branch in the stack wires it up.

## Changes

- `core/speech-to-text/build.gradle.kts` gains `spmForKmp` with `cinteropName = "speechBridge"`, matching how `:core:ai-text` declares its bridge.
- `src/swift/speechBridge/SpeechBridge.swift` exposes `checkAvailability`, `start`, `finish` and `cancel` over plain closures and primitives. `start` reports partial and final transcripts, errors, and every voice-activity answer together with the audio time it applies to.
- `SpeechActivityWatch` in `commonMain` decides when the rider has finished: how long they have been quiet in audio time, and whether that is long enough. 3000ms once speech has been heard, 6000ms before any, covering someone who tapped the mic and is still deciding what to ask for.
- `SpeechActivityWatchTest`, 7 cases.

**The split between the two is deliberate.** The Swift file owns mechanism and decides nothing; the rule lives in `commonMain`. Swift source in this project has no test task, which is how three rider-facing faults lived in the `SFSpeechRecognizer` path unnoticed (`docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md`).

**On the window being 3000ms again:** it is the same number as Android's complete-sounding-phrase window, and for the first time the same measurement. Previously it counted seconds without a transcript update, which is recognition lag plus silence; here a real detector reports real silence. Equal numbers now mean equal behaviour, where before they hid a mismatched mechanism.

## Testing

- `./gradlew :core:speech-to-text:testAndroidHostTest` green, `SpeechActivityWatchTest` 7 cases.
- `./gradlew testAndroidHostTest --continue` green across all modules.
- `./scripts/fullQualityChecks.sh` green: `compileDebugSources`, `compileKotlinIosSimulatorArm64`, `detekt --continue`.
- `xcodebuild` of `iosApp` for the simulator succeeds with the second SPM package present, and the app installs, launches and renders the home screen with no crash.
- The Swift itself is type-checked by the cinterop build against the iOS 26.5 SDK (Xcode 26.6).
- Not verified: the analyzer has never run. Nothing calls this bridge in this branch, and the Ask KRAIL surface that will is gated on on-device AI, so it does not open on a simulator at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
