### PR TITLE
feat(speech): listen through SpeechAnalyzer on iOS 26, SFSpeechRecognizer below

### DIFF
--- a/core/speech-to-text/README.md
+++ b/core/speech-to-text/README.md
@@ -5,9 +5,9 @@ On-device speech-to-text for the "Speak" tab of the AI search-input flow
 Wraps each platform's own speech recognizer behind [`SpeechToTextService`](src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechToTextService.kt),
 the same `expect`/`actual`-per-platform shape as `core:ai-text`'s `AiTextService`.
 
-**Status: interface + module boundary only. Neither platform actual is implemented yet** —
-both `AndroidSpeechToTextService` and `IosSpeechToTextService` always report `Unavailable`.
-See the doc comment on each actual for exactly what real implementation needs.
+**Status: both platforms implemented.** iOS has two, chosen at runtime by
+`PreferredSpeechToTextService`: `SpeechAnalyzerSpeechToTextService` on iOS 26 and
+`IosSpeechToTextService` (`SFSpeechRecognizer`) everywhere else. See "The two iOS paths" below.
 
 ## Why a new module, not an existing library
 
@@ -45,10 +45,39 @@ real Android/iOS actuals is reasonable; taking it as a live dependency is not.
   `RecognizerIntent.EXTRA_PREFER_OFFLINE` requests on-device recognition where the device
   supports it, falling back to network otherwise. Needs the `RECORD_AUDIO` runtime
   permission.
-- **iOS**: `SFSpeechRecognizer` + `AVAudioEngine`. Unlike Foundation Models (Swift-only, no
-  Objective-C header — the reason `IosAiTextService` needs an SPM cinterop bridge),
-  `SFSpeechRecognizer` is a plain Objective-C-compatible framework and is directly callable
-  from Kotlin/Native — **no SPM bridge needed for this one**. Needs both
-  `NSSpeechRecognitionUsageDescription` and `NSMicrophoneUsageDescription` in Info.plist,
-  and per this project's `ios_permission_must_request.md` lesson, the wrapper must actually
-  call `requestAuthorization`, not just inspect `authorizationStatus()`.
+- **iOS**: two implementations. See below.
+
+## The two iOS paths
+
+`SFSpeechRecognizer` is a plain Objective-C-compatible framework, directly callable from
+Kotlin/Native with no bridge. It is also, as a design, a transcription **stream**: it never
+decides a speaker has finished, because `isFinal` arrives only after the app calls
+`endAudio()`. Everything about end-of-speech therefore had to be inferred from how text
+happened to arrive, and every fault in
+[the 2026-08-23 learning entry](../../docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md)
+came from that inference.
+
+iOS 26 replaced it with `SpeechAnalyzer`, a modular analyzer. Two of its modules are exactly
+the jobs that were being done by hand:
+
+| Module | What it does | Replaces |
+|---|---|---|
+| `DictationTranscriber` | short queries, same on-device model `SFSpeechRecognizer` uses | the transcription half |
+| `SpeechDetector` | voice activity detection, reported in **audio time** | the hand-rolled silence watcher |
+
+`SpeechAnalyzer` is a Swift `actor` with `AsyncSequence` results and no Objective-C surface,
+so unlike `SFSpeechRecognizer` it **does** need an SPM cinterop bridge: `src/swift/speechBridge/`,
+same shape and same reason as `AiTextBridge` in `core:ai-text`.
+
+The bridge owns mechanism only. It reports what Apple's modules say and never decides when the
+rider has finished; that rule is [`SpeechActivityWatch`](src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatch.kt)
+in `commonMain`, because Swift source here has no test task. Same reason
+[`TranscriptWatch`](src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/TranscriptWatch.kt)
+lives there and is shared by both paths.
+
+Permissions differ between the two, which is a rider-visible difference: `SFSpeechRecognizer`
+needs both `NSSpeechRecognitionUsageDescription` and `NSMicrophoneUsageDescription`, and per
+this project's `ios_permission_must_request.md` lesson its wrapper must actually call
+`requestAuthorization` rather than only inspecting `authorizationStatus()`. `SpeechAnalyzer`
+needs the microphone alone, so the iOS 26 path shows one system prompt where the legacy path
+shows two. Both Info.plist keys stay, because the legacy path is still live below iOS 26.

--- a/core/speech-to-text/build.gradle.kts
+++ b/core/speech-to-text/build.gradle.kts
@@ -1,3 +1,4 @@
+import io.github.frankois944.spmForKmp.swiftPackageConfig
 import xyz.ksharma.krail.gradle.AndroidVersion
 
 plugins {
@@ -5,6 +6,7 @@ plugins {
     alias(libs.plugins.krail.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.krail.android.kmp.library)
+    alias(libs.plugins.spmForKmp)
 }
 
 kotlin {
@@ -17,8 +19,9 @@ kotlin {
         withHostTest {}
     }
 
-    iosArm64()
-    iosSimulatorArm64()
+    listOf(iosArm64(), iosSimulatorArm64()).forEach { target ->
+        target.swiftPackageConfig(cinteropName = "speechBridge") {}
+    }
 
     java {
         toolchain {

--- a/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/PreferredSpeechToTextServiceTest.kt
+++ b/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/PreferredSpeechToTextServiceTest.kt
@@ -1,0 +1,86 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.krail.core.speechtotext.testfakes.FakeSpeechToTextService
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Which of the two iOS implementations answers, and what the rider is told when the newer one
+ * cannot run. Tested here because the alternative is testing it nowhere: both implementations
+ * live in `iosMain`, which has no test task in this project.
+ */
+class PreferredSpeechToTextServiceTest {
+
+    @Test
+    fun `a device that can run the preferred implementation uses it`() = runTest {
+        val preferred = FakeSpeechToTextService(SpeechToTextAvailability.Available, "analyzer")
+        val fallback = FakeSpeechToTextService(SpeechToTextAvailability.Available, "legacy")
+        val service = PreferredSpeechToTextService(preferred = preferred, fallback = fallback)
+
+        assertEquals(SpeechToTextAvailability.Available, service.checkAvailability())
+        assertEquals("analyzer", service.firstTranscript())
+    }
+
+    @Test
+    fun `a device that cannot falls back, and the fallback's answer is the one reported`() =
+        runTest {
+            // The two implementations do not share a set of reasons. Reporting the newer one's
+            // "the model for this locale is still downloading" on a device whose older
+            // recogniser will listen right now would take the feature away for no reason.
+            val preferred = FakeSpeechToTextService(
+                SpeechToTextAvailability.Unavailable("model_downloading"),
+                "analyzer",
+            )
+            val fallback = FakeSpeechToTextService(SpeechToTextAvailability.Available, "legacy")
+            val service = PreferredSpeechToTextService(preferred = preferred, fallback = fallback)
+
+            assertEquals(SpeechToTextAvailability.Available, service.checkAvailability())
+            assertEquals("legacy", service.firstTranscript())
+        }
+
+    @Test
+    fun `when neither can listen the rider hears about the fallback`() = runTest {
+        val preferred = FakeSpeechToTextService(SpeechToTextAvailability.Unavailable("not_available"), "a")
+        val fallback = FakeSpeechToTextService(
+            SpeechToTextAvailability.Unavailable(SpeechUnavailableReasons.PERMISSION_REQUIRED),
+            "b",
+        )
+        val service = PreferredSpeechToTextService(preferred = preferred, fallback = fallback)
+
+        assertEquals(
+            SpeechToTextAvailability.Unavailable(SpeechUnavailableReasons.PERMISSION_REQUIRED),
+            service.checkAvailability(),
+        )
+    }
+
+    @Test
+    fun `listening before checking availability uses the one every device has`() = runTest {
+        // A caller doing it in the wrong order still gets a working microphone rather than the
+        // implementation that may not exist on this OS version.
+        val preferred = FakeSpeechToTextService(SpeechToTextAvailability.Available, "analyzer")
+        val fallback = FakeSpeechToTextService(SpeechToTextAvailability.Available, "legacy")
+        val service = PreferredSpeechToTextService(preferred = preferred, fallback = fallback)
+
+        assertEquals("legacy", service.firstTranscript())
+    }
+
+    @Test
+    fun `stopping goes to whichever one is listening`() = runTest {
+        val preferred = FakeSpeechToTextService(SpeechToTextAvailability.Available, "analyzer")
+        val fallback = FakeSpeechToTextService(SpeechToTextAvailability.Available, "legacy")
+        val service = PreferredSpeechToTextService(preferred = preferred, fallback = fallback)
+        service.checkAvailability()
+
+        service.stopListening()
+
+        assertEquals(1, preferred.stopCount)
+        assertEquals(0, fallback.stopCount)
+    }
+
+    private suspend fun SpeechToTextService.firstTranscript(): String {
+        var text = ""
+        startListening().collect { if (it is SpeechToTextResult.Final) text = it.text }
+        return text
+    }
+}

--- a/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatchTest.kt
+++ b/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatchTest.kt
@@ -1,0 +1,100 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The end-of-speech rule for the iOS 26 path, tested here because Swift source has no test task
+ * in this project. The bridge reports Apple's voice activity answers; this decides what they
+ * mean, and everything the rider notices about how long listening lasts comes from these rules.
+ */
+class SpeechActivityWatchTest {
+
+    @Test
+    fun `quiet is measured from the last speech, in audio time`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 2.0)
+        watch.record(speechDetected = false, audioSeconds = 3.5)
+
+        assertEquals(1.5, watch.quietForSeconds())
+    }
+
+    @Test
+    fun `a rider still speaking has not finished`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 1.0)
+        watch.record(speechDetected = true, audioSeconds = 4.0)
+        watch.record(speechDetected = false, audioSeconds = 5.0)
+
+        assertFalse(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `three seconds of silence after speech ends the session`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 2.4)
+        watch.record(speechDetected = false, audioSeconds = 5.4)
+
+        assertTrue(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `a thinking pause inside the window does not end the session`() {
+        val watch = SpeechActivityWatch()
+
+        // "from Central to..." then a pause, then the rest. The pause is real silence, so only
+        // the window's length protects the rider here. Two seconds of it must not be enough.
+        watch.record(speechDetected = true, audioSeconds = 1.5)
+        watch.record(speechDetected = false, audioSeconds = 3.4)
+        assertFalse(watch.riderHasFinished())
+
+        watch.record(speechDetected = true, audioSeconds = 3.6)
+        watch.record(speechDetected = false, audioSeconds = 5.0)
+        assertFalse(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `a rider who has said nothing yet gets the longer wait`() {
+        val watch = SpeechActivityWatch()
+
+        // Tapped the mic, still deciding what to ask for. Four seconds of nothing would end a
+        // session that had heard words; here it must not.
+        watch.record(speechDetected = false, audioSeconds = 4.0)
+
+        assertFalse(watch.heardSpeech)
+        assertFalse(watch.riderHasFinished())
+
+        watch.record(speechDetected = false, audioSeconds = 6.0)
+        assertTrue(watch.riderHasFinished())
+    }
+
+    @Test
+    fun `an answer arriving late cannot move the clock backwards`() {
+        val watch = SpeechActivityWatch()
+
+        watch.record(speechDetected = true, audioSeconds = 2.0)
+        watch.record(speechDetected = false, audioSeconds = 5.2)
+
+        // Callbacks cross a thread boundary from Swift, so ordering is not guaranteed. An old
+        // answer arriving after a newer one must not rewind the session or resurrect speech
+        // that was already accounted for.
+        watch.record(speechDetected = false, audioSeconds = 3.0)
+        assertEquals(3.2, watch.quietForSeconds())
+
+        watch.record(speechDetected = true, audioSeconds = 1.0)
+        assertEquals(3.2, watch.quietForSeconds())
+    }
+
+    @Test
+    fun `quiet is never negative before any answer arrives`() {
+        val watch = SpeechActivityWatch()
+
+        assertEquals(0.0, watch.quietForSeconds())
+        assertFalse(watch.riderHasFinished())
+    }
+}

--- a/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/testfakes/FakeSpeechToTextService.kt
+++ b/core/speech-to-text/src/androidHostTest/kotlin/xyz/ksharma/krail/core/speechtotext/testfakes/FakeSpeechToTextService.kt
@@ -1,0 +1,34 @@
+package xyz.ksharma.krail.core.speechtotext.testfakes
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import xyz.ksharma.krail.core.speechtotext.SpeechToTextAvailability
+import xyz.ksharma.krail.core.speechtotext.SpeechToTextResult
+import xyz.ksharma.krail.core.speechtotext.SpeechToTextService
+
+/**
+ * A configurable stand-in for one of the two implementations
+ * `PreferredSpeechToTextService` chooses between.
+ *
+ * Named and shared rather than declared inside the test, which is the shape
+ * `verifyNoAdHocBoundaryFakes` is asking for and the same one
+ * `:feature:trip-planner:ui` uses for this interface. [transcript] is how a test tells which
+ * of the two answered, since that is the only thing the caller can observe about the choice.
+ */
+internal class FakeSpeechToTextService(
+    private val availability: SpeechToTextAvailability,
+    private val transcript: String,
+) : SpeechToTextService {
+
+    var stopCount: Int = 0
+        private set
+
+    override suspend fun checkAvailability(): SpeechToTextAvailability = availability
+
+    override fun startListening(): Flow<SpeechToTextResult> =
+        flowOf(SpeechToTextResult.Final(transcript))
+
+    override fun stopListening() {
+        stopCount++
+    }
+}

--- a/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/PreferredSpeechToTextService.kt
+++ b/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/PreferredSpeechToTextService.kt
@@ -1,0 +1,52 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlinx.coroutines.flow.Flow
+import xyz.ksharma.krail.core.log.log
+
+/**
+ * Uses [preferred] when the device can run it, and [fallback] otherwise.
+ *
+ * Built for iOS, where the two are `SpeechAnalyzerSpeechToTextService` (iOS 26's analyzer, with
+ * Apple's own voice activity detection) and `IosSpeechToTextService` (the `SFSpeechRecognizer`
+ * path, which works back to the deployment target). It lives in `commonMain` because choosing
+ * between two implementations is not an iOS idea, and because `iosMain` has no test task, which
+ * is the reason a run of faults lived in that source set unnoticed.
+ *
+ * The choice is made in [checkAvailability] and remembered, because that is the one call every
+ * caller already makes before listening, and it is the only call that can answer the question
+ * without asking the rider to wait twice.
+ *
+ * A device that cannot run the analyzer is not a device that cannot listen: the fallback answers
+ * for itself, and its answer is the one the caller sees. That matters because the analyzer's
+ * reasons and the fallback's are not the same set. Reporting "the locale's model is downloading"
+ * from a device whose `SFSpeechRecognizer` will happily listen right now would take the feature
+ * away for no reason.
+ */
+internal class PreferredSpeechToTextService(
+    private val preferred: SpeechToTextService,
+    private val fallback: SpeechToTextService,
+) : SpeechToTextService {
+
+    // Null until asked. Listening before checking availability is a caller doing it wrong, and
+    // the fallback is the safer of the two to be wrong with: it is the one every device has.
+    private var chosen: SpeechToTextService? = null
+
+    private val current: SpeechToTextService get() = chosen ?: fallback
+
+    override suspend fun checkAvailability(): SpeechToTextAvailability {
+        val fromPreferred = preferred.checkAvailability()
+        if (fromPreferred is SpeechToTextAvailability.Available) {
+            chosen = preferred
+            log("SpeechToText: using the preferred implementation")
+            return fromPreferred
+        }
+        chosen = fallback
+        val fromFallback = fallback.checkAvailability()
+        log("SpeechToText: preferred unavailable ($fromPreferred), falling back -> $fromFallback")
+        return fromFallback
+    }
+
+    override fun startListening(): Flow<SpeechToTextResult> = current.startListening()
+
+    override fun stopListening() = current.stopListening()
+}

--- a/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatch.kt
+++ b/core/speech-to-text/src/commonMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechActivityWatch.kt
@@ -1,0 +1,77 @@
+package xyz.ksharma.krail.core.speechtotext
+
+/**
+ * Decides when a rider has finished talking, from Apple's own voice activity detection.
+ *
+ * The iOS 26 `SpeechDetector` module answers one question, "is there speech", and stamps every
+ * answer with the **audio time** it applies to. This turns that stream of answers into one
+ * decision. It lives in `commonMain` rather than beside the bridge that feeds it because Swift
+ * source in this project has no test task, and this is the rule the whole surface turns on.
+ *
+ * ## Why audio time is the point
+ *
+ * The previous implementation had no voice activity detection available to it, so it watched
+ * the transcript instead and called a sentence finished when the words stopped changing. That
+ * measured the recogniser, not the rider: recognition lags speech, so every session waited its
+ * window **plus** however long the last word took to come back, and revisions arriving after
+ * the rider stopped restarted the wait. See
+ * `docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md`.
+ *
+ * Here, [record] is given the time in the audio itself, so the window is the rider's silence
+ * and nothing else. It is the same quantity Android's recogniser measures internally, which is
+ * why [QUIET_THAT_ENDS_THE_SESSION_SECONDS] can carry the same number Android uses and mean it
+ * this time.
+ */
+internal class SpeechActivityWatch(
+    private val quietThatEndsTheSession: Double = QUIET_THAT_ENDS_THE_SESSION_SECONDS,
+    private val quietBeforeAnySpeech: Double = QUIET_BEFORE_ANY_SPEECH_SECONDS,
+) {
+
+    /** Whether any speech has been detected at all, which changes how long the wait is. */
+    var heardSpeech: Boolean = false
+        private set
+
+    private var lastSpeechAt: Double = 0.0
+    private var latestAudioAt: Double = 0.0
+
+    /**
+     * Takes one detector answer. [audioSeconds] is where in the audio it applies, so answers
+     * arriving out of order or late cannot move the clock backwards.
+     */
+    fun record(speechDetected: Boolean, audioSeconds: Double) {
+        if (audioSeconds > latestAudioAt) latestAudioAt = audioSeconds
+        if (speechDetected) {
+            heardSpeech = true
+            if (audioSeconds > lastSpeechAt) lastSpeechAt = audioSeconds
+        }
+    }
+
+    /** Seconds of audio since speech was last heard. Zero until the first answer arrives. */
+    fun quietForSeconds(): Double = (latestAudioAt - lastSpeechAt).coerceAtLeast(0.0)
+
+    /**
+     * True once the rider has been quiet long enough to be finished.
+     *
+     * A session that has heard nothing yet gets the longer wait: that window covers someone who
+     * tapped the mic and is still deciding what to ask for, not someone who trailed off mid
+     * sentence.
+     */
+    fun riderHasFinished(): Boolean {
+        val longEnough = if (heardSpeech) quietThatEndsTheSession else quietBeforeAnySpeech
+        return quietForSeconds() >= longEnough
+    }
+}
+
+// The same number as Android's SILENCE_AFTER_A_COMPLETE_SOUNDING_PHRASE_MILLIS, and for the
+// first time the same measurement: seconds of actual silence, from a real voice activity
+// detector, rather than seconds without a transcript update. Android picks between two windows
+// by how finished the phrase sounds; iOS cannot tell those apart, so it takes the one that fires
+// for a trip sentence, which almost always ends on something complete sounding.
+//
+// A trip said out loud has thinking pauses in it. This is the tolerance for those, and it is why
+// the window is seconds rather than the few hundred milliseconds true silence detection would
+// otherwise allow.
+private const val QUIET_THAT_ENDS_THE_SESSION_SECONDS = 3.0
+
+// Before the first word, matching the legacy path's own grace period.
+private const val QUIET_BEFORE_ANY_SPEECH_SECONDS = 6.0

--- a/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechAnalyzerSpeechToTextService.kt
+++ b/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/SpeechAnalyzerSpeechToTextService.kt
@@ -1,0 +1,110 @@
+package xyz.ksharma.krail.core.speechtotext
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.AVFAudio.AVAudioApplication
+import platform.AVFAudio.AVAudioApplicationRecordPermissionGranted
+import speechBridge.SpeechBridge
+import xyz.ksharma.krail.core.log.log
+import kotlin.coroutines.resume
+
+/**
+ * iOS 26's `SpeechAnalyzer`, via the `@objc` Swift shim in `src/swift/speechBridge/`.
+ *
+ * Apple replaced `SFSpeechRecognizer` with a modular analyzer, and two of its modules are
+ * exactly the jobs [IosSpeechToTextService] had to do by hand:
+ *
+ * - `DictationTranscriber` is the documented migration path for short queries, on the same
+ *   on-device model `SFSpeechRecognizer` uses. A rider saying where they are going is a short
+ *   query, not the long-form audio `SpeechTranscriber` is built for.
+ * - `SpeechDetector` is Apple's voice activity detection, reported in **audio time**. The
+ *   legacy path had nothing like it and had to infer the rider from how text happened to
+ *   arrive, which is where every fault in
+ *   `docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md` came from.
+ *
+ * What is left here is small on purpose: the analyzer owns the microphone and the session,
+ * [SpeechActivityWatch] owns the one decision, and this class is the plumbing between them and
+ * a Flow. There is no silence-polling coroutine any more, because there is nothing to poll: the
+ * detector reports, and each report is enough to decide on.
+ *
+ * Ending is still ours to ask for. Apple is explicit that terminating the input sequence does
+ * not finish a session, so the bridge's `finish()` does both, in the order that matters.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal class SpeechAnalyzerSpeechToTextService : SpeechToTextService {
+
+    private val bridge = SpeechBridge()
+
+    override suspend fun checkAvailability(): SpeechToTextAvailability {
+        // Microphone only. SpeechAnalyzer needs no speech-recognition authorization of its own,
+        // unlike SFSpeechRecognizer, so this path shows the rider one system prompt where the
+        // legacy one showed two. Permission is still asked for at the Compose layer; this only
+        // reads the answer, same contract as every other service here.
+        if (!microphoneAuthorized()) {
+            return SpeechToTextAvailability.Unavailable(
+                reason = SpeechUnavailableReasons.PERMISSION_REQUIRED,
+            )
+        }
+        val result = suspendCancellableCoroutine { continuation ->
+            bridge.checkAvailabilityWithCompletion { available, reason ->
+                continuation.resume(
+                    if (available) {
+                        SpeechToTextAvailability.Available
+                    } else {
+                        SpeechToTextAvailability.Unavailable(
+                            reason = reason ?: SpeechUnavailableReasons.NOT_AVAILABLE,
+                        )
+                    },
+                )
+            }
+        }
+        log("SpeechAnalyzerService: checkAvailability -> $result")
+        return result
+    }
+
+    override fun startListening(): Flow<SpeechToTextResult> = callbackFlow {
+        val activity = SpeechActivityWatch()
+
+        // The same TranscriptWatch the legacy path uses, for the same reason: it owns what a
+        // transcript means, including that a blank one is never sent on as one. Its own quiet
+        // clock goes unused here, because the detector answers that question far better.
+        val transcript = TranscriptWatch()
+
+        bridge.startOnPartial(
+            onPartial = { text ->
+                transcript.record(text = text.orEmpty(), isFinal = false)?.let { trySend(it) }
+            },
+            onFinal = { text ->
+                transcript.record(text = text.orEmpty(), isFinal = true)?.let { trySend(it) }
+                close()
+            },
+            onSpeechActivity = { speechDetected, audioSeconds ->
+                activity.record(speechDetected = speechDetected, audioSeconds = audioSeconds)
+                if (activity.riderHasFinished()) {
+                    log("SpeechAnalyzerService: rider finished, finalising")
+                    // finish, not cancel: the analyzer still owes a final transcript and the
+                    // flow stays open to receive it.
+                    bridge.finish()
+                }
+            },
+            onError = { reason ->
+                trySend(
+                    SpeechToTextResult.Error(
+                        reason = reason ?: SpeechUnavailableReasons.NOT_AVAILABLE,
+                    ),
+                )
+                close()
+            },
+        )
+
+        awaitClose { bridge.cancel() }
+    }
+
+    override fun stopListening() = bridge.finish()
+
+    private fun microphoneAuthorized(): Boolean =
+        AVAudioApplication.sharedInstance().recordPermission == AVAudioApplicationRecordPermissionGranted
+}

--- a/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/di/SpeechToTextModule.kt
+++ b/core/speech-to-text/src/iosMain/kotlin/xyz/ksharma/krail/core/speechtotext/di/SpeechToTextModule.kt
@@ -2,8 +2,18 @@ package xyz.ksharma.krail.core.speechtotext.di
 
 import org.koin.dsl.module
 import xyz.ksharma.krail.core.speechtotext.IosSpeechToTextService
+import xyz.ksharma.krail.core.speechtotext.PreferredSpeechToTextService
+import xyz.ksharma.krail.core.speechtotext.SpeechAnalyzerSpeechToTextService
 import xyz.ksharma.krail.core.speechtotext.SpeechToTextService
 
 actual val speechToTextModule = module {
-    single<SpeechToTextService> { IosSpeechToTextService() }
+    // iOS 26's analyzer where the device has it, the SFSpeechRecognizer path everywhere else.
+    // Both are built either way: neither opens a microphone or touches a model until asked, and
+    // deciding between them needs an availability answer only the implementations can give.
+    single<SpeechToTextService> {
+        PreferredSpeechToTextService(
+            preferred = SpeechAnalyzerSpeechToTextService(),
+            fallback = IosSpeechToTextService(),
+        )
+    }
 }

--- a/core/speech-to-text/src/swift/speechBridge/SpeechBridge.swift
+++ b/core/speech-to-text/src/swift/speechBridge/SpeechBridge.swift
@@ -1,0 +1,273 @@
+import AVFoundation
+import Foundation
+import Speech
+
+/// Wraps iOS 26's `SpeechAnalyzer` behind plain Objective-C entry points, because
+/// Kotlin/Native cinterop reads Objective-C headers and `SpeechAnalyzer` is a Swift `actor`
+/// with `AsyncSequence` results and no Objective-C surface at all.
+///
+/// Same shape and same reason as `AiTextBridge` in `:core:ai-text`: primitives and closures
+/// only across the boundary, no Swift types, no generics, no async.
+///
+/// **This file owns mechanism, never policy.** It reports what Apple's modules say, including
+/// `SpeechDetector`'s voice activity in audio time, and it does not decide when the rider has
+/// finished talking. That decision lives in `SpeechActivityWatch` in `commonMain`, where a test
+/// can reach it. Swift source in this project has no test task, which is exactly how three
+/// rider-facing faults lived in the old `SFSpeechRecognizer` path unnoticed.
+@objcMembers public class SpeechBridge: NSObject {
+
+    private var session: AnyObject?
+
+    /// Availability reasons are the shared vocabulary in `SpeechUnavailableReasons`, never
+    /// Swift's own spelling of anything. The lesson `AiTextBridge` documents: a reason string
+    /// only one side knows is a message the rider never sees.
+    public func checkAvailability(completion: @escaping (Bool, String) -> Void) {
+        guard #available(iOS 26.0, *) else {
+            completion(false, "not_available")
+            return
+        }
+        Task {
+            let locale = Locale.current
+            let installed = await DictationTranscriber.installedLocales
+            if installed.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+                completion(true, "available")
+                return
+            }
+            let supported = await DictationTranscriber.supportedLocales
+            if supported.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+                // Downloadable, not missing. Same distinction the AI side draws, and the
+                // caller words the two differently.
+                completion(false, "model_downloading")
+            } else {
+                completion(false, "not_available")
+            }
+        }
+    }
+
+    /// Starts listening. Every callback may arrive on any thread.
+    ///
+    /// `onSpeechActivity` carries `SpeechDetector`'s answer and the audio time it applies to,
+    /// in seconds. Audio time, not wall clock, is the whole reason this exists: it is when the
+    /// rider spoke, not when a transcription happened to reach us.
+    public func start(
+        onPartial: @escaping (String) -> Void,
+        onFinal: @escaping (String) -> Void,
+        onSpeechActivity: @escaping (Bool, Double) -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        guard #available(iOS 26.0, *) else {
+            onError("not_available")
+            return
+        }
+        let session = AnalyzerSession(
+            onPartial: onPartial,
+            onFinal: onFinal,
+            onSpeechActivity: onSpeechActivity,
+            onError: onError
+        )
+        self.session = session
+        session.start()
+    }
+
+    /// Stops the microphone and asks for a final transcript. The caller still gets `onFinal`.
+    public func finish() {
+        guard #available(iOS 26.0, *), let session = session as? AnalyzerSession else { return }
+        session.finish()
+    }
+
+    /// Tears everything down without waiting for a final transcript.
+    public func cancel() {
+        guard #available(iOS 26.0, *), let session = session as? AnalyzerSession else { return }
+        session.cancel()
+        self.session = nil
+    }
+}
+
+@available(iOS 26.0, *)
+private final class AnalyzerSession {
+
+    private let onPartial: (String) -> Void
+    private let onFinal: (String) -> Void
+    private let onSpeechActivity: (Bool, Double) -> Void
+    private let onError: (String) -> Void
+
+    private let audioEngine = AVAudioEngine()
+    private var analyzer: SpeechAnalyzer?
+    private var transcriber: DictationTranscriber?
+    private var inputBuilder: AsyncStream<AnalyzerInput>.Continuation?
+    private var converter: AVAudioConverter?
+    private var tasks: [Task<Void, Never>] = []
+    private var didFinish = false
+
+    init(
+        onPartial: @escaping (String) -> Void,
+        onFinal: @escaping (String) -> Void,
+        onSpeechActivity: @escaping (Bool, Double) -> Void,
+        onError: @escaping (String) -> Void
+    ) {
+        self.onPartial = onPartial
+        self.onFinal = onFinal
+        self.onSpeechActivity = onSpeechActivity
+        self.onError = onError
+    }
+
+    func start() {
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.startAnalyzing()
+            } catch {
+                self.onError(error.localizedDescription)
+            }
+        }
+    }
+
+    private func startAnalyzing() async throws {
+        // .progressiveShortDictation, not .shortDictation: the rider watches their words
+        // arrive as they speak, so results have to be delivered live rather than at the end.
+        // Not .phrase either, which produces no live results at all.
+        let transcriber = DictationTranscriber(
+            locale: Locale.current,
+            preset: .progressiveShortDictation
+        )
+        self.transcriber = transcriber
+
+        // Apple's own voice activity detection, which is the thing the old implementation had
+        // to fake by watching the transcript change. It cannot run alone; pairing it with the
+        // transcriber in one analyzer is the documented arrangement.
+        let detector = SpeechDetector(
+            detectionOptions: SpeechDetector.DetectionOptions(sensitivityLevel: .medium),
+            reportResults: true
+        )
+
+        let analyzer = SpeechAnalyzer(modules: [detector, transcriber])
+        self.analyzer = analyzer
+
+        let (inputSequence, inputBuilder) = AsyncStream.makeStream(of: AnalyzerInput.self)
+        self.inputBuilder = inputBuilder
+
+        let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(
+            compatibleWith: [detector, transcriber]
+        )
+
+        try startMicrophone(analyzerFormat: analyzerFormat)
+        try await analyzer.start(inputSequence: inputSequence)
+
+        tasks.append(Task { [weak self] in
+            guard let self else { return }
+            do {
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    if result.isFinal {
+                        self.onFinal(text)
+                    } else {
+                        self.onPartial(text)
+                    }
+                }
+            } catch {
+                self.onError(error.localizedDescription)
+            }
+        })
+
+        tasks.append(Task { [weak self] in
+            guard let self else { return }
+            do {
+                for try await result in detector.results {
+                    self.onSpeechActivity(
+                        result.speechDetected,
+                        CMTimeGetSeconds(result.range.end)
+                    )
+                }
+            } catch {
+                // A detector that stops reporting is not a failed session: the transcriber is
+                // still running and the caller's own ceiling still ends it. Reporting an error
+                // here would tear down a working transcription.
+            }
+        })
+    }
+
+    /// Feeds the microphone into the analyzer, converting to the format the modules asked for.
+    ///
+    /// The tap's own format is whatever the hardware gives; the analyzer publishes what it
+    /// wants. Handing it the wrong one is silent, in that the session runs and never
+    /// transcribes anything, so the conversion is not optional.
+    private func startMicrophone(analyzerFormat: AVAudioFormat?) throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+        let inputNode = audioEngine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+        if let analyzerFormat, analyzerFormat != inputFormat {
+            converter = AVAudioConverter(from: inputFormat, to: analyzerFormat)
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            guard let self else { return }
+            guard let converted = self.convert(buffer: buffer, to: analyzerFormat) else { return }
+            self.inputBuilder?.yield(AnalyzerInput(buffer: converted))
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    private func convert(buffer: AVAudioPCMBuffer, to format: AVAudioFormat?) -> AVAudioPCMBuffer? {
+        guard let format, let converter else { return buffer }
+        let ratio = format.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1024
+        guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
+            return nil
+        }
+        var consumed = false
+        var error: NSError?
+        converter.convert(to: output, error: &error) { _, status in
+            if consumed {
+                status.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            status.pointee = .haveData
+            return buffer
+        }
+        return error == nil ? output : nil
+    }
+
+    /// The graceful finish. Apple is explicit that ending the input sequence does not end the
+    /// session, so both are needed, and the microphone goes first: nothing should be arriving
+    /// after we have said that was all the audio there is.
+    func finish() {
+        guard !didFinish else { return }
+        didFinish = true
+        stopMicrophone()
+        inputBuilder?.finish()
+        Task { [weak self] in
+            guard let self, let analyzer = self.analyzer else { return }
+            do {
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+            } catch {
+                self.onError(error.localizedDescription)
+            }
+        }
+    }
+
+    func cancel() {
+        didFinish = true
+        stopMicrophone()
+        inputBuilder?.finish()
+        tasks.forEach { $0.cancel() }
+        tasks.removeAll()
+        let analyzer = self.analyzer
+        Task { await analyzer?.cancelAndFinishNow() }
+        self.analyzer = nil
+    }
+
+    private func stopMicrophone() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        try? AVAudioSession.sharedInstance().setActive(
+            false,
+            options: .notifyOthersOnDeactivation
+        )
+    }
+}


### PR DESCRIPTION
## What

Replaces the iOS speech path with iOS 26's `SpeechAnalyzer`, falling back to `SFSpeechRecognizer` on anything older.

`SFSpeechRecognizer` is a transcription **stream**: it never decides a speaker has finished, because `isFinal` arrives only after the app calls `endAudio()`. Every end-of-speech decision therefore had to be inferred from how text happened to arrive, and every fault in [the 2026-08-23 learning entry](../blob/main/docs/learning/2026-08-23-the-blank-transcript-that-cleared-the-field.md) came from that inference. iOS 26 ships the two missing pieces as modules: `DictationTranscriber` (short queries, same on-device model) and `SpeechDetector` (voice activity detection, reported in audio time).

Two commits, kept separate: the bridge and its rule, then the wiring.

## Changes

**`feat(speech): add an iOS SpeechAnalyzer bridge and its end-of-speech rule`**

- `spmForKmp` with `cinteropName = "speechBridge"`, matching how `:core:ai-text` declares its bridge. `SpeechAnalyzer` is a Swift `actor` with `AsyncSequence` results and no Objective-C surface, so cinterop cannot see it.
- `src/swift/speechBridge/SpeechBridge.swift` exposes `checkAvailability`, `start`, `finish` and `cancel` over plain closures and primitives. It reports what Apple's modules say, including each voice-activity answer with the audio time it applies to, and decides nothing.
- `SpeechActivityWatch` in `commonMain` owns the decision instead: how long the rider has been quiet, and whether that is enough. 3000ms once speech has been heard, 6000ms before any.
- `SpeechActivityWatchTest`, 7 cases.

**`feat(speech): listen through SpeechAnalyzer on iOS 26, SFSpeechRecognizer below`**

- `SpeechAnalyzerSpeechToTextService` drives the analyzer. There is **no silence-polling coroutine any more**: the detector reports, and each report is enough to decide on.
- It reuses `TranscriptWatch`, so the rule that a blank transcript is never sent on as one is written once and both iOS paths get it.
- `PreferredSpeechToTextService` picks between them inside `checkAvailability`, the call every caller already makes before listening. In `commonMain`, because choosing between two implementations is not an iOS idea and `iosMain` has no test task.
- When the analyzer cannot run, the fallback's availability answer is the one reported. The two do not share a set of reasons, and reporting "the locale's model is still downloading" from a device whose older recogniser will listen right now would take the feature away for no reason.
- `PreferredSpeechToTextServiceTest`, 5 cases.
- README rewritten: it claimed neither platform actual was implemented, and that iOS needed no SPM bridge. Neither is true any more.

**Why the split between Swift and Kotlin is where it is.** The bridge owns mechanism, `commonMain` owns policy. Swift source in this project has no test task, which is how three rider-facing faults lived in the `SFSpeechRecognizer` path unnoticed.

**On the window being 3000ms again:** same number as Android's complete-sounding-phrase window, and for the first time the same measurement. It previously counted seconds without a transcript update, which is recognition lag plus silence; now a real detector reports real silence.

**Permissions change for riders on iOS 26:** `SpeechAnalyzer` needs the microphone alone, where `SFSpeechRecognizer` also needs speech-recognition authorization, so that path shows one system prompt instead of two. Both Info.plist keys stay, because the legacy path is still live below iOS 26.

**Left untouched:** `IosSpeechToTextService` keeps its name. Renaming it to say "legacy" would have rippled into a merged learning-log entry that records what was true when it was written.

## Testing

- `./gradlew testAndroidHostTest --continue` green across all modules. 26 tests in `:core:speech-to-text`, 12 of them new.
- `./scripts/fullQualityChecks.sh` green: `compileDebugSources`, `compileKotlinIosSimulatorArm64`, `detekt --continue`.
- `xcodebuild` of `iosApp` for the simulator succeeds with the second SPM package present; the app installs, launches and renders the home screen with no crash.
- The Swift is type-checked by the cinterop build against the iOS 26.5 SDK (Xcode 26.6).

**Not verified on hardware, deliberately merged anyway.** No microphone has been through the analyzer: the Ask KRAIL surface is gated on on-device AI, so it does not open on a simulator, and there is no iOS device on hand. The audio-format conversion, the detector's reporting cadence, and whether `finalizeAndFinishThroughEndOfInput()` yields a transcript in practice are reasoned from Apple's documentation and held up by the compiler, not by a device. Verification happens through TestFlight after this lands, which is why it lands as two readable commits rather than waiting. The fallback contains the blast radius: anything short of `Available` from the analyzer routes back to the `SFSpeechRecognizer` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
