### PR TITLE
fix(searchai): add spoken words to the field instead of replacing it

### DIFF
--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/SearchStopRow.kt
@@ -58,7 +58,7 @@ import krail.feature.trip_planner.ui.generated.resources.ic_search
 import org.jetbrains.compose.resources.painterResource
 import xyz.ksharma.krail.taj.LocalContentColor
 import xyz.ksharma.krail.taj.LocalThemeColor
-import xyz.ksharma.krail.taj.components.AiWheelMark
+import xyz.ksharma.krail.taj.components.AiMicButton
 import xyz.ksharma.krail.taj.components.Button
 import xyz.ksharma.krail.taj.components.ButtonDefaults
 import xyz.ksharma.krail.taj.components.RoundIconButton
@@ -459,6 +459,12 @@ private fun StopFieldText(text: String, isActive: Boolean, slideUp: Boolean, lab
  * and every failure they can hit, so this button has one job and one look. It used to change
  * into a mic and back, which meant the row had to explain a mode it was not showing.
  *
+ * A mic that stays a mic, rather than the wheel that used to sit here. The wheel is KRAIL's
+ * mark for *on-device AI produced this*, which is exactly right on the alert-summary card and
+ * wrong on a door: it named the technology to a rider who was looking for a way to say where
+ * they are going. The gradient moved to the button's ring, so the surface still announces
+ * itself without the glyph having to.
+ *
  * Not rendered at all when the feature is off. It used to render regardless, because the flag
  * stopped at the ViewModel — the sheet opened, the rider typed a sentence, and Continue did
  * nothing.
@@ -468,24 +474,19 @@ private fun AiSheetEntryButton(
     onAiEvent: (AiSearchInputEvent) -> Unit,
     spinning: Boolean = false,
 ) {
-    val dim = KrailTheme.dimensions
     val themeColorHex by LocalThemeColor.current
 
-    RoundIconButton(
-        content = {
-            // The theme's own pair, not the fixed cool gradient the mark defaults to. This
-            // button is the door to a surface that is now painted in these exact colours, so a
-            // wheel in somebody else's blue and violet reads as a different product's button.
-            //
-            // It spins exactly once outside that surface: the settle beat after the dialog
-            // closes onto this row with an answer, so the motion lands where the answer did.
-            AiWheelMark(
-                spinning = spinning,
-                markSize = dim.iconDefault,
-                colors = AiThemeGradientTokens.stopsFor(themeColorHex),
-            )
-        },
+    // The theme's own pair, not the fixed gradient the ring defaults to. This button is the
+    // door to a surface painted in these exact colours, so a ring in somebody else's blue and
+    // violet reads as a different product's button.
+    //
+    // It turns exactly once outside that surface: the settle beat after the dialog closes onto
+    // this row with an answer, so the motion lands where the answer did.
+    AiMicButton(
         onClick = { onAiEvent(AiSearchInputEvent.OpenInput) },
+        spinning = spinning,
+        colors = AiThemeGradientTokens.stopsFor(themeColorHex),
+        contentDescription = "Ask KRAIL",
         modifier = Modifier.testTag(TripPlannerTestTags.SEARCH_ROW_ASK_KRAIL),
     )
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModel.kt
@@ -120,6 +120,11 @@ class AiSearchInputViewModel(
     // Only ever compared against an earlier reading of itself, never read as a total.
     private var wordsHeardSoFar: Int = 0
 
+    // What the field held when the rider tapped the mic. Spoken words are added to it rather
+    // than replacing it, so a half-typed sentence survives being spoken into. Held outside the
+    // state because it is not something the screen renders, and cleared wherever the draft is.
+    private var textBeforeSpeaking: String = ""
+
     // Held outside the state as well as in it, because every reset below rebuilds the state
     // from scratch and this is the one fact about the device that a reset must not forget.
     private var isDeviceCapable: Boolean = true
@@ -177,6 +182,7 @@ class AiSearchInputViewModel(
             // (phase RESOLVED, the resolved intent, the sentence) — reopening onto that would
             // show a stale answer for a row the rider may have edited since.
             AiSearchInputEvent.OpenInput -> {
+                textBeforeSpeaking = ""
                 val enabled = isAiSearchInputEnabled()
                 _uiState.update {
                     AiSearchInputUiState(
@@ -190,13 +196,16 @@ class AiSearchInputViewModel(
             AiSearchInputEvent.Submit -> submit()
             // Everything the rider produced is thrown away; what the app knows about itself
             // is not, or starting over would hide the way back in.
-            AiSearchInputEvent.StartOver ->
+            AiSearchInputEvent.StartOver -> {
+                textBeforeSpeaking = ""
                 _uiState.update {
                     AiSearchInputUiState(
                         isFeatureEnabled = it.isFeatureEnabled,
                         isDeviceCapable = isDeviceCapable,
                     )
                 }
+            }
+
             AiSearchInputEvent.StartListening -> startListening()
             AiSearchInputEvent.StopListening -> stopListening()
         }
@@ -217,6 +226,7 @@ class AiSearchInputViewModel(
         listeningJob = null
         listeningTimeoutJob?.cancel()
         listeningTimeoutJob = null
+        textBeforeSpeaking = ""
         if (_uiState.value.isListening) speechToTextService.stopListening()
         _uiState.update {
             AiSearchInputUiState(
@@ -258,8 +268,19 @@ class AiSearchInputViewModel(
                 return@launch
             }
 
-            // Clears any previous failure message as the new attempt begins, so a retry does
-            // not start under the last attempt's error.
+            // Whatever is already in the field is kept, and the spoken words are added to it.
+            //
+            // Speaking used to replace it. A rider who typed half a sentence, tapped the mic
+            // and watched their own words disappear had no way back to them: the field is the
+            // only copy. Every mic that lives inside a text field works this way, from the iOS
+            // keyboard's own dictation to Gboard's, because a mic beside a keyboard is another
+            // way to type rather than a different way to ask.
+            //
+            // Replacing does have one case going for it, a rider re-tapping the mic to redo a
+            // mis-heard sentence, and adding gives them the sentence twice. That is a worse
+            // reading of the same tap but a far better failure: it is on screen, it is
+            // obviously wrong, and it is one gesture to clear. Losing typed words is silent.
+            textBeforeSpeaking = _uiState.value.typedText
             _uiState.update {
                 it.copy(isListening = true, speechTranscript = "", speechUnavailableReason = null)
             }
@@ -282,7 +303,12 @@ class AiSearchInputViewModel(
                         // has nothing to add, not that the rider unsaid what they said, and
                         // writing it through erases words already in the field.
                         if (result.text.isNotBlank()) {
-                            _uiState.update { it.copy(speechTranscript = result.text, typedText = result.text) }
+                            _uiState.update {
+                                it.copy(
+                                    speechTranscript = result.text,
+                                    typedText = joinSpokenText(textBeforeSpeaking, result.text),
+                                )
+                            }
                         }
                     }
 
@@ -308,7 +334,7 @@ class AiSearchInputViewModel(
                                 it.copy(
                                     isListening = false,
                                     speechTranscript = result.text,
-                                    typedText = result.text,
+                                    typedText = joinSpokenText(textBeforeSpeaking, result.text),
                                 )
                             }
                         }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/SpokenTextJoin.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/SpokenTextJoin.kt
@@ -1,0 +1,24 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai
+
+/**
+ * Joins spoken words onto whatever the rider had already written in the field.
+ *
+ * Speaking adds to the field rather than replacing it, because the field is the only copy of
+ * what they typed and a mic that lives inside a text field is another way to type. See
+ * `AiSearchInputViewModel.startListening`.
+ *
+ * A single space separates the two, unless one side already carries whitespace at the join, so
+ * "meet me at" spoken into gives "meet me at central station" rather than running the words
+ * together or doubling the gap. An empty field returns the transcript untouched: that is the
+ * ordinary case and it must not gain a leading space.
+ *
+ * A top-level function in its own file rather than a private method, because
+ * `AiSearchInputViewModel` is at its `TooManyFunctions` limit and a local function would not
+ * have helped. It is a pure string join with no ViewModel state in it, so it tests directly.
+ */
+internal fun joinSpokenText(existing: String, spoken: String): String = when {
+    existing.isBlank() -> spoken
+    spoken.isEmpty() -> existing
+    existing.last().isWhitespace() || spoken.first().isWhitespace() -> existing + spoken
+    else -> "$existing $spoken"
+}

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/AiSearchInputViewModelTest.kt
@@ -1057,6 +1057,69 @@ class AiSearchInputViewModelTest {
         }
 
     @Test
+    fun `speaking adds to what the rider already typed instead of replacing it`() =
+        runTest(testDispatcher) {
+            // Reported from a device: type a little, tap the mic, and the typed words were
+            // gone. The field is the only copy, so replacing it destroys input with no undo.
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("meet me at"))
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+
+            speechToTextService.results.emit(SpeechToTextResult.Partial("central"))
+            runCurrent()
+            assertEquals("meet me at central", viewModel.uiState.value.typedText)
+
+            speechToTextService.results.emit(SpeechToTextResult.Final("central station"))
+            runCurrent()
+            assertEquals("meet me at central station", viewModel.uiState.value.typedText)
+        }
+
+    @Test
+    fun `speaking into an empty field adds no leading space`() = runTest(testDispatcher) {
+        // The ordinary case, and the one a naive join gets wrong.
+        viewModel.onEvent(AiSearchInputEvent.StartListening)
+        runCurrent()
+
+        speechToTextService.results.emit(SpeechToTextResult.Final("central to town hall"))
+        runCurrent()
+
+        assertEquals("central to town hall", viewModel.uiState.value.typedText)
+    }
+
+    @Test
+    fun `a second session adds to the first one's words, not to a stale copy`() =
+        runTest(testDispatcher) {
+            // The text captured when the mic is tapped has to be re-read every session. Held
+            // from the first one, the second would append to what the field looked like before
+            // the rider ever spoke.
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+            speechToTextService.results.emit(SpeechToTextResult.Final("central"))
+            runCurrent()
+
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+            speechToTextService.results.emit(SpeechToTextResult.Final("to town hall"))
+            runCurrent()
+
+            assertEquals("central to town hall", viewModel.uiState.value.typedText)
+        }
+
+    @Test
+    fun `starting over drops the text a later session would have added to`() =
+        runTest(testDispatcher) {
+            viewModel.onEvent(AiSearchInputEvent.TypedTextChanged("meet me at"))
+            viewModel.onEvent(AiSearchInputEvent.StartOver)
+            viewModel.onEvent(AiSearchInputEvent.StartListening)
+            runCurrent()
+
+            speechToTextService.results.emit(SpeechToTextResult.Final("central station"))
+            runCurrent()
+
+            assertEquals("central station", viewModel.uiState.value.typedText)
+        }
+
+    @Test
     fun `a blank final does not wipe the sentence the rider watched arrive`() =
         runTest(testDispatcher) {
             // The iOS bug this guards: ending a session asks the recogniser to finish, and the

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/SpokenTextJoinTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/SpokenTextJoinTest.kt
@@ -1,0 +1,44 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The join between what the rider typed and what they then said. Every case here is something
+ * a rider can see in the field, so the edges matter more than they look: a stray leading space
+ * or two words run together is the whole visible result of speaking.
+ */
+class SpokenTextJoinTest {
+
+    @Test
+    fun `an empty field gives the transcript untouched`() {
+        // The ordinary case, and the one a naive join gets wrong with a leading space.
+        assertEquals("central to town hall", joinSpokenText("", "central to town hall"))
+    }
+
+    @Test
+    fun `a whitespace-only field is treated as empty`() {
+        assertEquals("central station", joinSpokenText("   ", "central station"))
+    }
+
+    @Test
+    fun `typed words keep a single space before the spoken ones`() {
+        assertEquals("meet me at central", joinSpokenText("meet me at", "central"))
+    }
+
+    @Test
+    fun `a field already ending in a space does not gain a second one`() {
+        assertEquals("meet me at central", joinSpokenText("meet me at ", "central"))
+    }
+
+    @Test
+    fun `a transcript that starts with a space does not gain one either`() {
+        assertEquals("meet me at central", joinSpokenText("meet me at", " central"))
+    }
+
+    @Test
+    fun `an empty transcript leaves the field exactly as it was`() {
+        // Nothing heard must not append a trailing space to what the rider typed.
+        assertEquals("meet me at", joinSpokenText("meet me at", ""))
+    }
+}

--- a/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
+++ b/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2ae5c0e63aa2dc136f8c3c3c41aa7cd5b1d0a4fb8038334edb3b865e77ceb5
+size 23979

--- a/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
+++ b/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37e781b87a6f1f382a56aefb3ae274b3ffc05d3d99ee9cfa02cb57ab634f064
+size 24124

--- a/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
+++ b/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37e781b87a6f1f382a56aefb3ae274b3ffc05d3d99ee9cfa02cb57ab634f064
+size 24124

--- a/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
+++ b/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e99999d49ac3ebf2938b7e5ffca8e22562dd1ac25cd1b7763f8abc7ba248345c
+size 23682

--- a/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
+++ b/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e139127f5025442eff290221841f75646155f072e9875dccb31d057b6d4ae71d
+size 23605

--- a/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
+++ b/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e139127f5025442eff290221841f75646155f072e9875dccb31d057b6d4ae71d
+size 23605

--- a/taj/screenshots/PreviewAiMicButtonSpinning.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
+++ b/taj/screenshots/PreviewAiMicButtonSpinning.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2ae5c0e63aa2dc136f8c3c3c41aa7cd5b1d0a4fb8038334edb3b865e77ceb5
+size 23979

--- a/taj/screenshots/PreviewAiMicButtonSpinning.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
+++ b/taj/screenshots/PreviewAiMicButtonSpinning.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37e781b87a6f1f382a56aefb3ae274b3ffc05d3d99ee9cfa02cb57ab634f064
+size 24124

--- a/taj/screenshots/PreviewAiMicButtonSpinning.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
+++ b/taj/screenshots/PreviewAiMicButtonSpinning.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_xlarge.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a37e781b87a6f1f382a56aefb3ae274b3ffc05d3d99ee9cfa02cb57ab634f064
+size 24124

--- a/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/AiMicButton.kt
+++ b/taj/src/commonMain/kotlin/xyz/ksharma/krail/taj/components/AiMicButton.kt
@@ -1,0 +1,109 @@
+package xyz.ksharma.krail.taj.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import xyz.ksharma.krail.core.snapshot.ScreenshotTest
+import xyz.ksharma.krail.taj.LocalContentColor
+import xyz.ksharma.krail.taj.animations.rememberAiSpinAngle
+import xyz.ksharma.krail.taj.modifier.aiGradientBorder
+import xyz.ksharma.krail.taj.preview.PreviewComponent
+import xyz.ksharma.krail.taj.theme.KrailTheme
+import xyz.ksharma.krail.taj.theme.KrailThemeStyle
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.taj.tokens.AiCoolGradientTokens
+import xyz.ksharma.krail.taj.tokens.AiGradientTokens
+import xyz.ksharma.krail.taj.tokens.ButtonTokens
+import xyz.ksharma.krail.taj.tokens.StrokeTokens
+
+/**
+ * The way in to speaking: an ordinary mic on an ordinary button, wearing the AI gradient as a
+ * ring around its edge.
+ *
+ * The colour is deliberately all in the ring. The glyph and the fill stay the theme's own
+ * content and surface colours, so the button reads as a mic first and as an AI surface second,
+ * which is the right order for a control whose job is to open a microphone. A gradient-filled
+ * glyph would have said "AI" before it said "speak".
+ *
+ * It replaced [AiWheelMark] in this position. The wheel is KRAIL's mark for *on-device AI did
+ * this*, which is what the alert-summary card needs, but on the way in it named the technology
+ * rather than the action: a rider looking for a way to say where they are going has no reason
+ * to recognise a wheel. The mark stays where it belongs and the door says what it opens.
+ *
+ * @param spinning While `true`, the ring turns, then decelerates to a stop when it flips back
+ * (see [rememberAiSpinAngle]). The ring is drawn either way: at rest it is this surface's
+ * identity, and turning is reserved for the beat when something is actually happening.
+ * @param colors Gradient stops for the ring. Defaults to [AiGradientTokens]; pass
+ * [AiCoolGradientTokens] or a theme-derived set to match a surrounding surface.
+ */
+@Composable
+fun AiMicButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    spinning: Boolean = false,
+    colors: List<Color> = AiGradientTokens.stops,
+    contentDescription: String? = null,
+    onClickLabel: String? = null,
+) {
+    RoundIconButton(
+        onClick = onClick,
+        onClickLabel = onClickLabel,
+        // On the button's own edge, so the ring traces the control rather than floating inside
+        // it. Half the button's size is the radius that makes this rounded rect a circle, and
+        // it is read from the same token the button sizes itself with so the two cannot drift.
+        modifier = modifier.aiGradientBorder(
+            spinning = spinning,
+            cornerRadius = ButtonTokens.RoundButtonSize / 2,
+            // Thinner than the modifier's default, which is tuned for a card's edge. At 4dp on
+            // a 48dp circle the ring stops being a border and becomes the button.
+            strokeWidth = StrokeTokens.Regular,
+            colors = colors,
+        ),
+        content = {
+            Image(
+                imageVector = MicIcon,
+                contentDescription = contentDescription,
+                colorFilter = ColorFilter.tint(LocalContentColor.current),
+                modifier = Modifier.size(KrailTheme.dimensions.iconDefault),
+            )
+        },
+    )
+}
+
+// region Previews
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewAiMicButtonAtRest() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Train) {
+        AiMicButton(onClick = {}, contentDescription = "Ask KRAIL")
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewAiMicButtonCool() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Metro) {
+        AiMicButton(
+            onClick = {},
+            colors = AiCoolGradientTokens.stops,
+            contentDescription = "Ask KRAIL",
+        )
+    }
+}
+
+@ScreenshotTest
+@PreviewComponent
+@Composable
+private fun PreviewAiMicButtonSpinning() {
+    PreviewTheme(themeStyle = KrailThemeStyle.Bus) {
+        AiMicButton(onClick = {}, spinning = true, contentDescription = "Ask KRAIL")
+    }
+}
+
+// endregion


### PR DESCRIPTION
## What

Two pieces of device feedback on Ask KRAIL.

1. Speaking replaced whatever was already in the field. Now it adds to it.
2. The way in was the AI wheel. Now it is a mic wearing the gradient as a ring.

Both are shared code, so Android and iOS behave identically.

## Changes

**`fix(searchai): add spoken words to the field instead of replacing it`**

- The field's contents are captured when listening starts, and every partial and final is joined onto them. Captured per session, so a second session adds to what the first left rather than to a stale copy, and cleared wherever the draft is thrown away.
- `joinSpokenText` is a top-level function in its own file. `AiSearchInputViewModel` is at its `TooManyFunctions` limit and a local function would not have helped; a pure string join also tests directly.
- `SpokenTextJoinTest` covers the empty field, a whitespace-only field, and whitespace already present on either side of the join. Each of those is something the rider sees, as either a leading space or two words run together.
- Four new `AiSearchInputViewModelTest` cases for the behaviour end to end.

*Why adding rather than replacing.* The field is the only copy of what the rider typed, so replacing destroys input with no way back. Every mic that lives inside a text field adds to what is there, from the iOS keyboard's own dictation to Gboard's, because a mic beside a keyboard is another way to type rather than a different way to ask. Replacing has one case going for it, a rider re-tapping the mic to redo a mis-heard sentence, where adding gives them the sentence twice. That is the worse reading of the tap but the better failure: it is on screen, obviously wrong, and one gesture to clear. Losing typed words is silent.

**`feat(taj): open Ask KRAIL from a mic with a turning gradient ring`**

- `AiMicButton` keeps the glyph and the fill in the theme's own content and surface colours and puts the gradient in a ring around the button's edge, so the control reads as a mic first and an AI surface second.
- The ring is drawn at rest and turns for the same one beat the wheel did: the settle after the dialog closes onto the row with an answer.
- It lives in `:taj`, where `ButtonTokens.RoundButtonSize` is visible, so the ring's radius comes from the same token the button sizes itself with and the two cannot drift into an oval.
- Ring stroke is `Regular` rather than the modifier's `Thick` default, which is tuned for a card's edge. At 4dp on a 48dp circle the ring stops being a border and becomes the button.

*Why not the wheel.* The wheel is KRAIL's mark for *on-device AI produced this*, which is right on the alert-summary card and wrong on a door: on the way in it named the technology to a rider looking for a way to say where they are going. `AiWheelMark` is unchanged and still used by the alert-summary card.

## Testing

- `./gradlew testAndroidHostTest --continue -PciQuality=true` green across all modules. `AiSearchInputViewModelTest` 58 cases, `SpokenTextJoinTest` 6 new.
- `./gradlew verifyTestWiring verifyTestingModuleUsage verifyNoAdHocBoundaryFakes verifyIosTestClassification --continue -PciQuality=true` green.
- `./scripts/fullQualityChecks.sh` green: `compileDebugSources`, `compileKotlinIosSimulatorArm64`, `detekt --continue`.
- `TooManyFunctions` on the ViewModel was resolved by extracting to a separate file, not suppressed.
- Screenshots recorded for the new component. No existing screenshot changed.

## Snapshots

The Ask KRAIL entry point is gated on on-device AI, so it does not render on a simulator at all. These previews are the only way to see it.

| Screen | Light | Dark |
|---|---|---|
| AiMicButton, at rest (theme gradient) | <img src="https://raw.githubusercontent.com/ksharma-xyz/KRAIL/feat/ask-krail-mic-and-append/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png" width="220"> | <img src="https://raw.githubusercontent.com/ksharma-xyz/KRAIL/feat/ask-krail-mic-and-append/taj/screenshots/PreviewAiMicButtonAtRest.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png" width="220"> |
| AiMicButton, cool gradient | <img src="https://raw.githubusercontent.com/ksharma-xyz/KRAIL/feat/ask-krail-mic-and-append/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_light_normal.png" width="220"> | <img src="https://raw.githubusercontent.com/ksharma-xyz/KRAIL/feat/ask-krail-mic-and-append/taj/screenshots/PreviewAiMicButtonCool.1._Light_Mode_Screen_WITH_BACKGROUND_WIDTH_411DP_HEIGHT_891DP_dark_normal.png" width="220"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
