### PR TITLE
fix(searchai): fall back to Home for the From stop, and document both ladders

### DIFF
--- a/docs/marketing/ASK_KRAIL_CAPABILITIES.md
+++ b/docs/marketing/ASK_KRAIL_CAPABILITIES.md
@@ -75,8 +75,8 @@ the other is left to them.
 ## What it looks like
 
 The surface is painted from the rider's chosen theme: two colours from that theme drifting
-behind the input, the same pair on the AI wheel, the border, and the search screen's background.
-Change the theme and all of it follows.
+behind the input, the same pair on the mic ring that opens it, the border, and the search
+screen's background. Change the theme and all of it follows.
 
 ---
 

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -30,7 +30,7 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 
 | # | Failure | Rider sees | Test |
 |---|---|---|---|
-| 1 | Feature flag off | **No way in.** The wheel is not drawn | `with the flag off there is no way in`, `with the flag on the way in is there and opens`, `starting over keeps the way in`, plus `submit while flag is off does nothing` |
+| 1 | Feature flag off | **No way in.** The mic is not drawn | `with the flag off there is no way in`, `with the flag on the way in is there and opens`, `starting over keeps the way in`, plus `submit while flag is off does nothing` |
 | 2 | Model not downloaded, or downloading | "still downloading… try again in a moment" | `model downloadable lands in DOWNLOADING`, `model downloading lands in DOWNLOADING too` |
 | 3 | Device unsupported | Generic unresolved message | `unsupported device lands in UNRESOLVED, not DOWNLOADING` — reads as a parse failure rather than "not available here" |
 | 4 | Model returns nothing usable | "did not come through, have another go" | `failed extraction resolves to UNRESOLVED`, `a model that gives nothing back is its own kind of failure` |
@@ -40,10 +40,27 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 | 8 | Only one end resolves | That field fills, the other is left | `one stop resolving is still a result` |
 | 9 | Origin unstated, destination found, GPS off or denied | From left empty | `nearby-stop resolver failure leaves origin unresolved, not a crash` |
 | 10 | Microphone denied, blocked, unsupported, or the recogniser errors | A different message for each; a blocked mic opens Settings | `speech unavailable surfaces the reason`, `a recogniser error is reported as itself` |
-| 11 | Recogniser never reports an end | Stops itself at 10s, or 15s if words were still arriving. This is a backstop: both platforms end an ordinary session on their own, Android on its own silence windows (3s after a complete-sounding phrase, 4s otherwise) and iOS on 3s without a new word | `listening stops itself once it hits the ceiling`, `a rider still speaking at the ceiling is given longer`, `words that stopped before the ceiling do not earn the extension` |
+| 11 | Recogniser never reports an end | Stops itself at 10s, or 15s if words were still arriving. This is a backstop: every path ends an ordinary session on its own. See "How each platform decides you stopped" below | `listening stops itself once it hits the ceiling`, `a rider still speaking at the ceiling is given longer`, `words that stopped before the ceiling do not earn the extension` |
 | 12 | Time understood ("by 6pm") | Shown on the search row, and the timetable opens with it | `resolves a time intent into the confirm state`, plus three in `TimeTableViewModelTest` covering the route carrying it, no time meaning now, and unreadable JSON falling back to now |
 | 13 | Dismissed mid-flight | Mic stopped, draft discarded | `closing the box while listening stops the mic`, `closing the box throws the draft away` |
 | 14 | Recogniser reports a blank transcript | Nothing. The words already heard stay in the field; a session that heard nothing at all ends as a recogniser error | `a blank final does not wipe the sentence the rider watched arrive`, `a blank partial does not wipe the words already heard` |
+
+### How each platform decides you stopped
+
+Three code paths, and they do not measure the same thing. The numbers being equal is a
+coincidence worth not relying on.
+
+| Path | What it measures | Window | Where |
+|---|---|---|---|
+| Android | silence, inside the OS recogniser | 3s after a complete-sounding phrase, 4s otherwise | `AndroidSpeechToTextService` intent extras |
+| iOS 26 | silence, from Apple's `SpeechDetector`, in audio time | 3s | `SpeechActivityWatch` |
+| iOS below 26 | the transcript gaining a **word**, which lags speech by however long recognition takes | 3s | `TranscriptWatch` |
+
+The third is the weakest and is the fallback for exactly that reason:
+`SFSpeechAudioBufferRecognitionRequest` never decides a speaker has finished, so the end of a
+sentence has to be inferred from how text arrives. iOS 26's `SpeechAnalyzer` supplies the real
+signal, which is why the app prefers it wherever it exists (`PreferredSpeechToTextService`).
+`core/speech-to-text/README.md` has the full comparison.
 
 **#14 was iOS only, and rider-facing.** `endAudio` asks `SFSpeechRecognizer` to finish, and the
 result that comes back can carry an empty transcription for the segment that was open rather
@@ -57,7 +74,7 @@ the field whichever platform produced it.
 
 Both of the open defects recorded here are now fixed.
 
-**#1.** The flag now reaches the state as `isFeatureEnabled`, the row does not draw the wheel
+**#1.** The flag now reaches the state as `isFeatureEnabled`, the row does not draw the mic
 without it, and `OpenInput` refuses as well as the button being absent — a caller that has not
 been told cannot open a sheet whose only action would be inert.
 

--- a/feature/trip-planner/ui/AI_SEARCH_UX.md
+++ b/feature/trip-planner/ui/AI_SEARCH_UX.md
@@ -45,6 +45,41 @@ Every way this can fail, what the rider gets, and whether a test holds it in pla
 | 13 | Dismissed mid-flight | Mic stopped, draft discarded | `closing the box while listening stops the mic`, `closing the box throws the draft away` |
 | 14 | Recogniser reports a blank transcript | Nothing. The words already heard stay in the field; a session that heard nothing at all ends as a recogniser error | `a blank final does not wipe the sentence the rider watched arrive`, `a blank partial does not wipe the words already heard` |
 
+### How the From stop is decided
+
+The rider names one end far more often than two ("get me home", "I want to go to Bondi"), so
+the other end is worked out. The ladder is ordered by how much each signal knows about **right
+now**, and a guess never overrules something known.
+
+| | Signal | Knows | Where |
+|---|---|---|---|
+| 1 | What the rider said | Their intent, certainly | `StopTextResolver` chain, via `resolveTripOrigin` |
+| 2 | A labelled stop within walking distance | Their position, certainly. The label is the platform they actually use, where the nearest stop is often a shelter nobody uses | `LabelledStopLocator.nearestLabelledStop` |
+| 3 | The nearest stop | Their position | `NearbyStopsRepository` |
+| 4 | **Home, if set** | Only their habit | `LabelledStopLocator.homeStop` |
+| 5 | Nothing. Field left blank | | |
+
+**Location always beats Home.** A trip starts where you are: a rider at work asking for the
+airport is served correctly by position and wrongly by habit. Home is reached only when there is
+no location at all, which is the same null whether permission was denied, restricted, or the fix
+timed out.
+
+**Two cases deliberately stay blank rather than reaching for Home.** Standing at the destination,
+and a known location with no stop near it. Both are things the app knows about the rider right
+now, and a guess must not contradict them.
+
+**Home is the only label used this way**, because with no location there is no distance by which
+to rank any other. It is also the one label the app treats as permanent: it cannot be renamed,
+only reassigned or cleared, which is what makes keying behaviour on it safe. One spelling of it,
+in `HOME_STOP_LABEL`.
+
+Filling this in is answering a question the rider asked, not inventing one: it happens only when
+a destination was actually understood. A sentence that resolved to no places takes no fallback
+at all, which is failure mode 5.
+
+Every branch logs under `[AI_ORIGIN]`, including why a location was unavailable, because all of
+them otherwise arrive as the same blank field with nothing to tell them apart.
+
 ### How each platform decides you stopped
 
 Three code paths, and they do not measure the same thing. The numbers being equal is a

--- a/feature/trip-planner/ui/ASK_KRAIL_UX.md
+++ b/feature/trip-planner/ui/ASK_KRAIL_UX.md
@@ -154,6 +154,16 @@ commute exactly as `Work` does. Two lists would have drifted the moment one gain
 - **Partial transcripts go into `typedText`**, not just `speechTranscript`. The field renders
   `typedText`; writing only the transcript meant a rider watched an empty box while they talked
   and everything appeared at once when they stopped.
+- **Speaking adds to the field, it does not replace it.** Whatever is already there when the mic
+  is tapped is kept, and the spoken words are joined onto it (`joinSpokenText`). Replacing meant
+  a rider who typed half a sentence and then tapped the mic watched their own words vanish, and
+  the field is the only copy. Every mic that lives inside a text field works this way, from the
+  iOS keyboard's own dictation to Gboard's, because a mic beside a keyboard is another way to
+  type rather than a different way to ask. Re-tapping to redo a mis-heard sentence therefore
+  gives the sentence twice: the worse reading of that tap, but the better failure, because it is
+  on screen and one gesture to clear where lost typing is silent.
+- **A blank transcript is never written in.** A recogniser reporting one is saying it has nothing
+  to add, not that the rider unsaid what they said. See failure mode 14 in `AI_SEARCH_UX.md`.
 - **Listening stops itself** at 10 seconds, extended to 15 if words were still arriving in the
   last 4. The recogniser does not always report an end, and a mic that stays open with no way
   out is worse than one that closes early. The rider's stop button is the real control; the
@@ -177,7 +187,7 @@ card taller than the screen is worse than the screen.
 **A resolve is a handoff.** The stops and the time are written into the home row on the
 RESOLVED emission (`SavedTripsEntry`), the dialog stays up for one settle beat
 (`closeAfterHandoff`, 1.5s) so the border can finish, then closes itself onto the row it
-filled. The row's wheel spins once as it lands (`isAiHandoffSettling`), so the eye follows
+filled. The row's mic ring turns once as it lands (`isAiHandoffSettling`), so the eye follows
 the answer. There is no result card: the row IS the result, and a copy of it inside the
 dialog was a second thing to keep in step with the first.
 
@@ -217,9 +227,16 @@ fallback cannot be deleted casually.
   appearance from whatever happens to be behind it, and behind this is a gradient that moves.
 - **`ImeAction.Default`, never `Search`.** Search makes the IME replace its enter key, so a
   rider writing more than one line has no way to start one.
-- **The way-in slot is never empty.** The wheel is the top of a two-button column in
+- **The way in is a mic, not the wheel.** `AiMicButton` keeps the glyph and the fill in the
+  theme's own content and surface colours and puts the AI gradient in a ring around the button's
+  edge, so the control reads as a mic first and an AI surface second. The wheel (`AiWheelMark`)
+  is KRAIL's mark for *on-device AI produced this*, which is right on the alert-summary card and
+  wrong on a door: on the way in it named the technology to a rider looking for a way to say
+  where they are going. The ring is drawn at rest and turns for one beat on handoff, which is
+  the same motion the wheel had.
+- **The way-in slot is never empty.** That mic is the top of a two-button column in
   `SearchStopRow`, with Search below it. Where `isWayInAvailable` is false the slot holds the
-  reverse-stops button instead, so Search does not rise into the wheel's place. Two devices
+  reverse-stops button instead, so Search does not rise into the mic's place. Two devices
   differing only in a capability the rider never chose should not have differently shaped rows,
   and the button that commits the trip should not move next to a different field.
 - **No second speak control.** A worded `Speak` button used to appear below the bar at large

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/components/ai/AiGreeting.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.remember
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.HOME_STOP_LABEL
 import xyz.ksharma.krail.trip.planner.ui.search.ai.resolve.LabelSynonyms
 import xyz.ksharma.krail.trip.planner.ui.state.savedtrip.StopLabel
 import xyz.ksharma.krail.trip.planner.ui.state.timetable.Trip
@@ -43,8 +44,6 @@ internal data class AiGreeting(val suggestion: String)
 // commute for the weekend rule exactly as "Work" does. Two lists would have drifted the moment
 // one of them gained a word.
 private val COMMUTE_LABELS = LabelSynonyms.commuteLabels
-
-private const val HOME_LABEL = "home"
 
 // The label is home by definition here, so the sentence says home rather than quoting whatever
 // casing the rider typed. "Get me home" is also what somebody would actually say out loud.
@@ -149,9 +148,9 @@ private fun eligibleTrip(savedTrips: List<Trip>, labels: List<StopLabel>, allows
  */
 private fun labelPair(labels: List<StopLabel>, allowsCommute: Boolean): Pair<String, String>? {
     val set = labels.filter { it.isSet }
-    val home = set.firstOrNull { it.label.equals(HOME_LABEL, ignoreCase = true) }
+    val home = set.firstOrNull { it.label.equals(HOME_STOP_LABEL, ignoreCase = true) }
 
-    val others = set.filterNot { it.label.equals(HOME_LABEL, ignoreCase = true) }
+    val others = set.filterNot { it.label.equals(HOME_STOP_LABEL, ignoreCase = true) }
     val eligible = if (allowsCommute) {
         others.sortedByDescending { it.label.lowercase() in COMMUTE_LABELS }
     } else {
@@ -164,7 +163,7 @@ private fun labelPair(labels: List<StopLabel>, allowsCommute: Boolean): Pair<Str
 
 /** Whether the rider has a home pinned to a stop, which is all the home-bound line needs. */
 private fun homeLabel(labels: List<StopLabel>): String? =
-    labels.firstOrNull { it.isSet && it.label.equals(HOME_LABEL, ignoreCase = true) }?.label
+    labels.firstOrNull { it.isSet && it.label.equals(HOME_STOP_LABEL, ignoreCase = true) }?.label
 
 /**
  * `Seven Hills Station` reads as `Seven Hills`. Only the trailing word goes: everything else in

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/navigation/entries/SavedTripsEntry.kt
@@ -8,6 +8,7 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.maps.data.location.rememberUserLocationManager
 import xyz.ksharma.krail.core.navigation.ResultEffect
 import xyz.ksharma.krail.trip.planner.ui.mapstopselection.MapStopSelectionPane
@@ -50,7 +51,20 @@ internal fun EntryProviderScope<NavKey>.SavedTripsEntry(
         // Composable-supplied param.
         val userLocationManager = rememberUserLocationManager()
         val aiSearchInputViewModel: AiSearchInputViewModel = koinViewModel(
-            parameters = { parametersOf(suspend { userLocationManager.getCurrentLocation().getOrNull() }) },
+            parameters = {
+                parametersOf(
+                    suspend {
+                        // The Result is unwrapped here and nowhere else, so this is the only
+                        // place that can say WHY a location was not available. Downstream all
+                        // three causes (denied, restricted, timed out) arrive as the same null
+                        // and produce the same blank From field, which is what made the
+                        // reported bug impossible to tell apart from "no stops nearby".
+                        userLocationManager.getCurrentLocation()
+                            .onFailure { log("[AI_ORIGIN] location unavailable: $it") }
+                            .getOrNull()
+                    },
+                )
+            },
         )
         val aiSearchInputState by aiSearchInputViewModel.uiState.collectAsStateWithLifecycle()
 

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelledStopLocator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/LabelledStopLocator.kt
@@ -28,6 +28,25 @@ class LabelledStopLocator(
 ) {
 
     /**
+     * The stop pinned as Home, or null when the rider has not set one.
+     *
+     * Deliberately not distance-aware, because it is asked only when there is no location to
+     * measure against: it is the last thing tried before leaving the field blank. Home is the
+     * one label this app treats as permanent (it cannot be renamed, only reassigned or
+     * cleared), which is what makes "is Home set" a question worth asking at all.
+     *
+     * [excludeStopId] is the destination, so "home to home" cannot be produced here either.
+     */
+    suspend fun homeStop(excludeStopId: String?): StopItem? =
+        sandook.observeStopLabels().first()
+            .firstOrNull { it.label.equals(HOME_STOP_LABEL, ignoreCase = true) }
+            ?.let { label ->
+                val id = label.stop_id ?: return@let null
+                val name = label.stop_name ?: return@let null
+                if (id == excludeStopId) null else StopItem(stopId = id, stopName = name)
+            }
+
+    /**
      * The nearest labelled stop within [RADIUS_KM], or null.
      *
      * [excludeStopId] is the destination. Standing at home and saying "get me home" must not

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/RiderOriginLocator.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/RiderOriginLocator.kt
@@ -1,6 +1,7 @@
 package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
 
 import xyz.ksharma.dhruva.location.Location
+import xyz.ksharma.krail.core.log.log
 import xyz.ksharma.krail.core.maps.data.repository.NearbyStopsRepository
 import xyz.ksharma.krail.trip.planner.ui.state.searchstop.model.StopItem
 
@@ -33,24 +34,71 @@ class RiderOriginLocator(
      * understood at all.
      */
     suspend fun originStop(excludeStopId: String?): StopItem? {
-        val location = resolveCurrentLocation() ?: return null
+        val location = resolveCurrentLocation()
+        return if (location == null) {
+            homeAsALastGuess(excludeStopId)
+        } else {
+            whereTheRiderIsStanding(location = location, excludeStopId = excludeStopId)
+        }
+    }
 
+    /**
+     * No location at all: denied, restricted, or the fix timed out. All three arrive as the same
+     * null and all three mean the same thing here, which is that nothing is known about where
+     * the rider is right now.
+     *
+     * Home is a guess about habit rather than a fact about now, which is exactly why it sits
+     * below location and never overrides it: a rider at work asking for the airport is served
+     * correctly by where they are and wrongly by where they usually start. With no location
+     * there is nothing else to go on, the destination is already understood, and so filling
+     * this in answers a question the rider asked rather than inventing one. One tap changes it.
+     */
+    private suspend fun homeAsALastGuess(excludeStopId: String?): StopItem? =
+        labelledStopLocator?.homeStop(excludeStopId).also { home ->
+            log(
+                "$ORIGIN_TAG no location; " +
+                    if (home == null) "no Home set, origin left blank" else "using Home",
+            )
+        }
+
+    /**
+     * Location is known, so the guess is never reached from here. Two of these outcomes are
+     * deliberately blank: both are things the app knows about the rider right now, and Home
+     * would contradict them.
+     */
+    private suspend fun whereTheRiderIsStanding(
+        location: Location,
+        excludeStopId: String?,
+    ): StopItem? = when {
         // Already there. "To home by 9pm" while standing at home used to fill the origin with
         // the next stop along the road, which is a journey from one bus stop to its neighbour.
-        // Leaving it blank says nothing untrue and leaves the field editable.
-        val alreadyThere = excludeStopId != null && labelledStopLocator?.isStandingAt(
+        standingAt(location, excludeStopId) ->
+            null.also { log("$ORIGIN_TAG standing at the destination, origin left blank") }
+
+        else -> {
+            val labelled = labelledStopLocator?.nearestLabelledStop(
+                latitude = location.latitude,
+                longitude = location.longitude,
+                excludeStopId = excludeStopId,
+            )
+            val stop = labelled ?: nearestStop(location, excludeStopId)
+            log(
+                "$ORIGIN_TAG " + when {
+                    labelled != null -> "using a labelled stop within walking distance"
+                    stop != null -> "using the nearest stop"
+                    else -> "no stop near the rider, origin left blank"
+                },
+            )
+            stop
+        }
+    }
+
+    private suspend fun standingAt(location: Location, excludeStopId: String?): Boolean =
+        excludeStopId != null && labelledStopLocator?.isStandingAt(
             stopId = excludeStopId,
             latitude = location.latitude,
             longitude = location.longitude,
         ) == true
-        if (alreadyThere) return null
-
-        return labelledStopLocator?.nearestLabelledStop(
-            latitude = location.latitude,
-            longitude = location.longitude,
-            excludeStopId = excludeStopId,
-        ) ?: nearestStop(location, excludeStopId)
-    }
 
     private suspend fun nearestStop(location: Location, excludeStopId: String?): StopItem? =
         nearbyStopsRepository?.getStopsNearby(
@@ -68,3 +116,7 @@ class RiderOriginLocator(
         const val NEARBY_STOP_RADIUS_KM = 1.0
     }
 }
+
+// One greppable tag for every way a journey's start is decided, because every one of them ends
+// as either a filled field or a blank one and the rider cannot tell which happened or why.
+private const val ORIGIN_TAG = "[AI_ORIGIN]"

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopLabelVocabulary.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/StopLabelVocabulary.kt
@@ -1,0 +1,14 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+/**
+ * The one spelling of the Home label, because more than one is how these drift.
+ *
+ * Home is the only label this app treats as permanent: it cannot be renamed, only reassigned or
+ * cleared (see `ManageStopLabelRow`). That is what makes it safe to key behaviour on, and why
+ * two places now ask the same question about it: the greeting on the Ask KRAIL surface, and
+ * [RiderOriginLocator], which uses Home as the last guess at where a journey starts.
+ *
+ * Compared case-insensitively at every call site. Riders never type this string, so the
+ * constant is about the two readers agreeing rather than about what is stored.
+ */
+internal const val HOME_STOP_LABEL = "home"

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/RiderOriginLocatorTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/search/ai/resolve/RiderOriginLocatorTest.kt
@@ -1,0 +1,121 @@
+package xyz.ksharma.krail.trip.planner.ui.search.ai.resolve
+
+import kotlinx.coroutines.test.runTest
+import xyz.ksharma.dhruva.location.Location
+import xyz.ksharma.krail.core.testing.fakes.FakeSandook
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Where a journey starts when the rider did not say, and in particular what happens when the
+ * app knows nothing about where they are.
+ *
+ * The ordering under test is the whole design: what the rider said beats where they are, where
+ * they are beats where they usually start, and a guess never overrules something known. Home
+ * sits at the bottom precisely because it is a guess about habit rather than a fact about now.
+ */
+class RiderOriginLocatorTest {
+
+    private val sandook = FakeSandook()
+    private val labelledStopLocator = LabelledStopLocator(sandook)
+
+    // Wynyard and Seven Hills, roughly. Real coordinates, because the locator measures real
+    // distances and invented units would pass while meaning something else on a map.
+    private val wynyard = Location(latitude = -33.8657, longitude = 151.2065, timestamp = 0L)
+    private val sevenHillsLat = -33.7743
+    private val sevenHillsLon = 150.9370
+
+    private fun putLabel(label: String, stopId: String, stopName: String, lat: Double, lon: Double) {
+        sandook.upsertStopLabel(
+            label = label,
+            emoji = "📍",
+            stopId = stopId,
+            stopName = stopName,
+            sortOrder = 0L,
+        )
+        sandook.insertNswStop(
+            stopId = stopId,
+            stopName = stopName,
+            stopLat = lat,
+            stopLon = lon,
+            isParent = null,
+        )
+    }
+
+    private fun locator(location: Location?) = RiderOriginLocator(
+        resolveCurrentLocation = { location },
+        labelledStopLocator = labelledStopLocator,
+        nearbyStopsRepository = null,
+    )
+
+    @Test
+    fun `no location and a Home set falls back to Home`() = runTest {
+        // The reported bug: a destination was understood, the rider asked for a trip, and the
+        // From field came back blank because nothing could be learned about where they were.
+        putLabel("Home", "SEVEN_HILLS", "Seven Hills Station", sevenHillsLat, sevenHillsLon)
+
+        val origin = locator(location = null).originStop(excludeStopId = "TOWN_HALL")
+
+        assertEquals("SEVEN_HILLS", origin?.stopId)
+    }
+
+    @Test
+    fun `no location and no Home leaves the field blank`() = runTest {
+        // Nothing is known and nothing is invented. A rider with location denied and no Home
+        // pinned has told the app nothing it can act on.
+        putLabel("Work", "WYNYARD", "Wynyard Station", wynyard.latitude, wynyard.longitude)
+
+        assertNull(locator(location = null).originStop(excludeStopId = "TOWN_HALL"))
+    }
+
+    @Test
+    fun `Home is never used as the origin when it is also the destination`() = runTest {
+        // "Get me home" with no location. Home to Home is a journey of no distance and reads as
+        // the app not having understood at all.
+        putLabel("Home", "SEVEN_HILLS", "Seven Hills Station", sevenHillsLat, sevenHillsLon)
+
+        assertNull(locator(location = null).originStop(excludeStopId = "SEVEN_HILLS"))
+    }
+
+    @Test
+    fun `a known location beats Home, even when Home is set`() = runTest {
+        // The case that decides the ordering. A rider at Wynyard asking for somewhere is served
+        // correctly by where they are and wrongly by where they usually start.
+        putLabel("Home", "SEVEN_HILLS", "Seven Hills Station", sevenHillsLat, sevenHillsLon)
+        putLabel("Work", "WYNYARD", "Wynyard Station", wynyard.latitude, wynyard.longitude)
+
+        val origin = locator(location = wynyard).originStop(excludeStopId = "TOWN_HALL")
+
+        assertEquals("WYNYARD", origin?.stopId)
+    }
+
+    @Test
+    fun `standing at the destination stays blank rather than falling back to Home`() = runTest {
+        // Standing at the destination is something the app knows about right now, so the guess
+        // must not overrule it. Filling From with Home here would invent a trip the rider is
+        // already at the end of.
+        putLabel("Home", "SEVEN_HILLS", "Seven Hills Station", sevenHillsLat, sevenHillsLon)
+        putLabel("Work", "WYNYARD", "Wynyard Station", wynyard.latitude, wynyard.longitude)
+
+        assertNull(locator(location = wynyard).originStop(excludeStopId = "WYNYARD"))
+    }
+
+    @Test
+    fun `a known location with no stop anywhere near does not reach for Home`() = runTest {
+        // Location is known and says the rider is nowhere near their Home stop. Home would
+        // contradict a fact the app holds, so the field stays blank.
+        putLabel("Home", "SEVEN_HILLS", "Seven Hills Station", sevenHillsLat, sevenHillsLon)
+
+        assertNull(locator(location = wynyard).originStop(excludeStopId = "TOWN_HALL"))
+    }
+
+    @Test
+    fun `the Home label is matched whatever case it was stored in`() = runTest {
+        putLabel("home", "SEVEN_HILLS", "Seven Hills Station", sevenHillsLat, sevenHillsLon)
+
+        val origin = locator(location = null).originStop(excludeStopId = null)
+
+        assertEquals("SEVEN_HILLS", origin?.stopId)
+    }
+}


### PR DESCRIPTION
## What

Reported on iOS: "I want to go to `<somewhere>`" filled the destination and left **From** blank, even with location available.

Two commits. The fix, and the docs catch-up that should have shipped with the mic change.

## The bug

The fallback that fills From needs a location, and **every way of not having one arrives as the same `null`**: permission denied, restricted, or the fix timing out. All three produced the same blank field with nothing to tell them apart, which is why the report could not be narrowed down.

Rather than guess which, this does two things: adds a last resort so the common case stops being blank at all, and logs each branch so the next build says definitively which one happened.

## How the From stop is decided now

Ordered by how much each signal knows about **right now**. A guess never overrules something known.

| | Signal | Knows |
|---|---|---|
| 1 | What the rider said | Their intent, certainly |
| 2 | A labelled stop within walking distance | Their position. The label is the platform they actually use, where the nearest stop is often a shelter nobody uses |
| 3 | The nearest stop | Their position |
| 4 | **Home, if set** | Only their habit |
| 5 | Blank | Nothing |

**Location always beats Home**, and that ordering is the whole design. A rider at work asking for the airport is served correctly by where they are and wrongly by where they usually start. Home is reached only when there is no location at all.

**Two cases deliberately stay blank rather than reaching for Home**: standing at the destination, and a known location with no stop near it. Both are things the app knows about the rider right now, and a guess must not contradict them.

Filling From in is answering a question the rider asked, not inventing one: it happens only when a destination was actually understood. A sentence that resolved to no places still takes no fallback, which is the existing failure mode 5.

## Changes

- `LabelledStopLocator.homeStop` reads the Home label. Home is the only label this app treats as permanent (it cannot be renamed, only reassigned or cleared), which is what makes keying behaviour on it safe.
- `HOME_STOP_LABEL` replaces a second spelling of `"home"` that had grown in `AiGreeting`, so the two readers cannot drift.
- Every branch logs under `[AI_ORIGIN]`, including **why** a location was unavailable, unwrapped at the one place the `Result` still exists.
- `originStop` restructured to one return per function rather than suppressing `ReturnCount`.
- Docs: `AI_SEARCH_UX.md` gains this ladder and the end-of-speech ladder; `ASK_KRAIL_UX.md` gains the append-on-speak rule and says mic rather than wheel; `ASK_KRAIL_CAPABILITIES.md` no longer describes a wheel riders cannot see.

## Testing

- `RiderOriginLocatorTest`, 7 new cases covering the full ladder: Home used when location is missing, location beating Home when both exist, Home refused when it is also the destination, and both deliberate blanks.
- `./gradlew testAndroidHostTest --continue -PciQuality=true` green across all modules.
- `./gradlew verifyTestWiring verifyTestingModuleUsage verifyNoAdHocBoundaryFakes verifyIosTestClassification --continue -PciQuality=true` green.
- `./scripts/fullQualityChecks.sh` green.

**Not verified on a device.** The reported symptom is iOS and cannot be reproduced here (Ask KRAIL does not open on a simulator). The logging is what will confirm the original cause; the fallback makes the common case correct regardless of which it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
