### PR TITLE
fix(ci): reboot iOS simulator before Maestro nightly retry

### DIFF
--- a/.github/workflows/maestro-nightly.yml
+++ b/.github/workflows/maestro-nightly.yml
@@ -225,6 +225,13 @@ jobs:
       # is a no-op on the simulator: it reports success, the app stays portrait,
       # and the accessibility tree empties for that moment, so the flow fails
       # against a screen that is drawn correctly. See that file's own header.
+      #
+      # The retry restarts the simulator itself, not just the app: a run seen on
+      # 2026-08-24 (Actions run 32757573292) hit an IOSDriverTimeoutException on
+      # the first attempt ("iOS driver not ready in time"), and terminating only
+      # the app left the retry's XCTest driver session equally wedged — every
+      # flow failed within seconds on the retry. A full shutdown/boot between
+      # attempts gives the retry a clean simulator to attach to.
       - name: Run smoke and nightly flows
         run: |
           set -o pipefail
@@ -234,8 +241,11 @@ jobs:
               -e APP_ID=xyz.ksharma.krail .maestro/smoke/ .maestro/nightly/
           }
           if ! run_suite; then
-            echo "::warning::Maestro suite failed on iOS; retrying once."
+            echo "::warning::Maestro suite failed on iOS; restarting simulator and retrying once."
             xcrun simctl terminate "${{ steps.sim.outputs.udid }}" xyz.ksharma.krail || true
+            xcrun simctl shutdown "${{ steps.sim.outputs.udid }}" || true
+            xcrun simctl boot "${{ steps.sim.outputs.udid }}"
+            xcrun simctl bootstatus "${{ steps.sim.outputs.udid }}" -b
             run_suite
           fi
 


### PR DESCRIPTION
## Summary

- Today's Maestro Nightly run (`32757573292`) failed on iOS with an `IOSDriverTimeoutException` ("iOS driver not ready in time") on the first attempt of `.maestro/smoke/` + `.maestro/nightly/`.
- The workflow's own retry only ran `xcrun simctl terminate` on the app, not the simulator. On the retry every flow failed within seconds (`5/5 Flows Failed`), consistent with the XCTest driver session still being wedged rather than a fresh attempt.
- This PR makes the retry do a full `simctl shutdown` + `simctl boot` + `bootstatus` between attempts, so it gets a clean simulator to attach to instead of reusing the one the driver never attached to.

## Changes

- `.github/workflows/maestro-nightly.yml`: iOS leg's retry block now restarts the simulator before re-running the suite; comment explains why, with the triggering run ID.

No test assertions, flow YAML, golden images, or app code changed.

## Test plan

- [ ] Next scheduled Maestro Nightly run (or a manual `workflow_dispatch`) exercises the retry path only if the first attempt fails again; otherwise this is inert until the next flake.
- [ ] Confirm the iOS job still passes end-to-end on a clean first attempt (no change to that path).

---
Filed by the CI Sentinel routine. See `.github/docs-gardener/CHARTER.md` for the house bot etiquette this bot follows (small, transparent, never merging).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SumhbWKWf9uf6hccEFN7Ma)_