### PR TITLE
fix(search): match stop names token-wise so the comma need not be typed

### DIFF
--- a/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
+++ b/core/remote-config/src/commonMain/kotlin/xyz/ksharma/krail/core/remoteconfig/RemoteConfigDefaults.kt
@@ -161,9 +161,14 @@ object RemoteConfigDefaults {
                 first = FlagKeys.TRIP_TRACKING_ENABLED.key,
                 second = true,
             ),
+            // Matches the value served by Remote Config. These defaults only apply before the
+            // first fetch completes, so a default that disagrees with the served value makes
+            // the shipped behaviour unreadable from source: fuzzy search reads as off here
+            // while every install actually runs it. Keep this in step when the served value
+            // changes, and read `fetchFuzzyCandidates` as live code, not a dormant path.
             Pair(
                 first = FlagKeys.ENABLE_FUZZY_STOP_SEARCH.key,
-                second = false,
+                second = true,
             ),
             Pair(
                 first = FlagKeys.ENABLE_PROTO_BFF.key,

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/StopSearchPipelineReproTest.kt
@@ -69,7 +69,7 @@ class StopSearchPipelineReproTest {
         val sandook = object : Sandook {
             // Real SQL: exact id OR case-insensitive substring, file order, distinct by id.
             override fun selectStops(stopName: String, excludeProductClassList: List<Int>) =
-                stops.filter { it.stopId == stopName || it.stopName.contains(stopName, ignoreCase = true) }
+                stops.filter { it.stopId == stopName || it.stopName.matchesStopQuery(stopName) }
             override fun selectStopsByIds(stopIds: List<String>) =
                 stops.filter { it.stopId in stopIds.toSet() }
             override fun selectStopCoordinatesBatch(stopIds: List<String>) = emptyMap<String, Pair<Double, Double>>()
@@ -183,6 +183,11 @@ class StopSearchPipelineReproTest {
             "victoria cross station" to "Victoria Cross Station",
             "macquary park" to "Macquarie Park Station",
             "hutstville" to "Hurstville Station",
+            // NSW names are punctuated ("Wollongong Central, Burelli St") and riders are
+            // not. Typing the name without its comma used to return nothing at all while
+            // typing it with the comma worked.
+            "wollongong central burell" to "Wollongong Central, Burelli St",
+            "central station eddy" to "Central Station, Eddy Ave",
         )
         val misses = mutableListOf<String>()
         cases.forEach { (q, expect) ->
@@ -313,4 +318,22 @@ class StopSearchPipelineReproTest {
             )
         }
     }
+}
+
+/**
+ * Ordered-token containment — the Kotlin equivalent of the `%tok1%tok2%` pattern
+ * `stopNameLikePattern` builds, so this fake matches what SQLite actually does.
+ */
+private fun String.matchesStopQuery(query: String): Boolean {
+    var searchFrom = 0
+    val tokens = query.lowercase()
+        .replace(Regex("[^a-z0-9 ]"), " ")
+        .split(" ")
+        .filter { it.isNotEmpty() }
+    for (token in tokens) {
+        val found = indexOf(token, startIndex = searchFrom, ignoreCase = true)
+        if (found < 0) return false
+        searchFrom = found + token.length
+    }
+    return true
 }

--- a/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/NswStopsNameSearchTest.kt
+++ b/sandook/src/androidHostTest/kotlin/xyz/ksharma/krail/sandook/NswStopsNameSearchTest.kt
@@ -1,0 +1,124 @@
+package xyz.ksharma.krail.sandook
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import xyz.ksharma.krail.sandook.db.KrailSandook
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end name matching against real SQLite, not a fake.
+ *
+ * The bug these guard: NSW GTFS names are punctuated ("Wollongong Central, Burelli St") and
+ * riders are not. The old predicate matched the raw query as one contiguous substring, so
+ * typing the name without its comma returned "No match found" while typing it *with* the
+ * comma worked. Asserting on the pattern string alone would not have caught that — only
+ * running it through SQLite's own LIKE does.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NswStopsNameSearchTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var stops: NswStopsSandook
+
+    @Before
+    fun setup() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        KrailSandook.Schema.create(driver)
+        val sandook = KrailSandook(driver)
+        stops = RealNswStopsSandook(sandook)
+
+        listOf(
+            "200060" to "Wollongong Central, Burelli St",
+            "200061" to "Wollongong Central, Burelli St, Stand A",
+            "200062" to "Wollongong Central, Burelli St, Stand B",
+            "200070" to "Wollongong Station, Station St",
+            "200080" to "Central Station, Eddy Ave, Stand C",
+            "200090" to "Burwood Station, Burwood Rd",
+            "200100" to "100% Fun Park, George St",
+        ).forEach { (id, name) ->
+            stops.insertStop(stopId = id, stopName = name, stopLat = 0.0, stopLon = 0.0, isParent = 1)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        driver.close()
+    }
+
+    private fun search(query: String): List<String> =
+        stops.selectProductClassesForStop(stopId = query, stopName = query).map { it.stopName }
+
+    @Test
+    fun `query without the comma finds a comma-punctuated stop`() {
+        // The reported bug, verbatim: this returned nothing and the screen said "No match found".
+        val results = search("wollongong central burell")
+
+        assertTrue(
+            results.any { it == "Wollongong Central, Burelli St" },
+            "Expected the Burelli St stop, got: $results",
+        )
+    }
+
+    @Test
+    fun `query with and without the comma return identical results`() {
+        // Punctuation the rider happens to type must not change what they are shown.
+        assertEquals(
+            search("wollongong central, burell").toSet(),
+            search("wollongong central burell").toSet(),
+        )
+    }
+
+    @Test
+    fun `all stands of a stop are returned, not just the parent`() {
+        val results = search("wollongong central burelli")
+
+        assertEquals(
+            setOf(
+                "Wollongong Central, Burelli St",
+                "Wollongong Central, Burelli St, Stand A",
+                "Wollongong Central, Burelli St, Stand B",
+            ),
+            results.toSet(),
+        )
+    }
+
+    @Test
+    fun `matching stays order-preserving so tokens in the wrong order do not match`() {
+        // Reordered tokens are the fuzzy ranker's job. If this predicate matched them it
+        // would also match half the state, which is the failure mode it exists to avoid.
+        assertTrue(search("burelli wollongong").isEmpty())
+    }
+
+    @Test
+    fun `single-token query behaves exactly as before`() {
+        val results = search("burwood")
+
+        assertEquals(listOf("Burwood Station, Burwood Rd"), results)
+    }
+
+    @Test
+    fun `a typed percent is a literal, not a wildcard`() {
+        // Without ESCAPE, "%" matched every stop in the state.
+        val results = search("100%")
+
+        assertEquals(listOf("100% Fun Park, George St"), results)
+    }
+
+    @Test
+    fun `a typed underscore is a literal, not a single-character wildcard`() {
+        // "_" would otherwise match any one character, so this would surface Burwood.
+        assertTrue(search("burwoo_").isEmpty())
+    }
+
+    @Test
+    fun `exact stopId match still works`() {
+        val results = stops.selectProductClassesForStop(stopId = "200070", stopName = "zzzz nothing")
+
+        assertEquals(listOf("Wollongong Station, Station St"), results.map { it.stopName })
+    }
+}

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswStopsSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/NswStopsSandook.kt
@@ -55,7 +55,8 @@ interface NswStopsSandook {
      * Get stops by stop ID or name with their product classes.
      *
      * @param stopId Exact stop ID to match
-     * @param stopName Stop name to partially match (case-insensitive)
+     * @param stopName Stop name to partially match. Matching is case- and punctuation-insensitive
+     *   and order-preserving; the query's spaces become wildcards. See [stopNameLikePattern].
      * @return List of stops with their product classes
      */
     fun selectProductClassesForStop(
@@ -165,8 +166,9 @@ internal class RealNswStopsSandook(
         stopName: String,
     ): List<SelectProductClassesForStop> {
         return nswStopsQueries.selectProductClassesForStop(
+            // stopId stays raw — it is an exact-equality match, not a pattern.
             stopId = stopId,
-            stopName = stopName,
+            stopNamePattern = stopNameLikePattern(stopName),
         ).executeAsList()
     }
 

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/RealSandook.kt
@@ -166,8 +166,9 @@ internal class RealSandook(
         excludeProductClassList: List<Int>,
     ): List<SelectProductClassesForStop> {
         return nswStopsQueries.selectProductClassesForStop(
+            // stopId stays raw — it is an exact-equality match, not a pattern.
             stopId = stopName,
-            stopName = stopName,
+            stopNamePattern = stopNameLikePattern(stopName),
         ).executeAsList()
     }
 

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/Sandook.kt
@@ -85,6 +85,10 @@ interface Sandook {
     /**
      * Retrieves stops by matching an exact stop \id\ or partially matching a stop \name\.
      * Excludes stops having product classes in the given \excludeProductClassList\.
+     *
+     * Name matching is punctuation-insensitive and order-preserving: the query's spaces become
+     * wildcards, so "wollongong central burell" finds "Wollongong Central, Burelli St" without
+     * the rider having to type the comma. See [stopNameLikePattern].
      */
     fun selectStops(
         stopName: String,

--- a/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/StopNameSearchPattern.kt
+++ b/sandook/src/commonMain/kotlin/xyz/ksharma/krail/sandook/StopNameSearchPattern.kt
@@ -1,0 +1,48 @@
+package xyz.ksharma.krail.sandook
+
+private const val LIKE_ESCAPE_CHAR = '\\'
+
+private val LIKE_METACHARACTERS = Regex("""[\\%_]""")
+
+private val NON_SEARCHABLE_CHARACTERS = Regex("""[^a-z0-9\\%_ ]""")
+
+/**
+ * Builds the `LIKE` pattern used to match a rider's query against a stop name.
+ *
+ * NSW GTFS stop names are systematically punctuated - "Wollongong Central, Burelli St",
+ * "Central Station, Eddy Ave, Stand C" - but riders type them without the commas. Matching the
+ * raw query as one contiguous substring therefore fails on every multi-word stop:
+ * `'%wollongong central burell%'` does not occur in "Wollongong Central, Burelli St", while
+ * `'%wollongong central, burell%'` does. Making the rider guess the punctuation is not a search.
+ *
+ * So whitespace becomes a wildcard: the query is split into tokens and rejoined with `%`, which
+ * spans whatever punctuation the feed happens to use.
+ *
+ *     "wollongong central burell"  -> "%wollongong%central%burell%"
+ *     "wollongong central, burell" -> "%wollongong%central%burell%"   (same pattern)
+ *     "central"                    -> "%central%"                     (unchanged from before)
+ *
+ * Matching stays **order-preserving**, so this does not widen the result set the way an
+ * unordered AND-of-LIKEs would; a query whose tokens are in the wrong order is the fuzzy
+ * ranker's job, not this one's.
+ *
+ * Two details worth keeping:
+ * - [LIKE_METACHARACTERS] mean something to `LIKE`, so they are escaped with [LIKE_ESCAPE_CHAR]
+ *   and the result binds against an `ESCAPE` clause in `NswStops.sq`. A rider typing `%` would
+ *   otherwise match every stop in the state.
+ * - [NON_SEARCHABLE_CHARACTERS] are replaced with a space rather than deleted, so "st,burelli"
+ *   splits into two tokens instead of fusing into "stburelli".
+ *
+ * Deliberately not reusing `FuzzyStopRanker.normalize()`: that expands abbreviations
+ * ("st" to "street"), which would turn `%burell%st%` into `%burell%street%` and stop it
+ * matching "Burelli St".
+ */
+fun stopNameLikePattern(query: String): String {
+    val escaped = query.lowercase()
+        .replace(LIKE_METACHARACTERS) { match -> "$LIKE_ESCAPE_CHAR${match.value}" }
+        .replace(NON_SEARCHABLE_CHARACTERS, " ")
+
+    return escaped.split(" ")
+        .filter { it.isNotEmpty() }
+        .joinToString(separator = "%", prefix = "%", postfix = "%")
+}

--- a/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/db/NswStops.sq
+++ b/sandook/src/commonMain/sqldelight/xyz/ksharma/krail/sandook/db/NswStops.sq
@@ -61,6 +61,11 @@ WHERE s.stopId IN :stopIds
 GROUP BY s.stopId;
 
 -- select stops and their prodcut classes for a given stopId / name --
+-- :stopNamePattern is a whole LIKE pattern, not a bare substring — build it with
+-- stopNameLikePattern() so the rider's spaces become wildcards. NSW stop names are
+-- punctuated ("Wollongong Central, Burelli St") and riders are not, so a contiguous
+-- '%' || query || '%' match fails on every multi-word stop. ESCAPE keeps a typed
+-- '%' or '_' a literal instead of a wildcard.
 selectProductClassesForStop:
 SELECT s.*,
        COALESCE(GROUP_CONCAT(p.productClass), '') AS productClasses
@@ -69,7 +74,7 @@ LEFT JOIN NswStopProductClass AS p
     ON s.stopId = p.stopId
 WHERE (
     s.stopId = :stopId  -- Exact match for stop ID
-    OR s.stopName LIKE '%' || :stopName || '%' COLLATE NOCASE  -- Case-insensitive partial match for stop name
+    OR s.stopName COLLATE NOCASE LIKE :stopNamePattern ESCAPE '\'  -- Token-wise, case-insensitive
 )
 GROUP BY s.stopId;
 


### PR DESCRIPTION
## What

Stop name matching ignored the punctuation in NSW GTFS names, so a rider had to type the
comma to find any multi-word stop. `"wollongong central burell"` returned nothing while
`"wollongong central, burell"` returned the stop and all its stands.

## Changes

- `stopNameLikePattern` (new, `:sandook`) splits a query on whitespace and punctuation and
  rejoins the tokens with `%`, so the wildcard spans whatever separators the feed uses.
  `"wollongong central burell"` becomes `%wollongong%central%burell%`.
- `selectProductClassesForStop` binds that pattern through an `ESCAPE` clause instead of
  concatenating `'%' || :stopName || '%'`. This also closes a hole where a typed `%` or `_`
  acted as a SQL wildcard and matched every stop in the state.
- Both sandook implementations build the pattern, so every caller is covered. The `stopId`
  operand stays raw, since it is an exact-equality match rather than a pattern.
- Matching stays order-preserving, so this does not widen results the way an unordered
  AND-of-LIKEs would. Reordered tokens remain the fuzzy ranker's job.
- `RemoteConfigDefaults` had `enable_fuzzy_stop_search` defaulting to `false` while Remote
  Config serves `true`, which made the shipped behaviour unreadable from source. Corrected,
  with a comment on why the two must agree. Defaults only apply before the first fetch, so
  this changes nothing for an install that reaches Remote Config.

Left untouched: the fuzzy trigram prefilter drops a multi-word query's most distinctive word
before it reaches the database. Investigated during this change and filed separately as
#1963, because the prefilter and the ranker's score threshold are coupled and every strategy
that improved candidate recall regressed ranking on another tracked query.

## Testing

- `NswStopsNameSearchTest` (new, 8 cases) runs against real in-memory SQLite rather than a
  fake, because only SQLite's own `LIKE` shows the defect. Confirmed as a genuine regression
  test: 4 of the 8 fail against the previous predicate.
- `StopSearchPipelineReproTest` drives the real pipeline over the shipped NSW stop set. Its
  fake DB still hardcoded contiguous substring matching, which no longer describes the SQL,
  so it now uses ordered-token containment. Two scenarios added:
  `"wollongong central burell"` and `"central station eddy"`, both resolving in the top five.
- `./gradlew testAndroidHostTest --continue` green.
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS Simulator compile, detekt).

Device QA on `emulator-5554`, debug variant:

| Query | Before | After |
|---|---|---|
| `wollongong central burell` | "No match found!" | Burelli St plus Stands A/B/D/E |
| `wollongong central, burell` | worked | identical results |
| `burwood`, `central` | worked | unchanged |

Rotated with results loaded: query text and results survived, no `FATAL EXCEPTION` in logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
