### PR TITLE
fix(alerts): key service alerts on a stable id instead of the list index

### DIFF
--- a/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/alerts/ServiceAlert.kt
+++ b/feature/trip-planner/state/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/state/alerts/ServiceAlert.kt
@@ -9,6 +9,18 @@ data class ServiceAlert(
     val message: String,
 ) {
 
+    /**
+     * Stable identity for one alert, unique within any collection of alerts.
+     *
+     * The feed gives an alert no id, and the heading alone is not unique: NSW sends distinct
+     * alerts under one heading, which is how a `LazyColumn` keyed on heading crashed with
+     * "Key was already used". Since alerts reach the UI as a `Set` of this data class, the
+     * (heading, message) pair is distinct by construction, so it is the identity.
+     *
+     * Computed rather than stored, so it stays out of the serialized form.
+     */
+    val alertId: String get() = "$heading|$message"
+
     fun toJsonString() = Json.encodeToString(serializer(), this)
 
     @Suppress("ConstPropertyName")

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreenIdentityTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreenIdentityTest.kt
@@ -1,0 +1,131 @@
+package xyz.ksharma.krail.trip.planner.ui.alerts
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import kotlinx.collections.immutable.persistentSetOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.alerts.ServiceAlert
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Identity of a service alert row.
+ *
+ * NSW sends distinct alerts under one heading, and the list was once keyed on the heading
+ * alone. Compose rejects a duplicate key outright, so the second alert with a repeated
+ * heading took the Service Alerts sheet down with
+ * "Key ... was already used. If you are using LazyColumn/Row please make sure you provide a
+ * unique key for each item." Rendering the screen is the assertion: these tests fail by
+ * throwing, not by comparing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [34],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+class ServiceAlertScreenIdentityTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val restorationTester by lazy { StateRestorationTester(composeTestRule) }
+
+    private val duplicateHeadings = persistentSetOf(
+        ServiceAlert(heading = "Trackwork", message = "Buses replace trains on the T1."),
+        ServiceAlert(heading = "Trackwork", message = "Buses replace trains on the T8."),
+        ServiceAlert(heading = "Trackwork", message = "Buses replace trains on the T9."),
+    )
+
+    @Test
+    fun `alerts sharing a heading all render instead of crashing`() {
+        composeTestRule.setContent {
+            PreviewTheme {
+                ServiceAlertScreen(serviceAlerts = duplicateHeadings)
+            }
+        }
+
+        composeTestRule.onAllNodesWithText("Trackwork").assertCountEquals(3)
+    }
+
+    @Test
+    fun `expanding one alert does not expand its same-heading siblings`() {
+        // Expansion was keyed on hashCode(), so identity was an Int over unbounded text.
+        // It is now the same string the list is keyed on.
+        composeTestRule.setContent {
+            PreviewTheme {
+                ServiceAlertScreen(serviceAlerts = duplicateHeadings)
+            }
+        }
+
+        composeTestRule.onAllNodesWithText("Trackwork")[1].performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Buses replace trains on the T8.").assertExists()
+        composeTestRule.onAllNodesWithText("Buses replace trains on the T1.").assertCountEquals(0)
+        composeTestRule.onAllNodesWithText("Buses replace trains on the T9.").assertCountEquals(0)
+    }
+
+    @Test
+    fun `a single alert still renders`() {
+        composeTestRule.setContent {
+            PreviewTheme {
+                ServiceAlertScreen(
+                    serviceAlerts = persistentSetOf(
+                        ServiceAlert(heading = "Lift outage", message = "Use the ramp."),
+                    ),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Lift outage").assertExists()
+    }
+
+    @Test
+    fun `alertId separates alerts that share a heading`() {
+        val (first, second) = duplicateHeadings.toList()
+
+        assertNotEquals(first.alertId, second.alertId)
+    }
+
+    @Test
+    fun `alertId is stable across equal instances`() {
+        // The key has to survive a state emission that rebuilds the alert objects.
+        val alert = ServiceAlert(heading = "Trackwork", message = "Buses replace trains.")
+        val rebuilt = ServiceAlert(heading = "Trackwork", message = "Buses replace trains.")
+
+        assertEquals(alert.alertId, rebuilt.alertId)
+    }
+
+    @Test
+    fun `the expanded alert survives activity recreation`() {
+        // expandedAlertId changed from Int? to String?, and rememberSaveable only restores a
+        // type the saver understands. Rotation is the path a rider takes to this.
+        restorationTester.setContent {
+            PreviewTheme {
+                ServiceAlertScreen(serviceAlerts = duplicateHeadings)
+            }
+        }
+
+        composeTestRule.onAllNodesWithText("Trackwork")[1].performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Buses replace trains on the T8.").assertExists()
+
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        composeTestRule.onNodeWithText("Buses replace trains on the T8.").assertExists()
+        composeTestRule.onAllNodesWithText("Buses replace trains on the T1.").assertCountEquals(0)
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/alerts/ServiceAlertScreen.kt
@@ -39,7 +39,7 @@ fun ServiceAlertScreen(
     onSummaryEvent: (AlertSummaryEvent) -> Unit = {},
 ) {
     val dim = KrailTheme.dimensions
-    var expandedAlertId by rememberSaveable { mutableStateOf<Int?>(null) }
+    var expandedAlertId by rememberSaveable { mutableStateOf<String?>(null) }
 
     // Fires an event up to the owning ViewModel rather than calling AiTextService here —
     // this composable never touches DI directly. The ViewModel dedupes per alert-set
@@ -83,23 +83,23 @@ fun ServiceAlertScreen(
 
         itemsIndexed(
             items = serviceAlerts.toImmutableList(),
-            // ServiceAlert has no stable id from the feed - heading alone isn't unique
-            // (NSW's real feed can send two distinct alerts with an identical heading),
-            // so the index is prefixed in to guarantee uniqueness rather than crashing on
-            // the first duplicate heading, matching this repo's LazyColumn key convention.
-            key = { index, item -> "${index}_${item.heading.lowercase()}" },
+            // ServiceAlert.alertId, not the index. Prefixing the index would also be unique,
+            // but it makes identity positional: reordering or inserting an alert renumbers
+            // every key after it, so Compose treats untouched rows as new ones and drops
+            // their animation and state. The alerts arrive as a Set, so (heading, message)
+            // is distinct by construction and survives reordering. Prefixed to keep it clear
+            // of this list's static item keys.
+            key = { _, item -> "alert_${item.alertId}" },
         ) { index, alert ->
             CollapsibleAlert(
                 serviceAlert = alert,
                 index = index + 1,
                 modifier = Modifier.padding(horizontal = dim.spacingXL, vertical = dim.spacingM),
-                collapsed = expandedAlertId != alert.hashCode(),
+                // Same identity as the list key. hashCode() was an Int over unbounded
+                // text, so two alerts could collide and expand together.
+                collapsed = expandedAlertId != alert.alertId,
                 onClick = {
-                    expandedAlertId = if (expandedAlertId == alert.hashCode()) {
-                        null
-                    } else {
-                        alert.hashCode()
-                    }
+                    expandedAlertId = if (expandedAlertId == alert.alertId) null else alert.alertId
                 },
             )
         }


### PR DESCRIPTION
## What

Yes, this is a real crash, and it is live in `v1.26.0`.

NSW sends distinct alerts under a single heading. The Service Alerts sheet keyed its
`LazyColumn` on the heading alone, so the second alert with a repeated heading threw:

```
java.lang.IllegalArgumentException: Key "trackwork" was already used. If you are using
LazyColumn/Row please make sure you provide a unique key for each item.
```

`652e125bf` prefixed the list index in, which stops the crash. That commit is on `main` but
is in no tag and not on `prod/1.26.0`, so the shipped app still carries the crashing
expression:

```kotlin
key = { _, item -> item.heading.lowercase() }   // v1.26.0
```

The index prefix is unique, but it makes identity positional: reordering or inserting an
alert renumbers every key after it, so Compose treats untouched rows as new ones and drops
their animation and state. This replaces it with a stable id.

## Changes

- `ServiceAlert.alertId` is the `(heading, message)` pair. Alerts reach the UI as a `Set` of
  this data class, so the pair is distinct by construction and, unlike the index, survives
  reordering. Computed rather than stored, so it stays out of the serialized form.
- The `LazyColumn` key is now `"alert_${item.alertId}"`, prefixed to keep it clear of the
  sheet's static item keys (`title_bar`, `ai_alert_summary`, `bottom_spacing`).
- The expanded-row state uses the same id. It previously used `hashCode()`, an `Int` over
  unbounded text, so two alerts could collide and expand together. `expandedAlertId` changes
  from `Int?` to `String?`.

## Testing

`ServiceAlertScreenIdentityTest` (new, 6 cases) renders the real screen with three alerts
that share the heading "Trackwork":

- all three render rather than crashing
- expanding one does not expand its same-heading siblings
- the expanded alert survives `emulateSavedInstanceStateRestore`, which covers the
  `rememberSaveable` type change
- a single alert still renders, and `alertId` separates same-heading alerts while staying
  equal across rebuilt instances

Confirmed these catch the defect rather than merely passing: reverting the key to the
shipped `item.heading.lowercase()` fails 2 of the 6 with the exact
`Key "trackwork" was already used` exception.

- `./gradlew testAndroidHostTest --continue` green.
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS Simulator compile, detekt).

Device QA is incomplete and worth calling out: the app was installed and driven to a live
Central to Parramatta timetable with no crash, but no route carried a service alert at the
time, so the changed sheet could not be opened on device. The recreation case that rotation
would have exercised is covered by `StateRestorationTester` above instead.

## Follow-up, not in this PR

The fix is absent from `prod/1.26.0`, so riders on the current release still hit the crash.
Cherry-picking either this change or `652e125bf` onto that branch is a separate call.
