### PR TITLE
fix(search): prefix search result keys and guard product class uniqueness

### DIFF
--- a/core/transport/src/commonTest/kotlin/xyz/ksharma/krail/core/transport/TransportModeProductClassTest.kt
+++ b/core/transport/src/commonTest/kotlin/xyz/ksharma/krail/core/transport/TransportModeProductClassTest.kt
@@ -1,0 +1,67 @@
+package xyz.ksharma.krail.core.transport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+/**
+ * Guards the one invariant three separate features assume: every [TransportMode] owns a
+ * distinct [TransportMode.productClass].
+ *
+ * Nothing enforces it today. `TransportMode.byProductClass` is built with `associateBy`, so a
+ * duplicate class does not fail, it **silently overwrites** - eight modes become a seven-entry
+ * map and [TransportMode.fromProductClass] starts returning the wrong mode for the loser.
+ * That function is how every TfNSW response is turned into a mode, so the damage is quiet and
+ * app-wide: wrong icon, wrong colour and wrong name on journey cards, mode filters selecting
+ * the wrong chip, product-class analytics attributed to the wrong mode, and the mode-filter
+ * `LazyRow` in `TimeTableScreen` crashing on a duplicate key.
+ *
+ * This is a live footgun rather than a theoretical one: [TransportMode.SchoolBus] already
+ * shares both its colour and its `name` with [TransportMode.Bus] and differs only by product
+ * class, so adding a mode by copying that block is one forgotten edit away from a collision.
+ */
+class TransportModeProductClassTest {
+
+    @Test
+    fun `every transport mode has a distinct product class`() {
+        val productClasses = TransportMode.all.map { it.productClass }
+
+        assertEquals(
+            productClasses.size,
+            productClasses.distinct().size,
+            "Duplicate productClass in TransportMode.all: " +
+                "${productClasses.groupBy { it }.filterValues { it.size > 1 }.keys}. " +
+                "byProductClass would silently drop a mode.",
+        )
+    }
+
+    @Test
+    fun `every mode is reachable from its own product class`() {
+        // The `associateBy` round trip. Fails for the overwritten mode if two ever collide.
+        TransportMode.all.forEach { mode ->
+            val resolved = TransportMode.fromProductClass(mode.productClass)
+
+            assertNotNull(resolved, "No mode resolves for productClass ${mode.productClass}")
+            assertSame(mode, resolved, "productClass ${mode.productClass} resolves to $resolved")
+        }
+    }
+
+    @Test
+    fun `an unknown product class resolves to nothing rather than a wrong mode`() {
+        assertEquals(null, TransportMode.fromProductClass(productClass = -1))
+    }
+
+    @Test
+    fun `school bus stays distinct from bus despite sharing a colour and name`() {
+        // The pair most likely to be collapsed by a copy-paste edit.
+        assertEquals(TransportMode.Bus.name, TransportMode.SchoolBus.name)
+        assertEquals(TransportMode.Bus.colorCode, TransportMode.SchoolBus.colorCode)
+
+        assertSame(TransportMode.Bus, TransportMode.fromProductClass(TransportMode.Bus.productClass))
+        assertSame(
+            TransportMode.SchoolBus,
+            TransportMode.fromProductClass(TransportMode.SCHOOL_BUS_PRODUCT_CLASS),
+        )
+    }
+}

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchResultKeyCollisionTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchResultKeyCollisionTest.kt
@@ -1,0 +1,122 @@
+package xyz.ksharma.krail.trip.planner.ui.searchstop
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import xyz.ksharma.krail.core.transport.TransportMode
+import xyz.ksharma.krail.taj.theme.PreviewTheme
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.ListState
+import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
+
+/**
+ * The results list mixes three kinds of result, each carrying an id from an unrelated source:
+ * stop ids from the GTFS stop table, trip ids raw from the routes proto, address ids from the
+ * geocoder's `stop_finder`. Nothing makes those id spaces disjoint, and the list was keyed on
+ * the bare id, so one value appearing in two of them was enough to throw
+ * "Key ... was already used" and take the screen down.
+ *
+ * Route results only appear when the query is exactly a bus route short name, which is also
+ * when a short numeric id is most likely to be echoed by both sides. Rendering is the
+ * assertion here: these fail by throwing, not by comparing.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [34],
+    qualifiers = RobolectricDeviceQualifiers.Pixel6,
+    manifest = Config.NONE,
+)
+class SearchResultKeyCollisionTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val collidingId = "700"
+
+    private fun stateWith(vararg results: SearchStopState.SearchResult) = SearchStopState(
+        // The list renders listState.results, not searchResults.
+        listState = ListState.Results(results = persistentListOf(*results)),
+        searchQuery = "700",
+    )
+
+    @Test
+    fun `a trip and a stop sharing an id both render`() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = stateWith(
+                        SearchStopState.SearchResult.Trip(
+                            tripId = collidingId,
+                            routeShortName = "700",
+                            headsign = "Parramatta",
+                            transportMode = TransportMode.Bus,
+                        ),
+                        SearchStopState.SearchResult.Stop(
+                            stopName = "Seven Hills Station",
+                            stopId = collidingId,
+                        ),
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Seven Hills Station").assertIsDisplayed()
+    }
+
+    @Test
+    fun `an address and a stop sharing an id both render`() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = stateWith(
+                        SearchStopState.SearchResult.Stop(
+                            stopName = "Seven Hills Station",
+                            stopId = collidingId,
+                        ),
+                        SearchStopState.SearchResult.Address(
+                            addressId = collidingId,
+                            displayName = "700 George St",
+                            addressType = "street",
+                        ),
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Seven Hills Station").assertIsDisplayed()
+    }
+
+    @Test
+    fun `distinct stops still render side by side`() {
+        composeRule.setContent {
+            PreviewTheme {
+                SearchStopScreen(
+                    searchStopState = stateWith(
+                        SearchStopState.SearchResult.Stop(
+                            stopName = "Seven Hills Station",
+                            stopId = "2147",
+                        ),
+                        SearchStopState.SearchResult.Stop(
+                            stopName = "Blacktown Station",
+                            stopId = "2148",
+                        ),
+                    ),
+                    onEvent = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Seven Hills Station").assertIsDisplayed()
+        composeRule.onNodeWithText("Blacktown Station").assertIsDisplayed()
+    }
+}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopScreen.kt
@@ -926,11 +926,16 @@ private fun LazyListScope.searchResultsList(
 ) {
     items(
         items = searchResults,
+        // Prefixed per type. The three id spaces come from unrelated sources - stop ids from
+        // the GTFS stop table, trip ids raw from the routes proto, address ids from the
+        // geocoder - and nothing makes them disjoint, so an unprefixed key would let a trip
+        // and a stop collide and crash the list. Matches the prefixing the address and
+        // empty-state sections already use.
         key = { result ->
             when (result) {
-                is SearchStopState.SearchResult.Stop -> result.stopId
-                is SearchStopState.SearchResult.Trip -> result.tripId
-                is SearchStopState.SearchResult.Address -> result.addressId
+                is SearchStopState.SearchResult.Stop -> "stop_${result.stopId}"
+                is SearchStopState.SearchResult.Trip -> "trip_${result.tripId}"
+                is SearchStopState.SearchResult.Address -> "address_${result.addressId}"
             }
         },
     ) { result ->


### PR DESCRIPTION
## What

Two collision risks found while auditing every Lazy key after the service alert crash
(#1965). Neither reproduces today. Both rest on a convention that nothing enforces, and both
fail loudly rather than quietly once they do happen.

Also audited and found genuinely safe, so left alone: `recentSearchStopsList` keys stops on a
bare `stopId`, which would collide with the results list, except the two live in
mutually exclusive `when (listState)` branches and never coexist.

## Changes

**Search result keys are prefixed by type** (`SearchStopScreen.kt`). The results list mixes
`Stop`, `Trip` and `Address`, and keyed each on its bare id. Those ids come from unrelated
sources: stop ids from the GTFS stop table, trip ids raw from the routes proto, address ids
from `stop_finder`. Nothing makes the three spaces disjoint, so one shared value throws
`Key ... was already used` and takes the screen down. Route results only appear when the
query is exactly a bus route short name, which is also when a short numeric id is most likely
to be echoed by both sides. Now `"stop_"`, `"trip_"` and `"address_"`, matching the prefixing
`addressResultsSection` and `emptyStateStopsList` already use.

Within-type duplicates were already impossible and are unchanged: `NswBusTripOptions.tripId`
is `TEXT PRIMARY KEY` with no join in `selectTripsByRouteIds`, and stops come back
`GROUP BY s.stopId`.

**Product class uniqueness is now guarded** (test only, no production change).
`TransportMode.byProductClass` is built with `associateBy`, so a duplicate `productClass`
does not fail, it silently overwrites: eight modes become a seven-entry map and
`fromProductClass` returns the wrong mode for the loser. That function is how every TfNSW
response is turned into a mode, so the damage is quiet and app-wide (wrong icon, colour and
name on journey cards, mode filters selecting the wrong chip, product-class analytics
attributed to the wrong mode) and the mode filter `LazyRow` in `TimeTableScreen` crashes on
the duplicate key.

This is a live footgun rather than a theoretical one: `SchoolBus` already shares both its
colour and its `name` with `Bus` and differs only by product class, so adding a mode by
copying that block is one forgotten edit away from the collision.

## Testing

Both suites were confirmed to fail against the unguarded code rather than merely passing:

- `SearchResultKeyCollisionTest` (new, 3 cases) renders the real screen with a trip and a
  stop sharing an id, and an address and a stop sharing an id. Reverting the prefixes fails
  2 of 3 with `IllegalArgumentException: Key "700" was already used`.
- `TransportModeProductClassTest` (new, 4 cases) asserts distinct product classes, the
  `associateBy` round trip per mode, that an unknown class resolves to nothing, and that
  SchoolBus stays separable from Bus. Giving `OnDemand` Bus's product class fails 3 of 4,
  including `Duplicate productClass in TransportMode.all: [5] ... expected:<8> but was:<7>`.

- `./gradlew testAndroidHostTest --continue` green.
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS Simulator compile, detekt).

No device QA: the search results path needs a stop and a bus route sharing an id, which
cannot be produced against live data. The Robolectric cases cover it deterministically
instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
