### PR TITLE
fix(ci): retry Firebase CLI install to survive corrupted CDN downloads

### DIFF
--- a/.github/workflows/distribute-firebase.yml
+++ b/.github/workflows/distribute-firebase.yml
@@ -36,7 +36,22 @@ jobs:
         run: ls
 
       - name: Download Firebase CLI
-        run: curl -sL https://firebase.tools | bash
+        # The firebase.tools install script is occasionally served corrupted
+        # (e.g. an error page instead of the shell script), which the script
+        # itself detects and exits non-zero on. Retry a few times before
+        # failing the job, since this is a transient CDN issue, not an app
+        # or CI configuration problem.
+        run: |
+          for attempt in 1 2 3; do
+            if curl -sL https://firebase.tools | bash && firebase --version >/dev/null 2>&1; then
+              echo "Firebase CLI installed successfully on attempt $attempt"
+              exit 0
+            fi
+            echo "Firebase CLI install attempt $attempt failed, retrying in $((attempt * 5))s..."
+            sleep $((attempt * 5))
+          done
+          echo "Firebase CLI install failed after 3 attempts"
+          exit 1
 
       - name: Authenticate with Firebase
         env:


### PR DESCRIPTION
## Summary
- Three consecutive `main`-branch `Krail App CI` runs today ([33149590205](https://github.com/ksharma-xyz/KRAIL/actions/runs/33149590205), [33153294485](https://github.com/ksharma-xyz/KRAIL/actions/runs/33153294485), [33154240589](https://github.com/ksharma-xyz/KRAIL/actions/runs/33154240589)) failed at the same step, `Download Firebase CLI`, in both `distribute-debug-apk-firebase` and `distribute-release-apk-firebase`. Every other job (detekt, host tests, snapshot verification, Android/iOS builds) stayed green on all three commits.
- The failure log shows the `firebase.tools` install script downloaded corrupted content — its first line was literally `Not` instead of shell, so bash choked on it: `/usr/local/bin/firebase: line 1: Not: command not found`. This is an external CDN issue, not an app or workflow logic problem; the immediately preceding green run used the identical step successfully.
- This change wraps the install in a retry loop (3 attempts, short backoff) and verifies `firebase --version` actually works before proceeding, so a transient bad download self-heals instead of failing the whole distribution job.

This is a CI-only workflow YAML change — no application code, tests, or golden files are touched.

## Test plan
- [ ] `Krail App CI` distribution jobs (`distribute-debug-apk-firebase`, `distribute-release-apk-firebase`) run green on the next `main` push
- [x] Validated YAML syntax locally

---
_Filed by the CI Sentinel routine. Never merges its own PRs — a maintainer reviews and merges._


---
_Generated by [Claude Code](https://claude.ai/code/session_01BtgkUntS9pDpUzL4XWdduz)_