### PR TITLE
feat(search): mask digits in the query sent with search_stop_query

### DIFF
--- a/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
+++ b/core/analytics/src/commonMain/kotlin/xyz/ksharma/krail/core/analytics/event/AnalyticsEvent.kt
@@ -230,23 +230,22 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
     }
 
     /**
-     * Fired when a settled search query finishes resolving. Never carries the raw
-     * typed text by default: a query can be a street address, which identifies a home
-     * or workplace, and the privacy policy promises analytics hold no personally
-     * identifiable data.
+     * Fired when a settled search query finishes resolving.
      *
-     * [zeroResultQuery] is the single, deliberately narrow exception, kept for
-     * fuzzy-matcher diagnostics (the "townhall returned nothing" workflow). Callers
-     * must resolve it through `SearchQueryAnalyticsRedaction.zeroResultQueryOrNull`,
-     * which requires zero results everywhere, no digits, and a short length. It lands
-     * in the same "query" property historical dashboards already read.
+     * [maskedQuery] carries what the rider typed, with every digit replaced by `#`. The
+     * privacy policy discloses the collection and promises the masking; callers must
+     * resolve it through `SearchQueryAnalyticsRedaction.maskedQueryOrNull` rather than
+     * passing the raw query, because analytics is sent straight to Firebase and there is
+     * no later point at which a house number could be removed. It lands in the same
+     * "query" property historical dashboards already read - rows before 1.27 hold only
+     * the queries that found nothing anywhere.
      *
      * @param queryLength     Character count of the typed query - shape signal, no text.
      * @param searchSessionId Random ID minted per settled query; joins this event to
      *                        [StopSelectedEvent] so funnels work without query text.
      * @param resultsCount    Result count on success.
      * @param isError         True when the search pipeline threw.
-     * @param zeroResultQuery Raw text only under the redaction carve-out, else null.
+     * @param maskedQuery     Typed text with digits masked; null when nothing was typed\n     *                        or the query was too long to send.
      * @param resultSource    Which pipeline resolved: local stop search or the remote
      *                        NSW address/POI pipeline. One firing per pipeline per
      *                        settled query; join on [searchSessionId].
@@ -267,7 +266,7 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
         val searchSessionId: String,
         val resultsCount: Int? = null,
         val isError: Boolean = false,
-        val zeroResultQuery: String? = null,
+        val maskedQuery: String? = null,
         val resultSource: ResultSource = ResultSource.LOCAL,
         val localResultsCount: Int? = null,
         val addressSearchGate: AddressGate? = null,
@@ -283,7 +282,7 @@ sealed class AnalyticsEvent(val name: String, rawProperties: Map<String, Any>? =
             } else if (resultsCount != null) {
                 put("resultsCount", resultsCount)
             }
-            zeroResultQuery?.let { put("query", it) }
+            maskedQuery?.let { put("query", it) }
             localResultsCount?.let { put("localResultsCount", it) }
             addressSearchGate?.let { put("addressSearchGate", it.name) }
             queryHasDigit?.let { put("queryHasDigit", it) }

--- a/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryRedactionCallSiteTest.kt
+++ b/feature/trip-planner/ui/src/androidHostTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryRedactionCallSiteTest.kt
@@ -8,10 +8,11 @@ import kotlin.test.fail
  * The other half of `SearchQueryTextEgressTest`, which can only prove that the call sites that
  * exist today behave. This proves no new one appears that skips the redaction.
  *
- * `AnalyticsEvent.SearchStopQuery.zeroResultQuery` is the single parameter allowed to carry a
- * rider's typed text, and only when `SearchQueryAnalyticsRedaction.zeroResultQueryOrNull` says
- * so. Passing the raw query straight into it compiles, type-checks and reads plausibly, so the
- * only thing standing between that and shipping addresses is a reviewer noticing.
+ * `AnalyticsEvent.SearchStopQuery.maskedQuery` is the single parameter allowed to carry a
+ * rider's typed text, and only after `SearchQueryAnalyticsRedaction.maskedQueryOrNull` has
+ * masked the digits out of it. Passing the raw query straight into it compiles, type-checks and
+ * reads plausibly, so the only thing standing between that and shipping house numbers to
+ * Firebase is a reviewer noticing.
  *
  * Lives in androidHostTest rather than commonTest because it reads source files off disk, which
  * commonTest cannot do.
@@ -23,21 +24,20 @@ import kotlin.test.fail
  *
  * ## What it cannot see
  *
- *  - An assignment whose redaction call is further away than [WINDOW] lines.
+ *  - An assignment whose masking call is further away than [WINDOW] lines.
  *  - A wrapper function that itself returns the raw query. It checks the name at the call site,
- *    not what that name does; `resolveLocalZeroResultQuery` is trusted by name and pinned
- *    separately by its own tests.
+ *    not what that name does.
  */
 class SearchQueryRedactionCallSiteTest {
 
     @Test
-    fun `zeroResultQuery is only ever assigned from the redaction functions`() {
+    fun `maskedQuery is only ever assigned from the masking function`() {
         val offenders = mutableListOf<String>()
 
         productionSources().forEach { file ->
             val lines = file.readLines()
             lines.forEachIndexed { index, line ->
-                if (!line.isAssignmentToZeroResultQuery()) return@forEachIndexed
+                if (!line.isAssignmentToMaskedQuery()) return@forEachIndexed
                 val window = lines.subList(index, minOf(index + WINDOW, lines.size))
                     .joinToString("\n")
                 if (SANCTIONED.none { window.contains(it) }) {
@@ -48,18 +48,19 @@ class SearchQueryRedactionCallSiteTest {
 
         if (offenders.isNotEmpty()) {
             fail(
-                "zeroResultQuery is the one analytics parameter allowed to carry a rider's " +
-                    "typed text, and only through the redaction carve-out. These assignments " +
+                "maskedQuery is the one analytics parameter allowed to carry a rider's typed " +
+                    "text, and only with the digits masked out of it first. These assignments " +
                     "do not go through ${SANCTIONED.joinToString(" or ")}:\n" +
                     offenders.joinToString("\n") { "  - $it" } +
-                    "\n\nSee docs/SEARCH_QUERY_TELEMETRY_SPEC.md. A query that found results is " +
-                    "never sent, whatever else is true of it.",
+                    "\n\nSee docs/SEARCH_QUERY_TELEMETRY_SPEC.md. Analytics is sent straight to " +
+                    "Firebase, so a house number that reaches this parameter is a house number " +
+                    "a third party has stored.",
             )
         }
     }
 
-    /** The parameter's own declaration (`val zeroResultQuery: String? = null`) is not one. */
-    private fun String.isAssignmentToZeroResultQuery(): Boolean {
+    /** The parameter's own declaration (`val maskedQuery: String? = null`) is not one. */
+    private fun String.isAssignmentToMaskedQuery(): Boolean {
         val trimmed = trimStart()
         val isComment = trimmed.startsWith("//") || trimmed.startsWith("*")
         return !isComment &&
@@ -80,13 +81,10 @@ class SearchQueryRedactionCallSiteTest {
 
         const val WINDOW = 8
 
-        val SANCTIONED = listOf(
-            "SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(",
-            "resolveLocalZeroResultQuery(",
-        )
+        val SANCTIONED = listOf("SearchQueryAnalyticsRedaction.maskedQueryOrNull(")
 
-        val ASSIGNMENT = Regex("\\bzeroResultQuery\\s*=")
-        val DECLARATION = Regex("\\b(?:val|var)\\s+zeroResultQuery\\b")
+        val ASSIGNMENT = Regex("\\bmaskedQuery\\s*=")
+        val DECLARATION = Regex("\\b(?:val|var)\\s+maskedQuery\\b")
 
         val PRODUCTION_SOURCE_SETS =
             listOf("/src/commonMain/", "/src/androidMain/", "/src/iosMain/")

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalytics.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalytics.kt
@@ -8,8 +8,11 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 /**
  * One firing per resolved (non-stale) address fetch, which is also one firing per network
  * call - there is no result cache, so `resultSource = address` counts requests directly.
- * This is also the carve-out site for address-eligible queries - only here are both
- * pipelines' result counts known. [addressResults] is null when the fetch failed.
+ * [addressResults] is null when the fetch failed.
+ *
+ * Carries no query text. The local firing happens for every settled query and already
+ * carries it, so attaching it here too would send the same text twice for one keystroke
+ * and double-count it in the eval corpus. Join on [searchSessionId] instead.
  */
 internal fun Analytics.trackAddressSearchResolved(
     normalizedQuery: String,
@@ -25,13 +28,6 @@ internal fun Analytics.trackAddressSearchResolved(
             resultsCount = addressResults?.size,
             localResultsCount = localResultsCount,
             isError = addressResults == null,
-            zeroResultQuery = addressResults?.let {
-                SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                    query = normalizedQuery,
-                    localResultsCount = localResultsCount,
-                    addressResultsCount = it.size,
-                )
-            },
         ),
     )
 }
@@ -39,7 +35,7 @@ internal fun Analytics.trackAddressSearchResolved(
 /**
  * One firing per settled local stop search. Unlike the address firing this happens for
  * every query, so it is the only place a *suppressed* address call leaves a trace — hence
- * [addressSearchGate] riding along here.
+ * [addressSearchGate] riding along here, and the only firing that carries the query text.
  */
 internal fun Analytics.trackLocalSearchResolved(
     query: String,
@@ -52,11 +48,7 @@ internal fun Analytics.trackLocalSearchResolved(
             queryLength = query.length,
             searchSessionId = searchSessionId,
             resultsCount = localResultsCount,
-            zeroResultQuery = resolveLocalZeroResultQuery(
-                query = query,
-                localResultsCount = localResultsCount,
-                addressSearchGate = addressSearchGate,
-            ),
+            maskedQuery = SearchQueryAnalyticsRedaction.maskedQueryOrNull(query),
             addressSearchGate = addressSearchGateOutcome(addressSearchGate),
             queryHasDigit = queryHasDigit(query),
         ),
@@ -70,6 +62,7 @@ internal fun Analytics.trackLocalSearchFailed(query: String, searchSessionId: St
             queryLength = query.length,
             searchSessionId = searchSessionId,
             isError = true,
+            maskedQuery = SearchQueryAnalyticsRedaction.maskedQueryOrNull(query),
             queryHasDigit = queryHasDigit(query),
         ),
     )
@@ -92,21 +85,3 @@ internal fun addressSearchGateOutcome(
 
 /** A house number is the cheapest address signal there is - a bool, never the text. */
 internal fun queryHasDigit(query: String): Boolean = query.any { it.isDigit() }
-
-/**
- * Local-pipeline carve-out site. When the address pipeline is eligible for the query,
- * it resolves later and owns the carve-out decision (the query may be a real address
- * the NSW API recognises), so this returns null.
- */
-internal fun resolveLocalZeroResultQuery(
-    query: String,
-    localResultsCount: Int,
-    addressSearchGate: AddressSearchGate,
-): String? {
-    if (addressSearchGate == AddressSearchGate.ELIGIBLE) return null
-    return SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-        query = query,
-        localResultsCount = localResultsCount,
-        addressResultsCount = null,
-    )
-}

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedaction.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedaction.kt
@@ -1,45 +1,61 @@
 package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 /**
- * Decides whether a raw search query may be attached to analytics.
+ * Turns a raw search query into the only form of it allowed to leave the device.
  *
- * Default is never: typed text can be a street address, which identifies a home or
- * workplace, and the privacy policy promises analytics contain no personally
- * identifiable data. The one carve-out exists for fuzzy-matcher diagnostics: a query
- * that matched nothing anywhere, contains no digits (house and unit numbers are the
- * identifying part of an address), and is short. "townhall" returning zero results
- * stays diagnosable; "4 fulton place" is never sent.
+ * From 1.27 the privacy policy discloses that search text is kept to improve search, so
+ * the query is attached to every settled search rather than only to the ones that found
+ * nothing. What the policy also promises is that house and unit numbers are masked, and
+ * that promise is kept **here**, on the device, rather than downstream: analytics goes
+ * straight to Firebase from [xyz.ksharma.krail.core.analytics.RealAnalytics], so anything
+ * this function returns is stored as-is by a third party. A masking step further down the
+ * pipeline would be masking data that had already been sent.
  *
- * Call-site contract: when the address pipeline is eligible for the query, the
- * carve-out decision belongs to the address pipeline's completion site (which knows
- * the real address result count) - the local pipeline must not call this with
- * [addressResultsCount] = null in that case.
+ * ```
+ * "4 fulton place" -> "# fulton place"
+ * "T80"            -> "T##"
+ * "861"            -> "861"      // all digits, see below
+ * "wynyard"        -> "wynyard"
+ * ```
+ *
+ * A house number is the part of an address that identifies a home; the street is what the
+ * fuzzy stop matcher needs to be fixed. Masking keeps the second and destroys the first.
+ *
+ * **An all-digit query is sent as typed.** Riders search bus and train route numbers and
+ * stop IDs, and those are digits with nothing else in them. A number on its own is not an
+ * address: a house number identifies a home only in combination with the street beside it,
+ * and there is no street here to combine with. Masking these would erase a whole class of
+ * search - "861" and "200060" would arrive as "###" and "######", indistinguishable from
+ * each other and from every other number a rider types.
+ *
+ * The moment a query carries anything that is not a digit, it can carry a street, so every
+ * digit in it is masked.
+ *
+ * The length cap stays for the same reason it existed before masking: a long query carries
+ * street and suburb together even with no digits in it, and that pair is identifying in a
+ * way a stop name is not.
  */
 object SearchQueryAnalyticsRedaction {
 
-    const val MAX_ZERO_RESULT_QUERY_LENGTH = 25
+    const val MAX_QUERY_LENGTH = 40
+
+    /** Stands in for every digit, so "12" and "99" are indistinguishable but both visible. */
+    const val DIGIT_MASK = '#'
 
     /**
-     * Returns the trimmed query when every carve-out condition holds, else null.
+     * Returns the trimmed query - unchanged when it is all digits, digit-masked otherwise -
+     * or null when there is nothing safe to send.
      *
-     * @param localResultsCount   Local stop-search result count for the query.
-     * @param addressResultsCount Address-pipeline result count for the same query, or
-     *                            null when the address pipeline did not run (flag off
-     *                            or below the minimum query length).
+     * Null means blank (nothing typed) or longer than [MAX_QUERY_LENGTH]. Result counts do
+     * not appear here: whether a query found something is no longer part of the decision.
      */
-    fun zeroResultQueryOrNull(
-        query: String,
-        localResultsCount: Int,
-        addressResultsCount: Int?,
-    ): String? {
+    fun maskedQueryOrNull(query: String): String? {
         val trimmed = query.trim()
-        val addressRecognisedNothing = addressResultsCount == null || addressResultsCount == 0
-        return trimmed.takeIf {
-            localResultsCount == 0 &&
-                addressRecognisedNothing &&
-                it.isNotEmpty() &&
-                it.length <= MAX_ZERO_RESULT_QUERY_LENGTH &&
-                it.none(Char::isDigit)
+        return when {
+            trimmed.isEmpty() || trimmed.length > MAX_QUERY_LENGTH -> null
+            trimmed.all(Char::isDigit) -> trimmed
+            else -> trimmed.map { if (it.isDigit()) DIGIT_MASK else it }
+                .joinToString(separator = "")
         }
     }
 }

--- a/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
+++ b/feature/trip-planner/ui/src/commonMain/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModel.kt
@@ -534,18 +534,37 @@ class SearchStopViewModel(
 
         searchJob?.cancel()
         searchJob = viewModelScope.launch {
-            delay(100) // debounce / small throttle on VM side
-            runCatching {
-                val stopResults = stopResultsManager.fetchStopResults(query)
+            delay(SEARCH_DEBOUNCE_MS)
+
+            // suspendSafeResult, not runCatching: every keystroke cancels this job, and
+            // runCatching swallows the CancellationException it throws - which reported a
+            // cancelled keystroke as a failed search, and would now send its text too.
+            val stopResults = suspendSafeResult(ioDispatcher) {
+                stopResultsManager.fetchStopResults(query)
+            }.getOrNull()
+
+            if (stopResults != null) {
                 updateUiState { displayData(stopResults) }
+            } else {
+                updateUiState { displayError() }
+            }
+
+            // The screen is now up to date; analytics deliberately is not yet. Sitting out
+            // a quiet period first means a burst of typing reports the query the rider
+            // finished, not one row per prefix - "4", "4 f", "4 fu" are keystrokes, not
+            // searches, and counting them as failed searches skewed every read of the
+            // address gate. Cancellation does the work: the next keystroke cancels this
+            // job while it waits here.
+            delay(SEARCH_ANALYTICS_QUIET_MS)
+
+            if (stopResults != null) {
                 analytics.trackLocalSearchResolved(
                     query = query,
                     searchSessionId = searchSessionId,
                     localResultsCount = stopResults.size,
                     addressSearchGate = currentAddressSearchGate(normalizeAddressQuery(query)),
                 )
-            }.getOrElse {
-                updateUiState { displayError() }
+            } else {
                 analytics.trackLocalSearchFailed(
                     query = query,
                     searchSessionId = searchSessionId,
@@ -782,9 +801,23 @@ class SearchStopViewModel(
     }
 
     private companion object {
+        /** How long typing must pause before the local stop list is refreshed. */
+        const val SEARCH_DEBOUNCE_MS = 100L
+
         // Longer than local search's 100ms debounce - network round-trip is inherently
         // slower, and there's no benefit to firing it as eagerly as the local DB query.
         const val ADDRESS_SEARCH_DEBOUNCE_MS = 350L
+
+        /**
+         * Extra quiet time after the results are on screen before `search_stop_query`
+         * fires. Deliberately far longer than [SEARCH_DEBOUNCE_MS]: the screen must keep
+         * up with each keystroke, but an event per keystroke is a different thing - it
+         * inflates the failed-search count with prefixes of searches that then succeeded,
+         * and from 1.27 it would send each of those prefixes' text as well. Long enough to
+         * outlast a typing pause, short enough that a rider who types and reads still
+         * reports before they move on.
+         */
+        const val SEARCH_ANALYTICS_QUIET_MS = 600L
 
         fun newSearchSessionId(): String = Random.nextLong().toULong().toString(radix = 16)
     }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedactionTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryAnalyticsRedactionTest.kt
@@ -2,111 +2,123 @@ package xyz.ksharma.krail.trip.planner.ui.searchstop
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class SearchQueryAnalyticsRedactionTest {
 
     @Test
-    fun `zero results everywhere, no digits, short - query is kept`() {
+    fun `a query with no digits is sent as typed`() {
+        assertEquals("townhall", SearchQueryAnalyticsRedaction.maskedQueryOrNull("townhall"))
+    }
+
+    @Test
+    fun `a house number is masked, the street it identifies is not`() {
         assertEquals(
-            "townhall",
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "townhall",
-                localResultsCount = 0,
-                addressResultsCount = null,
-            ),
+            "# fulton place",
+            SearchQueryAnalyticsRedaction.maskedQueryOrNull("4 fulton place"),
         )
     }
 
     @Test
-    fun `address pipeline recognised nothing - query is kept`() {
+    fun `every digit of a unit number is masked, not just the first`() {
         assertEquals(
-            "townhall",
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "townhall",
-                localResultsCount = 0,
-                addressResultsCount = 0,
-            ),
+            "##/### smith st",
+            SearchQueryAnalyticsRedaction.maskedQueryOrNull("12/345 smith st"),
         )
     }
 
     @Test
-    fun `query is trimmed before length and emptiness checks`() {
-        assertEquals(
-            "townhall",
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "  townhall  ",
-                localResultsCount = 0,
-                addressResultsCount = null,
-            ),
-        )
+    fun `an all-digit query is sent as typed - it is a route number or a stop id`() {
+        // A number on its own is not an address: a house number identifies a home only in
+        // combination with the street beside it, and there is no street here.
+        assertEquals("861", SearchQueryAnalyticsRedaction.maskedQueryOrNull("861"))
+        assertEquals("200060", SearchQueryAnalyticsRedaction.maskedQueryOrNull("200060"))
+        assertEquals("4", SearchQueryAnalyticsRedaction.maskedQueryOrNull("4"))
     }
 
     @Test
-    fun `any digit blocks the query - house numbers are the PII carrier`() {
+    fun `an all-digit query is still trimmed before it is recognised as one`() {
+        assertEquals("861", SearchQueryAnalyticsRedaction.maskedQueryOrNull("  861  "))
+    }
+
+    @Test
+    fun `one non-digit character is enough to mask the whole query`() {
+        // The moment anything else is in there, the query can carry a street.
+        assertEquals("T##", SearchQueryAnalyticsRedaction.maskedQueryOrNull("T80"))
+        assertEquals("#/#", SearchQueryAnalyticsRedaction.maskedQueryOrNull("4/2"))
+        assertEquals("## #", SearchQueryAnalyticsRedaction.maskedQueryOrNull("12 3"))
+    }
+
+    @Test
+    fun `results found no longer changes anything - the query is sent either way`() {
+        // The 1.26 carve-out only sent queries that found nothing anywhere. From 1.27 the
+        // policy discloses the collection, so the result count is not part of the decision.
+        assertEquals("wynyard", SearchQueryAnalyticsRedaction.maskedQueryOrNull("wynyard"))
+    }
+
+    @Test
+    fun `query is trimmed before the length check`() {
+        assertEquals("townhall", SearchQueryAnalyticsRedaction.maskedQueryOrNull("  townhall  "))
+    }
+
+    @Test
+    fun `over max length is dropped - street plus suburb identifies even with no digits`() {
         assertNull(
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "4 fulton place",
-                localResultsCount = 0,
-                addressResultsCount = null,
-            ),
-        )
-    }
-
-    @Test
-    fun `local results present blocks the query`() {
-        assertNull(
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "townhall",
-                localResultsCount = 3,
-                addressResultsCount = null,
-            ),
-        )
-    }
-
-    @Test
-    fun `address results present blocks the query`() {
-        assertNull(
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "fulton place",
-                localResultsCount = 0,
-                addressResultsCount = 5,
-            ),
-        )
-    }
-
-    @Test
-    fun `over max length blocks the query`() {
-        assertNull(
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "a".repeat(SearchQueryAnalyticsRedaction.MAX_ZERO_RESULT_QUERY_LENGTH + 1),
-                localResultsCount = 0,
-                addressResultsCount = null,
+            SearchQueryAnalyticsRedaction.maskedQueryOrNull(
+                "a".repeat(SearchQueryAnalyticsRedaction.MAX_QUERY_LENGTH + 1),
             ),
         )
     }
 
     @Test
     fun `exactly max length is kept`() {
-        val query = "a".repeat(SearchQueryAnalyticsRedaction.MAX_ZERO_RESULT_QUERY_LENGTH)
+        val query = "a".repeat(SearchQueryAnalyticsRedaction.MAX_QUERY_LENGTH)
+        assertEquals(query, SearchQueryAnalyticsRedaction.maskedQueryOrNull(query))
+    }
+
+    @Test
+    fun `length is measured on the typed query, not on the masked one`() {
+        // Masking is 1:1 per character, so this can only break if that ever stops holding.
+        val query = "a".repeat(SearchQueryAnalyticsRedaction.MAX_QUERY_LENGTH - 1) + "1"
         assertEquals(
-            query,
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = query,
-                localResultsCount = 0,
-                addressResultsCount = null,
-            ),
+            SearchQueryAnalyticsRedaction.MAX_QUERY_LENGTH,
+            SearchQueryAnalyticsRedaction.maskedQueryOrNull(query)?.length,
+        )
+    }
+
+    @Test
+    fun `a real stop name fits inside the cap`() {
+        // The cap has to clear the names riders actually type, or the longest queries -
+        // which are the ones most likely to be failing - are the ones never reported.
+        assertEquals(
+            "north sydney interchange stand c",
+            SearchQueryAnalyticsRedaction.maskedQueryOrNull("north sydney interchange stand c"),
         )
     }
 
     @Test
     fun `blank query is never kept`() {
-        assertNull(
-            SearchQueryAnalyticsRedaction.zeroResultQueryOrNull(
-                query = "   ",
-                localResultsCount = 0,
-                addressResultsCount = null,
-            ),
-        )
+        assertNull(SearchQueryAnalyticsRedaction.maskedQueryOrNull("   "))
+        assertNull(SearchQueryAnalyticsRedaction.maskedQueryOrNull(""))
+    }
+
+    @Test
+    fun `no digit survives a query that has anything else in it`() {
+        // The policy promise, stated as one property rather than as examples: a digit only
+        // ever leaves as part of a query that is nothing but digits.
+        listOf(
+            "4 fulton place",
+            "unit 3, 27 park rd",
+            "level 10 tower 2",
+            "9/9/9",
+            "12a smith st",
+        ).forEach { query ->
+            val masked = SearchQueryAnalyticsRedaction.maskedQueryOrNull(query)
+            assertFalse(
+                masked.orEmpty().any(Char::isDigit),
+                "a digit survived masking of '$query': got '$masked'",
+            )
+        }
     }
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryTextEgressTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchQueryTextEgressTest.kt
@@ -7,48 +7,75 @@ import xyz.ksharma.krail.trip.planner.ui.state.searchstop.SearchStopState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
+import kotlin.test.assertNull
 import kotlin.test.fail
 
 /**
- * A typed search query can be a street address, and a street address is a home. The rule in
- * `docs/SEARCH_QUERY_TELEMETRY_SPEC.md` is that raw text leaves the device only under the
- * zero-result carve-out: nothing found anywhere, no digits, short.
+ * From 1.27 the typed query is sent for every settled search, disclosed by the privacy
+ * policy. What the policy also promises is that house and unit numbers are masked, and
+ * because analytics goes straight to Firebase there is no later stage that could do it -
+ * whatever these helpers build is what a third party stores.
  *
- * `SearchQueryAnalyticsRedactionTest` already pins the carve-out predicate. This test guards the
- * step after it — the event that actually goes out. It drives the production track helpers and
- * reads the built property map, because that map is what ships, and a leak could arrive through
- * a parameter nobody thought of rather than through a wrong carve-out decision.
+ * A query that is nothing but digits is a route number or a stop id, not an address, and
+ * goes out as typed. Everything else has its digits masked.
  *
- * The assertion deliberately checks **every** property value rather than just the `query` key,
- * and checks the query's individual words as well as the whole string, because the spec calls
- * out that "a first token, a normalised query or a hash of the text are all the text".
+ * `SearchQueryAnalyticsRedactionTest` pins the masking function. This test guards the step
+ * after it - the event that actually goes out. It drives the production track helpers and
+ * reads the built property map, because that map is what ships, and a digit could arrive
+ * through a parameter nobody thought of rather than through a broken mask.
  *
- * What it cannot see: a hash or an encoding of the query, which by construction does not
- * contain the query as a substring. That would have to be caught in review.
+ * What it cannot see: a hash or an encoding of the query, which by construction contains
+ * no digit and no substring of the text. That would have to be caught in review.
  */
 class SearchQueryTextEgressTest {
 
     @Test
-    fun `a local query that found results never leaves as text`() {
+    fun `no digit leaves an address-shaped query on a resolved local search`() {
         val analytics = FakeAnalytics()
 
         analytics.trackLocalSearchResolved(
-            query = QUERY,
+            query = ADDRESS_QUERY,
             searchSessionId = SESSION_ID,
             localResultsCount = 4,
             addressSearchGate = AddressSearchGate.DISABLED,
         )
 
-        assertNoRawQuery(analytics.searchEvent())
+        assertNoDigitAnywhere(analytics.searchEvent())
     }
 
     @Test
-    fun `an address query that found results never leaves as text`() {
+    fun `no digit leaves an address-shaped query on a failed local search`() {
+        val analytics = FakeAnalytics()
+
+        analytics.trackLocalSearchFailed(query = ADDRESS_QUERY, searchSessionId = SESSION_ID)
+
+        assertNoDigitAnywhere(analytics.searchEvent())
+    }
+
+    @Test
+    fun `the street survives so the query is still diagnosable`() {
+        // Control. Without this, every assertion above would also pass if the event stopped
+        // carrying any query at all, and the guard would be measuring nothing.
+        val analytics = FakeAnalytics()
+
+        analytics.trackLocalSearchResolved(
+            query = ADDRESS_QUERY,
+            searchSessionId = SESSION_ID,
+            localResultsCount = 0,
+            addressSearchGate = AddressSearchGate.BELOW_THRESHOLD,
+        )
+
+        assertEquals("# fulton place", analytics.searchEvent().properties?.get("query"))
+    }
+
+    @Test
+    fun `the address firing carries no query text at all`() {
+        // The local firing happens for every settled query and already carries the text.
+        // Sending it here too would double the egress and double-count the eval corpus.
         val analytics = FakeAnalytics()
 
         analytics.trackAddressSearchResolved(
-            normalizedQuery = QUERY,
+            normalizedQuery = ADDRESS_QUERY,
             searchSessionId = SESSION_ID,
             localResultsCount = 0,
             addressResults = listOf(
@@ -60,47 +87,40 @@ class SearchQueryTextEgressTest {
             ),
         )
 
-        assertNoRawQuery(analytics.searchEvent())
+        val event = analytics.searchEvent()
+        assertNull(event.properties?.get("query"))
+        assertNoDigitAnywhere(event)
     }
 
     @Test
-    fun `a failed local search never leaves as text`() {
-        val analytics = FakeAnalytics()
-
-        analytics.trackLocalSearchFailed(query = QUERY, searchSessionId = SESSION_ID)
-
-        assertNoRawQuery(analytics.searchEvent())
-    }
-
-    @Test
-    fun `an address-eligible query defers rather than leaking on the local event`() {
-        // The local site does not know the address count yet, so it must not decide.
+    fun `a query too long to send carries no text rather than a truncated one`() {
         val analytics = FakeAnalytics()
 
         analytics.trackLocalSearchResolved(
-            query = QUERY,
+            query = "unit ${"a".repeat(SearchQueryAnalyticsRedaction.MAX_QUERY_LENGTH)}",
             searchSessionId = SESSION_ID,
             localResultsCount = 0,
             addressSearchGate = AddressSearchGate.ELIGIBLE,
         )
 
-        assertNoRawQuery(analytics.searchEvent())
+        assertNull(analytics.searchEvent().properties?.get("query"))
     }
 
     @Test
-    fun `the carve-out itself still works`() {
-        // Control. Without this, every assertion above would also pass if the event stopped
-        // carrying any query at all, and the guard would be measuring nothing.
+    fun `an all-digit query goes out as typed - it is a route number, not an address`() {
+        // Masking these would collapse "861" and "200060" into "###" and "######", which
+        // erases the whole class of search rather than protecting anything: a number with
+        // no street beside it identifies no home.
         val analytics = FakeAnalytics()
 
         analytics.trackLocalSearchResolved(
-            query = QUERY,
+            query = "861",
             searchSessionId = SESSION_ID,
             localResultsCount = 0,
-            addressSearchGate = AddressSearchGate.DISABLED,
+            addressSearchGate = AddressSearchGate.BELOW_THRESHOLD,
         )
 
-        assertEquals(QUERY, analytics.searchEvent().properties?.get("query"))
+        assertEquals("861", analytics.searchEvent().properties?.get("query"))
     }
 
     private fun FakeAnalytics.searchEvent(): AnalyticsEvent.SearchStopQuery {
@@ -109,30 +129,33 @@ class SearchQueryTextEgressTest {
         return event
     }
 
-    private fun assertNoRawQuery(event: AnalyticsEvent.SearchStopQuery) {
-        val needles = listOf(QUERY) + QUERY.split(" ").filter { it.length >= MIN_TOKEN_LENGTH }
-        val values = event.properties.orEmpty().entries
+    /**
+     * Numeric parameters (`queryLength`, counts) are numbers, not text, so only String
+     * values are inspected - a digit inside a count is the count.
+     */
+    private fun assertNoDigitAnywhere(event: AnalyticsEvent.SearchStopQuery) {
+        val leaking = event.properties.orEmpty()
+            .filterKeys { it != PROP_SEARCH_SESSION_ID }
+            .filter { (_, value) -> value is String && value.any(Char::isDigit) }
 
-        needles.forEach { needle ->
-            val leaking = values.filter { it.value.toString().contains(needle, ignoreCase = true) }
-            if (leaking.isNotEmpty()) {
-                fail(
-                    "search_stop_query carried the rider's typed text for a query that found " +
-                        "results. Raw text may only ship under the zero-result carve-out in " +
-                        "SearchQueryAnalyticsRedaction.zeroResultQueryOrNull; see " +
-                        "docs/SEARCH_QUERY_TELEMETRY_SPEC.md.\n" +
-                        "  leaked '$needle' via " +
-                        leaking.joinToString { "${it.key}=${it.value}" },
-                )
-            }
+        if (leaking.isNotEmpty()) {
+            fail(
+                "search_stop_query carried a digit from a query that was not all digits. " +
+                    "A house or unit number is what makes a query identify a home, and the " +
+                    "privacy policy promises it is masked before it is stored. Masking " +
+                    "happens in SearchQueryAnalyticsRedaction.maskedQueryOrNull; see " +
+                    "docs/SEARCH_QUERY_TELEMETRY_SPEC.md.\n" +
+                    "  leaked via " + leaking.entries.joinToString { "${it.key}=${it.value}" },
+            )
         }
-        assertTrue(event.properties.orEmpty().isNotEmpty(), "event carried no properties at all")
     }
 
     private companion object {
-        const val QUERY = "wynyard quaybridge"
+        const val ADDRESS_QUERY = "4 fulton place"
         const val SESSION_ID = "session-egress"
         const val EVENT_NAME = "search_stop_query"
-        const val MIN_TOKEN_LENGTH = 4
+
+        /** A random hex id, unrelated to anything the rider typed. */
+        const val PROP_SEARCH_SESSION_ID = "searchSessionId"
     }
 }

--- a/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
+++ b/feature/trip-planner/ui/src/commonTest/kotlin/xyz/ksharma/krail/trip/planner/ui/searchstop/SearchStopViewModelTest.kt
@@ -5,6 +5,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -36,6 +37,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
+// Slower than the list debounce, faster than the analytics quiet period.
+private const val KEYSTROKE_GAP_MS = 200L
+
 class SearchStopViewModelTest {
 
     private val fakeAnalytics: Analytics = FakeAnalytics()
@@ -468,7 +472,7 @@ class SearchStopViewModelTest {
     // region Search query analytics redaction
 
     @Test
-    fun `GIVEN a query with results WHEN search completes THEN search_stop_query carries no raw text`() =
+    fun `GIVEN a query with results WHEN search completes THEN search_stop_query carries the text`() =
         runTest {
             viewModel.uiState.test {
                 skipItems(1)
@@ -481,14 +485,15 @@ class SearchStopViewModelTest {
                 assertEquals("Central".length, event.queryLength)
                 assertEquals(1, event.resultsCount)
                 assertTrue(event.searchSessionId.isNotBlank())
-                assertFalse(event.properties.orEmpty().containsKey("query"))
+                // 1.26 sent nothing here; 1.27 sends every settled query, results or not.
+                assertEquals("Central", event.properties?.get("query"))
 
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `GIVEN zero results and address pipeline off WHEN query has no digits THEN carve-out keeps the query`() =
+    fun `GIVEN zero results and no digits WHEN search completes THEN the query is sent as typed`() =
         runTest {
             viewModel.uiState.test {
                 skipItems(1)
@@ -499,7 +504,7 @@ class SearchStopViewModelTest {
                 val event = fakeAnalytics.getTrackedEvent("search_stop_query")
                 assertIs<AnalyticsEvent.SearchStopQuery>(event)
                 assertEquals(0, event.resultsCount)
-                assertEquals("townhall", event.zeroResultQuery)
+                assertEquals("townhall", event.maskedQuery)
                 assertEquals("townhall", event.properties?.get("query"))
 
                 cancelAndIgnoreRemainingEvents()
@@ -507,7 +512,7 @@ class SearchStopViewModelTest {
         }
 
     @Test
-    fun `GIVEN zero results WHEN query contains digits THEN carve-out never keeps the query`() =
+    fun `GIVEN a query with digits WHEN search completes THEN the house number is masked out`() =
         runTest {
             viewModel.uiState.test {
                 skipItems(1)
@@ -518,34 +523,58 @@ class SearchStopViewModelTest {
                 val event = fakeAnalytics.getTrackedEvent("search_stop_query")
                 assertIs<AnalyticsEvent.SearchStopQuery>(event)
                 assertEquals(0, event.resultsCount)
-                assertEquals(null, event.zeroResultQuery)
-                assertFalse(event.properties.orEmpty().containsKey("query"))
+                // The street is kept - it is what the fuzzy matcher has to be fixed against.
+                assertEquals("# fulton place", event.maskedQuery)
+                assertEquals(true, event.queryHasDigit)
 
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `GIVEN address pipeline eligible WHEN local results are zero THEN local event defers the carve-out`() =
+    fun `GIVEN address pipeline eligible WHEN local results are zero THEN the local event still carries the text`() =
         runTest {
+            // The local firing owns the text outright now - there is no deferral to the
+            // address site, because masking needs neither pipeline's result count.
             val addressViewModel = addressAwareViewModel(minQueryLength = 6)
             addressViewModel.uiState.test {
                 skipItems(1)
                 addressViewModel.onEvent(SearchStopUiEvent.SearchTextChanged("townhall"))
                 advanceUntilIdle()
 
-                assertTrue(fakeAnalytics is FakeAnalytics)
-                val event = fakeAnalytics.getTrackedEvent("search_stop_query")
-                assertIs<AnalyticsEvent.SearchStopQuery>(event)
-                assertEquals(null, event.zeroResultQuery)
-                assertFalse(event.properties.orEmpty().containsKey("query"))
+                assertEquals("townhall", localEvents().single().maskedQuery)
 
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `GIVEN search fails WHEN error event fires THEN it carries no raw text`() =
+    fun `GIVEN a burst of keystrokes WHEN typing settles THEN only the finished query is reported`() =
+        runTest {
+            viewModel.uiState.test {
+                skipItems(1)
+
+                // Each keystroke is far enough apart to refresh the list on screen, and
+                // close enough that none of them is a query the rider finished typing.
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("cen"))
+                advanceTimeBy(KEYSTROKE_GAP_MS)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("cent"))
+                advanceTimeBy(KEYSTROKE_GAP_MS)
+                viewModel.onEvent(SearchStopUiEvent.SearchTextChanged("Central"))
+                advanceUntilIdle()
+
+                // One row, not three. Prefixes are keystrokes, not searches - counting them
+                // as searches overstated the failed-search rate and the address gate with it.
+                val event = localEvents().single()
+                assertEquals("Central", event.maskedQuery)
+                assertEquals("Central".length, event.queryLength)
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `GIVEN search fails WHEN the error event fires THEN it carries the masked query`() =
         runTest {
             fakeStopResultsManager.shouldThrowError = true
             viewModel.uiState.test {
@@ -557,7 +586,8 @@ class SearchStopViewModelTest {
                 val event = fakeAnalytics.getTrackedEvent("search_stop_query")
                 assertIs<AnalyticsEvent.SearchStopQuery>(event)
                 assertTrue(event.isError)
-                assertFalse(event.properties.orEmpty().containsKey("query"))
+                // A search that threw is exactly the one worth having the text for.
+                assertEquals("townhall", event.properties?.get("query"))
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -761,6 +791,16 @@ class SearchStopViewModelTest {
             .filterIsInstance<AnalyticsEvent.SearchStopQuery>()
             .filter { it.resultSource == AnalyticsEvent.SearchStopQuery.ResultSource.ADDRESS }
 
+    /**
+     * The local firing waits out [SearchStopViewModel] analytics quiet time, so when the
+     * address pipeline is eligible its firing lands first - selecting by name alone picks
+     * the address event.
+     */
+    private fun localEvents(): List<AnalyticsEvent.SearchStopQuery> =
+        (fakeAnalytics as FakeAnalytics).getTrackedEvents("search_stop_query")
+            .filterIsInstance<AnalyticsEvent.SearchStopQuery>()
+            .filter { it.resultSource == AnalyticsEvent.SearchStopQuery.ResultSource.LOCAL }
+
     @Test
     fun `GIVEN an address fetch WHEN it resolves THEN one address-source event fires with the local session id`() =
         runTest {
@@ -794,8 +834,10 @@ class SearchStopViewModelTest {
         }
 
     @Test
-    fun `GIVEN zero results in both pipelines WHEN query has no digits THEN address event carries the carve-out`() =
+    fun `GIVEN zero results in both pipelines WHEN the address event fires THEN it carries no text`() =
         runTest {
+            // The local firing already carries the query for this same searchSessionId.
+            // Sending it here too would double the egress and double-count the eval corpus.
             fakeRemoteAddressResultsManager.results = emptyList()
             val addressViewModel = addressAwareViewModel(minQueryLength = 6)
 
@@ -806,14 +848,15 @@ class SearchStopViewModelTest {
 
                 val addressEvent = addressEvents().single()
                 assertEquals(0, addressEvent.resultsCount)
-                assertEquals("fulton place", addressEvent.zeroResultQuery)
+                assertEquals(null, addressEvent.maskedQuery)
+                assertFalse(addressEvent.properties.orEmpty().containsKey("query"))
 
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun `GIVEN the address pipeline recognises the query WHEN results return THEN the carve-out stays off`() =
+    fun `GIVEN the address pipeline recognises the query WHEN results return THEN it still carries no text`() =
         runTest {
             fakeRemoteAddressResultsManager.results = listOf(
                 SearchStopState.SearchResult.Address(
@@ -830,7 +873,7 @@ class SearchStopViewModelTest {
                 advanceUntilIdle()
 
                 val addressEvent = addressEvents().single()
-                assertEquals(null, addressEvent.zeroResultQuery)
+                assertEquals(null, addressEvent.maskedQuery)
                 assertFalse(addressEvent.properties.orEmpty().containsKey("query"))
 
                 cancelAndIgnoreRemainingEvents()
@@ -850,7 +893,7 @@ class SearchStopViewModelTest {
 
                 val addressEvent = addressEvents().single()
                 assertTrue(addressEvent.isError)
-                assertEquals(null, addressEvent.zeroResultQuery)
+                assertEquals(null, addressEvent.maskedQuery)
                 assertFalse(addressEvent.properties.orEmpty().containsKey("query"))
 
                 cancelAndIgnoreRemainingEvents()
@@ -877,11 +920,6 @@ class SearchStopViewModelTest {
                 cancelAndIgnoreRemainingEvents()
             }
         }
-
-    private fun localEvents(): List<AnalyticsEvent.SearchStopQuery> =
-        (fakeAnalytics as FakeAnalytics).getTrackedEvents("search_stop_query")
-            .filterIsInstance<AnalyticsEvent.SearchStopQuery>()
-            .filter { it.resultSource == AnalyticsEvent.SearchStopQuery.ResultSource.LOCAL }
 
     @Test
     fun `GIVEN an address fetch WHEN it resolves THEN the address event carries the local count`() =


### PR DESCRIPTION
## What

Attaches the typed search query to every settled search instead of only to the zero-result carve-out, with every digit masked out of it on the device.

Masking happens client-side because `RealAnalytics` logs directly to Firebase: there is no stage after this one that could remove a house number from a value already sent.

An all-digit query is sent as typed. Route numbers and stop IDs are digits with no street beside them, so they identify no address, and masking them would collapse every such search into a run of `#`. One non-digit character anywhere masks the whole query.

The event also stops firing per keystroke: it now waits 600 ms of quiet after the results render, and the next keystroke cancels the job while it waits. A typing burst reports the query the rider finished rather than one row per prefix. The list on screen still refreshes at 100 ms.

## Changes

- `SearchQueryAnalyticsRedaction`: `zeroResultQueryOrNull` becomes `maskedQueryOrNull`. Result counts are no longer part of the decision; the length cap goes from 25 to 40 so real stop names fit ("north sydney interchange stand c" is 32 characters)
- `AnalyticsEvent.SearchStopQuery`: `zeroResultQuery` renamed `maskedQuery`. The Firebase property key stays `query`, so existing dashboards read the same column
- Only the local firing carries the text. The address firing carries none, since both share a `searchSessionId` and duplicating it would double the egress
- `resolveLocalZeroResultQuery` deleted, along with the two-pipeline ownership rule it existed for
- `SearchStopViewModel`: analytics settle time split from the list debounce
- Fixes a defect in the same path: `runCatching` swallowed the `CancellationException` thrown when a keystroke cancelled the search job, so a cancelled keystroke rendered the error state and reported `isError = true`. Replaced with `suspendSafeResult`, which rethrows cancellation
- `AnalyticsParamSanitizer` untouched: address-ID hashing and param truncation are unrelated

Guard tests re-pinned to the new invariant, which is simpler than the carve-out it replaces: a digit only ever leaves as part of a query that is nothing but digits. Adds a test pinning the burst rule (three keystrokes, one reported search).

## Testing

- `./gradlew :feature:trip-planner:ui:testAndroidHostTest :core:analytics:testAndroidHostTest --continue` green
- `./scripts/fullQualityChecks.sh` green (Android compile, iOS simulator compile, detekt)
- Not yet exercised on a device; DebugView verification is tracked in `docs/SEARCH_TELEMETRY_1.27_TODO.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKyPckiZry4wKSq9W9TLSL