### PR TITLE
chore(android): stop collecting the Advertising ID

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -3,8 +3,15 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <!-- Required for Firebase -->
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+
+    <!--
+      The Firebase Analytics SDK merges in the AD_ID permission by default.
+      KRAIL shows no ads and does not use the Advertising ID, so it is removed
+      here rather than declared and left unused.
+    -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 
     <!-- Location permissions for foreground location tracking -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
@@ -25,6 +32,12 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Krail"
         tools:ignore="UnusedAttribute">
+
+        <!-- Analytics must not collect the Advertising ID; see the AD_ID removal above. -->
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.share.fileprovider"


### PR DESCRIPTION
## What

Stops the app collecting the Advertising ID. The Firebase Analytics SDK merges in the `AD_ID` permission and reads the Advertising ID by default. KRAIL shows no ads and does not use it, so it was being collected for no purpose.

The permission was declared by hand in `5ad52bc2f` with the comment "Required for Firebase". It is not: Analytics works without it.

## Changes

- Remove `com.google.android.gms.permission.AD_ID` with `tools:node="remove"` rather than declaring a permission nothing uses
- Set `google_analytics_adid_collection_enabled` to `false` so the SDK does not read it even where the permission is granted by another merge
- `android.permission.ACCESS_ADSERVICES_AD_ID` is left alone. It is the Privacy Sandbox API rather than the classic Advertising ID, and removing a permission the SDK declares for itself is not part of Google's documented opt-out

iOS is unaffected: `Info.plist` declares no tracking usage description and the app never links AdSupport.

Replaces #1972, which GitHub closed when its base branch was deleted on merge. Same commit, rebased onto `main`.

## Testing

- `./gradlew :androidApp:processDebugMainManifest` green; verified on the merged debug manifest that the permission is absent and the meta-data is present
- `./scripts/fullQualityChecks.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKyPckiZry4wKSq9W9TLSL